### PR TITLE
Schlage cleanup: Stop passing logs to last_changed_by

### DIFF
--- a/homeassistant/components/schlage/lock.py
+++ b/homeassistant/components/schlage/lock.py
@@ -48,11 +48,7 @@ class SchlageLockEntity(SchlageEntity, LockEntity):
         """Update our internal state attributes."""
         self._attr_is_locked = self._lock.is_locked
         self._attr_is_jammed = self._lock.is_jammed
-        # Only update changed_by if we get a valid value. This way a previous
-        # value will stay intact if the latest log message isn't related to a
-        # lock state change.
-        if changed_by := self._lock.last_changed_by(self._lock_data.logs):
-            self._attr_changed_by = changed_by
+        self._attr_changed_by = self._lock.last_changed_by()
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the device."""

--- a/tests/components/schlage/test_lock.py
+++ b/tests/components/schlage/test_lock.py
@@ -3,8 +3,6 @@
 from datetime import timedelta
 from unittest.mock import Mock
 
-from pyschlage.exceptions import UnknownError
-
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_LOCK, SERVICE_UNLOCK
@@ -62,26 +60,8 @@ async def test_changed_by(
     # Make the coordinator refresh data.
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=31))
     await hass.async_block_till_done()
-    mock_lock.last_changed_by.assert_called_once_with([])
+    mock_lock.last_changed_by.assert_called_once_with()
 
     lock_device = hass.states.get("lock.vault_door")
     assert lock_device is not None
     assert lock_device.attributes.get("changed_by") == "access code - foo"
-
-
-async def test_changed_by_uses_previous_logs_on_failure(
-    hass: HomeAssistant, mock_lock: Mock, mock_added_config_entry: ConfigEntry
-) -> None:
-    """Test that a failure to load logs is not terminal."""
-    mock_lock.last_changed_by.reset_mock()
-    mock_lock.last_changed_by.return_value = "thumbturn"
-    mock_lock.logs.side_effect = UnknownError("Cannot load logs")
-
-    # Make the coordinator refresh data.
-    async_fire_time_changed(hass, utcnow() + timedelta(seconds=31))
-    await hass.async_block_till_done()
-    mock_lock.last_changed_by.assert_called_once_with([])
-
-    lock_device = hass.states.get("lock.vault_door")
-    assert lock_device is not None
-    assert lock_device.attributes.get("changed_by") == "thumbturn"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Stop passing `logs` to the `last_changed_by` method. This is no longer necessary in `pyschlage 2023.9.0` (https://github.com/dknowles2/pyschlage/pull/84)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
