### PR TITLE
Simplify WS command entity/source

### DIFF
--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -19,7 +19,7 @@ from homeassistant.components.websocket_api.const import FEATURE_COALESCE_MESSAG
 from homeassistant.const import SIGNAL_BOOTSTRAP_INTEGRATIONS
 from homeassistant.core import Context, HomeAssistant, State, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import device_registry as dr, entity
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.loader import async_get_integration
 from homeassistant.setup import DATA_SETUP_TIME, async_setup_component
@@ -1481,75 +1481,9 @@ async def test_entity_source_admin(
     assert msg["type"] == const.TYPE_RESULT
     assert msg["success"]
     assert msg["result"] == {
-        "test_domain.entity_1": {
-            "custom_component": False,
-            "domain": "test_platform",
-            "source": entity.SOURCE_PLATFORM_CONFIG,
-        },
-        "test_domain.entity_2": {
-            "custom_component": False,
-            "domain": "test_platform",
-            "source": entity.SOURCE_PLATFORM_CONFIG,
-        },
+        "test_domain.entity_1": {"domain": "test_platform"},
+        "test_domain.entity_2": {"domain": "test_platform"},
     }
-
-    # Fetch one
-    await websocket_client.send_json(
-        {"id": 7, "type": "entity/source", "entity_id": ["test_domain.entity_2"]}
-    )
-
-    msg = await websocket_client.receive_json()
-    assert msg["id"] == 7
-    assert msg["type"] == const.TYPE_RESULT
-    assert msg["success"]
-    assert msg["result"] == {
-        "test_domain.entity_2": {
-            "custom_component": False,
-            "domain": "test_platform",
-            "source": entity.SOURCE_PLATFORM_CONFIG,
-        },
-    }
-
-    # Fetch two
-    await websocket_client.send_json(
-        {
-            "id": 8,
-            "type": "entity/source",
-            "entity_id": ["test_domain.entity_2", "test_domain.entity_1"],
-        }
-    )
-
-    msg = await websocket_client.receive_json()
-    assert msg["id"] == 8
-    assert msg["type"] == const.TYPE_RESULT
-    assert msg["success"]
-    assert msg["result"] == {
-        "test_domain.entity_1": {
-            "custom_component": False,
-            "domain": "test_platform",
-            "source": entity.SOURCE_PLATFORM_CONFIG,
-        },
-        "test_domain.entity_2": {
-            "custom_component": False,
-            "domain": "test_platform",
-            "source": entity.SOURCE_PLATFORM_CONFIG,
-        },
-    }
-
-    # Fetch non existing
-    await websocket_client.send_json(
-        {
-            "id": 9,
-            "type": "entity/source",
-            "entity_id": ["test_domain.entity_2", "test_domain.non_existing"],
-        }
-    )
-
-    msg = await websocket_client.receive_json()
-    assert msg["id"] == 9
-    assert msg["type"] == const.TYPE_RESULT
-    assert not msg["success"]
-    assert msg["error"]["code"] == const.ERR_NOT_FOUND
 
     # Mock policy
     hass_admin_user.groups = []
@@ -1565,23 +1499,8 @@ async def test_entity_source_admin(
     assert msg["type"] == const.TYPE_RESULT
     assert msg["success"]
     assert msg["result"] == {
-        "test_domain.entity_2": {
-            "custom_component": False,
-            "domain": "test_platform",
-            "source": entity.SOURCE_PLATFORM_CONFIG,
-        },
+        "test_domain.entity_2": {"domain": "test_platform"},
     }
-
-    # Fetch unauthorized
-    await websocket_client.send_json(
-        {"id": 11, "type": "entity/source", "entity_id": ["test_domain.entity_1"]}
-    )
-
-    msg = await websocket_client.receive_json()
-    assert msg["id"] == 11
-    assert msg["type"] == const.TYPE_RESULT
-    assert not msg["success"]
-    assert msg["error"]["code"] == const.ERR_UNAUTHORIZED
 
 
 async def test_subscribe_trigger(hass: HomeAssistant, websocket_client) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Simplify WS command `entity/source`

### Rationale:
Without this PR:
- We're sending a WS response which includes data which it not used by frontend
- The command is unnecessarily complicated because it allows fetching data for a specified list of entity ids, a feature not used by frontend

Frontend PR: https://github.com/home-assistant/frontend/pull/17770

Based on a quick search, the "entity/source" WS command has some use outside our own frontend: https://github.com/search?q=content%3A%22%5C%22entity%2Fsource%5C%22%22+-path%3Ahomeassistant%2Fcomponents%2Fwebsocket_api%2Fcommands.py+-path%3Atests%2Fcomponents%2Fwebsocket_api%2Ftest_commands.py&type=code

Of those hits, `vicfergar/HassClient` and `PiotrMachowski/lovelace-xiaomi-vacuum-map-card` would be affected by the change as I understand it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1904

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
