### PR TITLE
Move template coordinator to its own file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1300,6 +1300,7 @@ omit =
     homeassistant/components/tellstick/*
     homeassistant/components/telnet/switch.py
     homeassistant/components/temper/sensor.py
+    homeassistant/components/template/coordinator.py
     homeassistant/components/tensorflow/image_processing.py
     homeassistant/components/tfiac/climate.py
     homeassistant/components/thermoworks_smoke/sensor.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1300,7 +1300,6 @@ omit =
     homeassistant/components/tellstick/*
     homeassistant/components/telnet/switch.py
     homeassistant/components/temper/sensor.py
-    homeassistant/components/template/coordinator.py
     homeassistant/components/tensorflow/image_processing.py
     homeassistant/components/tfiac/climate.py
     homeassistant/components/thermoworks_smoke/sensor.py

--- a/homeassistant/components/template/__init__.py
+++ b/homeassistant/components/template/__init__.py
@@ -2,30 +2,21 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
 import logging
 
 from homeassistant import config as conf_util
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONF_UNIQUE_ID,
-    EVENT_HOMEASSISTANT_START,
-    SERVICE_RELOAD,
-)
-from homeassistant.core import CoreState, Event, HomeAssistant, ServiceCall, callback
+from homeassistant.const import CONF_UNIQUE_ID, SERVICE_RELOAD
+from homeassistant.core import Event, HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import (
-    discovery,
-    trigger as trigger_helper,
-    update_coordinator,
-)
+from homeassistant.helpers import discovery
 from homeassistant.helpers.reload import async_reload_integration_platforms
-from homeassistant.helpers.script import Script
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import async_get_integration
 
-from .const import CONF_ACTION, CONF_TRIGGER, DOMAIN, PLATFORMS
+from .const import CONF_TRIGGER, DOMAIN, PLATFORMS
+from .coordinator import TriggerUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -121,83 +112,3 @@ async def _process_config(hass: HomeAssistant, hass_config: ConfigType) -> None:
 
     if coordinator_tasks:
         hass.data[DOMAIN] = await asyncio.gather(*coordinator_tasks)
-
-
-class TriggerUpdateCoordinator(update_coordinator.DataUpdateCoordinator):
-    """Class to handle incoming data."""
-
-    REMOVE_TRIGGER = object()
-
-    def __init__(self, hass, config):
-        """Instantiate trigger data."""
-        super().__init__(hass, _LOGGER, name="Trigger Update Coordinator")
-        self.config = config
-        self._unsub_start: Callable[[], None] | None = None
-        self._unsub_trigger: Callable[[], None] | None = None
-        self._script: Script | None = None
-
-    @property
-    def unique_id(self) -> str | None:
-        """Return unique ID for the entity."""
-        return self.config.get("unique_id")
-
-    @callback
-    def async_remove(self):
-        """Signal that the entities need to remove themselves."""
-        if self._unsub_start:
-            self._unsub_start()
-        if self._unsub_trigger:
-            self._unsub_trigger()
-
-    async def async_setup(self, hass_config: ConfigType) -> None:
-        """Set up the trigger and create entities."""
-        if self.hass.state == CoreState.running:
-            await self._attach_triggers()
-        else:
-            self._unsub_start = self.hass.bus.async_listen_once(
-                EVENT_HOMEASSISTANT_START, self._attach_triggers
-            )
-
-        for platform_domain in PLATFORMS:
-            if platform_domain in self.config:
-                self.hass.async_create_task(
-                    discovery.async_load_platform(
-                        self.hass,
-                        platform_domain,
-                        DOMAIN,
-                        {"coordinator": self, "entities": self.config[platform_domain]},
-                        hass_config,
-                    )
-                )
-
-    async def _attach_triggers(self, start_event=None) -> None:
-        """Attach the triggers."""
-        if CONF_ACTION in self.config:
-            self._script = Script(
-                self.hass,
-                self.config[CONF_ACTION],
-                self.name,
-                DOMAIN,
-            )
-
-        if start_event is not None:
-            self._unsub_start = None
-
-        self._unsub_trigger = await trigger_helper.async_initialize_triggers(
-            self.hass,
-            self.config[CONF_TRIGGER],
-            self._handle_triggered,
-            DOMAIN,
-            self.name,
-            self.logger.log,
-            start_event is not None,
-        )
-
-    async def _handle_triggered(self, run_variables, context=None):
-        if self._script:
-            script_result = await self._script.async_run(run_variables, context)
-            if script_result:
-                run_variables = script_result.variables
-        self.async_set_updated_data(
-            {"run_variables": run_variables, "context": context}
-        )

--- a/homeassistant/components/template/coordinator.py
+++ b/homeassistant/components/template/coordinator.py
@@ -14,7 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class TriggerUpdateCoordinator(DataUpdateCoordinator):
-"""Data update coordinator for trigger based template entities."""
+    """Data update coordinator for trigger based template entities."""
 
     REMOVE_TRIGGER = object()
 

--- a/homeassistant/components/template/coordinator.py
+++ b/homeassistant/components/template/coordinator.py
@@ -1,0 +1,81 @@
+"""The template update coordinator."""
+from collections.abc import Callable
+import logging
+
+from homeassistant.const import EVENT_HOMEASSISTANT_START
+from homeassistant.core import CoreState, callback
+from homeassistant.helpers import discovery, trigger as trigger_helper
+from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import CONF_TRIGGER, DOMAIN, PLATFORMS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TriggerUpdateCoordinator(DataUpdateCoordinator):
+    """Class to handle incoming data."""
+
+    REMOVE_TRIGGER = object()
+
+    def __init__(self, hass, config):
+        """Instantiate trigger data."""
+        super().__init__(hass, _LOGGER, name="Trigger Update Coordinator")
+        self.config = config
+        self._unsub_start: Callable[[], None] | None = None
+        self._unsub_trigger: Callable[[], None] | None = None
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return unique ID for the entity."""
+        return self.config.get("unique_id")
+
+    @callback
+    def async_remove(self):
+        """Signal that the entities need to remove themselves."""
+        if self._unsub_start:
+            self._unsub_start()
+        if self._unsub_trigger:
+            self._unsub_trigger()
+
+    async def async_setup(self, hass_config: ConfigType) -> None:
+        """Set up the trigger and create entities."""
+        if self.hass.state == CoreState.running:
+            await self._attach_triggers()
+        else:
+            self._unsub_start = self.hass.bus.async_listen_once(
+                EVENT_HOMEASSISTANT_START, self._attach_triggers
+            )
+
+        for platform_domain in PLATFORMS:
+            if platform_domain in self.config:
+                self.hass.async_create_task(
+                    discovery.async_load_platform(
+                        self.hass,
+                        platform_domain,
+                        DOMAIN,
+                        {"coordinator": self, "entities": self.config[platform_domain]},
+                        hass_config,
+                    )
+                )
+
+    async def _attach_triggers(self, start_event=None) -> None:
+        """Attach the triggers."""
+        if start_event is not None:
+            self._unsub_start = None
+
+        self._unsub_trigger = await trigger_helper.async_initialize_triggers(
+            self.hass,
+            self.config[CONF_TRIGGER],
+            self._handle_triggered,
+            DOMAIN,
+            self.name,
+            self.logger.log,
+            start_event is not None,
+        )
+
+    @callback
+    def _handle_triggered(self, run_variables, context=None):
+        self.async_set_updated_data(
+            {"run_variables": run_variables, "context": context}
+        )

--- a/homeassistant/components/template/coordinator.py
+++ b/homeassistant/components/template/coordinator.py
@@ -1,4 +1,4 @@
-"""The template update coordinator."""
+"""Data update coordinator for trigger based template entities."""
 from collections.abc import Callable
 import logging
 
@@ -14,7 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class TriggerUpdateCoordinator(DataUpdateCoordinator):
-    """Class to handle incoming data."""
+"""Data update coordinator for trigger based template entities."""
 
     REMOVE_TRIGGER = object()
 


### PR DESCRIPTION
## Proposed change
Move the `TriggerUpdateCoordinator` of the `template` integration to its own file.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
