### PR TITLE
Motion blinds duplication reduction using entity baseclass

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -749,6 +749,7 @@ omit =
     homeassistant/components/moehlenhoff_alpha2/sensor.py
     homeassistant/components/motion_blinds/__init__.py
     homeassistant/components/motion_blinds/cover.py
+    homeassistant/components/motion_blinds/entity.py
     homeassistant/components/motion_blinds/sensor.py
     homeassistant/components/mpd/media_player.py
     homeassistant/components/mqtt_room/sensor.py

--- a/homeassistant/components/motion_blinds/const.py
+++ b/homeassistant/components/motion_blinds/const.py
@@ -18,7 +18,6 @@ KEY_COORDINATOR = "coordinator"
 KEY_MULTICAST_LISTENER = "multicast_listener"
 KEY_SETUP_LOCK = "setup_lock"
 KEY_UNSUB_STOP = "unsub_stop"
-KEY_VERSION = "version"
 
 ATTR_WIDTH = "width"
 ATTR_ABSOLUTE_POSITION = "absolute_position"

--- a/homeassistant/components/motion_blinds/entity.py
+++ b/homeassistant/components/motion_blinds/entity.py
@@ -1,8 +1,6 @@
 """Support for Motion Blinds using their WLAN API."""
 from __future__ import annotations
 
-from typing import TypeVar
-
 from motionblinds import DEVICE_TYPES_GATEWAY, DEVICE_TYPES_WIFI, MotionGateway
 from motionblinds.motion_blinds import MotionBlind
 

--- a/homeassistant/components/motion_blinds/entity.py
+++ b/homeassistant/components/motion_blinds/entity.py
@@ -1,0 +1,98 @@
+"""Support for Motion Blinds using their WLAN API."""
+from __future__ import annotations
+
+from typing import TypeVar
+
+from motionblinds import DEVICE_TYPES_GATEWAY, DEVICE_TYPES_WIFI, MotionGateway
+from motionblinds.motion_blinds import MotionBlind
+
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import DataUpdateCoordinatorMotionBlinds
+from .const import (
+    ATTR_AVAILABLE,
+    DEFAULT_GATEWAY_NAME,
+    DOMAIN,
+    KEY_GATEWAY,
+    MANUFACTURER,
+)
+from .gateway import device_name
+
+_T = TypeVar("_T")
+
+
+class MotionCoordinatorEntity(CoordinatorEntity[DataUpdateCoordinatorMotionBlinds]):
+    """Representation of a Motion Blind entity."""
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinatorMotionBlinds,
+        blind: MotionGateway | MotionBlind,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+
+        self._blind = blind
+        self._api_lock = coordinator.api_lock
+
+        if blind.device_type in DEVICE_TYPES_GATEWAY:
+            gateway = blind
+        else:
+            gateway = blind._gateway
+        if gateway.firmware is not None:
+            sw_version = f"{gateway.firmware}, protocol: {gateway.protocol}"
+        else:
+            sw_version = f"Protocol: {gateway.protocol}"
+
+        if blind.device_type in DEVICE_TYPES_GATEWAY:
+            self._attr_device_info = DeviceInfo(
+                connections={(dr.CONNECTION_NETWORK_MAC, blind.mac)},
+                identifiers={(DOMAIN, blind.mac)},
+                manufacturer=MANUFACTURER,
+                name=DEFAULT_GATEWAY_NAME,
+                model="Wi-Fi bridge",
+                sw_version=sw_version,
+            )
+        elif blind.device_type in DEVICE_TYPES_WIFI:
+            self._attr_device_info = DeviceInfo(
+                connections={(dr.CONNECTION_NETWORK_MAC, blind.mac)},
+                identifiers={(DOMAIN, blind.mac)},
+                manufacturer=MANUFACTURER,
+                model=blind.blind_type,
+                name=device_name(blind),
+                sw_version=sw_version,
+                hw_version=blind.wireless_name,
+            )
+        else:
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, blind.mac)},
+                manufacturer=MANUFACTURER,
+                model=blind.blind_type,
+                name=device_name(blind),
+                via_device=(DOMAIN, blind._gateway.mac),
+                hw_version=blind.wireless_name,
+            )
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        if self.coordinator.data is None:
+            return False
+
+        gateway_available = self.coordinator.data[KEY_GATEWAY][ATTR_AVAILABLE]
+        if not gateway_available or self._blind.device_type in DEVICE_TYPES_GATEWAY:
+            return gateway_available
+
+        return self.coordinator.data[self._blind.mac][ATTR_AVAILABLE]
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to multicast pushes and register signal handler."""
+        self._blind.Register_callback(self.unique_id, self.schedule_update_ha_state)
+        await super().async_added_to_hass()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Unsubscribe when removed."""
+        self._blind.Remove_callback(self.unique_id)
+        await super().async_will_remove_from_hass()

--- a/homeassistant/components/motion_blinds/entity.py
+++ b/homeassistant/components/motion_blinds/entity.py
@@ -20,8 +20,6 @@ from .const import (
 )
 from .gateway import device_name
 
-_T = TypeVar("_T")
-
 
 class MotionCoordinatorEntity(CoordinatorEntity[DataUpdateCoordinatorMotionBlinds]):
     """Representation of a Motion Blind entity."""

--- a/homeassistant/components/motion_blinds/sensor.py
+++ b/homeassistant/components/motion_blinds/sensor.py
@@ -1,5 +1,5 @@
 """Support for Motion Blinds sensors."""
-from motionblinds import DEVICE_TYPES_WIFI, BlindType
+from motionblinds import DEVICE_TYPES_GATEWAY, DEVICE_TYPES_WIFI, BlindType
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -12,8 +12,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, KEY_COORDINATOR, KEY_GATEWAY
-from .gateway import device_name
 from .entity import MotionCoordinatorEntity
+from .gateway import device_name
 
 ATTR_BATTERY_VOLTAGE = "battery_voltage"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implement entity base class for motion_blinds to reduce code duplication and make the motion blinds integration ready for entity translations.
Split out from PR https://github.com/home-assistant/core/pull/99078

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
