### PR TITLE
Add sensors to private_ble_device

### DIFF
--- a/homeassistant/components/private_ble_device/__init__.py
+++ b/homeassistant/components/private_ble_device/__init__.py
@@ -5,7 +5,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
-PLATFORMS = [Platform.DEVICE_TRACKER]
+PLATFORMS = [Platform.DEVICE_TRACKER, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/private_ble_device/entity.py
+++ b/homeassistant/components/private_ble_device/entity.py
@@ -24,7 +24,10 @@ class BasePrivateDeviceEntity(Entity):
         """Set up a new BleScanner entity."""
         irk = config_entry.data["irk"]
 
-        self._attr_unique_id = irk
+        if self.translation_key:
+            self._attr_unique_id = f"{irk}_{self.translation_key}"
+        else:
+            self._attr_unique_id = irk
 
         self._attr_device_info = DeviceInfo(
             name=f"Private BLE Device {irk[:6]}",

--- a/homeassistant/components/private_ble_device/sensor.py
+++ b/homeassistant/components/private_ble_device/sensor.py
@@ -51,6 +51,7 @@ SENSOR_DESCRIPTIONS = (
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda service_info: service_info.advertisement.tx_power,
         state_class=SensorStateClass.MEASUREMENT,
     ),

--- a/homeassistant/components/private_ble_device/sensor.py
+++ b/homeassistant/components/private_ble_device/sensor.py
@@ -41,6 +41,7 @@ SENSOR_DESCRIPTIONS = (
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,       
         value_fn=lambda service_info: service_info.advertisement.rssi,
         state_class=SensorStateClass.MEASUREMENT,
     ),

--- a/homeassistant/components/private_ble_device/sensor.py
+++ b/homeassistant/components/private_ble_device/sensor.py
@@ -1,0 +1,120 @@
+"""Support for iBeacon device sensors."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from bluetooth_data_tools import calculate_distance_meters
+
+from homeassistant.components import bluetooth
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import SIGNAL_STRENGTH_DECIBELS_MILLIWATT, UnitOfLength
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .entity import BasePrivateDeviceEntity
+
+
+@dataclass
+class PrivateDeviceSensorEntityDescriptionRequired:
+    """Required domain specific fields for sensor entity."""
+
+    value_fn: Callable[[bluetooth.BluetoothServiceInfoBleak], str | int | float | None]
+
+
+@dataclass
+class PrivateDeviceSensorEntityDescription(
+    SensorEntityDescription, PrivateDeviceSensorEntityDescriptionRequired
+):
+    """Describes sensor entity."""
+
+
+SENSOR_DESCRIPTIONS = (
+    PrivateDeviceSensorEntityDescription(
+        key="rssi",
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        entity_registry_enabled_default=False,
+        value_fn=lambda service_info: service_info.advertisement.rssi,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    PrivateDeviceSensorEntityDescription(
+        key="power",
+        translation_key="power",
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        entity_registry_enabled_default=False,
+        value_fn=lambda service_info: service_info.advertisement.tx_power,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    PrivateDeviceSensorEntityDescription(
+        key="estimated_distance",
+        translation_key="estimated_distance",
+        icon="mdi:signal-distance-variant",
+        native_unit_of_measurement=UnitOfLength.METERS,
+        value_fn=lambda service_info: service_info.advertisement
+        and service_info.advertisement.tx_power
+        and calculate_distance_meters(
+            service_info.advertisement.tx_power * 10, service_info.advertisement.rssi
+        ),
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.DISTANCE,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up sensors for Private BLE component."""
+    async_add_entities(
+        PrivateBLEDeviceSensor(entry, description)
+        for description in SENSOR_DESCRIPTIONS
+    )
+
+
+class PrivateBLEDeviceSensor(BasePrivateDeviceEntity, SensorEntity):
+    """A sensor entity."""
+
+    entity_description: PrivateDeviceSensorEntityDescription
+
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        entity_description: PrivateDeviceSensorEntityDescription,
+    ) -> None:
+        """Initialize an sensor entity."""
+        self.entity_description = entity_description
+        self._attr_available = False
+        super().__init__(config_entry)
+
+    @callback
+    def _async_track_service_info(
+        self,
+        service_info: bluetooth.BluetoothServiceInfoBleak,
+        change: bluetooth.BluetoothChange,
+    ) -> None:
+        """Update state."""
+        self._attr_available = True
+        self._last_info = service_info
+        self.async_write_ha_state()
+
+    @callback
+    def _async_track_unavailable(
+        self, service_info: bluetooth.BluetoothServiceInfoBleak
+    ) -> None:
+        """Update state."""
+        self._attr_available = False
+        self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> str | int | float | None:
+        """Return the state of the sensor."""
+        assert self._last_info
+        return self.entity_description.value_fn(self._last_info)

--- a/homeassistant/components/private_ble_device/sensor.py
+++ b/homeassistant/components/private_ble_device/sensor.py
@@ -14,7 +14,11 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import SIGNAL_STRENGTH_DECIBELS_MILLIWATT, UnitOfLength
+from homeassistant.const import (
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    EntityCategory,
+    UnitOfLength,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -41,7 +45,7 @@ SENSOR_DESCRIPTIONS = (
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         entity_registry_enabled_default=False,
-        entity_category=EntityCategory.DIAGNOSTIC,       
+        entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda service_info: service_info.advertisement.rssi,
         state_class=SensorStateClass.MEASUREMENT,
     ),

--- a/homeassistant/components/private_ble_device/strings.json
+++ b/homeassistant/components/private_ble_device/strings.json
@@ -16,5 +16,15 @@
     "abort": {
       "bluetooth_not_available": "At least one Bluetooth adapter or remote bluetooth proxy must be configured to track Private BLE Devices."
     }
+  },
+  "entity": {
+    "sensor": {
+      "power": {
+        "name": "Power"
+      },
+      "estimated_distance": {
+        "name": "Estimated distance"
+      }
+    }
   }
 }

--- a/tests/components/private_ble_device/test_sensor.py
+++ b/tests/components/private_ble_device/test_sensor.py
@@ -1,0 +1,47 @@
+"""Tests for sensors."""
+
+
+from homeassistant.core import HomeAssistant
+
+from . import MAC_RPA_VALID_1, async_inject_broadcast, async_mock_config_entry
+
+
+async def test_sensor_unavailable(
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+    entity_registry_enabled_by_default: None,
+) -> None:
+    """Test sensors are unavailable."""
+    await async_mock_config_entry(hass)
+
+    state = hass.states.get("sensor.private_ble_device_000000_signal_strength")
+    assert state
+    assert state.state == "unavailable"
+
+
+async def test_sensors_already_home(
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+    entity_registry_enabled_by_default: None,
+) -> None:
+    """Test sensors get value when we start at home."""
+    await async_inject_broadcast(hass, MAC_RPA_VALID_1)
+    await async_mock_config_entry(hass)
+
+    state = hass.states.get("sensor.private_ble_device_000000_signal_strength")
+    assert state
+    assert state.state == "-63"
+
+
+async def test_sensors_come_home(
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+    entity_registry_enabled_by_default: None,
+) -> None:
+    """Test sensors get value when we receive a broadcast."""
+    await async_mock_config_entry(hass)
+    await async_inject_broadcast(hass, MAC_RPA_VALID_1)
+
+    state = hass.states.get("sensor.private_ble_device_000000_signal_strength")
+    assert state
+    assert state.state == "-63"


### PR DESCRIPTION
## Proposed change

Add back the sensors that were developed as part of https://github.com/home-assistant/core/pull/99465.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28769

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
