### PR TITLE
Periodically refresh overkiz states

### DIFF
--- a/homeassistant/components/overkiz/const.py
+++ b/homeassistant/components/overkiz/const.py
@@ -37,6 +37,8 @@ DEFAULT_HUB: Final = "somfy_europe"
 UPDATE_INTERVAL: Final = timedelta(seconds=30)
 UPDATE_INTERVAL_ALL_ASSUMED_STATE: Final = timedelta(minutes=60)
 
+REFRESH_DEVICE_STATES_INTERVAL: Final = timedelta(minutes=5)
+
 PLATFORMS: list[Platform] = [
     Platform.ALARM_CONTROL_PANEL,
     Platform.BINARY_SENSOR,
@@ -57,6 +59,11 @@ PLATFORMS: list[Platform] = [
 IGNORED_OVERKIZ_DEVICES: list[UIClass | UIWidget] = [
     UIClass.PROTOCOL_GATEWAY,
     UIClass.POD,
+]
+
+OVERKIZ_REFRESH_DEVICE_STATES_DEVICES: list[UIClass | UIWidget] = [
+    UIClass.GARAGE_DOOR,
+    UIClass.GATE,
 ]
 
 # Used to map the Somfy widget and ui_class to the Home Assistant platform


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Somfy gates & garage doors will not automatically send state updates. They have to be explicitly requested. The TaHoma app/web interface therefore asks all devices to send their state updates on start.

This change adds a new `OverkizDeviceRefreshCoordinator` for impacted devices and will periodically (5min) ask the specific device to send state updates.

Note that even though these devices typically also provide commands such as `refreshPedestrianPosition`/`refreshPartialPosition` but they do not cause the device to send its actual state to the gateway.

See https://github.com/Somfy-Developer/Somfy-TaHoma-Developer-Mode/issues/26 and https://github.com/iMicknl/ha-tahoma/issues/167.

This PR still requires https://github.com/iMicknl/python-overkiz-api/pull/956 and a version bump of `python-overkiz-api`.

Note that this is my first contribution to Home Assistant and so far I have been able to test this only with a Somfy Dexxo Smart io garage door motor. It would certainly be helpful to get this tested by others impacted by https://github.com/iMicknl/ha-tahoma/issues/167.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: https://github.com/iMicknl/ha-tahoma/issues/167
- Link to documentation pull request: 
- This needs a new version of the python-overkiz-api: https://github.com/iMicknl/python-overkiz-api/pull/956

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
