### PR TITLE
Add Renson button entity

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1008,6 +1008,7 @@ omit =
     homeassistant/components/renson/const.py
     homeassistant/components/renson/entity.py
     homeassistant/components/renson/sensor.py
+    homeassistant/components/renson/button.py
     homeassistant/components/renson/fan.py
     homeassistant/components/renson/binary_sensor.py
     homeassistant/components/renson/number.py

--- a/homeassistant/components/renson/__init__.py
+++ b/homeassistant/components/renson/__init__.py
@@ -21,6 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.FAN,
     Platform.NUMBER,
     Platform.SENSOR,

--- a/homeassistant/components/renson/button.py
+++ b/homeassistant/components/renson/button.py
@@ -84,4 +84,6 @@ class RensonButton(RensonEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Triggers the action."""
-        await self.hass.async_add_executor_job(self._action)
+        await self.hass.async_add_executor_job(
+            self.entity_description.action_fn(self.api)
+        )

--- a/homeassistant/components/renson/button.py
+++ b/homeassistant/components/renson/button.py
@@ -58,10 +58,8 @@ async def async_setup_entry(
     data: RensonData = hass.data[DOMAIN][config_entry.entry_id]
 
     entities = [
-        RensonButton(SYNC_TIME_BUTTON, data.api, data.coordinator, data.api.sync_time),
-        RensonButton(
-            RESTART_BUTTON, data.api, data.coordinator, data.api.restart_device
-        ),
+        RensonButton(description, data.api, data.coordinator)
+        for description in ENTITY_DESCRIPTIONS
     ]
 
     async_add_entities(entities)

--- a/homeassistant/components/renson/button.py
+++ b/homeassistant/components/renson/button.py
@@ -75,7 +75,6 @@ class RensonButton(RensonEntity, ButtonEntity):
         description: ButtonEntityDescription,
         api: RensonVentilation,
         coordinator: RensonCoordinator,
-        action: Callable,
     ) -> None:
         """Initialize class."""
         super().__init__(description.key, api, coordinator)

--- a/homeassistant/components/renson/button.py
+++ b/homeassistant/components/renson/button.py
@@ -72,7 +72,7 @@ class RensonButton(RensonEntity, ButtonEntity):
 
     def __init__(
         self,
-        description: ButtonEntityDescription,
+        description: RensonButtonEntityDescription,
         api: RensonVentilation,
         coordinator: RensonCoordinator,
     ) -> None:

--- a/homeassistant/components/renson/button.py
+++ b/homeassistant/components/renson/button.py
@@ -23,7 +23,13 @@ SYNC_TIME_BUTTON: ButtonEntityDescription = ButtonEntityDescription(
     device_class=ButtonDeviceClass.UPDATE,
     entity_category=EntityCategory.CONFIG,
     translation_key="sync_time",
-    has_entity_name=True,
+)
+
+RESTART_BUTTON: ButtonEntityDescription = ButtonEntityDescription(
+    key="restart",
+    device_class=ButtonDeviceClass.RESTART,
+    entity_category=EntityCategory.CONFIG,
+    translation_key="restart",
 )
 
 
@@ -39,7 +45,10 @@ async def async_setup_entry(
     entities = [
         RensonButton(
             SYNC_TIME_BUTTON, data.api, data.coordinator, hass, data.api.sync_time
-        )
+        ),
+        RensonButton(
+            RESTART_BUTTON, data.api, data.coordinator, hass, data.api.restart_device
+        ),
     ]
 
     async_add_entities(entities)
@@ -62,8 +71,9 @@ class RensonButton(RensonEntity, ButtonEntity):
         super().__init__(description.key, api, coordinator)
 
         self.entity_description = description
+        self.action = action
 
     async def async_press(self) -> None:
         """Triggers the action."""
-        await self.hass.async_add_executor_job(self.api.sync_time)
+        await self.hass.async_add_executor_job(self.action)
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/renson/button.py
+++ b/homeassistant/components/renson/button.py
@@ -80,7 +80,6 @@ class RensonButton(RensonEntity, ButtonEntity):
         super().__init__(description.key, api, coordinator)
 
         self.entity_description = description
-        self._action = action
 
     async def async_press(self) -> None:
         """Triggers the action."""

--- a/homeassistant/components/renson/button.py
+++ b/homeassistant/components/renson/button.py
@@ -20,7 +20,6 @@ from .entity import RensonEntity
 
 SYNC_TIME_BUTTON: ButtonEntityDescription = ButtonEntityDescription(
     key="sync_time",
-    device_class=ButtonDeviceClass.UPDATE,
     entity_category=EntityCategory.CONFIG,
     translation_key="sync_time",
 )
@@ -29,7 +28,6 @@ RESTART_BUTTON: ButtonEntityDescription = ButtonEntityDescription(
     key="restart",
     device_class=ButtonDeviceClass.RESTART,
     entity_category=EntityCategory.CONFIG,
-    translation_key="restart",
 )
 
 
@@ -71,9 +69,8 @@ class RensonButton(RensonEntity, ButtonEntity):
         super().__init__(description.key, api, coordinator)
 
         self.entity_description = description
-        self.action = action
+        self._action = action
 
     async def async_press(self) -> None:
         """Triggers the action."""
-        await self.hass.async_add_executor_job(self.action)
-        await self.coordinator.async_request_refresh()
+        await self.hass.async_add_executor_job(self._action)

--- a/homeassistant/components/renson/button.py
+++ b/homeassistant/components/renson/button.py
@@ -1,6 +1,8 @@
 """Renson ventilation unit buttons."""
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from _collections_abc import Callable
 from renson_endura_delta.renson import RensonVentilation
 
@@ -17,6 +19,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import RensonCoordinator, RensonData
 from .const import DOMAIN
 from .entity import RensonEntity
+
 
 @dataclass
 class RensonButtonEntityDescriptionMixin:
@@ -82,8 +85,6 @@ class RensonButton(RensonEntity, ButtonEntity):
 
         self.entity_description = description
 
-    async def async_press(self) -> None:
+    def press(self) -> None:
         """Triggers the action."""
-        await self.hass.async_add_executor_job(
-            self.entity_description.action_fn(self.api)
-        )
+        self.entity_description.action_fn(self.api)

--- a/homeassistant/components/renson/button.py
+++ b/homeassistant/components/renson/button.py
@@ -1,4 +1,4 @@
-"""Sensor data of the Renson ventilation unit."""
+"""Renson ventilation unit buttons."""
 from __future__ import annotations
 
 from _collections_abc import Callable
@@ -41,11 +41,9 @@ async def async_setup_entry(
     data: RensonData = hass.data[DOMAIN][config_entry.entry_id]
 
     entities = [
+        RensonButton(SYNC_TIME_BUTTON, data.api, data.coordinator, data.api.sync_time),
         RensonButton(
-            SYNC_TIME_BUTTON, data.api, data.coordinator, hass, data.api.sync_time
-        ),
-        RensonButton(
-            RESTART_BUTTON, data.api, data.coordinator, hass, data.api.restart_device
+            RESTART_BUTTON, data.api, data.coordinator, data.api.restart_device
         ),
     ]
 
@@ -62,7 +60,6 @@ class RensonButton(RensonEntity, ButtonEntity):
         description: ButtonEntityDescription,
         api: RensonVentilation,
         coordinator: RensonCoordinator,
-        hass: HomeAssistant,
         action: Callable,
     ) -> None:
         """Initialize class."""

--- a/homeassistant/components/renson/button.py
+++ b/homeassistant/components/renson/button.py
@@ -1,0 +1,60 @@
+"""Sensor data of the Renson ventilation unit."""
+from __future__ import annotations
+
+from renson_endura_delta.renson import RensonVentilation
+
+from homeassistant.components.button import (
+    ButtonDeviceClass,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import RensonCoordinator, RensonData
+from .const import DOMAIN
+from .entity import RensonEntity
+
+SYNC_TIME_BUTTON: ButtonEntityDescription = ButtonEntityDescription(
+    key="sync_time",
+    device_class=ButtonDeviceClass.UPDATE,
+    entity_category=EntityCategory.CONFIG,
+    translation_key="sync_time",
+    has_entity_name=True,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Renson sensor platform."""
+
+    data: RensonData = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities = [RensonButton(SYNC_TIME_BUTTON, data.api, data.coordinator, hass)]
+
+    async_add_entities(entities)
+
+
+class RensonButton(RensonEntity, ButtonEntity):
+    """Get a sensor data from the Renson API and store it in the state of the class."""
+
+    def __init__(
+        self,
+        description: ButtonEntityDescription,
+        api: RensonVentilation,
+        coordinator: RensonCoordinator,
+        hass: HomeAssistant,
+    ) -> None:
+        """Initialize class."""
+        super().__init__(description.key, api, coordinator)
+
+        self.entity_description = description
+
+    async def async_press(self) -> None:
+        """Triggers the sync."""
+        await self.hass.async_add_executor_job(self.api.sync_time)

--- a/homeassistant/components/renson/button.py
+++ b/homeassistant/components/renson/button.py
@@ -18,16 +18,33 @@ from . import RensonCoordinator, RensonData
 from .const import DOMAIN
 from .entity import RensonEntity
 
-SYNC_TIME_BUTTON: ButtonEntityDescription = ButtonEntityDescription(
-    key="sync_time",
-    entity_category=EntityCategory.CONFIG,
-    translation_key="sync_time",
-)
+@dataclass
+class RensonButtonEntityDescriptionMixin:
+    """Action function called on press."""
 
-RESTART_BUTTON: ButtonEntityDescription = ButtonEntityDescription(
-    key="restart",
-    device_class=ButtonDeviceClass.RESTART,
-    entity_category=EntityCategory.CONFIG,
+    action_fn: Callable[[RensonVentilation], None]
+
+
+@dataclass
+class RensonButtonEntityDescription(
+    ButtonEntityDescription, RensonButtonEntityDescriptionMixin
+):
+    """Class describing Renson button entity."""
+
+
+ENTITY_DESCRIPTIONS: tuple[RensonButtonEntityDescription, ...] = (
+    RensonButtonEntityDescription(
+        key="sync_time",
+        entity_category=EntityCategory.CONFIG,
+        translation_key="sync_time",
+        action_fn=lambda api: api.sync_time(),
+    ),
+    RensonButtonEntityDescription(
+        key="restart",
+        device_class=ButtonDeviceClass.RESTART,
+        entity_category=EntityCategory.CONFIG,
+        action_fn=lambda api: api.restart_device(),
+    ),
 )
 
 

--- a/homeassistant/components/renson/button.py
+++ b/homeassistant/components/renson/button.py
@@ -69,6 +69,7 @@ class RensonButton(RensonEntity, ButtonEntity):
     """Representation of a Renson actions."""
 
     _attr_has_entity_name = True
+    entity_description: RensonButtonEntityDescription
 
     def __init__(
         self,

--- a/homeassistant/components/renson/button.py
+++ b/homeassistant/components/renson/button.py
@@ -48,6 +48,8 @@ async def async_setup_entry(
 class RensonButton(RensonEntity, ButtonEntity):
     """Representation of a Renson actions."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         description: ButtonEntityDescription,

--- a/homeassistant/components/renson/manifest.json
+++ b/homeassistant/components/renson/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/renson",
   "iot_class": "local_polling",
-  "requirements": ["renson-endura-delta==1.5.2"]
+  "requirements": ["renson-endura-delta==1.6.0"]
 }

--- a/homeassistant/components/renson/manifest.json
+++ b/homeassistant/components/renson/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/renson",
   "iot_class": "local_polling",
-  "requirements": ["renson-endura-delta==1.5.0"]
+  "requirements": ["renson-endura-delta==1.5.1"]
 }

--- a/homeassistant/components/renson/manifest.json
+++ b/homeassistant/components/renson/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/renson",
   "iot_class": "local_polling",
-  "requirements": ["renson-endura-delta==1.5.1"]
+  "requirements": ["renson-endura-delta==1.5.2"]
 }

--- a/homeassistant/components/renson/strings.json
+++ b/homeassistant/components/renson/strings.json
@@ -13,6 +13,11 @@
     }
   },
   "entity": {
+    "button": {
+      "sync_time": {
+        "name": "Sync time with device"
+      }
+    },
     "number": {
       "filter_change": {
         "name": "Filter clean/replacement"

--- a/homeassistant/components/renson/strings.json
+++ b/homeassistant/components/renson/strings.json
@@ -16,6 +16,9 @@
     "button": {
       "sync_time": {
         "name": "Sync time with device"
+      },
+      "restart": {
+        "name": "Restart device"
       }
     },
     "number": {

--- a/homeassistant/components/renson/strings.json
+++ b/homeassistant/components/renson/strings.json
@@ -16,9 +16,6 @@
     "button": {
       "sync_time": {
         "name": "Sync time with device"
-      },
-      "restart": {
-        "name": "Restart device"
       }
     },
     "number": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2292,7 +2292,7 @@ regenmaschine==2023.06.0
 renault-api==0.2.0
 
 # homeassistant.components.renson
-renson-endura-delta==1.5.2
+renson-endura-delta==1.6.0
 
 # homeassistant.components.reolink
 reolink-aio==0.7.9

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2292,7 +2292,7 @@ regenmaschine==2023.06.0
 renault-api==0.2.0
 
 # homeassistant.components.renson
-renson-endura-delta==1.5.1
+renson-endura-delta==1.5.2
 
 # homeassistant.components.reolink
 reolink-aio==0.7.9

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2292,7 +2292,7 @@ regenmaschine==2023.06.0
 renault-api==0.2.0
 
 # homeassistant.components.renson
-renson-endura-delta==1.5.0
+renson-endura-delta==1.5.1
 
 # homeassistant.components.reolink
 reolink-aio==0.7.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1688,7 +1688,7 @@ regenmaschine==2023.06.0
 renault-api==0.2.0
 
 # homeassistant.components.renson
-renson-endura-delta==1.5.2
+renson-endura-delta==1.6.0
 
 # homeassistant.components.reolink
 reolink-aio==0.7.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1688,7 +1688,7 @@ regenmaschine==2023.06.0
 renault-api==0.2.0
 
 # homeassistant.components.renson
-renson-endura-delta==1.5.1
+renson-endura-delta==1.5.2
 
 # homeassistant.components.reolink
 reolink-aio==0.7.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1688,7 +1688,7 @@ regenmaschine==2023.06.0
 renault-api==0.2.0
 
 # homeassistant.components.renson
-renson-endura-delta==1.5.0
+renson-endura-delta==1.5.1
 
 # homeassistant.components.reolink
 reolink-aio==0.7.9


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Creation of button sensor for syncing the time to the device and restarting device.

Dependecy has been updated because of a bug in it for syncing time incorrectly to the device.
Previously when syncing the time it throws an python error that datetime cannot be found in datetime. The update fixes this. https://github.com/jimmyd-be/Renson-endura-delta-library/compare/1.5.0...1.6.0


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28762

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
