### PR TITLE
Add zwave_js device config file change fix/repair

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -550,6 +550,24 @@ class NodeEvents:
                 node,
             )
 
+        # After ensuring the node is set up in HA, we should check if the node's
+        # device config has changed, and if so, issue a repair registry entry for a
+        # possible reinterview
+        if not node.is_controller_node and await node.async_has_device_config_changed():
+            async_create_issue(
+                self.hass,
+                DOMAIN,
+                f"device_config_file_changed.{device.id}",
+                data={"device_id": device.id},
+                is_fixable=True,
+                is_persistent=False,
+                translation_key="device_config_file_changed",
+                translation_placeholders={
+                    "device_name": device.name_by_user or device.name or ""
+                },
+                severity=IssueSeverity.WARNING,
+            )
+
     async def async_handle_discovery_info(
         self,
         device: dr.DeviceEntry,

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -563,7 +563,9 @@ class NodeEvents:
                 is_persistent=False,
                 translation_key="device_config_file_changed",
                 translation_placeholders={
-                    "device_name": device.name_by_user or device.name or ""
+                    "device_name": device.name_by_user
+                    or device.name
+                    or "Unnamed device"
                 },
                 severity=IssueSeverity.WARNING,
             )

--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -3,7 +3,7 @@
   "name": "Z-Wave",
   "codeowners": ["@home-assistant/z-wave"],
   "config_flow": true,
-  "dependencies": ["usb", "http", "websocket_api"],
+  "dependencies": ["usb", "http", "repairs", "websocket_api"],
   "documentation": "https://www.home-assistant.io/integrations/zwave_js",
   "integration_type": "hub",
   "iot_class": "local_push",

--- a/homeassistant/components/zwave_js/repairs.py
+++ b/homeassistant/components/zwave_js/repairs.py
@@ -1,0 +1,51 @@
+"""Repairs for Z-Wave JS."""
+from __future__ import annotations
+
+from typing import cast
+
+import voluptuous as vol
+from zwave_js_server.model.node import Node
+
+from homeassistant import data_entry_flow
+from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
+from homeassistant.core import HomeAssistant
+
+from .helpers import async_get_node_from_device_id
+
+
+class DeviceConfigFileChangedFlow(RepairsFlow):
+    """Handler for an issue fixing flow."""
+
+    def __init__(self, node: Node) -> None:
+        """Initialize."""
+        self.node = node
+        super().__init__()
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the first step of a fix flow."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the confirm step of a fix flow."""
+        if user_input is not None:
+            self.hass.async_create_task(self.node.async_refresh_info())
+            return self.async_create_entry(title="", data={})
+
+        return self.async_show_form(step_id="confirm", data_schema=vol.Schema({}))
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, str | int | float | None] | None,
+) -> RepairsFlow:
+    """Create flow."""
+    if issue_id.split(".")[0] == "device_config_file_changed":
+        return DeviceConfigFileChangedFlow(
+            async_get_node_from_device_id(hass, cast(dict, data)["device_id"])
+        )
+    return ConfirmRepairFlow()

--- a/homeassistant/components/zwave_js/repairs.py
+++ b/homeassistant/components/zwave_js/repairs.py
@@ -19,7 +19,6 @@ class DeviceConfigFileChangedFlow(RepairsFlow):
     def __init__(self, node: Node) -> None:
         """Initialize."""
         self.node = node
-        super().__init__()
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -161,6 +161,17 @@
           }
         }
       }
+    },
+    "device_config_file_changed": {
+      "title": "Z-Wave device configuration file changed: {device_name}",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Z-Wave device configuration file changed: {device_name}",
+            "description": "Z-Wave JS discovers a lot of device metadata by interviewing the device. However, some of the information has to be loaded from a configuration file. Some of this information is only evaluated once, during the device interview.\n\nWhen a device config file is updated, this information may be stale and and the device must be re-interviewed to pick up the changes.\n\n This is not strictly required and device functionality will be impacted during the re-interview process.\n\nIf you'd like to proceed, click on SUBMIT below. The re-interview will take place in the background."
+          }
+        }
+      }
     }
   },
   "services": {

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -168,7 +168,7 @@
         "step": {
           "confirm": {
             "title": "Z-Wave device configuration file changed: {device_name}",
-            "description": "Z-Wave JS discovers a lot of device metadata by interviewing the device. However, some of the information has to be loaded from a configuration file. Some of this information is only evaluated once, during the device interview.\n\nWhen a device config file is updated, this information may be stale and and the device must be re-interviewed to pick up the changes.\n\n This is not strictly required and device functionality will be impacted during the re-interview process.\n\nIf you'd like to proceed, click on SUBMIT below. The re-interview will take place in the background."
+            "description": "Z-Wave JS discovers a lot of device metadata by interviewing the device. However, some of the information has to be loaded from a configuration file. Some of this information is only evaluated once, during the device interview.\n\nWhen a device config file is updated, this information may be stale and and the device must be re-interviewed to pick up the changes.\n\n This is not a required operation and device functionality will be impacted during the re-interview process, but you may see improvements for your device once it is complete.\n\nIf you'd like to proceed, click on SUBMIT below. The re-interview will take place in the background."
           }
         }
       }

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -653,14 +653,6 @@ def nice_ibt4zwave_state_fixture():
 # model fixtures
 
 
