### PR TITLE
group: Fix executing services on new style groups

### DIFF
--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -35,7 +35,11 @@ from homeassistant.core import (
     split_entity_id,
 )
 from homeassistant.helpers import config_validation as cv, entity_registry as er, start
-from homeassistant.helpers.entity import Entity, async_generate_entity_id
+from homeassistant.helpers.entity import (
+    Entity,
+    async_generate_entity_id,
+    entity_sources,
+)
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.event import (
     EventStateChangedData,
@@ -183,7 +187,10 @@ def expand_entity_ids(hass: HomeAssistant, entity_ids: Iterable[Any]) -> list[st
 
         entity_id = entity_id.lower()
         # If entity_id points at a group, expand it
-        if entity_id.startswith(ENTITY_PREFIX):
+        if entity_id.startswith(ENTITY_PREFIX) or (
+            (source := entity_sources(hass).get(entity_id))
+            and source["domain"] == "group"
+        ):
             child_entities = get_entity_ids(hass, entity_id)
             if entity_id in child_entities:
                 child_entities = list(child_entities)

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -240,6 +240,29 @@ async def test_expand_entity_ids_ignores_non_strings(hass: HomeAssistant) -> Non
     assert [] == group.expand_entity_ids(hass, [5, True])
 
 
+async def test_expand_entity_ids_domain_group(hass: HomeAssistant) -> None:
+    """Test expand_entity_ids with domain group."""
+    hass.states.async_set("light.Bowl", STATE_ON)
+    hass.states.async_set("light.Ceiling", STATE_OFF)
+
+    assert await async_setup_component(
+        hass,
+        "light",
+        {
+            "light": {
+                "platform": "group",
+                "name": "Grouped",
+                "entities": ["light.bowl", "light.ceiling"],
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert sorted(["light.ceiling", "light.bowl"]) == sorted(
+        group.expand_entity_ids(hass, ["light.grouped"])
+    )
+
+
 async def test_get_entity_ids(hass: HomeAssistant) -> None:
     """Test get_entity_ids method."""
     hass.states.async_set("light.Bowl", STATE_ON)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently a group entity id in service calls is only correctly expanded if it uses the `group` platform (= old style groups). Trying to execute a service for a new style group will lead to an error message: "Referenced entities cover.livingroom are missing or not currently available".

The code extends the `expand_entity_ids` function to not only check the `group` platform but additionally also the `group` domain. This way it's possible to execute services on groups that belong for example to a `cover` group.

While testing #99589, I noticed that I cannot use the newly added service on my `cover.livingroom` group that I created through the UI in helpers/groups.

I've fixed the issue in the same way than it was fixed for templates in https://github.com/home-assistant/core/pull/68875/.

---
**Remark:** The groups (neither `cover.livingroom` nor `group.livingroup`) still do not show up in the developer tools. I can't tell if that's a generic problem, of an issue specific to the newly added service. I'd need some guidance for fixing this, but that should happen in a different PR anyhow because it's not really related to expanding groups.

![grafik](https://github.com/home-assistant/core/assets/1133994/481ea893-f210-44ee-9ee9-bcc922e2e23c)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
