### PR TITLE
Add binary_sensor to Schlage

### DIFF
--- a/homeassistant/components/schlage/__init__.py
+++ b/homeassistant/components/schlage/__init__.py
@@ -11,7 +11,12 @@ from homeassistant.core import HomeAssistant
 from .const import DOMAIN, LOGGER
 from .coordinator import SchlageDataUpdateCoordinator
 
-PLATFORMS: list[Platform] = [Platform.LOCK, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS: list[Platform] = [
+    Platform.BINARY_SENSOR,
+    Platform.LOCK,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/schlage/binary_sensor.py
+++ b/homeassistant/components/schlage/binary_sensor.py
@@ -82,7 +82,7 @@ class SchlageBinarySensor(SchlageEntity, BinarySensorEntity):
         device_id: str,
     ) -> None:
         """Initialize a SchlageBinarySensor."""
-        super().__init__(coordinator=coordinator, device_id=device_id)
+        super().__init__(coordinator, device_id)
         self.entity_description = description
         self._attr_unique_id = f"{device_id}_{self.entity_description.key}"
 

--- a/homeassistant/components/schlage/binary_sensor.py
+++ b/homeassistant/components/schlage/binary_sensor.py
@@ -1,0 +1,92 @@
+"""Platform for Schlage binary_sensor integration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import LockData, SchlageDataUpdateCoordinator
+from .entity import SchlageEntity
+
+
+@dataclass
+class SchlageBinarySensorEntityDescriptionMixin:
+    """Mixin for required keys."""
+
+    # NOTE: This has to be a mixin because these are required keys.
+    # BinarySensorEntityDescription has attributes with default values,
+    # which means we can't inherit from it because you haven't have
+    # non-default arguments follow default arguments in an initializer.
+
+    value_fn: Callable[[LockData], bool]
+
+
+@dataclass
+class SchlageBinarySensorEntityDescription(
+    BinarySensorEntityDescription, SchlageBinarySensorEntityDescriptionMixin
+):
+    """Entity description for a Schlage binary_sensor."""
+
+
+_DESCRIPTIONS: tuple[SchlageBinarySensorEntityDescription] = (
+    SchlageBinarySensorEntityDescription(
+        key="keypad_disabled",
+        translation_key="keypad_disabled",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.lock.keypad_disabled(data.logs),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up binary_sensors based on a config entry."""
+    coordinator: SchlageDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    entities = []
+    for device_id in coordinator.data.locks:
+        for description in _DESCRIPTIONS:
+            entities.append(
+                SchlageBinarySensor(
+                    coordinator=coordinator,
+                    description=description,
+                    device_id=device_id,
+                )
+            )
+    async_add_entities(entities)
+
+
+class SchlageBinarySensor(SchlageEntity, BinarySensorEntity):
+    """Schlage binary_sensor entity."""
+
+    entity_description: SchlageBinarySensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: SchlageDataUpdateCoordinator,
+        description: SchlageBinarySensorEntityDescription,
+        device_id: str,
+    ) -> None:
+        """Initialize a SchlageBinarySensor."""
+        super().__init__(coordinator=coordinator, device_id=device_id)
+        self.entity_description = description
+        self._attr_unique_id = f"{device_id}_{self.entity_description.key}"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the binary_sensor is on."""
+        return self.entity_description.value_fn(self._lock_data)

--- a/homeassistant/components/schlage/strings.json
+++ b/homeassistant/components/schlage/strings.json
@@ -17,6 +17,11 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "keypad_disabled": {
+        "name": "Keypad Disabled"
+      }
+    },
     "switch": {
       "beeper": {
         "name": "Keypress Beep"

--- a/homeassistant/components/schlage/strings.json
+++ b/homeassistant/components/schlage/strings.json
@@ -19,7 +19,7 @@
   "entity": {
     "binary_sensor": {
       "keypad_disabled": {
-        "name": "Keypad Disabled"
+        "name": "Keypad disabled"
       }
     },
     "switch": {

--- a/tests/components/schlage/conftest.py
+++ b/tests/components/schlage/conftest.py
@@ -85,4 +85,5 @@ def mock_lock():
     )
     mock_lock.logs.return_value = []
     mock_lock.last_changed_by.return_value = "thumbturn"
+    mock_lock.keypad_disabled.return_value = False
     return mock_lock

--- a/tests/components/schlage/test_binary_sensor.py
+++ b/tests/components/schlage/test_binary_sensor.py
@@ -1,0 +1,53 @@
+"""Test Schlage binary_sensor."""
+
+from datetime import timedelta
+from unittest.mock import Mock
+
+from pyschlage.exceptions import UnknownError
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.util.dt import utcnow
+
+from tests.common import async_fire_time_changed
+
+
+async def test_keypad_disabled_binary_sensor(
+    hass: HomeAssistant, mock_lock: Mock, mock_added_config_entry: ConfigEntry
+) -> None:
+    """Test the keypad_disabled binary_sensor."""
+    mock_lock.keypad_disabled.reset_mock()
+    mock_lock.keypad_disabled.return_value = True
+
+    # Make the coordinator refresh data.
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=31))
+    await hass.async_block_till_done()
+
+    keypad = hass.states.get("binary_sensor.vault_door_keypad_disabled")
+    assert keypad is not None
+    assert keypad.state == "on"
+    assert keypad.attributes["device_class"] == BinarySensorDeviceClass.PROBLEM
+
+    mock_lock.keypad_disabled.assert_called_once_with([])
+
+
+async def test_keypad_disabled_binary_sensor_use_previous_logs_on_failure(
+    hass: HomeAssistant, mock_lock: Mock, mock_added_config_entry: ConfigEntry
+) -> None:
+    """Test the keypad_disabled binary_sensor."""
+    mock_lock.keypad_disabled.reset_mock()
+    mock_lock.keypad_disabled.return_value = True
+    mock_lock.logs.reset_mock()
+    mock_lock.logs.side_effect = UnknownError("Cannot load logs")
+
+    # Make the coordinator refresh data.
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=31))
+    await hass.async_block_till_done()
+
+    keypad = hass.states.get("binary_sensor.vault_door_keypad_disabled")
+    assert keypad is not None
+    assert keypad.state == "on"
+    assert keypad.attributes["device_class"] == BinarySensorDeviceClass.PROBLEM
+
+    mock_lock.keypad_disabled.assert_called_once_with([])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Add the `binary_sensor` platform to Schlage, with the addition of a `keypad_disabled` entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28784

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
