### PR TITLE
Support for more features on smartthings AC

### DIFF
--- a/homeassistant/components/smartthings/climate.py
+++ b/homeassistant/components/smartthings/climate.py
@@ -346,7 +346,7 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateEntity):
         """Init the class."""
         super().__init__(device)
         self._hvac_modes = []
-        self._attr_preset_mode = ""
+        self._attr_preset_mode = None
         self._attr_preset_modes = self._determine_preset_modes()
         self._attr_swing_modes = self._determine_swing_modes()
         self._attr_supported_features = self._determine_supported_features()
@@ -366,7 +366,7 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateEntity):
         await self._device.set_fan_mode(fan_mode, set_status=True)
 
         # setting the fan must reset the preset mode (it deactivates the windFree function)
-        self._attr_preset_mode = ""
+        self._attr_preset_mode = None
 
         # State is set optimistically in the command above, therefore update
         # the entity state ahead of receiving the confirming push updates
@@ -516,7 +516,7 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateEntity):
         await self._device.set_fan_oscillation_mode(fan_oscillation_mode)
 
         # setting the fan must reset the preset mode (it deactivates the windFree function)
-        self._attr_preset_mode = ""
+        self._attr_preset_mode = None
 
         self.async_schedule_update_ha_state(True)
 
@@ -529,13 +529,12 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateEntity):
 
     def _determine_preset_modes(self) -> list[str]:
         """Return a list of available preset modes."""
-        modes = []
         supported_modes = self._device.status.attributes[
             "supportedAcOptionalMode"
         ].value
         if WINDFREE in supported_modes:
-            modes.append(WINDFREE)
-        return modes
+            return [WINDFREE]
+        return []
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set special modes (currently only windFree is supported)."""

--- a/homeassistant/components/smartthings/climate.py
+++ b/homeassistant/components/smartthings/climate.py
@@ -495,10 +495,7 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateEntity):
     @property
     def temperature_unit(self) -> str:
         """Return the unit of measurement."""
-        return (
-            UNIT_MAP.get(self._device.status.attributes[Attribute.temperature].unit)
-            or ""
-        )
+        return UNIT_MAP[self._device.status.attributes[Attribute.temperature].unit]
 
     def _determine_swing_modes(self) -> list[str]:
         """Return the list of available swing modes."""

--- a/homeassistant/components/smartthings/climate.py
+++ b/homeassistant/components/smartthings/climate.py
@@ -357,7 +357,7 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateEntity):
         )
         if self._device.get_capability(Capability.fan_oscillation_mode):
             features |= ClimateEntityFeature.SWING_MODE
-        if len(self._determine_preset_modes()) > 0:
+        if (self._attr_preset_modes is not None) and len(self._attr_preset_modes) > 0:
             features |= ClimateEntityFeature.PRESET_MODE
         return features
 
@@ -524,14 +524,14 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateEntity):
             self._device.status.fan_oscillation_mode, SWING_OFF
         )
 
-    def _determine_preset_modes(self) -> list[str]:
+    def _determine_preset_modes(self) -> list[str] | None:
         """Return a list of available preset modes."""
         supported_modes = self._device.status.attributes[
             "supportedAcOptionalMode"
         ].value
         if WINDFREE in supported_modes:
             return [WINDFREE]
-        return []
+        return None
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set special modes (currently only windFree is supported)."""

--- a/tests/components/smartthings/test_climate.py
+++ b/tests/components/smartthings/test_climate.py
@@ -629,7 +629,7 @@ async def test_set_windfree_off(hass: HomeAssistant, air_conditioner) -> None:
         blocking=True,
     )
     state = hass.states.get("climate.air_conditioner")
-    assert state.attributes[ATTR_PRESET_MODE] == ""
+    assert not state.attributes[ATTR_PRESET_MODE]
 
 
 async def test_set_swing_mode(hass: HomeAssistant, air_conditioner) -> None:

