### PR TITLE
Add `event` platform for Shelly gen2 devices

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -73,6 +73,7 @@ RPC_PLATFORMS: Final = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.COVER,
+    Platform.EVENT,
     Platform.LIGHT,
     Platform.SENSOR,
     Platform.SWITCH,

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -426,6 +426,7 @@ class ShellyRpcCoordinator(ShellyCoordinatorBase[RpcDevice]):
         self._ota_event_listeners.append(ota_event_callback)
 
         return _unsubscribe
+
     @callback
     def async_subscribe_input_events(
         self, input_event_callback: Callable[[dict[str, Any]], None]

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -429,16 +429,15 @@ class ShellyRpcCoordinator(ShellyCoordinatorBase[RpcDevice]):
     @callback
     def async_subscribe_input_events(
         self, input_event_callback: Callable[[dict[str, Any]], None]
-    ) -> None:
+    ) -> CALLBACK_TYPE:
         """Subscribe to input events."""
+
+        def _unsubscribe() -> None:
+            self._input_event_listeners.remove(input_event_callback)
+
         self._input_event_listeners.append(input_event_callback)
 
-    @callback
-    def async_unsubscribe_input_events(
-        self, input_event_callback: Callable[[dict[str, Any]], None]
-    ) -> None:
-        """Unsubscribe to input events."""
-        self._input_event_listeners.remove(input_event_callback)
+        return _unsubscribe
 
     @callback
     def async_subscribe_events(

--- a/homeassistant/components/shelly/event.py
+++ b/homeassistant/components/shelly/event.py
@@ -68,7 +68,7 @@ class ShellyRpcEvent(CoordinatorEntity[ShellyRpcCoordinator], EventEntity):
     ) -> None:
         """Initialize Shelly entity."""
         super().__init__(coordinator)
-        self.key = key
+        self.input_index = int(key.split(":")[-1])
         self._attr_device_info = {
             "connections": {(CONNECTION_NETWORK_MAC, coordinator.mac)}
         }
@@ -87,6 +87,6 @@ class ShellyRpcEvent(CoordinatorEntity[ShellyRpcCoordinator], EventEntity):
     @callback
     def _async_handle_event(self, event: dict[str, Any]) -> None:
         """Handle the demo button event."""
-        if event["component"] == self.key:
+        if event["id"] == self.input_index:
             self._trigger_event(event["event"])
             self.async_write_ha_state()

--- a/homeassistant/components/shelly/event.py
+++ b/homeassistant/components/shelly/event.py
@@ -13,7 +13,7 @@ from homeassistant.components.event import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -85,9 +85,9 @@ class ShellyRpcEvent(CoordinatorEntity[ShellyRpcCoordinator], EventEntity):
         """Initialize Shelly entity."""
         super().__init__(coordinator)
         self.input_index = int(key.split(":")[-1])
-        self._attr_device_info = {
-            "connections": {(CONNECTION_NETWORK_MAC, coordinator.mac)}
-        }
+        self._attr_device_info = DeviceInfo(
+            connections={(CONNECTION_NETWORK_MAC, coordinator.mac)}
+        )
         self._attr_unique_id = f"{coordinator.mac}-{key}"
         self._attr_name = get_rpc_input_name(coordinator.device, key)
         self.entity_description = description