-SETUP_COMMAND_RESPONSES = {
-    "node.has_device_config_changed": {"result": {"changed": False}},
-    "controller.get_available_firmware_updates": {
-        "result": {"success": True, "status": 255}
-    },
-}
-
-
 @pytest.fixture(name="client")
 def mock_client_fixture(
     controller_state, controller_node_state, version_state, log_config_state
@@ -698,8 +690,8 @@ def mock_client_fixture(
 
         async def async_send_command_side_effect(message, require_schema=None):
             """Return the command response."""
-            if resp := SETUP_COMMAND_RESPONSES.get(message["command"]):
-                return resp
+            if message["command"] == "node.has_device_config_changed":
+                return {"changed": False}
             return DEFAULT
 
         client.async_send_command.return_value = {

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -3,7 +3,7 @@ import asyncio
 import copy
 import io
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import DEFAULT, AsyncMock, patch
 
 import pytest
 from zwave_js_server.event import Event
@@ -687,9 +687,17 @@ def mock_client_fixture(
 
         client.version = VersionInfo.from_message(version_state)
         client.ws_server_url = "ws://test:3000/zjs"
+
+        def has_device_config_changed_side_effect(message, require_schema=None):
+            """Handle node.has_device_config_changed."""
+            if message["command"] == "node.has_device_config_changed":
+                return {"result": {"changed": False}}
+            return DEFAULT
+
         client.async_send_command.return_value = {
             "result": {"success": True, "status": 255}
         }
+        client.async_send_command.side_effect = has_device_config_changed_side_effect
 
         yield client
 

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -653,6 +653,14 @@ def nice_ibt4zwave_state_fixture():
 # model fixtures
 
 
+SETUP_COMMAND_RESPONSES = {
+    "node.has_device_config_changed": {"result": {"changed": False}},
+    "controller.get_available_firmware_updates": {
+        "result": {"success": True, "status": 255}
+    },
+}
+
+
 @pytest.fixture(name="client")
 def mock_client_fixture(
     controller_state, controller_node_state, version_state, log_config_state
@@ -688,16 +696,16 @@ def mock_client_fixture(
         client.version = VersionInfo.from_message(version_state)
         client.ws_server_url = "ws://test:3000/zjs"
 
-        def has_device_config_changed_side_effect(message, require_schema=None):
-            """Handle node.has_device_config_changed."""
-            if message["command"] == "node.has_device_config_changed":
-                return {"result": {"changed": False}}
+        async def async_send_command_side_effect(message, require_schema=None):
+            """Return the command response."""
+            if resp := SETUP_COMMAND_RESPONSES.get(message["command"]):
+                return resp
             return DEFAULT
 
         client.async_send_command.return_value = {
             "result": {"success": True, "status": 255}
         }
-        client.async_send_command.side_effect = has_device_config_changed_side_effect
+        client.async_send_command.side_effect = async_send_command_side_effect
 
         yield client
 

--- a/tests/components/zwave_js/test_number.py
+++ b/tests/components/zwave_js/test_number.py
@@ -124,7 +124,7 @@ async def test_number_writeable(
         blocking=True,
     )
 
-    assert len(client.async_send_command.call_args_list) == 1
+    assert len(client.async_send_command.call_args_list) == 2
     args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 4

--- a/tests/components/zwave_js/test_repairs.py
+++ b/tests/components/zwave_js/test_repairs.py
@@ -1,0 +1,91 @@
+"""Test the Z-Wave JS repairs module."""
+from copy import deepcopy
+from http import HTTPStatus
+from unittest.mock import patch
+
+from zwave_js_server.event import Event
+from zwave_js_server.model.node import Node
+
+from homeassistant.components.repairs.issue_handler import (
+    async_process_repairs_platforms,
+)
+from homeassistant.components.repairs.websocket_api import (
+    RepairsFlowIndexView,
+    RepairsFlowResourceView,
+)
+from homeassistant.components.zwave_js import DOMAIN
+from homeassistant.components.zwave_js.helpers import get_device_id
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.device_registry as dr
+
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
+
+
+async def test_device_config_file_changed(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+    client,
+    multisensor_6_state,
+    integration,
+) -> None:
+    """Test the device_config_file_changed issue."""
+    dev_reg = dr.async_get(hass)
+    # Create a node
+    node_state = deepcopy(multisensor_6_state)
+    node = Node(client, node_state)
+    event = Event(
+        "node added",
+        {
+            "source": "controller",
+            "event": "node added",
+            "node": node_state,
+            "result": "",
+        },
+    )
+    with patch(
+        "zwave_js_server.model.node.Node.async_has_device_config_changed",
+        return_value=True,
+    ):
+        client.driver.controller.receive_event(event)
+        await hass.async_block_till_done()
+
+    device = dev_reg.async_get_device(identifiers={get_device_id(client.driver, node)})
+    assert device
+    issue_id = f"device_config_file_changed.{device.id}"
+
+    await async_process_repairs_platforms(hass)
+    ws_client = await hass_ws_client(hass)
+    http_client = await hass_client()
+
+    # Assert the issue is present
+    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+    assert len(msg["result"]["issues"]) == 1
+    issue = msg["result"]["issues"][0]
+    assert issue["issue_id"] == issue_id
+    assert issue["translation_placeholders"] == {"device_name": device.name}
+
+    url = RepairsFlowIndexView.url
+    resp = await http_client.post(url, json={"handler": DOMAIN, "issue_id": issue_id})
+    assert resp.status == HTTPStatus.OK
+    data = await resp.json()
+
+    flow_id = data["flow_id"]
+    assert data["step_id"] == "confirm"
+
+    # Apply fix
+    url = RepairsFlowResourceView.url.format(flow_id=flow_id)
+    resp = await http_client.post(url)
+
+    assert resp.status == HTTPStatus.OK
+    data = await resp.json()
+
+    assert data["type"] == "create_entry"
+
+    # Assert the issue is resolved
+    await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+    assert len(msg["result"]["issues"]) == 0

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -271,12 +271,12 @@ async def test_update_entity_ha_not_running(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert len(client.async_send_command.call_args_list) == 0
+    assert len(client.async_send_command.call_args_list) == 1
 
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert len(client.async_send_command.call_args_list) == 0
+    assert len(client.async_send_command.call_args_list) == 1
 
     # Update should be delayed by a day because HA is not running
     hass.state = CoreState.starting
@@ -284,15 +284,15 @@ async def test_update_entity_ha_not_running(
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
     await hass.async_block_till_done()
 
-    assert len(client.async_send_command.call_args_list) == 0
+    assert len(client.async_send_command.call_args_list) == 1
 
     hass.state = CoreState.running
 
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=1))
     await hass.async_block_till_done()
 
-    assert len(client.async_send_command.call_args_list) == 1
-    args = client.async_send_command.call_args_list[0][0][0]
+    assert len(client.async_send_command.call_args_list) == 2
+    args = client.async_send_command.call_args_list[1][0][0]
     assert args["command"] == "controller.get_available_firmware_updates"
     assert args["nodeId"] == zen_31.node_id
 
@@ -591,26 +591,26 @@ async def test_update_entity_delay(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert len(client.async_send_command.call_args_list) == 0
+    assert len(client.async_send_command.call_args_list) == 2
 
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert len(client.async_send_command.call_args_list) == 0
+    assert len(client.async_send_command.call_args_list) == 2
 
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
     await hass.async_block_till_done()
 
-    assert len(client.async_send_command.call_args_list) == 1
-    args = client.async_send_command.call_args_list[0][0][0]
+    assert len(client.async_send_command.call_args_list) == 3
+    args = client.async_send_command.call_args_list[2][0][0]
     assert args["command"] == "controller.get_available_firmware_updates"
     assert args["nodeId"] == ge_in_wall_dimmer_switch.node_id
 
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=10))
     await hass.async_block_till_done()
 
-    assert len(client.async_send_command.call_args_list) == 2
-    args = client.async_send_command.call_args_list[1][0][0]
+    assert len(client.async_send_command.call_args_list) == 4
+    args = client.async_send_command.call_args_list[3][0][0]
     assert args["command"] == "controller.get_available_firmware_updates"
     assert args["nodeId"] == zen_31.node_id
 
@@ -741,8 +741,8 @@ async def test_update_entity_full_restore_data_update_available(
     attrs = state.attributes
     assert attrs[ATTR_IN_PROGRESS] is True
 
-    assert len(client.async_send_command.call_args_list) == 1
-    assert client.async_send_command.call_args_list[0][0][0] == {
+    assert len(client.async_send_command.call_args_list) == 2
+    assert client.async_send_command.call_args_list[1][0][0] == {
         "command": "controller.firmware_update_ota",
         "nodeId": climate_radio_thermostat_ct100_plus_different_endpoints.node_id,
         "updates": [{"target": 0, "url": "https://example2.com", "integrity": "sha2"}],


### PR DESCRIPTION
## Proposed change
Z-Wave JS now has the ability to detect if a device config file changed since the last interview of the node. With this PR, we add an issue and repair flow to trigger a reinterview of a node.

Closes https://github.com/home-assistant-libs/zwave-js-server-python/issues/739


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
