### PR TITLE
Change duration for timer.start service to only change running duration

### DIFF
--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -278,12 +278,14 @@ class Timer(collection.CollectionEntity, RestoreEntity):
 
         # Begin restoring state
         self._state = state.state
-        self._duration = cv.time_period(state.attributes[ATTR_DURATION])
 
         # Nothing more to do if the timer is idle
         if self._state == STATUS_IDLE:
+            self._duration = cv.time_period(state.attributes[ATTR_DURATION])
             return
 
+        self._duration = cv.time_period_str(self._config[CONF_DURATION])
+        self._running_duration = cv.time_period(state.attributes[ATTR_DURATION])
         # If the timer was paused, we restore the remaining time
         if self._state == STATUS_PAUSED:
             self._remaining = cv.time_period(state.attributes[ATTR_REMAINING])

--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -317,11 +317,11 @@ class Timer(collection.CollectionEntity, RestoreEntity):
         self._state = STATUS_ACTIVE
         start = dt_util.utcnow().replace(microsecond=0)
 
-        # Set remaining to new value if needed
+        # Set remaining and running duration unless resuming or restarting
         if duration:
             self._remaining = self._running_duration = duration
         elif not self._remaining:
-            self._remaining = self._duration
+            self._remaining = self._running_duration = self._duration
 
         self._end = start + self._remaining
 
@@ -339,9 +339,13 @@ class Timer(collection.CollectionEntity, RestoreEntity):
             raise HomeAssistantError(
                 f"Timer {self.entity_id} is not running, only active timers can be changed"
             )
