### PR TITLE
Don't set assumed_state in cover groups

### DIFF
--- a/tests/components/group/test_cover.py
+++ b/tests/components/group/test_cover.py
@@ -346,10 +346,10 @@ async def test_attributes(hass: HomeAssistant, setup_comp) -> None:
     assert state.attributes[ATTR_CURRENT_POSITION] == 70
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 60
 
-    # ### Test assumed state ###
+    # ### Test state when group members have different states ###
     # ##########################
 
-    # For covers - assumed state set true if position differ
+    # Covers
     hass.states.async_set(
         DEMO_COVER, STATE_OPEN, {ATTR_SUPPORTED_FEATURES: 4, ATTR_CURRENT_POSITION: 100}
     )
@@ -357,7 +357,7 @@ async def test_attributes(hass: HomeAssistant, setup_comp) -> None:
 
     state = hass.states.get(COVER_GROUP)
     assert state.state == STATE_OPEN
-    assert state.attributes[ATTR_ASSUMED_STATE] is True
+    assert ATTR_ASSUMED_STATE not in state.attributes
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 244
     assert state.attributes[ATTR_CURRENT_POSITION] == 85  # (70 + 100) / 2
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 60
@@ -373,7 +373,7 @@ async def test_attributes(hass: HomeAssistant, setup_comp) -> None:
     assert ATTR_CURRENT_POSITION not in state.attributes
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 60
 
-    # For tilts - assumed state set true if tilt position differ
+    # Tilts
     hass.states.async_set(
         DEMO_TILT,
         STATE_OPEN,
@@ -383,7 +383,7 @@ async def test_attributes(hass: HomeAssistant, setup_comp) -> None:
 
     state = hass.states.get(COVER_GROUP)
     assert state.state == STATE_OPEN
-    assert state.attributes[ATTR_ASSUMED_STATE] is True
+    assert ATTR_ASSUMED_STATE not in state.attributes
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 128
     assert ATTR_CURRENT_POSITION not in state.attributes
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 80  # (60 + 100) / 2
@@ -399,11 +399,12 @@ async def test_attributes(hass: HomeAssistant, setup_comp) -> None:
     assert ATTR_CURRENT_POSITION not in state.attributes
     assert ATTR_CURRENT_TILT_POSITION not in state.attributes
 
+    # Group member has set assumed_state
     hass.states.async_set(DEMO_TILT, STATE_CLOSED, {ATTR_ASSUMED_STATE: True})
     await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.attributes[ATTR_ASSUMED_STATE] is True
+    assert ATTR_ASSUMED_STATE not in state.attributes
 
     # Test entity registry integration
     entity_registry = er.async_get(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Don't set `assumed_state` in cover groups

### Rationale
Cover groups set `assumed_state` for cover groups where the group members do not all have the same position or tilt position to influence controls shown in frontend. This is not in line with the meaning of the `assumed_state` flag.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
