### PR TITLE
Fix ZHA startup creating entities with non-unique IDs

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -134,7 +134,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     else:
         _LOGGER.debug("ZHA storage file does not exist or was already removed")
 
-    zha_gateway = ZHAGateway(hass, config, config_entry)
+    # Re-use the gateway object between ZHA reloads
+    if (zha_gateway := zha_data.get(DATA_ZHA_GATEWAY)) is None:
+        zha_gateway = ZHAGateway(hass, config, config_entry)
 
     try:
         await zha_gateway.async_initialize()

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -149,6 +149,12 @@ class ZHAGateway:
         self.config_entry = config_entry
         self._unsubs: list[Callable[[], None]] = []
 
+        discovery.PROBE.initialize(self._hass)
+        discovery.GROUP_PROBE.initialize(self._hass)
+
+        self.ha_device_registry = dr.async_get(self._hass)
+        self.ha_entity_registry = er.async_get(self._hass)
+
     def get_application_controller_data(self) -> tuple[ControllerApplication, dict]:
         """Get an uninitialized instance of a zigpy `ControllerApplication`."""
         radio_type = self.config_entry.data[CONF_RADIO_TYPE]
@@ -191,12 +197,6 @@ class ZHAGateway:
 
     async def async_initialize(self) -> None:
         """Initialize controller and connect radio."""
-        discovery.PROBE.initialize(self._hass)
-        discovery.GROUP_PROBE.initialize(self._hass)
-
-        self.ha_device_registry = dr.async_get(self._hass)
-        self.ha_entity_registry = er.async_get(self._hass)
-
         app_controller_cls, app_config = self.get_application_controller_data()
         self.application_controller = await app_controller_cls.new(
             config=app_config,

--- a/tests/components/zha/test_init.py
+++ b/tests/components/zha/test_init.py
@@ -1,8 +1,10 @@
 """Tests for ZHA integration init."""
+import asyncio
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from zigpy.config import CONF_DEVICE, CONF_DEVICE_PATH
+from zigpy.exceptions import TransientConnectionError
 
 from homeassistant.components.zha import async_setup_entry
 from homeassistant.components.zha.core.const import (
@@ -11,9 +13,12 @@ from homeassistant.components.zha.core.const import (
     CONF_USB_PATH,
     DOMAIN,
 )
-from homeassistant.const import MAJOR_VERSION, MINOR_VERSION
+from homeassistant.const import MAJOR_VERSION, MINOR_VERSION, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.event import async_call_later
 from homeassistant.setup import async_setup_component
+
+from .test_light import LIGHT_ON_OFF
 
 from tests.common import MockConfigEntry
 
@@ -157,3 +162,46 @@ async def test_setup_with_v3_cleaning_uri(
     assert config_entry_v3.data[CONF_RADIO_TYPE] == DATA_RADIO_TYPE
     assert config_entry_v3.data[CONF_DEVICE][CONF_DEVICE_PATH] == cleaned_path
     assert config_entry_v3.version == 3
+
+
+@patch(
+    "homeassistant.components.zha.PLATFORMS",
+    [Platform.LIGHT, Platform.BUTTON, Platform.SENSOR, Platform.SELECT],
+)
+async def test_zha_retry_unique_ids(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    zigpy_device_mock,
+    mock_zigpy_connect,
+    caplog,
+) -> None:
+    """Test that ZHA retrying creates unique entity IDs."""
+
+    config_entry.add_to_hass(hass)
+
+    # Ensure we have some device to try to load
+    app = mock_zigpy_connect.return_value
+    light = zigpy_device_mock(LIGHT_ON_OFF)
+    app.devices[light.ieee] = light
+
+    # Re-try setup but have it fail once, so entities have two chances to be created
+    with patch.object(
+        app,
+        "startup",
+        side_effect=[TransientConnectionError(), None],
+    ) as mock_connect:
+        with patch(
+            "homeassistant.config_entries.async_call_later",
+            lambda hass, delay, action: async_call_later(hass, 0, action),
+        ):
+            await hass.config_entries.async_setup(config_entry.entry_id)
+            await hass.async_block_till_done()
+
+            # Wait for the config entry setup to retry
+            await asyncio.sleep(0.1)
+
+        assert len(mock_connect.mock_calls) == 2
+
+    await hass.config_entries.async_unload(config_entry.entry_id)
+
+    assert "does not generate unique IDs" not in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
#98082 introduced a regression where startup retries caused entities to be re-created multiple times with the same IDs, triggering errors. I've reorganized startup to only create entities only once.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #99522
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
