### PR TITLE
Fix battery reading in SOMA API

### DIFF
--- a/homeassistant/components/soma/sensor.py
+++ b/homeassistant/components/soma/sensor.py
@@ -43,11 +43,6 @@ class SomaSensor(SomaEntity, SensorEntity):
     async def async_update(self) -> None:
         """Update the sensor with the latest data."""
         response = await self.get_battery_level_from_api()
-
-        # https://support.somasmarthome.com/hc/en-us/articles/360026064234-HTTP-API
-        # battery_level response is expected to be min = 360, max 410 for
-        # 0-100% levels above 410 are consider 100% and below 360, 0% as the
-        # device considers 360 the minimum to move the motor.
-        _battery = round(2 * (response["battery_level"] - 360))
+        _battery = response["battery_percentage"]
         battery = max(min(100, _battery), 0)
         self.battery_state = battery

--- a/homeassistant/components/soma/sensor.py
+++ b/homeassistant/components/soma/sensor.py
@@ -43,6 +43,12 @@ class SomaSensor(SomaEntity, SensorEntity):
     async def async_update(self) -> None:
         """Update the sensor with the latest data."""
         response = await self.get_battery_level_from_api()
-        _battery = response["battery_percentage"]
+        _battery = response.get("battery_percentage")
+        if _battery is None:
+            # https://support.somasmarthome.com/hc/en-us/articles/360026064234-HTTP-API
+            # battery_level response is expected to be min = 360, max 410 for
+            # 0-100% levels above 410 are consider 100% and below 360, 0% as the
+            # device considers 360 the minimum to move the motor.
+            _battery = round(2 * (response["battery_level"] - 360))
         battery = max(min(100, _battery), 0)
         self.battery_state = battery


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  SOMA Connect API has for a long time now provided a battery level reading as a percentage. Doing that calculation in device makes much more sense. This fix is in response to our release of a new model that has a higher battery voltage. Doing the percentage calculation in the integration here breaks when faced with the newer higher voltage battery. Currently all SOMA Smart Shades v3 motors always report 100% battery in HA. This change fixes that.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #93034
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
