### PR TITLE
Fix ZHA wrong cover states

### DIFF
--- a/homeassistant/components/zha/cover.py
+++ b/homeassistant/components/zha/cover.py
@@ -282,11 +282,27 @@ class ZhaCover(ZhaEntity, CoverEntity):
             raise HomeAssistantError(f"Failed to open cover tilt: {res[1]}")
         self.async_update_state(STATE_OPENING)
 
+    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+        """Open the cover tilt."""
+        # 0 is open in ZCL
+        res = await self._cover_cluster_handler.go_to_tilt_percentage(0)
+        if res[1] is not Status.SUCCESS:
+            raise HomeAssistantError(f"Failed to open cover tilt: {res[1]}")
+        self.async_update_state(STATE_OPENING)
+
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         res = await self._cover_cluster_handler.down_close()
         if res[1] is not Status.SUCCESS:
             raise HomeAssistantError(f"Failed to close cover: {res[1]}")
+        self.async_update_state(STATE_CLOSING)
+
+    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+        """Close the cover tilt."""
+        # 100 is closed in ZCL
+        res = await self._cover_cluster_handler.go_to_tilt_percentage(100)
+        if res[1] is not Status.SUCCESS:
+            raise HomeAssistantError(f"Failed to close cover tilt: {res[1]}")
         self.async_update_state(STATE_CLOSING)
 
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:


### PR DESCRIPTION
## Proposed change
Bug Fix : https://github.com/home-assistant/core/issues/98933
Currently, the function async_set_position in the class ZhaCover is not able to manage the case when the cover reaches the desired position, causing the state to stay as Opening or Closing. Any final position that is not 0 should set the state to Open.
This fix saves the requested position so ZHA can know when the requested position has been reached and change the state to Open. Note that we need to clear that requested position when the set positon feature is not used to avoid conflicts when using the Open/Close/Stop features.


## Type of change
- [ ] Dependency upgrade
- [X ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #98933


## Checklist
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
