### PR TITLE
Check new IP of Reolink camera from DHCP

### DIFF
--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -20,6 +20,7 @@ from . import ReolinkData
 from .const import CONF_PROTOCOL, CONF_USE_HTTPS, DOMAIN
 from .exceptions import ReolinkException, ReolinkWebhookException, UserNotAdmin
 from .host import ReolinkHost
+from .util import has_connection_problem
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -74,18 +75,6 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Options callback for Reolink."""
         return ReolinkOptionsFlowHandler(config_entry)
 
-    def has_connection_problem(self, config_entry: config_entries.ConfigEntry) -> bool:
-        """Check if a existing entry has a connection problem."""
-        reolink_data: ReolinkData | None = self.hass.data.get(DOMAIN, {}).get(
-            config_entry.entry_id
-        )
-        connection_problem = (
-            reolink_data is not None
-            and config_entry.state == config_entries.ConfigEntryState.LOADED
-            and reolink_data.device_coordinator.last_update_success
-        )
-        return connection_problem
-
     async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> FlowResult:
         """Perform reauth upon an authentication error or no admin privileges."""
         self._host = entry_data[CONF_HOST]
@@ -115,7 +104,7 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             and CONF_PASSWORD in existing_entry.data
             and existing_entry.data[CONF_HOST] != discovery_info.ip
         ):
-            if self.has_connection_problem(existing_entry):
+            if has_connection_problem(self.hass, existing_entry):
                 _LOGGER.debug(
                     "Reolink DHCP reported new IP '%s', "
                     "but connection to camera seems to be okay, so sticking to IP '%s'",

--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import format_mac
 
+from . import ReolinkData
 from .const import CONF_PROTOCOL, CONF_USE_HTTPS, DOMAIN
 from .exceptions import ReolinkException, ReolinkWebhookException, UserNotAdmin
 from .host import ReolinkHost
@@ -103,10 +104,12 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             and existing_entry.data[CONF_HOST] != discovery_info.ip
         ):
             # check the existing entry indeed has a connection problem
-            reolink_data: ReolinkData | None = hass.data.get(DOMAIN, {}).get(existing_entry.entry_id)
+            reolink_data: ReolinkData | None = self.hass.data.get(DOMAIN, {}).get(
+                existing_entry.entry_id
+            )
             if (
                 reolink_data
-                and existing_entry.state == config_entries.ConfigEntryState.LOADED 
+                and existing_entry.state == config_entries.ConfigEntryState.LOADED
                 and reolink_data.device_coordinator.last_update_success
             ):
                 _LOGGER.debug(

--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -98,7 +98,8 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         mac_address = format_mac(discovery_info.macaddress)
         existing_entry = await self.async_set_unique_id(mac_address)
         if (
-            existing_entry and CONF_PASSWORD in existing_entry.data
+            existing_entry
+            and CONF_PASSWORD in existing_entry.data
             and existing_entry.data[CONF_HOST] != discovery_info.ip
         ):
             # check if the camera is reachable at the new IP
@@ -108,8 +109,11 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 host.api.logout()
             except ReolinkError as err:
                 _LOGGER.debug(
-                    "Reolink DHCP reported new IP '%s', but got error '%s' trying to connect, "
-                    "so sticking to IP '%s'", discovery_info.ip, str(err), existing_entry.data[CONF_HOST]
+                    "Reolink DHCP reported new IP '%s', "
+                    "but got error '%s' trying to connect, so sticking to IP '%s'",
+                    discovery_info.ip,
+                    str(err),
+                    existing_entry.data[CONF_HOST],
                 )
                 raise AbortFlow("already_configured")
 

--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -80,7 +80,7 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             config_entry.entry_id
         )
         connection_problem = (
-            reolink_data
+            reolink_data is not None
             and config_entry.state == config_entries.ConfigEntryState.LOADED
             and reolink_data.device_coordinator.last_update_success
         )

--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -16,7 +16,6 @@ from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import format_mac
 
-from . import ReolinkData
 from .const import CONF_PROTOCOL, CONF_USE_HTTPS, DOMAIN
 from .exceptions import ReolinkException, ReolinkWebhookException, UserNotAdmin
 from .host import ReolinkHost

--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -75,7 +75,7 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return ReolinkOptionsFlowHandler(config_entry)
 
     def has_connection_problem(self, config_entry: config_entries.ConfigEntry) -> bool:
-        """Check if a existing entry has a connection problem"""
+        """Check if a existing entry has a connection problem."""
         reolink_data: ReolinkData | None = self.hass.data.get(DOMAIN, {}).get(
             config_entry.entry_id
         )

--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -105,7 +105,7 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             # check if the camera is reachable at the new IP
             host = ReolinkHost(self.hass, existing_entry.data, existing_entry.options)
             try:
-                host.api.login()
+                host.api.get_state("GetLocalLink")
                 host.api.logout()
             except ReolinkError as err:
                 _LOGGER.debug(
@@ -116,6 +116,8 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     existing_entry.data[CONF_HOST],
                 )
                 raise AbortFlow("already_configured") from err
+            if format_mac(host.api.mac_address) != mac_address:
+                raise AbortFlow("already_configured")
 
         self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.ip})
 

--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -123,8 +123,8 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             # check if the camera is reachable at the new IP
             host = ReolinkHost(self.hass, existing_entry.data, existing_entry.options)
             try:
-                host.api.get_state("GetLocalLink")
-                host.api.logout()
+                await host.api.get_state("GetLocalLink")
+                await host.api.logout()
             except ReolinkError as err:
                 _LOGGER.debug(
                     "Reolink DHCP reported new IP '%s', "

--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -115,7 +115,7 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     str(err),
                     existing_entry.data[CONF_HOST],
                 )
-                raise AbortFlow("already_configured")
+                raise AbortFlow("already_configured") from err
 
         self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.ip})
 

--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -117,6 +117,14 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 )
                 raise AbortFlow("already_configured") from err
             if format_mac(host.api.mac_address) != mac_address:
+                _LOGGER.debug(
+                    "Reolink mac address '%s' at new IP '%s' from DHCP, "
+                    "does not match mac '%s' of config entry, so sticking to IP '%s'",
+                    format_mac(host.api.mac_address),
+                    discovery_info.ip,
+                    mac_address,
+                    existing_entry.data[CONF_HOST],
+                )
                 raise AbortFlow("already_configured")
 
         self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.ip})

--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant import config_entries
 from homeassistant.components import dhcp
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import format_mac
 
@@ -96,8 +96,24 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_dhcp(self, discovery_info: dhcp.DhcpServiceInfo) -> FlowResult:
         """Handle discovery via dhcp."""
         mac_address = format_mac(discovery_info.macaddress)
-        await self.async_set_unique_id(mac_address)
-        self._abort_if_unique_id_configured()
+        existing_entry = await self.async_set_unique_id(mac_address)
+        if (
+            existing_entry and CONF_PASSWORD in existing_entry.data
+            and existing_entry.data[CONF_HOST] != discovery_info.ip
+        ):
+            # check if the camera is reachable at the new IP
+            host = ReolinkHost(self.hass, existing_entry.data, existing_entry.options)
+            try:
+                host.api.login()
+                host.api.logout()
+            except ReolinkError as err:
+                _LOGGER.debug(
+                    "Reolink DHCP reported new IP '%s', but got error '%s' trying to connect, "
+                    "so sticking to IP '%s'", discovery_info.ip, str(err), existing_entry.data[CONF_HOST]
+                )
+                raise AbortFlow("already_configured")
+
+        self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.ip})
 
         self.context["title_placeholders"] = {
             "ip_address": discovery_info.ip,

--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -97,7 +97,7 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle discovery via dhcp."""
         mac_address = format_mac(discovery_info.macaddress)
         await self.async_set_unique_id(mac_address)