--- a/tests/components/smartthings/test_climate.py
+++ b/tests/components/smartthings/test_climate.py
@@ -15,16 +15,20 @@ from homeassistant.components.climate import (
     ATTR_HVAC_ACTION,
     ATTR_HVAC_MODE,
     ATTR_HVAC_MODES,
+    ATTR_PRESET_MODE,
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
     DOMAIN as CLIMATE_DOMAIN,
     SERVICE_SET_FAN_MODE,
     SERVICE_SET_HVAC_MODE,
+    SERVICE_SET_PRESET_MODE,
+    SERVICE_SET_SWING_MODE,
     SERVICE_SET_TEMPERATURE,
     ClimateEntityFeature,
     HVACAction,
     HVACMode,
 )
+from homeassistant.components.climate.const import ATTR_SWING_MODE
 from homeassistant.components.smartthings import climate
 from homeassistant.components.smartthings.const import DOMAIN
 from homeassistant.const import (
@@ -155,6 +159,7 @@ def air_conditioner_fixture(device_factory):
             Capability.switch,
             Capability.temperature_measurement,
             Capability.thermostat_cooling_setpoint,
+            Capability.fan_oscillation_mode,
         ],
         status={
             Attribute.air_conditioner_mode: "auto",
@@ -182,6 +187,14 @@ def air_conditioner_fixture(device_factory):
             ],
             Attribute.switch: "on",
             Attribute.cooling_setpoint: 23,
+            "supportedAcOptionalMode": ["windFree"],
+            Attribute.supported_fan_oscillation_modes: [
+                "all",
+                "horizontal",
+                "vertical",
+                "fixed",
+            ],
+            Attribute.fan_oscillation_mode: "vertical",
         },
     )
     device.status.attributes[Attribute.temperature] = Status(24, "C", None)
@@ -303,7 +316,10 @@ async def test_air_conditioner_entity_state(
     assert state.state == HVACMode.HEAT_COOL
     assert (
         state.attributes[ATTR_SUPPORTED_FEATURES]
-        == ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TARGET_TEMPERATURE
+        == ClimateEntityFeature.FAN_MODE
+        | ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.PRESET_MODE
+        | ClimateEntityFeature.SWING_MODE
     )
     assert sorted(state.attributes[ATTR_HVAC_MODES]) == [
         HVACMode.COOL,
@@ -591,3 +607,40 @@ async def test_entity_and_device_attributes(hass: HomeAssistant, thermostat) -> 
     assert entry.manufacturer == "Generic manufacturer"
     assert entry.hw_version == "v4.56"
     assert entry.sw_version == "v7.89"
+
+
+async def test_set_windfree_off(hass: HomeAssistant, air_conditioner) -> None:
+    """Test if the windfree preset can be turned on and is turned off when fan mode is set."""
+    entity_ids = ["climate.air_conditioner"]
+    air_conditioner.status.update_attribute_value(Attribute.switch, "on")
+    await setup_platform(hass, CLIMATE_DOMAIN, devices=[air_conditioner])
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_PRESET_MODE,
+        {ATTR_ENTITY_ID: entity_ids, ATTR_PRESET_MODE: "windFree"},
+        blocking=True,
+    )
+    state = hass.states.get("climate.air_conditioner")
+    assert state.attributes[ATTR_PRESET_MODE] == "windFree"
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_FAN_MODE,
+        {ATTR_ENTITY_ID: entity_ids, ATTR_FAN_MODE: "low"},
+        blocking=True,
+    )
+    state = hass.states.get("climate.air_conditioner")
+    assert state.attributes[ATTR_PRESET_MODE] == ""
+
+
+async def test_set_swing_mode(hass: HomeAssistant, air_conditioner) -> None:
+    """Test the fan swing is set successfully."""
+    await setup_platform(hass, CLIMATE_DOMAIN, devices=[air_conditioner])
+    entity_ids = ["climate.air_conditioner"]
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_SWING_MODE,
+        {ATTR_ENTITY_ID: entity_ids, ATTR_SWING_MODE: "vertical"},
+        blocking=True,
+    )
+    state = hass.states.get("climate.air_conditioner")
+    assert state.attributes[ATTR_SWING_MODE] == "vertical"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This small feature adds a possibility to set swing modes and to activate WindFree mode on Samsung air conditioners integrated using SmartThings.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://community.home-assistant.io/t/samsung-smartthings-climate-swing-mode/313244
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
--  no change needed in documentation


If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [X] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
