### PR TITLE
Add support for number via remote GPIO

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1019,6 +1019,7 @@ build.json @home-assistant/supervisor
 /homeassistant/components/rejseplanen/ @DarkFox
 /homeassistant/components/remote/ @home-assistant/core
 /tests/components/remote/ @home-assistant/core
+/homeassistant/components/remote_rpi_gpio/ @antonverburg
 /homeassistant/components/renault/ @epenet
 /tests/components/renault/ @epenet
 /homeassistant/components/renson/ @jimmyd-be

--- a/homeassistant/components/remote_rpi_gpio/const.py
+++ b/homeassistant/components/remote_rpi_gpio/const.py
@@ -1,0 +1,22 @@
+"""Constants for the remote_rpi_gpio integration."""
+
+CONF_FREQUENCY = "frequency"
+CONF_NORMALIZE_LOWER = "normalize_lower"
+CONF_NORMALIZE_UPPER = "normalize_upper"
+CONF_NUMBERS = "numbers"
+CONF_INVERT = "invert"
+CONF_STEP = "step"
+
+MODE_SLIDER = "slider"
+MODE_BOX = "box"
+MODE_AUTO = "auto"
+
+ATTR_FREQUENCY = "frequency"
+ATTR_INVERT = "invert"
+
+CONF_LEDS = "leds"
+CONF_PINS = "pins"
+CONF_FREQUENCY = "frequency"
+
+DEFAULT_BRIGHTNESS = 255
+DEFAULT_COLOR = [0, 0]

