### PR TITLE
Allow specifying a custom log function for template render

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -786,7 +786,7 @@ jobs:
               2>&1 | tee pytest-${{ matrix.python-version }}-${{ matrix.group }}.txt
       - name: Run pytest (partially)
         if: needs.info.outputs.test_full_suite == 'false'
-        timeout-minutes: 10
+        timeout-minutes: 1
         id: pytest-partial
         shell: bash
         env:
@@ -809,9 +809,8 @@ jobs:
           fi
 
           python3 -X dev -m pytest \
-            -vv \
+            -svv \
             --timeout=9 \
-            -n auto \
             ${cov_params[@]} \
             -o console_output_style=count \
             --durations=0 \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -188,16 +188,6 @@ jobs:
             skip_coverage="true"
           fi
 
-          # Temporary hack
-          mariadb_groups="[]"
-          postgresql_groups="[]"
-          test_full_suite="false"
-          integrations_glob="websocket_api"
-          test_group_count=1
-          test_groups="[\"websocket_api\"]"
-          tests="[\"websocket_api\"]"
-          tests_glob="websocket_api"
-
           # Output & sent to GitHub Actions
           echo "mariadb_groups: ${mariadb_groups}"
           echo "mariadb_groups=${mariadb_groups}" >> $GITHUB_OUTPUT
@@ -786,7 +776,7 @@ jobs:
               2>&1 | tee pytest-${{ matrix.python-version }}-${{ matrix.group }}.txt
       - name: Run pytest (partially)
         if: needs.info.outputs.test_full_suite == 'false'
-        timeout-minutes: 1
+        timeout-minutes: 10
         id: pytest-partial
         shell: bash
         env:
@@ -809,8 +799,9 @@ jobs:
           fi
 
           python3 -X dev -m pytest \
-            -svv \
+            -qq \
             --timeout=9 \
+            -n auto \
             ${cov_params[@]} \
             -o console_output_style=count \
             --durations=0 \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -809,7 +809,7 @@ jobs:
           fi
 
           python3 -X dev -m pytest \
-            -qq \
+            -vv \
             --timeout=9 \
             -n auto \
             ${cov_params[@]} \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -188,6 +188,16 @@ jobs:
             skip_coverage="true"
           fi
 
