### PR TITLE
Update Stream logging on EVENT_LOGGING_CHANGED

### DIFF
--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Any, Final, cast
 import voluptuous as vol
 from yarl import URL
 
+from homeassistant.components.logger import EVENT_LOGGING_CHANGED
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
@@ -188,36 +189,36 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-def filter_libav_logging() -> None:
-    """Filter libav logging to only log when the stream logger is at DEBUG."""
+@callback
+def update_pyav_logging(_event: Event | None = None) -> None:
+    """Adjust libav logging to only log when the stream logger is at DEBUG."""
 
-    def libav_filter(record: logging.LogRecord) -> bool:
-        return logging.getLogger(__name__).isEnabledFor(logging.DEBUG)
+    def set_pyav_logging(enable: bool) -> None:
+        """Turn PyAV logging on or off."""
+        # PyAV messages are logged at several different levels. Setting the logger level
+        # to CRITICAL should silence nearly all of them.
+        logging.getLogger("libav").setLevel(
+            logging.INFO if enable else logging.CRITICAL
+        )
+        # libav.mp4 and libav.swscaler have a few unimportant messages that are logged
+        # at logging.WARNING. Set those levels to logging.ERROR if enabled.
+        for logging_namespace in ("libav.mp4", "libav.swscaler"):
+            logging.getLogger(logging_namespace).setLevel(
+                logging.ERROR if enable else logging.CRITICAL
+            )
 
-    for logging_namespace in (
-        "libav.NULL",
-        "libav.h264",
-        "libav.hevc",
-        "libav.hls",
-        "libav.mp4",
-        "libav.mpegts",
-        "libav.rtsp",
-        "libav.tcp",
-        "libav.tls",
-    ):
-        logging.getLogger(logging_namespace).addFilter(libav_filter)
-
-    # Set log level to error for libav.mp4
-    logging.getLogger("libav.mp4").setLevel(logging.ERROR)
-    # Suppress "deprecated pixel format" WARNING
-    logging.getLogger("libav.swscaler").setLevel(logging.ERROR)
+    # enable PyAV logging iff Stream logger is set to debug
+    set_pyav_logging(logging.getLogger(__name__).isEnabledFor(logging.DEBUG))
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up stream."""
 
-    # Drop libav log messages if stream logging is above DEBUG
-    filter_libav_logging()
+    # Only pass through PyAV log messages if stream logging is above DEBUG
+    cancel_logging_listener = hass.bus.async_listen(
+        EVENT_LOGGING_CHANGED, update_pyav_logging
+    )
+    update_pyav_logging()
 
     # Keep import here so that we can import stream integration without installing reqs
     # pylint: disable-next=import-outside-toplevel
@@ -258,6 +259,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         ]:
             await asyncio.wait(awaitables)
         _LOGGER.debug("Stopped stream workers")
+        cancel_logging_listener()
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, shutdown)
 

--- a/homeassistant/components/stream/manifest.json
+++ b/homeassistant/components/stream/manifest.json
@@ -2,7 +2,7 @@
   "domain": "stream",
   "name": "Stream",
   "codeowners": ["@hunterjm", "@uvjustin", "@allenporter"],
-  "dependencies": ["http"],
+  "dependencies": ["http", "logger"],
   "documentation": "https://www.home-assistant.io/integrations/stream",
   "integration_type": "system",
   "iot_class": "local_push",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ load-plugins = [
 persistent = false
 extension-pkg-allow-list = [
     "av.audio.stream",
+    "av.logging",
     "av.stream",
     "ciso8601",
     "orjson",

--- a/tests/components/stream/test_init.py
+++ b/tests/components/stream/test_init.py
@@ -4,6 +4,7 @@ import logging
 import av
 import pytest
 
+from homeassistant.components.logger import EVENT_LOGGING_CHANGED
 from homeassistant.components.stream import __name__ as stream_name
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -13,8 +14,6 @@ async def test_log_levels(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test that the worker logs the url without username and password."""
-
-    logging.getLogger(stream_name).setLevel(logging.INFO)
 
     await async_setup_component(hass, "stream", {"stream": {}})
 
@@ -31,11 +30,17 @@ async def test_log_levels(
         "NULL",
     )
 
+    logging.getLogger(stream_name).setLevel(logging.INFO)
+    hass.bus.async_fire(EVENT_LOGGING_CHANGED)
+    await hass.async_block_till_done()
+
     # Since logging is at INFO, these should not pass
     for namespace in namespaces_to_toggle:
         av.logging.log(av.logging.ERROR, namespace, "SHOULD NOT PASS")
 
     logging.getLogger(stream_name).setLevel(logging.DEBUG)
+    hass.bus.async_fire(EVENT_LOGGING_CHANGED)
+    await hass.async_block_till_done()
 
     # Since logging is now at DEBUG, these should now pass
     for namespace in namespaces_to_toggle:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Stream integration passes through error messages from `libav` when the `Stream` log level is set to `DEBUG`. The existing implementation uses Logging filters which runs a runtime check of the `Stream` logger level on every logged message and also requires a filter to be set for every libav namespace. This PR uses <strike>`Logger.setLevel`</strike> `av.logging.set_level` to achieve the same effect, using a listener to only update the log levels on `EVENT_LOGGING_CHANGED` events and doing this mostly without having to set each libav namespace separately (`libav.mp4` and `libav.swscaler` are exceptions).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