--- a/homeassistant/components/remote_rpi_gpio/light.py
+++ b/homeassistant/components/remote_rpi_gpio/light.py
@@ -1,0 +1,229 @@
+"""Support for LED lights that can be controlled using PWM."""
+from __future__ import annotations
+
+import logging
+
+from pwmled import Color
+from pwmled.driver.gpio import GpioDriver
+from pwmled.led import SimpleLed
+from pwmled.led.rgb import RgbLed
+from pwmled.led.rgbw import RgbwLed
+import voluptuous as vol
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_HS_COLOR,
+    ATTR_TRANSITION,
+    PLATFORM_SCHEMA,
+    ColorMode,
+    LightEntity,
+    LightEntityFeature,
+)
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, STATE_ON
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+import homeassistant.util.color as color_util
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_LEDS = "leds"
+CONF_DRIVER = "driver"
+CONF_PINS = "pins"
+CONF_FREQUENCY = "frequency"
+
+DEFAULT_BRIGHTNESS = 255
+DEFAULT_COLOR = [0, 0]
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_LEDS): vol.All(
+            cv.ensure_list,
+            [
+                {
+                    vol.Required(CONF_NAME): cv.string,
+                    vol.Required(CONF_PINS): vol.All(cv.ensure_list, [cv.positive_int]),
+                    vol.Optional(CONF_FREQUENCY): cv.positive_int,
+                    vol.Optional(CONF_HOST): cv.string,
+                    vol.Optional(CONF_PORT): cv.positive_int,
+                }
+            ],
+        )
+    }
+)
+
+
+def setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up the PWM LED lights."""
+    leds = []
+    for led_conf in config[CONF_LEDS]:
+        pins = led_conf[CONF_PINS]
+        opt_args = {}
+
+        if CONF_FREQUENCY in led_conf:
+            opt_args["freq"] = led_conf[CONF_FREQUENCY]
+        if CONF_HOST in led_conf:
+            opt_args["host"] = led_conf[CONF_HOST]
+        if CONF_PORT in led_conf:
+            opt_args["port"] = led_conf[CONF_PORT]
+
+        driver = GpioDriver(pins, **opt_args)
+
+        name = led_conf[CONF_NAME]
+        if len(pins) == 1:
+            led = PwmSimpleLed(SimpleLed(driver), name)
+        elif len(pins) == 3:
+            led = PwmRgbLed(RgbLed(driver), name)
+        elif len(pins) == 4:
+            led = PwmRgbLed(RgbwLed(driver), name)
+        else:
+            _LOGGER.error(
+                "Invalid number of pins: configure 1 (simple), 3 (RGB) or 4 (RGBW) pins to create a light"
+            )
+            return
+        leds.append(led)
+
+    add_entities(leds)
+
+
+class PwmSimpleLed(LightEntity, RestoreEntity):
+    """Representation of a simple one-color PWM LED."""
+
+    _attr_color_mode = ColorMode.BRIGHTNESS
+    _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
+
+    def __init__(self, led, name):
+        """Initialize one-color PWM LED."""
+        self._led = led
+        self._name = name
+        self._is_on = False
+        self._brightness = DEFAULT_BRIGHTNESS
+        self._attr_supported_features |= LightEntityFeature.TRANSITION
+
+    async def async_added_to_hass(self):
+        """Handle entity about to be added to hass event."""
+        await super().async_added_to_hass()
+        if last_state := await self.async_get_last_state():
+            self._is_on = last_state.state == STATE_ON
+            self._brightness = last_state.attributes.get(
+                "brightness", DEFAULT_BRIGHTNESS
+            )
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the group."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._is_on
+
+    @property
+    def brightness(self):
+        """Return the brightness property."""
+        return self._brightness
+
+    def turn_on(self, **kwargs):
+        """Turn on a led."""
+        if ATTR_BRIGHTNESS in kwargs:
+            self._brightness = kwargs[ATTR_BRIGHTNESS]
+
+        if ATTR_TRANSITION in kwargs:
+            transition_time = kwargs[ATTR_TRANSITION]
+            self._led.transition(
+                transition_time,
+                is_on=True,
+                brightness=_from_hass_brightness(self._brightness),
+            )
+        else:
+            self._led.set(
+                is_on=True, brightness=_from_hass_brightness(self._brightness)
+            )
+
+        self._is_on = True
+        self.schedule_update_ha_state()
+
+    def turn_off(self, **kwargs):
+        """Turn off a LED."""
+        if self.is_on:
+            if ATTR_TRANSITION in kwargs:
+                transition_time = kwargs[ATTR_TRANSITION]
+                self._led.transition(transition_time, is_on=False)
+            else:
+                self._led.off()
+
+        self._is_on = False
+        self.schedule_update_ha_state()
+
+
+class PwmRgbLed(PwmSimpleLed):
+    """Representation of a RGB(W) PWM LED."""
+
+    _attr_color_mode = ColorMode.HS
+    _attr_supported_color_modes = {ColorMode.HS}
+
+    def __init__(self, led, name):
+        """Initialize a RGB(W) PWM LED."""
+        super().__init__(led, name)
+        self._color = DEFAULT_COLOR
+        self._attr_supported_features |= LightEntityFeature.TRANSITION
+
+    async def async_added_to_hass(self):
+        """Handle entity about to be added to hass event."""
+        await super().async_added_to_hass()
+        if last_state := await self.async_get_last_state():
+            self._color = last_state.attributes.get("hs_color", DEFAULT_COLOR)
+
+    @property
+    def hs_color(self):
+        """Return the color property."""
+        return self._color
+
+    def turn_on(self, **kwargs):
+        """Turn on a LED."""
+        if ATTR_HS_COLOR in kwargs:
+            self._color = kwargs[ATTR_HS_COLOR]
+        if ATTR_BRIGHTNESS in kwargs:
+            self._brightness = kwargs[ATTR_BRIGHTNESS]
+
+        if ATTR_TRANSITION in kwargs:
+            transition_time = kwargs[ATTR_TRANSITION]
+            self._led.transition(
+                transition_time,
+                is_on=True,
+                brightness=_from_hass_brightness(self._brightness),
+                color=_from_hass_color(self._color),
+            )
+        else:
+            self._led.set(
+                is_on=True,
+                brightness=_from_hass_brightness(self._brightness),
+                color=_from_hass_color(self._color),
+            )
+
+        self._is_on = True
+        self.schedule_update_ha_state()
+
+
+def _from_hass_brightness(brightness):
+    """Convert Home Assistant brightness units to percentage."""
+    return brightness / 255
+
+
+def _from_hass_color(color):
+    """Convert Home Assistant RGB list to Color tuple."""
+    rgb = color_util.color_hs_to_RGB(*color)
+    return Color(*tuple(rgb))

--- a/homeassistant/components/remote_rpi_gpio/light.py
+++ b/homeassistant/components/remote_rpi_gpio/light.py
@@ -27,15 +27,16 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 import homeassistant.util.color as color_util
 
+from .const import (
+    CONF_FREQUENCY,
+    CONF_LEDS,
+    CONF_PINS,
+    DEFAULT_BRIGHTNESS,
+    DEFAULT_COLOR,
+)
+
 _LOGGER = logging.getLogger(__name__)
 
-CONF_LEDS = "leds"
-CONF_DRIVER = "driver"
-CONF_PINS = "pins"
-CONF_FREQUENCY = "frequency"
-
-DEFAULT_BRIGHTNESS = 255
-DEFAULT_COLOR = [0, 0]
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {

--- a/homeassistant/components/remote_rpi_gpio/manifest.json
+++ b/homeassistant/components/remote_rpi_gpio/manifest.json
@@ -1,9 +1,9 @@
 {
   "domain": "remote_rpi_gpio",
   "name": "Raspberry Pi Remote GPIO",
-  "codeowners": [],
+  "codeowners": ["@antonverburg"],
   "documentation": "https://www.home-assistant.io/integrations/remote_rpi_gpio",
   "iot_class": "local_push",
   "loggers": ["gpiozero", "pigpio"],
-  "requirements": ["gpiozero==1.6.2", "pigpio==1.78"]
+  "requirements": ["gpiozero==1.6.2", "pigpio==1.78", "pwmled==1.6.7"]
 }

--- a/homeassistant/components/remote_rpi_gpio/manifest.json
+++ b/homeassistant/components/remote_rpi_gpio/manifest.json
@@ -1,9 +1,14 @@
 {
   "domain": "remote_rpi_gpio",
   "name": "Raspberry Pi Remote GPIO",
-  "codeowners": [],
+  "codeowners": ["@antonverburg"],
   "documentation": "https://www.home-assistant.io/integrations/remote_rpi_gpio",
   "iot_class": "local_push",
   "loggers": ["gpiozero", "pigpio"],
-  "requirements": ["gpiozero==1.6.2", "pigpio==1.78"]
+  "requirements": [
+    "gpiozero==1.6.2",
+    "pigpio==1.78",
+    "pwmled==1.6.11",
+    "RPi.GPIO==0.7.1"
+  ]
 }

--- a/homeassistant/components/remote_rpi_gpio/number.py
+++ b/homeassistant/components/remote_rpi_gpio/number.py
@@ -1,0 +1,178 @@
+"""Support for numbers that can be controlled using PWM."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pwmled.driver.gpio import GpioDriver
+import voluptuous as vol
+
+from homeassistant.components.number import (
+    DEFAULT_MAX_VALUE,
+    DEFAULT_MIN_VALUE,
+    DEFAULT_STEP,
+    PLATFORM_SCHEMA,
+    RestoreNumber,
+)
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_MAXIMUM,
+    CONF_MINIMUM,
+    CONF_MODE,
+    CONF_NAME,
+    CONF_PIN,
+    CONF_PORT,
+)
+import homeassistant.helpers.config_validation as cv
+
+from .const import (
+    ATTR_FREQUENCY,
+    ATTR_INVERT,
+    CONF_FREQUENCY,
+    CONF_INVERT,
+    CONF_NORMALIZE_LOWER,
+    CONF_NORMALIZE_UPPER,
+    CONF_NUMBERS,
+    CONF_STEP,
+    MODE_AUTO,
+    MODE_BOX,
+    MODE_SLIDER,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_NUMBERS): vol.All(
+            cv.ensure_list,
+            [
+                {
+                    vol.Required(CONF_NAME): cv.string,
+                    vol.Required(CONF_PIN): cv.positive_int,
+                    vol.Optional(CONF_INVERT, default=False): cv.boolean,
+                    vol.Optional(CONF_FREQUENCY): cv.positive_int,
+                    vol.Optional(CONF_HOST): cv.string,
+                    vol.Optional(CONF_PORT): cv.positive_int,
+                    vol.Optional(CONF_MINIMUM, default=DEFAULT_MIN_VALUE): vol.Coerce(
+                        float
+                    ),
+                    vol.Optional(CONF_MAXIMUM, default=DEFAULT_MAX_VALUE): vol.Coerce(
+                        float
+                    ),
+                    vol.Optional(
+                        CONF_NORMALIZE_LOWER, default=DEFAULT_MIN_VALUE
+                    ): vol.Coerce(float),
+                    vol.Optional(
+                        CONF_NORMALIZE_UPPER, default=DEFAULT_MAX_VALUE
+                    ): vol.Coerce(float),
+                    vol.Optional(CONF_STEP, default=DEFAULT_STEP): cv.positive_float,
+                    vol.Optional(CONF_MODE, default=MODE_SLIDER): vol.In(
+                        [MODE_BOX, MODE_SLIDER, MODE_AUTO]
+                    ),
+                }
+            ],
+        )
+    }
+)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the PWM-output numbers."""
+    numbers = []
+    for number_conf in config[CONF_NUMBERS]:
+        pin = number_conf[CONF_PIN]
+        opt_args = {}
+        if CONF_FREQUENCY in number_conf:
+            opt_args["freq"] = number_conf[CONF_FREQUENCY]
+        if CONF_HOST in number_conf:
+            opt_args["host"] = number_conf[CONF_HOST]
+        if CONF_PORT in number_conf:
+            opt_args["port"] = number_conf[CONF_PORT]
+        driver = GpioDriver([pin], **opt_args)
+        number = PwmNumber(hass, number_conf, driver)
+        numbers.append(number)
+
+    add_entities(numbers)
+
+
+class PwmNumber(RestoreNumber):
+    """Representation of a simple  PWM output."""
+
+    def __init__(self, hass, config, driver):
+        """Initialize one-color PWM LED."""
+        self._driver = driver
+        self._config = config
+        self._hass = hass
+        self._attr_native_min_value = config[CONF_MINIMUM]
+        self._attr_native_max_value = config[CONF_MAXIMUM]
+        self._attr_native_step = config[CONF_STEP]
+        self._attr_mode = config[CONF_MODE]
+        self._attr_native_value = config[CONF_MINIMUM]
+
+    async def async_added_to_hass(self):
+        """Handle entity about to be added to hass event."""
+        await super().async_added_to_hass()
+        if last_data := await self.async_get_last_number_data():
+            try:
+                await self.async_set_native_value(float(last_data.native_value))
+            except ValueError:
+                _LOGGER.warning(
+                    "Could not read value %s from last state data for %s!",
+                    last_data.native_value,
+                    self.name,
+                )
+        else:
+            await self.async_set_native_value(self._config[CONF_MINIMUM])
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the number."""
+        return self._config[CONF_NAME]
+
+    @property
+    def frequency(self):
+        """Return PWM frequency."""
+        return self._config[CONF_FREQUENCY]
+
+    @property
+    def invert(self):
+        """Return if output is inverted."""
+        return self._config[CONF_INVERT]
+
+    @property
+    def capability_attributes(self) -> dict[str, Any]:
+        """Return capability attributes."""
+        attr = super().capability_attributes
+        attr[ATTR_FREQUENCY] = self.frequency
+        attr[ATTR_INVERT] = self.invert
+        return attr
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set new value."""
+        # Clip value to limits (don't know if this is required?)
+        if value < self._config[CONF_MINIMUM]:
+            value = self._config[CONF_MINIMUM]
+        if value > self._config[CONF_MAXIMUM]:
+            value = self._config[CONF_MAXIMUM]
+
+        # In case the invert bit is on, invert the value
+        used_value = value
+        if self._config[CONF_INVERT]:
+            used_value = self._config[CONF_NORMALIZE_UPPER] - value
+
+        # Scale range from N_L..N_U to 0..255 (GPIO maximum)
+        range_pwm = 255.0
+        range_value = (
+            self._config[CONF_NORMALIZE_UPPER] - self._config[CONF_NORMALIZE_LOWER]
+        )
+        # Scale to range of the driver
+        scaled_value = int(round((used_value / range_value) * range_pwm))
+        # Set value to driver
+        self._driver._set_pwm([scaled_value])  # pylint: disable=protected-access
+        self._attr_native_value = value
+        self.async_write_ha_state()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1480,6 +1480,9 @@ pushover-complete==1.1.1
 # homeassistant.components.pvoutput
 pvo==1.0.0
 
+# homeassistant.components.remote_rpi_gpio
+pwmled==1.6.7
+
 # homeassistant.components.canary
 py-canary==0.5.3
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -117,6 +117,9 @@ PyViCare==2.25.0
 # homeassistant.components.xiaomi_aqara
 PyXiaomiGateway==0.14.3
 
+# homeassistant.components.remote_rpi_gpio
+RPi.GPIO==0.7.1
+
 # homeassistant.components.rachio
 RachioPy==1.0.3
 
@@ -1479,6 +1482,9 @@ pushover-complete==1.1.1
 
 # homeassistant.components.pvoutput
 pvo==1.0.0
+
+# homeassistant.components.remote_rpi_gpio
+pwmled==1.6.11
 
 # homeassistant.components.canary
 py-canary==0.5.3


### PR DESCRIPTION
## Proposed change
Add support for number that  controls a PWM output via PIGPIO on raspberries.


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/99324 (please merge that first)
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/28751

## Checklist
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
