### PR TITLE
Reduce overhead to retry config entry setup

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -329,7 +329,6 @@ class ConfigEntry:
         hass: HomeAssistant,
         *,
         integration: loader.Integration | None = None,
-        tries: int | None = None,
     ) -> None:
         """Set up an entry."""
         current_entry.set(self)
@@ -339,9 +338,6 @@ class ConfigEntry:
         if integration is None:
             integration = await loader.async_get_integration(hass, self.domain)
             self._integration_for_domain = integration
-
-        if tries is not None:
-            self._tries = tries
 
         # Only store setup result as state if it was not forwarded.
         if self.domain == integration.domain:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -496,7 +496,7 @@ class ConfigEntry:
         if self._setup_again_job:
             return self._setup_again_job
         self._setup_again_job = HassJob(
-            functools.partial(self._async_setup_again, hass)
+            functools.partial(self._async_setup_again, hass), cancel_on_shutdown=True
         )
         return self._setup_again_job
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -336,7 +336,7 @@ class ConfigEntry:
         if self.source == SOURCE_IGNORE or self.disabled_by:
             return
 
-        if not integration:
+        if integration is None:
             integration = await loader.async_get_integration(hass, self.domain)
             self._integration_for_domain = integration
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -148,6 +148,11 @@ EVENT_FLOW_DISCOVERED = "config_entry_discovered"
 
 SIGNAL_CONFIG_ENTRY_CHANGED = "config_entry_changed"
 
+NO_RESET_TRIES_STATES = {
+    ConfigEntryState.SETUP_RETRY,
+    ConfigEntryState.SETUP_IN_PROGRESS,
+}
+
 
 class ConfigEntryChange(StrEnum):
     """What was changed in a config entry."""
@@ -610,10 +615,7 @@ class ConfigEntry:
         self, hass: HomeAssistant, state: ConfigEntryState, reason: str | None
     ) -> None:
         """Set the state of the config entry."""
-        if state not in {
-            ConfigEntryState.SETUP_RETRY,
-            ConfigEntryState.SETUP_IN_PROGRESS,
-        }:
+        if state not in NO_RESET_TRIES_STATES:
             self._tries = 0
         self.state = state
         self.reason = reason

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -493,11 +493,11 @@ class ConfigEntry:
     @callback
     def _async_get_setup_again_job(self, hass: HomeAssistant) -> HassJob:
         """Get a job that will call setup again."""
-        if self._setup_again_job:
-            return self._setup_again_job
-        self._setup_again_job = HassJob(
-            functools.partial(self._async_setup_again, hass), cancel_on_shutdown=True
-        )
+        if not self._setup_again_job:
+            self._setup_again_job = HassJob(
+                functools.partial(self._async_setup_again, hass),
+                cancel_on_shutdown=True,
+            )
         return self._setup_again_job
 
     async def async_shutdown(self) -> None:

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -960,7 +960,7 @@ async def test_setup_raise_not_ready(
     mock_setup_entry.side_effect = None
     mock_setup_entry.return_value = True
 
-    await p_setup(None)
+    await hass.async_run_hass_job(p_setup, None)
     assert entry.state is config_entries.ConfigEntryState.LOADED
     assert entry.reason is None
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

If the user has a lot of config entries that are retrying over and over or the network has an issue at startup, we can end up with a lot of config entries in a retry state.

If the config entry keeps retrying over and over again we would generate a closure and we would have to inspect the closure each time `async_call_later` was called to see what kind of function it was. We now generate a `HassJob` once and let it be called over and over to avoid this overhead.

The integration is now cached in the config entry as well to avoid loading it each retry (only the integration for the config entry `domain`, and not the platforms since only that is checked each retry)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
