### PR TITLE
Reorganize ZHA initialization

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -134,10 +134,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     else:
         _LOGGER.debug("ZHA storage file does not exist or was already removed")
 
-    # Re-use the gateway object between ZHA reloads
-    if (zha_gateway := zha_data.get(DATA_ZHA_GATEWAY)) is None:
-        zha_gateway = ZHAGateway(hass, config, config_entry)
-
+    zha_gateway = ZHAGateway(hass, config, config_entry)
     config_entry.async_on_unload(zha_gateway.shutdown)
 
     try:

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -138,6 +138,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     if (zha_gateway := zha_data.get(DATA_ZHA_GATEWAY)) is None:
         zha_gateway = ZHAGateway(hass, config, config_entry)
 
+    config_entry.async_on_unload(zha_gateway.shutdown)
+
     try:
         await zha_gateway.async_initialize()
     except Exception:  # pylint: disable=broad-except
@@ -154,8 +156,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         raise
 
     repairs.async_delete_blocking_issues(hass)
-
-    config_entry.async_on_unload(zha_gateway.shutdown)
 
     device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -1,5 +1,6 @@
 """Support for Zigbee Home Automation devices."""
 import asyncio
+import contextlib
 import copy
 import logging
 import os
@@ -135,7 +136,19 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         _LOGGER.debug("ZHA storage file does not exist or was already removed")
 
     zha_gateway = ZHAGateway(hass, config, config_entry)
-    config_entry.async_on_unload(zha_gateway.shutdown)
+
+    async def async_zha_shutdown():
+        """Handle shutdown tasks."""
+        await zha_gateway.shutdown()
+        # clean up any remaining entity metadata
+        # (entities that have been discovered but not yet added to HA)
+        # suppress KeyError because we don't know what state we may
+        # be in when we get here in failure cases
+        with contextlib.suppress(KeyError):
+            for platform in PLATFORMS:
+                del hass.data[DATA_ZHA][platform]
+
+    config_entry.async_on_unload(async_zha_shutdown)
 
     try:
         await zha_gateway.async_initialize()

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -48,6 +48,7 @@ from .const import (
     CONF_ZIGPY,
     DATA_ZHA,
     DATA_ZHA_BRIDGE_ID,
+    DATA_ZHA_CONFIG,
     DATA_ZHA_GATEWAY,
     DEBUG_COMP_BELLOWS,
     DEBUG_COMP_ZHA,
@@ -771,7 +772,13 @@ class ZHAGateway:
             and self.application_controller is not None
         ):
             await self.application_controller.shutdown()
-        self._hass.data[DATA_ZHA] = {}
+
+        # save a reference to configuration.yaml config since it is not reloaded
+        # when a config entry is reloaded
+        config = {}
+        if DATA_ZHA_CONFIG in self._hass.data[DATA_ZHA]:
+            config[DATA_ZHA_CONFIG] = self._hass.data[DATA_ZHA][DATA_ZHA_CONFIG]
+        self._hass.data[DATA_ZHA] = config
 
     def handle_message(
         self,

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -149,12 +149,6 @@ class ZHAGateway:
         self.config_entry = config_entry
         self._unsubs: list[Callable[[], None]] = []
 
-        discovery.PROBE.initialize(self._hass)
-        discovery.GROUP_PROBE.initialize(self._hass)
-
-        self.ha_device_registry = dr.async_get(self._hass)
-        self.ha_entity_registry = er.async_get(self._hass)
-
     def get_application_controller_data(self) -> tuple[ControllerApplication, dict]:
         """Get an uninitialized instance of a zigpy `ControllerApplication`."""
         radio_type = self.config_entry.data[CONF_RADIO_TYPE]
@@ -197,6 +191,12 @@ class ZHAGateway:
 
     async def async_initialize(self) -> None:
         """Initialize controller and connect radio."""
+        discovery.PROBE.initialize(self._hass)
+        discovery.GROUP_PROBE.initialize(self._hass)
+
+        self.ha_device_registry = dr.async_get(self._hass)
+        self.ha_entity_registry = er.async_get(self._hass)
+
         app_controller_cls, app_config = self.get_application_controller_data()
         self.application_controller = await app_controller_cls.new(
             config=app_config,
@@ -766,7 +766,12 @@ class ZHAGateway:
             unsubscribe()
         for device in self.devices.values():
             device.async_cleanup_handles()
-        await self.application_controller.shutdown()
+        if (
+            hasattr(self, "application_controller")
+            and self.application_controller is not None
+        ):
+            await self.application_controller.shutdown()
+        self._hass.data[DATA_ZHA] = {}
 
     def handle_message(
         self,

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -48,7 +48,6 @@ from .const import (
     CONF_ZIGPY,
     DATA_ZHA,
     DATA_ZHA_BRIDGE_ID,
-    DATA_ZHA_CONFIG,
     DATA_ZHA_GATEWAY,
     DEBUG_COMP_BELLOWS,
     DEBUG_COMP_ZHA,
@@ -767,18 +766,15 @@ class ZHAGateway:
             unsubscribe()
         for device in self.devices.values():
             device.async_cleanup_handles()
+        # shutdown is called when the config entry unloads are processed
+        # there are cases where unloads are processed because of a failure of
+        # some sort and the application controller may not have been
+        # created yet
         if (
             hasattr(self, "application_controller")
             and self.application_controller is not None
         ):
             await self.application_controller.shutdown()
-
-        # save a reference to configuration.yaml config since it is not reloaded
-        # when a config entry is reloaded
-        config = {}
-        if DATA_ZHA_CONFIG in self._hass.data[DATA_ZHA]:
-            config[DATA_ZHA_CONFIG] = self._hass.data[DATA_ZHA][DATA_ZHA_CONFIG]
-        self._hass.data[DATA_ZHA] = config
 
     def handle_message(
         self,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is potentially another solution to the issue #99679 fixed (addresses this comment: https://github.com/home-assistant/core/pull/99679/files#r1316240684). This PR partially reverts #99679 and it ensures that our unload is actually registered before it can potentially be called (`zha_gateway.async_initialize()` can throw a not ready exception but we didn't have the unload registered at that point). It also fixes attempting to reference `application_controller` in failure cases before it has been created. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