-        self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.ip})
+        self._abort_if_unique_id_configured()
 
         self.context["title_placeholders"] = {
             "ip_address": discovery_info.ip,

--- a/homeassistant/components/reolink/util.py
+++ b/homeassistant/components/reolink/util.py
@@ -1,0 +1,35 @@
+"""Config flow for the Reolink camera component."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+import logging
+from typing import Any
+
+from reolink_aio.exceptions import ApiError, CredentialsInvalidError, ReolinkError
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.components import dhcp
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import AbortFlow, FlowResult
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.device_registry import format_mac
+
+from . import ReolinkData
+from .const import CONF_PROTOCOL, CONF_USE_HTTPS, DOMAIN
+from .exceptions import ReolinkException, ReolinkWebhookException, UserNotAdmin
+from .host import ReolinkHost
+
+
+def has_connection_problem(hass: HomeAssistant, config_entry: config_entries.ConfigEntry) -> bool:
+    """Check if a existing entry has a connection problem."""
+    reolink_data: ReolinkData | None = hass.data.get(DOMAIN, {}).get(
+        config_entry.entry_id
+    )
+    connection_problem = (
+        reolink_data is not None
+        and config_entry.state == config_entries.ConfigEntryState.LOADED
+        and reolink_data.device_coordinator.last_update_success
+    )
+    return connection_problem

--- a/homeassistant/components/reolink/util.py
+++ b/homeassistant/components/reolink/util.py
@@ -1,4 +1,4 @@
-"""Config flow for the Reolink camera component."""
+"""utility functions for the Reolink component."""
 from __future__ import annotations
 
 from homeassistant import config_entries

--- a/homeassistant/components/reolink/util.py
+++ b/homeassistant/components/reolink/util.py
@@ -1,4 +1,4 @@
-"""utility functions for the Reolink component."""
+"""Utility functions for the Reolink component."""
 from __future__ import annotations
 
 from homeassistant import config_entries

--- a/homeassistant/components/reolink/util.py
+++ b/homeassistant/components/reolink/util.py
@@ -1,28 +1,16 @@
 """Config flow for the Reolink camera component."""
 from __future__ import annotations
 
-from collections.abc import Mapping
-import logging
-from typing import Any
-
-from reolink_aio.exceptions import ApiError, CredentialsInvalidError, ReolinkError
-import voluptuous as vol
-
 from homeassistant import config_entries
-from homeassistant.components import dhcp
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import AbortFlow, FlowResult
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.device_registry import format_mac
 
 from . import ReolinkData
-from .const import CONF_PROTOCOL, CONF_USE_HTTPS, DOMAIN
-from .exceptions import ReolinkException, ReolinkWebhookException, UserNotAdmin
-from .host import ReolinkHost
+from .const import DOMAIN
 
 
-def has_connection_problem(hass: HomeAssistant, config_entry: config_entries.ConfigEntry) -> bool:
+def has_connection_problem(
+    hass: HomeAssistant, config_entry: config_entries.ConfigEntry
+) -> bool:
     """Check if a existing entry has a connection problem."""
     reolink_data: ReolinkData | None = hass.data.get(DOMAIN, {}).get(
         config_entry.entry_id

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -380,7 +380,7 @@ async def test_dhcp_flow(hass: HomeAssistant, mock_setup_entry: MagicMock) -> No
 
 
 @pytest.mark.parametrize(
-    ("last_update_succes", "attr", "value", "expected"),
+    ("last_update_success", "attr", "value", "expected"),
     [
         (
             False,

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -1,18 +1,22 @@
 """Test the Reolink config flow."""
+from datetime import timedelta
 import json
-from unittest.mock import MagicMock
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from reolink_aio.exceptions import ApiError, CredentialsInvalidError, ReolinkError
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import dhcp
-from homeassistant.components.reolink import const
+from homeassistant.components.reolink import DEVICE_UPDATE_INTERVAL, const
 from homeassistant.components.reolink.config_flow import DEFAULT_PROTOCOL
 from homeassistant.components.reolink.exceptions import ReolinkWebhookException
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import format_mac
+from homeassistant.util.dt import utcnow
 
 from .conftest import (
     TEST_HOST,
@@ -27,12 +31,14 @@ from .conftest import (
     TEST_USERNAME2,
 )
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
-pytestmark = pytest.mark.usefixtures("mock_setup_entry", "reolink_connect")
+pytestmark = pytest.mark.usefixtures("reolink_connect")
 
 
-async def test_config_flow_manual_success(hass: HomeAssistant) -> None:
+async def test_config_flow_manual_success(
+    hass: HomeAssistant, mock_setup_entry: MagicMock
+) -> None:
     """Successful flow manually initialized by the user."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -66,7 +72,7 @@ async def test_config_flow_manual_success(hass: HomeAssistant) -> None:
 
 
 async def test_config_flow_errors(
-    hass: HomeAssistant, reolink_connect: MagicMock
+    hass: HomeAssistant, reolink_connect: MagicMock, mock_setup_entry: MagicMock
 ) -> None:
     """Successful flow manually initialized by the user after some errors."""
     result = await hass.config_entries.flow.async_init(
@@ -192,7 +198,7 @@ async def test_config_flow_errors(
     }
 
 
-async def test_options_flow(hass: HomeAssistant) -> None:
+async def test_options_flow(hass: HomeAssistant, mock_setup_entry: MagicMock) -> None:
     """Test specifying non default settings using options flow."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,
@@ -230,7 +236,9 @@ async def test_options_flow(hass: HomeAssistant) -> None:
     }
 
 
-async def test_change_connection_settings(hass: HomeAssistant) -> None:
+async def test_change_connection_settings(
+    hass: HomeAssistant, mock_setup_entry: MagicMock
+) -> None:
     """Test changing connection settings by issuing a second user config flow."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,
@@ -273,7 +281,7 @@ async def test_change_connection_settings(hass: HomeAssistant) -> None:
     assert config_entry.data[CONF_PASSWORD] == TEST_PASSWORD2
 
 
-async def test_reauth(hass: HomeAssistant) -> None:
+async def test_reauth(hass: HomeAssistant, mock_setup_entry: MagicMock) -> None:
     """Test a reauth flow."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,
@@ -333,7 +341,7 @@ async def test_reauth(hass: HomeAssistant) -> None:
     assert config_entry.data[CONF_PASSWORD] == TEST_PASSWORD2
 
 
-async def test_dhcp_flow(hass: HomeAssistant) -> None:
+async def test_dhcp_flow(hass: HomeAssistant, mock_setup_entry: MagicMock) -> None:
     """Successful flow from DHCP discovery."""
     dhcp_data = dhcp.DhcpServiceInfo(
         ip=TEST_HOST,
@@ -371,8 +379,44 @@ async def test_dhcp_flow(hass: HomeAssistant) -> None:
     }
 
 
-async def test_dhcp_abort_flow(hass: HomeAssistant) -> None:
-    """Test dhcp discovery aborts if already configured."""
+@pytest.mark.parametrize(
+    ("last_update_succes", "attr", "value", "expected"),
+    [
+        (
+            False,
+            None,
+            None,
+            TEST_HOST2,
+        ),
+        (
+            True,
+            None,
+            None,
+            TEST_HOST,
+        ),
+        (
+            False,
+            "get_state",
+            AsyncMock(side_effect=ReolinkError("Test error")),
+            TEST_HOST,
+        ),
+        (
+            False,
+            "mac_address",
+            "aa:aa:aa:aa:aa:aa",
+            TEST_HOST,
+        ),
+    ],
+)
+async def test_dhcp_ip_update(
+    hass: HomeAssistant,
+    reolink_connect: MagicMock,
+    last_update_succes: bool,
+    attr: str,
+    value: Any,
+    expected: str,
+) -> None:
+    """Test dhcp discovery aborts if already configured where the IP is updated if appropriate."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,
         unique_id=format_mac(TEST_MAC),
@@ -392,12 +436,24 @@ async def test_dhcp_abort_flow(hass: HomeAssistant) -> None:
 
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
+    assert config_entry.state == ConfigEntryState.LOADED
+
+    if not last_update_succes:
+        # ensure the last_update_succes is False for the device_coordinator.
+        reolink_connect.get_states = AsyncMock(side_effect=ReolinkError("Test error"))
+        async_fire_time_changed(
+            hass, utcnow() + DEVICE_UPDATE_INTERVAL + timedelta(minutes=1)
+        )
+        await hass.async_block_till_done()
 
     dhcp_data = dhcp.DhcpServiceInfo(
-        ip=TEST_HOST,
+        ip=TEST_HOST2,
         hostname="Reolink",
         macaddress=TEST_MAC,
     )
+
+    if attr is not None:
+        setattr(reolink_connect, attr, value)
 
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_DHCP}, data=dhcp_data
@@ -405,3 +461,6 @@ async def test_dhcp_abort_flow(hass: HomeAssistant) -> None:
 
     assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+    await hass.async_block_till_done()
+    assert config_entry.data[CONF_HOST] == expected

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -411,7 +411,7 @@ async def test_dhcp_flow(hass: HomeAssistant, mock_setup_entry: MagicMock) -> No
 async def test_dhcp_ip_update(
     hass: HomeAssistant,
     reolink_connect: MagicMock,
-    last_update_succes: bool,
+    last_update_success: bool,
     attr: str,
     value: Any,
     expected: str,
@@ -438,7 +438,7 @@ async def test_dhcp_ip_update(
     await hass.async_block_till_done()
     assert config_entry.state == ConfigEntryState.LOADED
 
-    if not last_update_succes:
+    if not last_update_success:
         # ensure the last_update_succes is False for the device_coordinator.
         reolink_connect.get_states = AsyncMock(side_effect=ReolinkError("Test error"))
         async_fire_time_changed(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I now have had multiple reported issues where people had wrong DHCP information comming in from the camera. This causes the IP of the reolink device to wrongly change causing disconnections. The users can't really resolve this since when they use the re-auth flow to change the IP it will work for a short while until the next DHCP update will put the IP back wrongly.

This PR will first check if the camera is reachable on the new IP, before using the new IP.

Note that it is already adviced to use a static IP/DHCP reservation in the router for users of the reolink integration:
https://www.home-assistant.io/integrations/reolink/#troubleshooting

~TO DO: still needs tests for this new code.~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/99330
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
