### PR TITLE
Don't set assumed_state in fan groups

### DIFF
--- a/homeassistant/components/group/fan.py
+++ b/homeassistant/components/group/fan.py
@@ -25,7 +25,6 @@ from homeassistant.components.fan import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    ATTR_ASSUMED_STATE,
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
     CONF_ENTITIES,
@@ -41,12 +40,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import GroupEntity
-from .util import (
-    attribute_equal,
-    most_frequent_attribute,
-    reduce_attribute,
-    states_equal,
-)
+from .util import attribute_equal, most_frequent_attribute, reduce_attribute
 
 SUPPORTED_FLAGS = {
     FanEntityFeature.SET_SPEED,
@@ -110,7 +104,6 @@ class FanGroup(GroupEntity, FanEntity):
     """Representation of a FanGroup."""
 
     _attr_available: bool = False
-    _attr_assumed_state: bool = True
 
     def __init__(self, unique_id: str | None, name: str, entities: list[str]) -> None:
         """Initialize a FanGroup entity."""
@@ -243,19 +236,16 @@ class FanGroup(GroupEntity, FanEntity):
         """Set an attribute based on most frequent supported entities attributes."""
         states = self._async_states_by_support_flag(flag)
         setattr(self, attr, most_frequent_attribute(states, entity_attr))
-        self._attr_assumed_state |= not attribute_equal(states, entity_attr)
 
     @callback
     def async_update_group_state(self) -> None:
         """Update state and attributes."""
-        self._attr_assumed_state = False
 
         states = [
             state
             for entity_id in self._entity_ids
             if (state := self.hass.states.get(entity_id)) is not None
         ]
-        self._attr_assumed_state |= not states_equal(states)
 
         # Set group as unavailable if all members are unavailable or missing
         self._attr_available = any(state.state != STATE_UNAVAILABLE for state in states)
@@ -274,9 +264,6 @@ class FanGroup(GroupEntity, FanEntity):
             FanEntityFeature.SET_SPEED
         )
         self._percentage = reduce_attribute(percentage_states, ATTR_PERCENTAGE)
-        self._attr_assumed_state |= not attribute_equal(
-            percentage_states, ATTR_PERCENTAGE
-        )
         if (
             percentage_states
             and percentage_states[0].attributes.get(ATTR_PERCENTAGE_STEP)
@@ -300,7 +287,4 @@ class FanGroup(GroupEntity, FanEntity):
             reduce(
                 ior, [feature for feature in SUPPORTED_FLAGS if self._fans[feature]], 0
             )
-        )
-        self._attr_assumed_state |= any(
-            state.attributes.get(ATTR_ASSUMED_STATE) for state in states
         )

--- a/tests/components/group/test_config_flow.py
+++ b/tests/components/group/test_config_flow.py
@@ -468,7 +468,7 @@ async def test_options_flow_hides_members(
 
 COVER_ATTRS = [{"supported_features": 0}, {}]
 EVENT_ATTRS = [{"event_types": []}, {"event_type": None}]
-FAN_ATTRS = [{"supported_features": 0}, {"assumed_state": True}]
+FAN_ATTRS = [{"supported_features": 0}, {}]
 LIGHT_ATTRS = [
     {
         "icon": "mdi:lightbulb-group",

--- a/tests/components/group/test_fan.py
+++ b/tests/components/group/test_fan.py
@@ -247,11 +247,7 @@ async def test_attributes(hass: HomeAssistant, setup_comp) -> None:
     assert state.attributes[ATTR_PERCENTAGE] == 50
     assert ATTR_ASSUMED_STATE not in state.attributes
 
-    # Add Entity that supports
-    # ### Test assumed state ###
-    # ##########################
-
-    # Add Entity with a different speed should set assumed state
+    # Add Entity with a different speed should not set assumed state
     hass.states.async_set(
         PERCENTAGE_LIMITED_FAN_ENTITY_ID,
         STATE_ON,
@@ -264,7 +260,7 @@ async def test_attributes(hass: HomeAssistant, setup_comp) -> None:
 
     state = hass.states.get(FAN_GROUP)
     assert state.state == STATE_ON
-    assert state.attributes[ATTR_ASSUMED_STATE] is True
+    assert ATTR_ASSUMED_STATE not in state.attributes
     assert state.attributes[ATTR_PERCENTAGE] == int((50 + 75) / 2)
 
 
@@ -306,11 +302,7 @@ async def test_direction_oscillating(hass: HomeAssistant, setup_comp) -> None:
     assert state.attributes[ATTR_DIRECTION] == DIRECTION_FORWARD
     assert ATTR_ASSUMED_STATE not in state.attributes
 
-    # Add Entity that supports
-    # ### Test assumed state ###
-    # ##########################
-
-    # Add Entity with a different direction should set assumed state
+    # Add Entity with a different direction should not set assumed state
     hass.states.async_set(
         PERCENTAGE_FULL_FAN_ENTITY_ID,
         STATE_ON,
@@ -325,11 +317,10 @@ async def test_direction_oscillating(hass: HomeAssistant, setup_comp) -> None:
 
     state = hass.states.get(FAN_GROUP)
     assert state.state == STATE_ON
-    assert state.attributes[ATTR_ASSUMED_STATE] is True
+    assert ATTR_ASSUMED_STATE not in state.attributes
     assert ATTR_PERCENTAGE in state.attributes
     assert state.attributes[ATTR_PERCENTAGE] == 50
     assert state.attributes[ATTR_OSCILLATING] is True
-    assert ATTR_ASSUMED_STATE in state.attributes
 
     # Now that everything is the same, no longer assumed state
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Don't set `assumed_state` in fan groups

### Rationale
Fan groups set `assumed_state` for fan groups where the group members do not all have the same position or tilt position to influence controls shown in frontend. This is not in line with the meaning of the `assumed_state` flag.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