-        if self._remaining and (self._remaining + duration) > self._duration:
+        if (
+            self._remaining
+            and self._running_duration
+            and (self._remaining + duration) > self._running_duration
+        ):
             raise HomeAssistantError(
-                f"Not possible to change timer {self.entity_id} beyond configured duration"
+                f"Not possible to change timer {self.entity_id} beyond duration"
             )
         if self._remaining and (self._remaining + duration) < timedelta():
             raise HomeAssistantError(

--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -316,7 +316,7 @@ class Timer(collection.CollectionEntity, RestoreEntity):
 
         # Set remaining to new value if needed
         if duration:
-            self._remaining = self._duration = duration
+            self._remaining = duration
         elif not self._remaining:
             self._remaining = self._duration
 

--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -281,10 +281,8 @@ class Timer(collection.CollectionEntity, RestoreEntity):
 
         # Nothing more to do if the timer is idle
         if self._state == STATUS_IDLE:
-            self._duration = cv.time_period(state.attributes[ATTR_DURATION])
             return
 
-        self._duration = cv.time_period_str(self._config[CONF_DURATION])
         self._running_duration = cv.time_period(state.attributes[ATTR_DURATION])
         # If the timer was paused, we restore the remaining time
         if self._state == STATUS_PAUSED:

--- a/tests/components/timer/test_init.py
+++ b/tests/components/timer/test_init.py
@@ -319,7 +319,7 @@ async def test_start_service(hass: HomeAssistant) -> None:
 
     with pytest.raises(
         HomeAssistantError,
-        match="Not possible to change timer timer.test1 beyond configured duration",
+        match="Not possible to change timer timer.test1 beyond duration",
     ):
         await hass.services.async_call(
             DOMAIN,

--- a/tests/components/timer/test_init.py
+++ b/tests/components/timer/test_init.py
@@ -844,43 +844,6 @@ async def test_setup_no_config(hass: HomeAssistant, hass_admin_user: MockUser) -
     assert count_start == len(hass.states.async_entity_ids())
 
 
-async def test_restore_idle(hass: HomeAssistant) -> None:
-    """Test entity restore logic when timer is idle."""
-    utc_now = utcnow()
-    stored_state = StoredState(
-        State(
-            "timer.test",
-            STATUS_IDLE,
-            {ATTR_DURATION: "0:00:30"},
-        ),
-        None,
-        utc_now,
-    )
-
-    data = async_get(hass)
-    await data.store.async_save([stored_state.as_dict()])
-    await data.async_load()
-
-    entity = Timer.from_storage(
-        {
-            CONF_ID: "test",
-            CONF_NAME: "test",
-            CONF_DURATION: "0:01:00",
-            CONF_RESTORE: True,
-        }
-    )
-    entity.hass = hass
-    entity.entity_id = "timer.test"
-
-    await entity.async_added_to_hass()
-    await hass.async_block_till_done()
-    assert entity.state == STATUS_IDLE
-    assert entity.extra_state_attributes[ATTR_DURATION] == "0:01:00"
-    assert ATTR_REMAINING not in entity.extra_state_attributes
-    assert ATTR_FINISHES_AT not in entity.extra_state_attributes
-    assert entity.extra_state_attributes[ATTR_RESTORE]
-
-
 @pytest.mark.freeze_time("2023-06-05 17:47:50")
 async def test_restore_paused(hass: HomeAssistant) -> None:
     """Test entity restore logic when timer is paused."""

--- a/tests/components/timer/test_init.py
+++ b/tests/components/timer/test_init.py
@@ -314,7 +314,7 @@ async def test_start_service(hass: HomeAssistant) -> None:
     state = hass.states.get("timer.test1")
     assert state
     assert state.state == STATUS_ACTIVE
-    assert state.attributes[ATTR_DURATION] == "0:00:15"
+    assert state.attributes[ATTR_DURATION] == "0:00:10"
     assert state.attributes[ATTR_REMAINING] == "0:00:15"
 
     with pytest.raises(
@@ -342,14 +342,14 @@ async def test_start_service(hass: HomeAssistant) -> None:
     await hass.services.async_call(
         DOMAIN,
         SERVICE_CHANGE,
-        {CONF_ENTITY_ID: "timer.test1", CONF_DURATION: -3},
+        {CONF_ENTITY_ID: "timer.test1", CONF_DURATION: -7},
         blocking=True,
     )
     state = hass.states.get("timer.test1")
     assert state
     assert state.state == STATUS_ACTIVE
-    assert state.attributes[ATTR_DURATION] == "0:00:15"
-    assert state.attributes[ATTR_REMAINING] == "0:00:12"
+    assert state.attributes[ATTR_DURATION] == "0:00:10"
+    assert state.attributes[ATTR_REMAINING] == "0:00:08"
 
     await hass.services.async_call(
         DOMAIN,
@@ -360,8 +360,8 @@ async def test_start_service(hass: HomeAssistant) -> None:
     state = hass.states.get("timer.test1")
     assert state
     assert state.state == STATUS_ACTIVE
-    assert state.attributes[ATTR_DURATION] == "0:00:15"
-    assert state.attributes[ATTR_REMAINING] == "0:00:14"
+    assert state.attributes[ATTR_DURATION] == "0:00:10"
+    assert state.attributes[ATTR_REMAINING] == "0:00:10"
 
     await hass.services.async_call(
         DOMAIN, SERVICE_CANCEL, {CONF_ENTITY_ID: "timer.test1"}, blocking=True
@@ -370,7 +370,7 @@ async def test_start_service(hass: HomeAssistant) -> None:
     state = hass.states.get("timer.test1")
     assert state
     assert state.state == STATUS_IDLE
-    assert state.attributes[ATTR_DURATION] == "0:00:15"
+    assert state.attributes[ATTR_DURATION] == "0:00:10"
     assert ATTR_REMAINING not in state.attributes
 
     with pytest.raises(
@@ -387,7 +387,7 @@ async def test_start_service(hass: HomeAssistant) -> None:
     state = hass.states.get("timer.test1")
     assert state
     assert state.state == STATUS_IDLE
-    assert state.attributes[ATTR_DURATION] == "0:00:15"
+    assert state.attributes[ATTR_DURATION] == "0:00:10"
     assert ATTR_REMAINING not in state.attributes
 
 

--- a/tests/components/timer/test_init.py
+++ b/tests/components/timer/test_init.py
@@ -314,7 +314,7 @@ async def test_start_service(hass: HomeAssistant) -> None:
     state = hass.states.get("timer.test1")
     assert state
     assert state.state == STATUS_ACTIVE
-    assert state.attributes[ATTR_DURATION] == "0:00:10"
+    assert state.attributes[ATTR_DURATION] == "0:00:15"
     assert state.attributes[ATTR_REMAINING] == "0:00:15"
 
     with pytest.raises(
@@ -348,7 +348,7 @@ async def test_start_service(hass: HomeAssistant) -> None:
     state = hass.states.get("timer.test1")
     assert state
     assert state.state == STATUS_ACTIVE
-    assert state.attributes[ATTR_DURATION] == "0:00:10"
+    assert state.attributes[ATTR_DURATION] == "0:00:15"
     assert state.attributes[ATTR_REMAINING] == "0:00:08"
 
     await hass.services.async_call(
@@ -360,7 +360,7 @@ async def test_start_service(hass: HomeAssistant) -> None:
     state = hass.states.get("timer.test1")
     assert state
     assert state.state == STATUS_ACTIVE
-    assert state.attributes[ATTR_DURATION] == "0:00:10"
+    assert state.attributes[ATTR_DURATION] == "0:00:15"
     assert state.attributes[ATTR_REMAINING] == "0:00:10"
 
     await hass.services.async_call(

--- a/tests/components/timer/test_init.py
+++ b/tests/components/timer/test_init.py
@@ -1007,7 +1007,7 @@ async def test_restore_active_finished_outside_grace(hass: HomeAssistant) -> Non
         await hass.async_block_till_done()
 
     assert entity.state == STATUS_IDLE
-    assert entity.extra_state_attributes[ATTR_DURATION] == "0:00:30"
+    assert entity.extra_state_attributes[ATTR_DURATION] == "0:01:00"
     assert ATTR_REMAINING not in entity.extra_state_attributes
     assert ATTR_FINISHES_AT not in entity.extra_state_attributes
     assert entity.extra_state_attributes[ATTR_RESTORE]

--- a/tests/components/timer/test_init.py
+++ b/tests/components/timer/test_init.py
@@ -342,14 +342,14 @@ async def test_start_service(hass: HomeAssistant) -> None:
     await hass.services.async_call(
         DOMAIN,
         SERVICE_CHANGE,
-        {CONF_ENTITY_ID: "timer.test1", CONF_DURATION: -7},
+        {CONF_ENTITY_ID: "timer.test1", CONF_DURATION: -3},
         blocking=True,
     )
     state = hass.states.get("timer.test1")
     assert state
     assert state.state == STATUS_ACTIVE
     assert state.attributes[ATTR_DURATION] == "0:00:15"
-    assert state.attributes[ATTR_REMAINING] == "0:00:08"
+    assert state.attributes[ATTR_REMAINING] == "0:00:12"
 
     await hass.services.async_call(
         DOMAIN,
@@ -361,7 +361,7 @@ async def test_start_service(hass: HomeAssistant) -> None:
     assert state
     assert state.state == STATUS_ACTIVE
     assert state.attributes[ATTR_DURATION] == "0:00:15"
-    assert state.attributes[ATTR_REMAINING] == "0:00:10"
+    assert state.attributes[ATTR_REMAINING] == "0:00:14"
 
     await hass.services.async_call(
         DOMAIN, SERVICE_CANCEL, {CONF_ENTITY_ID: "timer.test1"}, blocking=True

--- a/tests/components/timer/test_init.py
+++ b/tests/components/timer/test_init.py
@@ -875,7 +875,7 @@ async def test_restore_idle(hass: HomeAssistant) -> None:
     await entity.async_added_to_hass()
     await hass.async_block_till_done()
     assert entity.state == STATUS_IDLE
-    assert entity.extra_state_attributes[ATTR_DURATION] == "0:00:30"
+    assert entity.extra_state_attributes[ATTR_DURATION] == "0:01:00"
     assert ATTR_REMAINING not in entity.extra_state_attributes
     assert ATTR_FINISHES_AT not in entity.extra_state_attributes
     assert entity.extra_state_attributes[ATTR_RESTORE]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change so `timer.start` does not modify config but only to adjust the time remaining (config unchanged)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28875

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