+          # Temporary hack
+          mariadb_groups="[]"
+          postgresql_groups="[]"
+          test_full_suite="false"
+          integrations_glob="websocket_api"
+          test_group_count=1
+          test_groups="[\"websocket_api\"]"
+          tests="[\"websocket_api\"]"
+          tests_glob="websocket_api"
+
           # Output & sent to GitHub Actions
           echo "mariadb_groups: ${mariadb_groups}"
           echo "mariadb_groups=${mariadb_groups}" >> $GITHUB_OUTPUT

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -524,6 +524,8 @@ async def handle_render_template(
 
     @callback
     def _error_listener(template_error: str) -> None:
+        if not report_errors:
+            return
         connection.send_message(
             messages.event_message(msg["id"], {"error": template_error})
         )
@@ -555,6 +557,8 @@ async def handle_render_template(
         track_template_result = updates.pop()
         result = track_template_result.result
         if isinstance(result, TemplateError):
+            if not report_errors:
+                return
             connection.send_message(
                 messages.event_message(msg["id"], {"error": str(result)})
             )

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -513,7 +513,11 @@ async def handle_render_template(
 ) -> None:
     """Handle render_template command."""
     template_str = msg["template"]
-    template_obj = _cached_template(template_str, hass)
+    report_errors: bool = msg["report_errors"]
+    if report_errors:
+        template_obj = template.Template(template_str, hass)
+    else:
+        template_obj = _cached_template(template_str, hass)
     variables = msg.get("variables")
     timeout = msg.get("timeout")
 
@@ -521,7 +525,7 @@ async def handle_render_template(
     def _error_listener(template_error: str) -> None:
         connection.send_error(msg["id"], const.ERR_TEMPLATE_ERROR, template_error)
 
-    log_fn = _error_listener if msg["report_errors"] else None
+    log_fn = _error_listener if report_errors else None
 
     if timeout:
         try:

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -504,6 +504,7 @@ def _cached_template(template_str: str, hass: HomeAssistant) -> template.Templat
         vol.Optional("entity_ids"): cv.entity_ids,
         vol.Optional("variables"): dict,
         vol.Optional("timeout"): vol.Coerce(float),
+        vol.Optional("strict", default=False): bool,
         vol.Optional("report_errors", default=False): bool,
     }
 )
@@ -532,7 +533,7 @@ async def handle_render_template(
     if timeout:
         try:
             timed_out = await template_obj.async_render_will_timeout(
-                timeout, variables, log_fn=log_fn
+                timeout, variables, strict=msg["strict"], log_fn=log_fn
             )
         except TemplateError as ex:
             connection.send_error(msg["id"], const.ERR_TEMPLATE_ERROR, str(ex))
@@ -571,6 +572,7 @@ async def handle_render_template(
             [TrackTemplate(template_obj, variables)],
             _template_listener,
             raise_on_template_error=True,
+            strict=msg["strict"],
             log_fn=log_fn,
         )
     except TemplateError as ex:

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -523,7 +523,9 @@ async def handle_render_template(
 
     @callback
     def _error_listener(template_error: str) -> None:
-        connection.send_error(msg["id"], const.ERR_TEMPLATE_ERROR, template_error)
+        connection.send_message(
+            messages.event_message(msg["id"], {"error": template_error})
+        )
 
     log_fn = _error_listener if report_errors else None
 
@@ -552,7 +554,9 @@ async def handle_render_template(
         track_template_result = updates.pop()
         result = track_template_result.result
         if isinstance(result, TemplateError):
-            connection.send_error(msg["id"], const.ERR_TEMPLATE_ERROR, str(result))
+            connection.send_message(
+                messages.event_message(msg["id"], {"error": str(result)})
+            )
             return
 
         connection.send_message(

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -524,7 +524,7 @@ async def handle_render_template(
     timeout = msg.get("timeout")
 
     @callback
-    def _error_listener(template_error: str, level: int) -> None:
+    def _error_listener(level: int, template_error: str) -> None:
         connection.send_message(
             messages.event_message(
                 msg["id"],
@@ -533,8 +533,8 @@ async def handle_render_template(
         )
 
     @callback
-    def _thread_safe_error_listener(template_error: str, level: int) -> None:
-        hass.loop.call_soon_threadsafe(_error_listener, template_error, level)
+    def _thread_safe_error_listener(level: int, template_error: str) -> None:
+        hass.loop.call_soon_threadsafe(_error_listener, level, template_error)
 
     if timeout:
         try:

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -919,7 +919,7 @@ class TrackTemplateResultInfo:
         self,
         raise_on_template_error: bool,
         strict: bool = False,
-        log_fn: Callable[[str], None] | None = None,
+        log_fn: Callable[[str, int], None] | None = None,
     ) -> None:
         """Activation of template tracking."""
         block_render = False
@@ -1238,7 +1238,7 @@ def async_track_template_result(
     action: TrackTemplateResultListener,
     raise_on_template_error: bool = False,
     strict: bool = False,
-    log_fn: Callable[[str], None] | None = None,
+    log_fn: Callable[[str, int], None] | None = None,
     has_super_template: bool = False,
 ) -> TrackTemplateResultInfo:
     """Add a listener that fires when the result of a template changes.

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -918,6 +918,7 @@ class TrackTemplateResultInfo:
     def async_setup(
         self,
         raise_on_template_error: bool,
+        strict: bool = False,
         log_fn: Callable[[str], None] | None = None,
     ) -> None:
         """Activation of template tracking."""
@@ -929,7 +930,7 @@ class TrackTemplateResultInfo:
             template = super_template.template
             variables = super_template.variables
             self._info[template] = info = template.async_render_to_info(
-                variables, log_fn=log_fn
+                variables, strict=strict, log_fn=log_fn
             )
 
             # If the super template did not render to True, don't update other templates
@@ -950,7 +951,7 @@ class TrackTemplateResultInfo:
             template = track_template_.template
             variables = track_template_.variables
             self._info[template] = info = template.async_render_to_info(
-                variables, log_fn=log_fn
+                variables, strict=strict, log_fn=log_fn
             )
 
             if info.exception:
@@ -1236,6 +1237,7 @@ def async_track_template_result(
     track_templates: Sequence[TrackTemplate],
     action: TrackTemplateResultListener,
     raise_on_template_error: bool = False,
+    strict: bool = False,
     log_fn: Callable[[str], None] | None = None,
     has_super_template: bool = False,
 ) -> TrackTemplateResultInfo:
@@ -1266,6 +1268,8 @@ def async_track_template_result(
         processing the template during setup, the system
         will raise the exception instead of setting up
         tracking.
+    strict
+        When set to True, raise on undefined variables
     log_fn
         If not None, template error messages will logging by calling log_fn
         instead of the normal logging facility.
@@ -1279,7 +1283,7 @@ def async_track_template_result(
 
     """
     tracker = TrackTemplateResultInfo(hass, track_templates, action, has_super_template)
-    tracker.async_setup(raise_on_template_error, log_fn=log_fn)
+    tracker.async_setup(raise_on_template_error, strict=strict, log_fn=log_fn)
     return tracker
 
 

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1269,7 +1269,7 @@ def async_track_template_result(
         will raise the exception instead of setting up
         tracking.
     strict
-        When set to True, raise on undefined variables
+        When set to True, raise on undefined variables.
     log_fn
         If not None, template error messages will logging by calling log_fn
         instead of the normal logging facility.

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -919,7 +919,7 @@ class TrackTemplateResultInfo:
         self,
         raise_on_template_error: bool,
         strict: bool = False,
-        log_fn: Callable[[str, int], None] | None = None,
+        log_fn: Callable[[int, str], None] | None = None,
     ) -> None:
         """Activation of template tracking."""
         block_render = False
@@ -1238,7 +1238,7 @@ def async_track_template_result(
     action: TrackTemplateResultListener,
     raise_on_template_error: bool = False,
     strict: bool = False,
-    log_fn: Callable[[str, int], None] | None = None,
+    log_fn: Callable[[int, str], None] | None = None,
     has_super_template: bool = False,
 ) -> TrackTemplateResultInfo:
     """Add a listener that fires when the result of a template changes.

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -643,25 +643,35 @@ class Template:
         self._exc_info = None
         finish_event = asyncio.Event()
 
+        # pylint: disable=hass-logger-capital, unnecessary-pass
+
         def _render_template() -> None:
+            _LOGGER.info("_render_template enter")
             assert self.hass is not None, "hass variable not set on template"
             try:
                 _render_with_context(self.template, compiled, **kwargs)
             except TimeoutError:
+                _LOGGER.exception("_render_template timeout")
                 pass
             except Exception:  # pylint: disable=broad-except
                 self._exc_info = sys.exc_info()
+                _LOGGER.exception("_render_template exception")
             finally:
                 run_callback_threadsafe(self.hass.loop, finish_event.set)
+            _LOGGER.info("_render_template leave")
 
         try:
+            _LOGGER.info("start render thread")
             template_render_thread = ThreadWithException(target=_render_template)
             template_render_thread.start()
             async with asyncio.timeout(timeout):
+                _LOGGER.info("wait render thread")
                 await finish_event.wait()
+            _LOGGER.info("render thread done")
             if self._exc_info:
                 raise TemplateError(self._exc_info[1].with_traceback(self._exc_info[2]))
         except asyncio.TimeoutError:
+            _LOGGER.info("kill render thread")
             template_render_thread.raise_exc(TimeoutError)
             return True
         finally:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -484,11 +484,11 @@ class Template:
         wanted_env = _ENVIRONMENT_LIMITED if self._limited else _ENVIRONMENT
         ret: TemplateEnvironment | None = None
         # Bypass cache if a custom log function is specified
-        if self._log_fn is not None:
+        if self._log_fn is None:
             ret = self.hass.data.get(wanted_env)
         if ret is None:
             ret = TemplateEnvironment(self.hass, self._limited, self._log_fn)
-        if self._log_fn is not None:
+        if self._log_fn is None:
             self.hass.data[wanted_env] = ret
         return ret
 

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -1240,11 +1240,9 @@ EMPTY_LISTENERS = {"all": False, "entities": [], "domains": [], "time": False}
             "{{ my_unknown_func() + 1 }}",
             [
                 {
-                    "type": "result",
-                    "success": False,
-                    "error": {
-                        "code": "template_error",
-                        "message": (
+                    "type": "event",
+                    "event": {
+                        "error": (
                             "Template variable error: 'my_unknown_func' is undefined "
                             "when rendering '{{ my_unknown_func() + 1 }}'"
                         ),
@@ -1264,11 +1262,9 @@ EMPTY_LISTENERS = {"all": False, "entities": [], "domains": [], "time": False}
             "{{ my_unknown_var }}",
             [
                 {
-                    "type": "result",
-                    "success": False,
-                    "error": {
-                        "code": "template_error",
-                        "message": (
+                    "type": "event",
+                    "event": {
+                        "error": (
                             "Template variable warning: 'my_unknown_var' is undefined "
                             "when rendering '{{ my_unknown_var }}'"
                         ),
@@ -1276,11 +1272,9 @@ EMPTY_LISTENERS = {"all": False, "entities": [], "domains": [], "time": False}
                 },
                 {"success": True},
                 {
-                    "type": "result",
-                    "success": False,
-                    "error": {
-                        "code": "template_error",
-                        "message": (
+                    "type": "event",
+                    "event": {
+                        "error": (
                             "Template variable warning: 'my_unknown_var' is undefined "
                             "when rendering '{{ my_unknown_var }}'"
                         ),

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -1359,7 +1359,7 @@ async def test_render_template_with_timeout_and_error(
     expected_events: list[dict[str, str]],
 ) -> None:
     """Test a template with an error with a timeout."""
-    caplog.set_level(logging.INFO)
+    caplog.set_level(logging.DEBUG)
     await websocket_client.send_json(
         {
             "id": 5,
@@ -1371,13 +1371,13 @@ async def test_render_template_with_timeout_and_error(
     )
 
     for expected_event in expected_events:
-        msg = await websocket_client.receive_json()
+        msg = await websocket_client.receive_json(timeout=0.5)
         assert msg["id"] == 5
         for key, value in expected_event.items():
             assert msg[key] == value
 
-    assert "Template variable error" not in caplog.text
-    assert "TemplateError" not in caplog.text
+    # assert "Template variable error" not in caplog.text
+    # assert "TemplateError" not in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -1234,19 +1234,25 @@ EMPTY_LISTENERS = {"all": False, "entities": [], "domains": [], "time": False}
 
 ERR_MSG = {"type": "result", "success": False}
 
-VARIABLE_ERROR_UNDEFINED_FUNC = (
-    "Template variable error: 'my_unknown_func' is undefined "
-    "when rendering '{{ my_unknown_func() + 1 }}'"
-)
+VARIABLE_ERROR_UNDEFINED_FUNC = {
+    "error": (
+        "Template variable error: 'my_unknown_func' is undefined "
+        "when rendering '{{ my_unknown_func() + 1 }}'"
+    ),
+    "level": "ERROR",
+}
 TEMPLATE_ERROR_UNDEFINED_FUNC = {
     "code": "template_error",
     "message": "UndefinedError: 'my_unknown_func' is undefined",
 }
 
-VARIABLE_ERROR_UNDEFINED_VAR = (
-    "Template variable warning: 'my_unknown_var' is undefined "
-    "when rendering '{{ my_unknown_var }}'"
-)
+VARIABLE_WARNING_UNDEFINED_VAR = {
+    "error": (
+        "Template variable warning: 'my_unknown_var' is undefined "
+        "when rendering '{{ my_unknown_var }}'"
+    ),
+    "level": "WARNING",
+}
 TEMPLATE_ERROR_UNDEFINED_VAR = {
     "code": "template_error",
     "message": "UndefinedError: 'my_unknown_var' is undefined",
@@ -1264,16 +1270,16 @@ TEMPLATE_ERROR_UNDEFINED_FILTER = {
         (
             "{{ my_unknown_func() + 1 }}",
             [
-                {"type": "event", "event": {"error": VARIABLE_ERROR_UNDEFINED_FUNC}},
+                {"type": "event", "event": VARIABLE_ERROR_UNDEFINED_FUNC},
                 ERR_MSG | {"error": TEMPLATE_ERROR_UNDEFINED_FUNC},
             ],
         ),
         (
             "{{ my_unknown_var }}",
             [
-                {"type": "event", "event": {"error": VARIABLE_ERROR_UNDEFINED_VAR}},
+                {"type": "event", "event": VARIABLE_WARNING_UNDEFINED_VAR},
                 {"type": "result", "success": True, "result": None},
-                {"type": "event", "event": {"error": VARIABLE_ERROR_UNDEFINED_VAR}},
+                {"type": "event", "event": VARIABLE_WARNING_UNDEFINED_VAR},
                 {
                     "type": "event",
                     "event": {"result": "", "listeners": EMPTY_LISTENERS},
@@ -1325,16 +1331,16 @@ async def test_render_template_with_error(
         (
             "{{ my_unknown_func() + 1 }}",
             [
-                {"type": "event", "event": {"error": VARIABLE_ERROR_UNDEFINED_FUNC}},
+                {"type": "event", "event": VARIABLE_ERROR_UNDEFINED_FUNC},
                 ERR_MSG | {"error": TEMPLATE_ERROR_UNDEFINED_FUNC},
             ],
         ),
         (
             "{{ my_unknown_var }}",
             [
-                {"type": "event", "event": {"error": VARIABLE_ERROR_UNDEFINED_VAR}},
+                {"type": "event", "event": VARIABLE_WARNING_UNDEFINED_VAR},
                 {"type": "result", "success": True, "result": None},
-                {"type": "event", "event": {"error": VARIABLE_ERROR_UNDEFINED_VAR}},
+                {"type": "event", "event": VARIABLE_WARNING_UNDEFINED_VAR},
                 {
                     "type": "event",
                     "event": {"result": "", "listeners": EMPTY_LISTENERS},

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -1235,10 +1235,7 @@ EMPTY_LISTENERS = {"all": False, "entities": [], "domains": [], "time": False}
 ERR_MSG = {"type": "result", "success": False}
 
 VARIABLE_ERROR_UNDEFINED_FUNC = {
-    "error": (
-        "Template variable error: 'my_unknown_func' is undefined "
-        "when rendering '{{ my_unknown_func() + 1 }}'"
-    ),
+    "error": "'my_unknown_func' is undefined",
     "level": "ERROR",
 }
 TEMPLATE_ERROR_UNDEFINED_FUNC = {
@@ -1247,10 +1244,7 @@ TEMPLATE_ERROR_UNDEFINED_FUNC = {
 }
 
 VARIABLE_WARNING_UNDEFINED_VAR = {
-    "error": (
-        "Template variable warning: 'my_unknown_var' is undefined "
-        "when rendering '{{ my_unknown_var }}'"
-    ),
+    "error": "'my_unknown_var' is undefined",
     "level": "WARNING",
 }
 TEMPLATE_ERROR_UNDEFINED_VAR = {
@@ -1512,9 +1506,7 @@ async def test_render_template_with_delayed_error(
     assert msg["id"] == 5
     assert msg["type"] == "event"
     event = msg["event"]
-    assert event["error"].startswith(
-        "Template variable warning: 'None' has no attribute 'state'"
-    )
+    assert event["error"] == "'None' has no attribute 'state'"
 
     msg = await websocket_client.receive_json()
     assert msg["id"] == 5

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -1371,7 +1371,7 @@ async def test_render_template_with_timeout_and_error(
     )
 
     for expected_event in expected_events:
-        msg = await websocket_client.receive_json(timeout=0.5)
+        msg = await websocket_client.receive_json(timeout=8)
         assert msg["id"] == 5
         for key, value in expected_event.items():
             assert msg[key] == value

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -1463,7 +1463,12 @@ async def test_render_template_with_delayed_error(
     """
 
     await websocket_client.send_json(
-        {"id": 5, "type": "render_template", "template": template_str}
+        {
+            "id": 5,
+            "type": "render_template",
+            "template": template_str,
+            "report_errors": True,
+        }
     )
     await hass.async_block_till_done()
 
@@ -1489,6 +1494,14 @@ async def test_render_template_with_delayed_error(
             "time": False,
         },
     }
+
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 5
+    assert msg["type"] == "event"
+    event = msg["event"]
+    assert event["error"].startswith(
+        "Template variable warning: 'None' has no attribute 'state'"
+    )
 
     msg = await websocket_client.receive_json()
     assert msg["id"] == 5

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -1332,7 +1332,6 @@ async def test_render_template_with_error(
             "{{ my_unknown_var }}",
             [
                 {"type": "event", "event": {"error": VARIABLE_ERROR_UNDEFINED_VAR}},
-                {"type": "event", "event": {"error": VARIABLE_ERROR_UNDEFINED_VAR}},
                 {"type": "result", "success": True, "result": None},
                 {"type": "event", "event": {"error": VARIABLE_ERROR_UNDEFINED_VAR}},
                 {

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -1358,7 +1358,7 @@ async def test_render_template_with_timeout_and_error(
     expected_events: list[dict[str, str]],
 ) -> None:
     """Test a template with an error with a timeout."""
-    caplog.set_level(logging.DEBUG)
+    caplog.set_level(logging.INFO)
     await websocket_client.send_json(
         {
             "id": 5,
@@ -1370,13 +1370,13 @@ async def test_render_template_with_timeout_and_error(
     )
 
     for expected_event in expected_events:
-        msg = await websocket_client.receive_json(timeout=8)
+        msg = await websocket_client.receive_json()
         assert msg["id"] == 5
         for key, value in expected_event.items():
             assert msg[key] == value
 
-    # assert "Template variable error" not in caplog.text
-    # assert "TemplateError" not in caplog.text
+    assert "Template variable error" not in caplog.text
+    assert "TemplateError" not in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -1359,13 +1359,14 @@ async def test_render_template_with_timeout_and_error(
     hass: HomeAssistant, websocket_client, caplog: pytest.LogCaptureFixture, template
 ) -> None:
     """Test a template with an error with a timeout."""
+    caplog.set_level(logging.INFO)
     await websocket_client.send_json(
         {
             "id": 5,
             "type": "render_template",
             "template": template,
             "timeout": 5,
-            "strict": True,
+            "report_errors": True,
         }
     )
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -4466,15 +4466,25 @@ async def test_parse_result(hass: HomeAssistant) -> None:
         assert template.Template(tpl, hass).async_render() == result
 
 
-async def test_undefined_variable(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+@pytest.mark.parametrize(
+    "template_string",
+    [
+        "{{ no_such_variable }}",
+        "{{ no_such_variable and True }}",
+        "{{ no_such_variable | join(', ') }}",
+    ],
+)
+async def test_undefined_symbol_warnings(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    template_string: str,
 ) -> None:
     """Test a warning is logged on undefined variables."""
-    tpl = template.Template("{{ no_such_variable }}", hass)
+    tpl = template.Template(template_string, hass)
     assert tpl.async_render() == ""
     assert (
         "Template variable warning: 'no_such_variable' is undefined when rendering "
-        "'{{ no_such_variable }}'" in caplog.text
+        f"'{template_string}'" in caplog.text
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow specifying a custom log function for template render and use it for the `render_template` WS command

Drop the `strict` parameter to the `render_template`

### Background:
The `strict` parameter to the `render_template` was added to avoid logging errors from the template developer tool. However, the `strict` mode also unintentionally changed the result when rendering templates.
This PR captures the log messages and send them over the websocket without affecting the result of rendering templates.

Needs (and currently includes) https://github.com/home-assistant/core/pull/99571


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
