### PR TITLE
overkiz: Add set_cover_position_and_tilt service

### DIFF
--- a/homeassistant/components/overkiz/cover.py
+++ b/homeassistant/components/overkiz/cover.py
@@ -1,9 +1,16 @@
 """Support for Overkiz covers - shutters etc."""
 from pyoverkiz.enums import OverkizCommand, UIClass
+import voluptuous as vol
 
+from homeassistant.components.cover import (
+    ATTR_POSITION,
+    ATTR_TILT_POSITION,
+    CoverEntityFeature,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HomeAssistantOverkizData
@@ -11,6 +18,8 @@ from .const import DOMAIN
 from .cover_entities.awning import Awning
 from .cover_entities.generic_cover import OverkizGenericCover
 from .cover_entities.vertical_cover import LowSpeedCover, VerticalCover
+
+SERVICE_SET_COVER_POSITION = "set_cover_position_and_tilt"
 
 
 async def async_setup_entry(
@@ -38,3 +47,18 @@ async def async_setup_entry(
     ]
 
     async_add_entities(entities)
+
+    platform = entity_platform.async_get_current_platform()
+    platform.async_register_entity_service(
+        SERVICE_SET_COVER_POSITION,
+        {
+            vol.Required(ATTR_POSITION): vol.All(
+                vol.Coerce(int), vol.Range(min=0, max=100)
+            ),
+            vol.Required(ATTR_TILT_POSITION): vol.All(
+                vol.Coerce(int), vol.Range(min=0, max=100)
+            ),
+        },
+        "async_set_cover_position_and_tilt",
+        [CoverEntityFeature.SET_POSITION, CoverEntityFeature.SET_TILT_POSITION],
+    )

--- a/homeassistant/components/overkiz/cover_entities/vertical_cover.py
+++ b/homeassistant/components/overkiz/cover_entities/vertical_cover.py
@@ -13,6 +13,7 @@ from pyoverkiz.enums import (
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
+    ATTR_TILT_POSITION,
     CoverDeviceClass,
     CoverEntityFeature,
 )
@@ -40,6 +41,8 @@ OVERKIZ_DEVICE_TO_DEVICE_CLASS = {
     UIClass.SWINGING_SHUTTER: CoverDeviceClass.SHUTTER,
     UIClass.WINDOW: CoverDeviceClass.WINDOW,
 }
+
+SERVICE_SET_COVER_POSITION = "set_cover_position_and_tilt"
 
 
 class VerticalCover(OverkizGenericCover):
@@ -106,6 +109,17 @@ class VerticalCover(OverkizGenericCover):
         """Close the cover."""
         if command := self.executor.select_command(*COMMANDS_CLOSE):
             await self.executor.async_execute_command(command)
+
+    async def async_set_cover_position_and_tilt(self, **kwargs: Any) -> None:
+        """Move the cover position and tilt to a specific position."""
+        if command := self.executor.select_command(
+            *[OverkizCommand.SET_CLOSURE_AND_ORIENTATION]
+        ):
+            await self.executor.async_execute_command(
+                command,
+                100 - kwargs[ATTR_POSITION],
+                100 - kwargs[ATTR_TILT_POSITION],
+            )
 
     @property
     def is_opening(self) -> bool | None:

--- a/homeassistant/components/overkiz/manifest.json
+++ b/homeassistant/components/overkiz/manifest.json
@@ -13,7 +13,7 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "loggers": ["boto3", "botocore", "pyhumps", "pyoverkiz", "s3transfer"],
-  "requirements": ["pyoverkiz==1.9.0"],
+  "requirements": ["pyoverkiz==1.11.0"],
   "zeroconf": [
     {
       "type": "_kizbox._tcp.local.",

--- a/homeassistant/components/overkiz/services.yaml
+++ b/homeassistant/components/overkiz/services.yaml
@@ -1,0 +1,26 @@
+set_cover_position_and_tilt:
+  target:
+    entity:
+      integration: overkiz
+      domain: cover
+  fields:
+    position:
+      required: true
+      example: 30
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          unit_of_measurement: "%"
+          mode: slider
+    tilt_position:
+      required: true
+      example: 30
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          unit_of_measurement: "%"
+          mode: slider

--- a/homeassistant/components/overkiz/strings.json
+++ b/homeassistant/components/overkiz/strings.json
@@ -128,5 +128,21 @@
         }
       }
     }
+  },
+  "services": {
+    "set_cover_position_and_tilt": {
+      "name": "Set cover position and tilt",
+      "description": "Set cover position and tilt.",
+      "fields": {
+        "position": {
+          "name": "Position",
+          "description": "Position of the cover."
+        },
+        "tilt_position": {
+          "name": "Tilt Position",
+          "description": "Tilt position of the cover."
+        }
+      }
+    }
   }
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1925,7 +1925,7 @@ pyotgw==2.1.3
 pyotp==2.8.0
 
 # homeassistant.components.overkiz
-pyoverkiz==1.9.0
+pyoverkiz==1.11.0
 
 # homeassistant.components.openweathermap
 pyowm==3.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1450,7 +1450,7 @@ pyotgw==2.1.3
 pyotp==2.8.0
 
 # homeassistant.components.overkiz
-pyoverkiz==1.9.0
+pyoverkiz==1.11.0
 
 # homeassistant.components.openweathermap
 pyowm==3.2.0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Somfy J4 protect motors support setting the cover position and tilt
position in one command.

The main advantage for using this command (compared to individual
commands) is that the slides will not change the orientation if the
motor is already in the correct closure position. There's also no need
to wait for the target position to be reached before modifying the
orientation. It's also helpful for automating multiple motors, because
it allows that in less commands overall.

Needs a new version of the `python-overkiz-api` that includes https://github.com/iMicknl/python-overkiz-api/pull/955.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/iMicknl/python-overkiz-api/pull/955, https://github.com/iMicknl/ha-tahoma/issues/788
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
