### PR TITLE
Refactor MQTT discovery to avoid creating closure if hash already in discovery_pending_discovered

### DIFF
--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -275,32 +275,34 @@ async def async_start(  # noqa: C901
 
         _LOGGER.debug("Process discovery payload %s", payload)
         discovery_hash = (component, discovery_id)
-        if discovery_hash in mqtt_data.discovery_already_discovered or payload:
+
+        already_discovered = discovery_hash in mqtt_data.discovery_already_discovered
+        if (
+            already_discovered or payload
+        ) and discovery_hash not in mqtt_data.discovery_pending_discovered:
+            discovery_pending_discovered = mqtt_data.discovery_pending_discovered
 
             @callback
             def discovery_done(_: Any) -> None:
-                pending = mqtt_data.discovery_pending_discovered[discovery_hash][
-                    "pending"
-                ]
+                pending = discovery_pending_discovered[discovery_hash]["pending"]
                 _LOGGER.debug("Pending discovery for %s: %s", discovery_hash, pending)
                 if not pending:
-                    mqtt_data.discovery_pending_discovered[discovery_hash]["unsub"]()
-                    mqtt_data.discovery_pending_discovered.pop(discovery_hash)
+                    discovery_pending_discovered[discovery_hash]["unsub"]()
+                    discovery_pending_discovered.pop(discovery_hash)
                 else:
                     payload = pending.pop()
                     async_process_discovery_payload(component, discovery_id, payload)
 
-            if discovery_hash not in mqtt_data.discovery_pending_discovered:
-                mqtt_data.discovery_pending_discovered[discovery_hash] = {
-                    "unsub": async_dispatcher_connect(
-                        hass,
-                        MQTT_DISCOVERY_DONE.format(discovery_hash),
-                        discovery_done,
-                    ),
-                    "pending": deque([]),
-                }
+            discovery_pending_discovered[discovery_hash] = {
+                "unsub": async_dispatcher_connect(
+                    hass,
+                    MQTT_DISCOVERY_DONE.format(discovery_hash),
+                    discovery_done,
+                ),
+                "pending": deque([]),
+            }
 
-        if discovery_hash in mqtt_data.discovery_already_discovered:
+        if already_discovered:
             # Dispatch update
             message = f"Component has already been discovered: {component} {discovery_id}, sending update"
             async_log_discovery_origin_info(message, payload)


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The async_process_discovery_payload function would always create the closure function discovery_done even if discovery_hash was in discovery_pending_discovered

![async_process_discovery_payload](https://github.com/home-assistant/core/assets/663432/3011e78b-bd99-4f32-b965-e1220f5d1187)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
