### PR TITLE
Fix pylint plugin test DeprecationWarning

### DIFF
--- a/tests/pylint/conftest.py
+++ b/tests/pylint/conftest.py
@@ -1,6 +1,7 @@
 """Configuration for pylint tests."""
-from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
+import sys
 from types import ModuleType
 
 from pylint.checkers import BaseChecker
@@ -13,11 +14,17 @@ BASE_PATH = Path(__file__).parents[2]
 @pytest.fixture(name="hass_enforce_type_hints", scope="session")
 def hass_enforce_type_hints_fixture() -> ModuleType:
     """Fixture to provide a requests mocker."""
-    loader = SourceFileLoader(
-        "hass_enforce_type_hints",
+    module_name = "hass_enforce_type_hints"
+    spec = spec_from_file_location(
+        module_name,
         str(BASE_PATH.joinpath("pylint/plugins/hass_enforce_type_hints.py")),
     )
-    return loader.load_module(None)
+    assert spec and spec.loader
+
+    module = module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 @pytest.fixture(name="linter")
@@ -37,11 +44,16 @@ def type_hint_checker_fixture(hass_enforce_type_hints, linter) -> BaseChecker:
 @pytest.fixture(name="hass_imports", scope="session")
 def hass_imports_fixture() -> ModuleType:
     """Fixture to provide a requests mocker."""
-    loader = SourceFileLoader(
-        "hass_imports",
-        str(BASE_PATH.joinpath("pylint/plugins/hass_imports.py")),
+    module_name = "hass_imports"
+    spec = spec_from_file_location(
+        module_name, str(BASE_PATH.joinpath("pylint/plugins/hass_imports.py"))
     )
-    return loader.load_module(None)
+    assert spec and spec.loader
+
+    module = module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 @pytest.fixture(name="imports_checker")


### PR DESCRIPTION
## Proposed change
```
tests/pylint/test_enforce_type_hints.py::test_regex_get_module_platform[homeassistant-None-False]
tests/pylint/test_imports.py::test_good_import[homeassistant.components.pylint_test.sensor-homeassistant.const-CONSTANT]
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead
```

`load_module` from `importlib` has been deprecated since Python 3.6.
https://docs.python.org/3.11/library/importlib.html#importlib.machinery.SourceFileLoader.load_module

Refactor conftest to use `exec_module` instead. Example from the Python docs:
https://docs.python.org/3.11/library/importlib.html#importing-a-source-file-directly

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
