### PR TITLE
Display correct mode when Ecobee via HomeKit is in vacation mode

### DIFF
--- a/homeassistant/components/homekit_controller/select.py
+++ b/homeassistant/components/homekit_controller/select.py
@@ -17,6 +17,7 @@ _ECOBEE_MODE_TO_TEXT = {
     0: "home",
     1: "sleep",
     2: "away",
+    3: "vacation",
 }
 _ECOBEE_MODE_TO_NUMBERS = {v: k for (k, v) in _ECOBEE_MODE_TO_TEXT.items()}
 
@@ -24,7 +25,7 @@ _ECOBEE_MODE_TO_NUMBERS = {v: k for (k, v) in _ECOBEE_MODE_TO_TEXT.items()}
 class EcobeeModeSelect(CharacteristicEntity, SelectEntity):
     """Represents a ecobee mode select entity."""
 
-    _attr_options = ["home", "sleep", "away"]
+    _attr_options = list(_ECOBEE_MODE_TO_TEXT.values())
     _attr_translation_key = "ecobee_mode"
 
     @property

--- a/homeassistant/components/homekit_controller/select.py
+++ b/homeassistant/components/homekit_controller/select.py
@@ -49,6 +49,8 @@ class EcobeeModeSelect(CharacteristicEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Set the current mode."""
         option_int = _ECOBEE_MODE_TO_NUMBERS[option]
+        if option_int == 3:
+            raise ValueError(f"Option {option} not valid for {self.entity_id}")
         await self.async_put_characteristics(
             {CharacteristicsTypes.VENDOR_ECOBEE_SET_HOLD_SCHEDULE: option_int}
         )

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -100,7 +100,8 @@
         "state": {
           "away": "[%key:common::state::not_home%]",
           "home": "[%key:common::state::home%]",
-          "sleep": "Sleep"
+          "sleep": "Sleep",
+          "vacation": "Vacation"
         }
       }
     },

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -133,7 +133,7 @@ async def test_ecobee3_setup(hass: HomeAssistant) -> None:
                     entity_id="select.homew_current_mode",
                     friendly_name="HomeW Current Mode",
                     unique_id="00:00:00:00:00:00_1_16_33",
-                    capabilities={"options": ["home", "sleep", "away"]},
+                    capabilities={"options": ["home", "sleep", "away", "vacation"]},
                     state="home",
                 ),
             ],

--- a/tests/components/homekit_controller/test_select.py
+++ b/tests/components/homekit_controller/test_select.py
@@ -78,6 +78,14 @@ async def test_read_current_mode(hass: HomeAssistant, utcnow) -> None:
     )
     assert state.state == "away"
 
+    state = await ecobee_mode.async_update(
+        ServicesTypes.THERMOSTAT,
+        {
+            CharacteristicsTypes.VENDOR_ECOBEE_CURRENT_MODE: 3,
+        },
+    )
+    assert state.state == "vacation"
+
 
 async def test_write_current_mode(hass: HomeAssistant, utcnow) -> None:
     """Test can set a specific mode."""


### PR DESCRIPTION
Display correct mode when Ecobee is in vacation mode.

**Note that that Ecobee doesn't allow changing the current mode to vacation via HomeKit.**

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When Ecobee thermostat is in vacation mode, the HomeKit Controller integration shows blanks for the Current Mode.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/99524
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