--- a/homeassistant/components/shelly/event.py
+++ b/homeassistant/components/shelly/event.py
@@ -29,13 +29,13 @@ from .utils import (
 
 
 @dataclass
-class RpcEventDescription(EventEntityDescription):
-    """Class to describe a RPC event."""
+class ShellyEventDescription(EventEntityDescription):
+    """Class to describe Shelly event."""
 
     removal_condition: Callable[[dict, dict, str], bool] | None = None
 
 
-RPC_EVENT: Final = RpcEventDescription(
+RPC_EVENT: Final = ShellyEventDescription(
     key="input",
     device_class=EventDeviceClass.BUTTON,
     event_types=list(RPC_INPUTS_EVENTS_TYPES),
@@ -71,16 +71,16 @@ async def async_setup_entry(
 
 
 class ShellyRpcEvent(CoordinatorEntity[ShellyRpcCoordinator], EventEntity):
-    """Represent a RPC binary sensor entity."""
+    """Represent RPC event entity."""
 
     _attr_should_poll = False
-    entity_description: RpcEventDescription
+    entity_description: ShellyEventDescription
 
     def __init__(
         self,
         coordinator: ShellyRpcCoordinator,
         key: str,
-        description: RpcEventDescription,
+        description: ShellyEventDescription,
     ) -> None:
         """Initialize Shelly entity."""
         super().__init__(coordinator)

--- a/homeassistant/components/shelly/event.py
+++ b/homeassistant/components/shelly/event.py
@@ -22,7 +22,7 @@ from .coordinator import ShellyRpcCoordinator, get_entry_data
 from .utils import (
     async_remove_shelly_entity,
     get_device_entry_gen,
-    get_rpc_entity_name,
+    get_rpc_input_name,
     get_rpc_key_instances,
     is_rpc_momentary_input,
 )
@@ -74,6 +74,7 @@ class ShellyRpcEvent(CoordinatorEntity[ShellyRpcCoordinator], EventEntity):
     """Represent RPC event entity."""
 
     _attr_should_poll = False
+    _attr_has_entity_name = True
     entity_description: ShellyEventDescription
 
     def __init__(
@@ -89,7 +90,7 @@ class ShellyRpcEvent(CoordinatorEntity[ShellyRpcCoordinator], EventEntity):
             "connections": {(CONNECTION_NETWORK_MAC, coordinator.mac)}
         }
         self._attr_unique_id = f"{coordinator.mac}-{key}"
-        self._attr_name = get_rpc_entity_name(coordinator.device, key)
+        self._attr_name = get_rpc_input_name(coordinator.device, key)
         self.entity_description = description
 
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/shelly/event.py
+++ b/homeassistant/components/shelly/event.py
@@ -96,11 +96,9 @@ class ShellyRpcEvent(CoordinatorEntity[ShellyRpcCoordinator], EventEntity):
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
-        self.coordinator.async_subscribe_input_events(self._async_handle_event)
-
-    async def async_will_remove_from_hass(self) -> None:
-        """When entity will be removed from hass."""
-        self.coordinator.async_unsubscribe_input_events(self._async_handle_event)
+        self.async_on_remove(
+            self.coordinator.async_subscribe_input_events(self._async_handle_event)
+        )
 
     @callback
     def _async_handle_event(self, event: dict[str, Any]) -> None:

--- a/homeassistant/components/shelly/event.py
+++ b/homeassistant/components/shelly/event.py
@@ -1,0 +1,92 @@
+"""Event for Shelly."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Final
+
+from homeassistant.components.event import (
+    EventDeviceClass,
+    EventEntity,
+    EventEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import RPC_INPUTS_EVENTS_TYPES
+from .coordinator import ShellyRpcCoordinator, get_entry_data
+from .entity import RpcEntityDescription
+from .utils import get_device_entry_gen, get_rpc_entity_name, get_rpc_key_instances
+
+
+@dataclass
+class RpcEventDescription(RpcEntityDescription, EventEntityDescription):
+    """Class to describe a RPC event."""
+
+
+RPC_EVENT: Final = RpcEventDescription(
+    key="input",
+    sub_key="state",
+    name="Input",
+    device_class=EventDeviceClass.BUTTON,
+    event_types=list(RPC_INPUTS_EVENTS_TYPES),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up sensors for device."""
+    if get_device_entry_gen(config_entry) == 2:
+        coordinator = get_entry_data(hass)[config_entry.entry_id].rpc
+        assert coordinator
+
+        entities = []
+        key_instances = get_rpc_key_instances(coordinator.device.status, RPC_EVENT.key)
+
+        for key in key_instances:
+            entities.append(ShellyRpcEvent(coordinator, key, RPC_EVENT))
+
+        async_add_entities(entities)
+
+
+class ShellyRpcEvent(CoordinatorEntity[ShellyRpcCoordinator], EventEntity):
+    """Represent a RPC binary sensor entity."""
+
+    _attr_should_poll = False
+    entity_description: RpcEventDescription
+
+    def __init__(
+        self,
+        coordinator: ShellyRpcCoordinator,
+        key: str,
+        description: RpcEventDescription,
+    ) -> None:
+        """Initialize Shelly entity."""
+        super().__init__(coordinator)
+        self.key = key
+        self._attr_device_info = {
+            "connections": {(CONNECTION_NETWORK_MAC, coordinator.mac)}
+        }
+        self._attr_unique_id = f"{coordinator.mac}-{key}"
+        self._attr_name = get_rpc_entity_name(coordinator.device, key)
+        self.entity_description = description
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to hass."""
+        self.coordinator.async_subscribe_input_events(self._async_handle_event)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """When entity will be removed from hass."""
+        self.coordinator.async_unsubscribe_input_events(self._async_handle_event)
+
+    @callback
+    def _async_handle_event(self, event: dict[str, Any]) -> None:
+        """Handle the demo button event."""
+        if event["component"] == self.key:
+            self._trigger_event(event["event"])
+            self.async_write_ha_state()

--- a/homeassistant/components/shelly/event.py
+++ b/homeassistant/components/shelly/event.py
@@ -74,7 +74,6 @@ class ShellyRpcEvent(CoordinatorEntity[ShellyRpcCoordinator], EventEntity):
     """Represent RPC event entity."""
 
     _attr_should_poll = False
-    _attr_has_entity_name = True
     entity_description: ShellyEventDescription
 
     def __init__(

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -285,6 +285,16 @@ def get_model_name(info: dict[str, Any]) -> str:
     return cast(str, MODEL_NAMES.get(info["type"], info["type"]))
 
 
+def get_rpc_input_name(device: RpcDevice, key: str) -> str:
+    """Get input name based from the device configuration."""
+    input_config = device.config[key]
+
+    if input_name := input_config.get("name"):
+        return cast(str, input_name)
+
+    return key.replace(":", " ").capitalize()
+
+
 def get_rpc_channel_name(device: RpcDevice, key: str) -> str:
     """Get name based on device and channel name."""
     key = key.replace("emdata", "em")

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -290,9 +290,9 @@ def get_rpc_input_name(device: RpcDevice, key: str) -> str:
     input_config = device.config[key]
 
     if input_name := input_config.get("name"):
-        return cast(str, input_name)
+        return f"{device.name} {input_name}"
 
-    return key.replace(":", " ").capitalize()
+    return f"{device.name} {key.replace(':', ' ').capitalize()}"
 
 
 def get_rpc_channel_name(device: RpcDevice, key: str) -> str:

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -191,6 +191,7 @@ MOCK_STATUS_COAP = {
 
 MOCK_STATUS_RPC = {
     "switch:0": {"output": True},
+    "input:0": {"id": 0, "state": None},
     "light:0": {"output": True, "brightness": 53.0},
     "cloud": {"connected": False},
     "cover:0": {

--- a/tests/components/shelly/test_event.py
+++ b/tests/components/shelly/test_event.py
@@ -18,7 +18,7 @@ from . import init_integration, inject_rpc_device_event
 async def test_rpc_button(hass: HomeAssistant, mock_rpc_device, monkeypatch) -> None:
     """Test RPC device event."""
     await init_integration(hass, 2)
-    entity_id = "event.test_switch_0"
+    entity_id = "event.test_name_input_0"
     registry = async_get(hass)
 
     state = hass.states.get(entity_id)

--- a/tests/components/shelly/test_event.py
+++ b/tests/components/shelly/test_event.py
@@ -6,13 +6,14 @@ from pytest_unordered import unordered
 from homeassistant.components.event import (
     ATTR_EVENT_TYPE,
     ATTR_EVENT_TYPES,
+    DOMAIN as EVENT_DOMAIN,
     EventDeviceClass,
 )
 from homeassistant.const import ATTR_DEVICE_CLASS, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import async_get
 
-from . import init_integration, inject_rpc_device_event
+from . import init_integration, inject_rpc_device_event, register_entity
 
 
 async def test_rpc_button(hass: HomeAssistant, mock_rpc_device, monkeypatch) -> None:
@@ -52,3 +53,18 @@ async def test_rpc_button(hass: HomeAssistant, mock_rpc_device, monkeypatch) -> 
 
     state = hass.states.get(entity_id)
     assert state.attributes.get(ATTR_EVENT_TYPE) == "single_push"
+
+
+async def test_rpc_event_removal(
+    hass: HomeAssistant, mock_rpc_device, monkeypatch
+) -> None:
+    """Test RPC event entity is removed due to removal_condition."""
+    registry = async_get(hass)
+    entity_id = register_entity(hass, EVENT_DOMAIN, "test_name_input_0", "input:0")
+
+    assert registry.async_get(entity_id) is not None
+
+    monkeypatch.setitem(mock_rpc_device.config, "input:0", {"id": 0, "type": "switch"})
+    await init_integration(hass, 2)
+
+    assert registry.async_get(entity_id) is None

--- a/tests/components/shelly/test_event.py
+++ b/tests/components/shelly/test_event.py
@@ -1,0 +1,54 @@
+"""Tests for Shelly button platform."""
+from __future__ import annotations
+
+from pytest_unordered import unordered
+
+from homeassistant.components.event import (
+    ATTR_EVENT_TYPE,
+    ATTR_EVENT_TYPES,
+    EventDeviceClass,
+)
+from homeassistant.const import ATTR_DEVICE_CLASS, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_registry import async_get
+
+from . import init_integration, inject_rpc_device_event
+
+
+async def test_rpc_button(hass: HomeAssistant, mock_rpc_device, monkeypatch) -> None:
+    """Test RPC device event."""
+    await init_integration(hass, 2)
+    entity_id = "event.test_switch_0"
+    registry = async_get(hass)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(ATTR_EVENT_TYPES) == unordered(
+        ["btn_down", "btn_up", "double_push", "long_push", "single_push", "triple_push"]
+    )
+    assert state.attributes.get(ATTR_EVENT_TYPE) is None
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == EventDeviceClass.BUTTON
+
+    entry = registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-input:0"
+
+    inject_rpc_device_event(
+        monkeypatch,
+        mock_rpc_device,
+        {
+            "events": [
+                {
+                    "event": "single_push",
+                    "id": 0,
+                    "ts": 1668522399.2,
+                }
+            ],
+            "ts": 1668522399.2,
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.attributes.get(ATTR_EVENT_TYPE) == "single_push"

--- a/tests/components/shelly/test_utils.py
+++ b/tests/components/shelly/test_utils.py
@@ -8,6 +8,7 @@ from homeassistant.components.shelly.utils import (
     get_device_uptime,
     get_number_of_channels,
     get_rpc_channel_name,
+    get_rpc_input_name,
     get_rpc_input_triggers,
     is_block_momentary_input,
 )
@@ -208,6 +209,18 @@ async def test_get_rpc_channel_name(mock_rpc_device) -> None:
     """Test get RPC channel name."""
     assert get_rpc_channel_name(mock_rpc_device, "input:0") == "test switch_0"
     assert get_rpc_channel_name(mock_rpc_device, "input:3") == "Test name switch_3"
+
+
+async def test_get_rpc_input_name(mock_rpc_device, monkeypatch) -> None:
+    """Test get RPC input name."""
+    assert get_rpc_input_name(mock_rpc_device, "input:0") == "Input 0"
+
+    monkeypatch.setitem(
+        mock_rpc_device.config,
+        "input:0",
+        {"id": 0, "type": "button", "name": "Test name"},
+    )
+    assert get_rpc_input_name(mock_rpc_device, "input:0") == "Test name"
 
 
 async def test_get_rpc_input_triggers(mock_rpc_device, monkeypatch) -> None:

--- a/tests/components/shelly/test_utils.py
+++ b/tests/components/shelly/test_utils.py
@@ -213,14 +213,14 @@ async def test_get_rpc_channel_name(mock_rpc_device) -> None:
 
 async def test_get_rpc_input_name(mock_rpc_device, monkeypatch) -> None:
     """Test get RPC input name."""
-    assert get_rpc_input_name(mock_rpc_device, "input:0") == "Input 0"
+    assert get_rpc_input_name(mock_rpc_device, "input:0") == "Test name Input 0"
 
     monkeypatch.setitem(
         mock_rpc_device.config,
         "input:0",
-        {"id": 0, "type": "button", "name": "Test name"},
+        {"id": 0, "type": "button", "name": "Input name"},
     )
-    assert get_rpc_input_name(mock_rpc_device, "input:0") == "Test name"
+    assert get_rpc_input_name(mock_rpc_device, "input:0") == "Test name Input name"
 
 
 async def test_get_rpc_input_triggers(mock_rpc_device, monkeypatch) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds `event` platform for Shelly Gen2 devices.

I'll open a second PR for Gen1 devices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28800

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
