### PR TITLE
Bump bleak to 0.21.0

### DIFF
--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -14,7 +14,7 @@
   ],
   "quality_scale": "internal",
   "requirements": [
-    "bleak==0.20.2",
+    "bleak==0.21.0",
     "bleak-retry-connector==3.1.1",
     "bluetooth-adapters==0.16.0",
     "bluetooth-auto-recovery==1.2.1",

--- a/homeassistant/components/bluetooth/wrappers.py
+++ b/homeassistant/components/bluetooth/wrappers.py
@@ -120,15 +120,17 @@ class HaBleakScannerWrapper(BaseBleakScanner):
 
     def register_detection_callback(
         self, callback: AdvertisementDataCallback | None
-    ) -> None:
+    ) -> Callable[[], None]:
         """Register a detection callback.
 
         The callback is called when a device is discovered or has a property changed.
 
-        This method takes the callback and registers it with the long running sscanner.
+        This method takes the callback and registers it with the long running scanner.
         """
         self._advertisement_data_callback = callback
         self._setup_detection_callback()
+        assert self._detection_cancel is not None
+        return self._detection_cancel
 
     def _setup_detection_callback(self) -> None:
         """Set up the detection callback."""

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -9,7 +9,7 @@ attrs==23.1.0
 awesomeversion==22.9.0
 bcrypt==4.0.1
 bleak-retry-connector==3.1.1
-bleak==0.20.2
+bleak==0.21.0
 bluetooth-adapters==0.16.0
 bluetooth-auto-recovery==1.2.1
 bluetooth-data-tools==1.11.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -522,7 +522,7 @@ bizkaibus==0.1.1
 bleak-retry-connector==3.1.1
 
 # homeassistant.components.bluetooth
-bleak==0.20.2
+bleak==0.21.0
 
 # homeassistant.components.blebox
 blebox-uniapi==2.1.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -440,7 +440,7 @@ bimmer-connected==0.14.0
 bleak-retry-connector==3.1.1
 
 # homeassistant.components.bluetooth
-bleak==0.20.2
+bleak==0.21.0
 
 # homeassistant.components.blebox
 blebox-uniapi==2.1.4


### PR DESCRIPTION
~~blocked by `gardena-bluetooth`: https://github.com/elupus/gardena-bluetooth/pull/6~~
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
fixes https://github.com/home-assistant/core/issues/93036#issuecomment-1646780765 fixes https://github.com/home-assistant/core/issues/93222#issue-1714777046 fixes https://github.com/home-assistant/core/issues/93171

changelog: https://github.com/hbldh/bleak/compare/v0.20.2...v0.21.0

bleak>=0.21.0 has a fix for BlueZ connection attempts hanging

This will unblock the following:
https://github.com/esphome/aioesphomeapi/pull/528
https://github.com/Bluetooth-Devices/bleak-retry-connector/pull/101

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
