### PR TITLE
Add support for opening/closing state in Tuya Cover

### DIFF
--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -29,6 +29,7 @@ class TuyaCoverEntityDescription(CoverEntityDescription):
     """Describe an Tuya cover entity."""
 
     current_state: DPCode | None = None
+    current_instruction: bool = False
     current_state_inverse: bool = False
     current_position: DPCode | tuple[DPCode, ...] | None = None
     set_position: DPCode | None = None
@@ -115,6 +116,7 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
         TuyaCoverEntityDescription(
             key=DPCode.CONTROL,
             translation_key="curtain",
+            current_instruction=True,
             current_position=DPCode.PERCENT_CONTROL,
             set_position=DPCode.PERCENT_CONTROL,
             device_class=CoverDeviceClass.CURTAIN,
@@ -122,6 +124,7 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
         TuyaCoverEntityDescription(
             key=DPCode.CONTROL_2,
             translation_key="curtain_2",
+            current_instruction=True,
             current_position=DPCode.PERCENT_CONTROL_2,
             set_position=DPCode.PERCENT_CONTROL_2,
             device_class=CoverDeviceClass.CURTAIN,
@@ -258,6 +261,35 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
             return None
 
         return round(self._tilt.remap_value_to(angle, 0, 100))
+
+
+    @property
+    def is_opening(self) -> bool | None:
+        if (
+            self.entity_description.current_instruction
+            and (
+                current_instruction := self.device.status.get(
+                    self.entity_description.key
+                )
+            )
+            is not None
+        ):
+            return current_instruction == self.entity_description.open_instruction_value
+        return super().is_opening
+
+    @property
+    def is_closing(self) -> bool | None:
+        if (
+            self.entity_description.current_instruction
+            and (
+                current_instruction := self.device.status.get(
+                    self.entity_description.key
+                )
+            )
+            is not None
+        ):
+            return current_instruction == self.entity_description.close_instruction_value
+        return super().is_closing
 
     @property
     def is_closed(self) -> bool | None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

The TUYA cover `clkg` does not report the state (`closed` or `opened`), however, it does report the currently executing command (`open` or `close`).

The cover's state is required to define automation (for example `turn_on` a switch when the `cover` is manually pressed.
The current implementation always reports the `unknown` state, because nothing tells that the cover is opening or closing. Which prevents to configure any automation,

This PR uses the information reported by the API to set the real of `is_opening` / `is_closing` property.

Here is the debug logs of home assistant when I press the physical cover

```
2023-09-04 10:57:49.084 DEBUG (Thread-6 (_thread_main)) [tuya_iot] mq _on_device_report-> [{'1': 'open', 'code': 'control', 't': '1693817868', 'value': 'open'}]
2023-09-04 10:57:49.085 DEBUG (Thread-6 (_thread_main)) [homeassistant.components.tuya] Received update for device bf901d2be92db26fc9ikyy: {'control': 'open', 'switch_backlight': False, 'tr_timecon': 10}

...

2023-09-04 10:57:59.033 DEBUG (Thread-6 (_thread_main)) [tuya_iot] mq _on_device_report-> [{'1': 'stop', 'code': 'control', 't': '1693817878', 'value': 'stop'}]
2023-09-04 10:57:59.033 DEBUG (Thread-6 (_thread_main)) [homeassistant.components.tuya] Received update for device bf901d2be92db26fc9ikyy: {'control': 'stop', 'switch_backlight': False, 'tr_timecon': 10}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: Part of #59099
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
