### PR TITLE
Significantly reduce overhead to filter event triggers

### DIFF
--- a/homeassistant/components/homeassistant/triggers/event.py
+++ b/homeassistant/components/homeassistant/triggers/event.py
@@ -80,7 +80,11 @@ async def async_attach_trigger(
             template.render_complex(config[CONF_EVENT_CONTEXT], variables, limited=True)
         )
         # Build the schema or a an items view if the schema is simple
-        # and does not contain lists
+        # and does not contain lists. Lists are a special case to support
+        # matching events by user_id. (see test test_if_fires_on_multiple_user_ids)
+        # This can likely be optimized further in the future to handle the
+        # multiple user_id case without requiring expensive schema
+        # validation.
         if any(isinstance(value, list) for value in event_context.values()):
             event_context_schema = vol.Schema(
                 {

--- a/homeassistant/components/homeassistant/triggers/event.py
+++ b/homeassistant/components/homeassistant/triggers/event.py
@@ -102,14 +102,19 @@ async def async_attach_trigger(
             # Check that the event data and context match the configured
             # schema if one was provided
             if event_data_items:
+                # Fast path for simple items comparison
                 if not (event.data.items() >= event_data_items):
                     return False
             elif event_data_schema:
+                # Slow path for schema validation
                 event_data_schema(event.data)
+
             if event_context_items:
+                # Fast path for simple items comparison
                 if not (event.context.as_dict().items() >= event_context_items):
                     return False
             elif event_context_schema:
+                # Slow path for schema validation
                 event_context_schema(dict(event.context.as_dict()))
         except vol.Invalid:
             # If event doesn't match, skip event

--- a/homeassistant/components/homeassistant/triggers/event.py
+++ b/homeassistant/components/homeassistant/triggers/event.py
@@ -58,7 +58,9 @@ async def async_attach_trigger(
             template.render_complex(config[CONF_EVENT_DATA], variables, limited=True)
         )
         # Build the schema or a an items view if the schema is simple
-        # and does not contain sub-dicts
+        # and does not contain sub-dicts. We explicitly do not check for
+        # list like the context data below since lists are a special case
+        # only for context data. (see test test_event_data_with_list)
         if any(isinstance(value, dict) for value in event_data.values()):
             event_data_schema = vol.Schema(
                 {vol.Required(key): value for key, value in event_data.items()},

--- a/homeassistant/components/homeassistant/triggers/event.py
+++ b/homeassistant/components/homeassistant/triggers/event.py
@@ -57,7 +57,8 @@ async def async_attach_trigger(
         event_data.update(
             template.render_complex(config[CONF_EVENT_DATA], variables, limited=True)
         )
-        # Build the schema
+        # Build the schema or a an items view if the schema is simple
+        # and does not contain sub-dicts
         if any(isinstance(value, dict) for value in event_data.values()):
             event_data_schema = vol.Schema(
                 {vol.Required(key): value for key, value in event_data.items()},
@@ -76,7 +77,8 @@ async def async_attach_trigger(
         event_context.update(
             template.render_complex(config[CONF_EVENT_CONTEXT], variables, limited=True)
         )
-        # Build the schema
+        # Build the schema or a an items view if the schema is simple
+        # and does not contain lists
         if any(isinstance(value, list) for value in event_context.values()):
             event_context_schema = vol.Schema(
                 {

--- a/homeassistant/components/homeassistant/triggers/event.py
+++ b/homeassistant/components/homeassistant/triggers/event.py
@@ -1,6 +1,7 @@
 """Offer event listening automation rules."""
 from __future__ import annotations
 
+from collections.abc import ItemsView
 from typing import Any
 
 import voluptuous as vol
@@ -47,10 +48,8 @@ async def async_attach_trigger(
     event_types = template.render_complex(
         config[CONF_EVENT_TYPE], variables, limited=True
     )
-    removes = []
-
-    event_data_schema = None
-    event_data_items = None
+    event_data_schema: vol.Schema | None = None
+    event_data_items: ItemsView | None = None
     if CONF_EVENT_DATA in config:
         # Render the schema input
         template.attach(hass, config[CONF_EVENT_DATA])
@@ -68,8 +67,8 @@ async def async_attach_trigger(
             # Use a simple items comparison if possible
             event_data_items = event_data.items()
 
-    event_context_schema = None
-    event_context_items = None
+    event_context_schema: vol.Schema | None = None
+    event_context_items: ItemsView | None = None
     if CONF_EVENT_CONTEXT in config:
         # Render the schema input
         template.attach(hass, config[CONF_EVENT_CONTEXT])

--- a/tests/components/homeassistant/triggers/test_event.py
+++ b/tests/components/homeassistant/triggers/test_event.py
@@ -339,6 +339,63 @@ async def test_if_fires_on_event_with_empty_data(hass: HomeAssistant, calls) -> 
     assert len(calls) == 1
 
 
+async def test_if_fires_on_sample_zha_event(hass: HomeAssistant, calls) -> None:
+    """Test the firing of events with a sample zha event.
+
+    This test exercises the fast path to validate matching event data.
+    """
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "event",
+                    "event_type": "zha_event",
+                    "event_data": {
+                        "device_ieee": "00:15:8d:00:02:93:04:11",
+                        "command": "attribute_updated",
+                        "args": {
+                            "attribute_id": 0,
+                            "attribute_name": "on_off",
+                            "value": True,
+                        },
+                    },
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+
+    hass.bus.async_fire(
+        "zha_event",
+        {
+            "device_ieee": "00:15:8d:00:02:93:04:11",
+            "unique_id": "00:15:8d:00:02:93:04:11:1:0x0006",
+            "endpoint_id": 1,
+            "cluster_id": 6,
+            "command": "attribute_updated",
+            "args": {"attribute_id": 0, "attribute_name": "on_off", "value": True},
+        },
+    )
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    hass.bus.async_fire(
+        "zha_event",
+        {
+            "device_ieee": "00:15:8d:00:02:93:04:11",
+            "unique_id": "00:15:8d:00:02:93:04:11:1:0x0006",
+            "endpoint_id": 1,
+            "cluster_id": 6,
+            "command": "attribute_updated",
+            "args": {"attribute_id": 0, "attribute_name": "on_off", "value": False},
+        },
+    )
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+
 async def test_if_not_fires_if_event_data_not_matches(
     hass: HomeAssistant, calls
 ) -> None:

--- a/tests/components/homeassistant/triggers/test_event.py
+++ b/tests/components/homeassistant/triggers/test_event.py
@@ -288,7 +288,11 @@ async def test_if_fires_on_event_with_empty_data_and_context_config(
 
 
 async def test_if_fires_on_event_with_nested_data(hass: HomeAssistant, calls) -> None:
-    """Test the firing of events with nested data."""
+    """Test the firing of events with nested data.
+
+    This test exercises the slow path of using vol.Schema to validate
+    matching event data.
+    """
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -362,7 +366,11 @@ async def test_if_not_fires_if_event_context_not_matches(
 async def test_if_fires_on_multiple_user_ids(
     hass: HomeAssistant, calls, context_with_user
 ) -> None:
-    """Test the firing of event when the trigger has multiple user ids."""
+    """Test the firing of event when the trigger has multiple user ids.
+
+    This test exercises the slow path of using vol.Schema to validate
+    matching event context.
+    """
     assert await async_setup_component(
         hass,
         automation.DOMAIN,

--- a/tests/components/homeassistant/triggers/test_event.py
+++ b/tests/components/homeassistant/triggers/test_event.py
@@ -315,6 +315,30 @@ async def test_if_fires_on_event_with_nested_data(hass: HomeAssistant, calls) ->
     assert len(calls) == 1
 
 
+async def test_if_fires_on_event_with_empty_data(hass: HomeAssistant, calls) -> None:
+    """Test the firing of events with empty data.
+
+    This test exercises the fast path to validate matching event data.
+    """
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "event",
+                    "event_type": "test_event",
+                    "event_data": {},
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+    hass.bus.async_fire("test_event", {"any_attr": {}})
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+
 async def test_if_not_fires_if_event_data_not_matches(
     hass: HomeAssistant, calls
 ) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The large number of `vol.Schema` `validate_mapping` calls was contributing to sluggish performance and poor response times.  In most cases we can avoid it and do a simple `dict` `.items()` compare. For complex nested cases, continue to fallback to the expensive `vol.Schema` `validate_mapping` path (these should be rare and there are much better ways to write the automations already available).

profile courtesy of @Madelena

![filter_event](https://github.com/home-assistant/core/assets/663432/9f2e188b-072b-4a4d-b8e8-08ac08db466c)
![filter_event_cycle](https://github.com/home-assistant/core/assets/663432/d68b5351-d42a-4736-a60d-64039cbbc3a4)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
