### PR TITLE
Fix Bluetooth passive update processor dispatching updates to unchanged entities

### DIFF
--- a/homeassistant/components/bluetooth/passive_update_coordinator.py
+++ b/homeassistant/components/bluetooth/passive_update_coordinator.py
@@ -85,6 +85,7 @@ class PassiveBluetoothDataUpdateCoordinator(
         change: BluetoothChange,
     ) -> None:
         """Handle a Bluetooth event."""
+        self._available = True
         self.async_update_listeners()
 
 

--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -548,7 +548,9 @@ class PassiveBluetoothDataProcessor(Generic[_T]):
                     update_callback(data)
 
     @callback
-    def async_handle_update(self, update: _T, was_available: bool) -> None:
+    def async_handle_update(
+        self, update: _T, was_available: bool | None = None
+    ) -> None:
         """Handle a Bluetooth event."""
         try:
             new_data = self.update_method(update)

--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -341,6 +341,8 @@ class PassiveBluetoothProcessorCoordinator(
         change: BluetoothChange,
     ) -> None:
         """Handle a Bluetooth event."""
+        was_available = self._available
+        self._available = True
         super()._async_handle_bluetooth_event(service_info, change)
         if self.hass.is_stopping:
             return
@@ -359,7 +361,7 @@ class PassiveBluetoothProcessorCoordinator(
             self.logger.info("Coordinator %s recovered", self.name)
 
         for processor in self._processors:
-            processor.async_handle_update(update)
+            processor.async_handle_update(update, was_available)
 
 
 _PassiveBluetoothDataProcessorT = TypeVar(
@@ -516,31 +518,37 @@ class PassiveBluetoothDataProcessor(Generic[_T]):
 
     @callback
     def async_update_listeners(
-        self, data: PassiveBluetoothDataUpdate[_T] | None
+        self,
+        data: PassiveBluetoothDataUpdate[_T] | None,
+        was_available: bool | None = None,
     ) -> None:
         """Update all registered listeners."""
+        if was_available is None:
+            was_available = self.coordinator.available
+
         # Dispatch to listeners without a filter key
         for update_callback in self._listeners:
             update_callback(data)
 
-        if data is not None:
-            # Dispatch to listeners with a filter key
-            # if the key is in the data
-            entity_key_listeners = self._entity_key_listeners
-            for entity_key in data.entity_data:
-                if listeners := entity_key_listeners.get(entity_key):
-                    for update_callback in listeners:
-                        update_callback(data)
+        if not was_available or data is None:
+            # When data is None, or was_available is False,
+            # dispatch to all listeners as it means the device
+            # is flipping between available and unavailable
+            for listeners in self._entity_key_listeners.values():
+                for update_callback in listeners:
+                    update_callback(data)
             return
 
-        # When data is None, dispatch to all listeners
-        # as it means the device is unavailable
-        for listeners in self._entity_key_listeners.values():
-            for update_callback in listeners:
-                update_callback(None)
+        # Dispatch to listeners with a filter key
+        # if the key is in the data
+        entity_key_listeners = self._entity_key_listeners
+        for entity_key in data.entity_data:
+            if maybe_listener := entity_key_listeners.get(entity_key):
+                for update_callback in maybe_listener:
+                    update_callback(data)
 
     @callback
-    def async_handle_update(self, update: _T) -> None:
+    def async_handle_update(self, update: _T, was_available: bool) -> None:
         """Handle a Bluetooth event."""
         try:
             new_data = self.update_method(update)
@@ -565,7 +573,7 @@ class PassiveBluetoothDataProcessor(Generic[_T]):
             )
 
         self.data.update(new_data)
-        self.async_update_listeners(new_data)
+        self.async_update_listeners(new_data, was_available)
 
 
 class PassiveBluetoothProcessorEntity(Entity, Generic[_PassiveBluetoothDataProcessorT]):

--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -523,10 +523,21 @@ class PassiveBluetoothDataProcessor(Generic[_T]):
         for update_callback in self._listeners:
             update_callback(data)
 
-        # Dispatch to listeners with a filter key
+        if data is not None:
+            # Dispatch to listeners with a filter key
+            # if the key is in the data
+            entity_key_listeners = self._entity_key_listeners
+            for entity_key in data.entity_data:
+                if listeners := entity_key_listeners.get(entity_key):
+                    for update_callback in listeners:
+                        update_callback(data)
+            return
+
+        # When data is None, dispatch to all listeners
+        # as it means the device is unavailable
         for listeners in self._entity_key_listeners.values():
             for update_callback in listeners:
-                update_callback(data)
+                update_callback(None)
 
     @callback
     def async_handle_update(self, update: _T) -> None:

--- a/homeassistant/components/bluetooth/update_coordinator.py
+++ b/homeassistant/components/bluetooth/update_coordinator.py
@@ -39,6 +39,11 @@ class BasePassiveBluetoothCoordinator(ABC):
         self.mode = mode
         self._last_unavailable_time = 0.0
         self._last_name = address
+        # Subclasses are responsible for setting _available to True
+        # when the abstractmethod _async_handle_bluetooth_event is called.
+        #
+        # We do not set it to True here because we want to make sure that
+        # the subclass has a chance to see the value change.
         self._available = async_address_present(hass, address, connectable)
 
     @callback
@@ -89,22 +94,12 @@ class BasePassiveBluetoothCoordinator(ABC):
         return self._available
 
     @callback
-    def _async_handle_bluetooth_event_internal(
-        self,
-        service_info: BluetoothServiceInfoBleak,
-        change: BluetoothChange,
-    ) -> None:
-        """Handle a bluetooth event."""
-        self._available = True
-        self._async_handle_bluetooth_event(service_info, change)
-
-    @callback
     def _async_start(self) -> None:
         """Start the callbacks."""
         self._on_stop.append(
             async_register_callback(
                 self.hass,
-                self._async_handle_bluetooth_event_internal,
+                self._async_handle_bluetooth_event,
                 BluetoothCallbackMatcher(
                     address=self.address, connectable=self.connectable
                 ),

--- a/homeassistant/components/bluetooth/update_coordinator.py
+++ b/homeassistant/components/bluetooth/update_coordinator.py
@@ -41,9 +41,6 @@ class BasePassiveBluetoothCoordinator(ABC):
         self._last_name = address
         # Subclasses are responsible for setting _available to True
         # when the abstractmethod _async_handle_bluetooth_event is called.
-        #
-        # We do not set it to True here because we want to make sure that
-        # the subclass has a chance to see the value change.
         self._available = async_address_present(hass, address, connectable)
 
     @callback

--- a/tests/components/bluetooth/test_active_update_processor.py
+++ b/tests/components/bluetooth/test_active_update_processor.py
@@ -91,7 +91,7 @@ async def test_basic_usage(
     # The first time, it was passed the data from parsing the advertisement
     # The second time, it was passed the data from polling
     assert len(async_handle_update.mock_calls) == 2
-    assert async_handle_update.mock_calls[0] == call({"testdata": 0})
+    assert async_handle_update.mock_calls[0] == call({"testdata": 0}, False)
     assert async_handle_update.mock_calls[1] == call({"testdata": 1})
 
     cancel()
@@ -148,7 +148,7 @@ async def test_poll_can_be_skipped(
 
     inject_bluetooth_service_info(hass, GENERIC_BLUETOOTH_SERVICE_INFO_2)
     await hass.async_block_till_done()
-    assert async_handle_update.mock_calls[-1] == call({"testdata": None})
+    assert async_handle_update.mock_calls[-1] == call({"testdata": None}, True)
 
     flag = True
 
@@ -208,7 +208,7 @@ async def test_bleak_error_and_recover(
     # First poll fails
     inject_bluetooth_service_info(hass, GENERIC_BLUETOOTH_SERVICE_INFO)
     await hass.async_block_till_done()
-    assert async_handle_update.mock_calls[-1] == call({"testdata": None})
+    assert async_handle_update.mock_calls[-1] == call({"testdata": None}, False)
 
     assert (
         "aa:bb:cc:dd:ee:ff: Bluetooth error whilst polling: Connection was aborted"
@@ -272,7 +272,7 @@ async def test_poll_failure_and_recover(
     # First poll fails
     inject_bluetooth_service_info(hass, GENERIC_BLUETOOTH_SERVICE_INFO)
     await hass.async_block_till_done()
-    assert async_handle_update.mock_calls[-1] == call({"testdata": None})
+    assert async_handle_update.mock_calls[-1] == call({"testdata": None}, False)
 
     # Second poll works
     flag = False
@@ -433,7 +433,7 @@ async def test_no_polling_after_stop_event(
     # The first time, it was passed the data from parsing the advertisement
     # The second time, it was passed the data from polling
     assert len(async_handle_update.mock_calls) == 2
-    assert async_handle_update.mock_calls[0] == call({"testdata": 0})
+    assert async_handle_update.mock_calls[0] == call({"testdata": 0}, False)
     assert async_handle_update.mock_calls[1] == call({"testdata": 1})
 
     hass.state = CoreState.stopping


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix passive update processor dispatching updates to unchanged entities

TLDR: Updates were being dispatched to entities that had not changed.

The original design assumed all entities would be updated from the advertisment data but since its limited to 31 bytes this is only true for a subset of the passive BLE integrations. We should only dispatch updates to entities that are contained in the update. Examples of integrations that use split advertisments: `xiaomi_ble`, `govee_ble`, `bthome`, `qingping`, etc.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
