### PR TITLE
Add some tests to Freebox

### DIFF
--- a/tests/components/freebox/test_binary_sensor.py
+++ b/tests/components/freebox/test_binary_sensor.py
@@ -1,29 +1,24 @@
 """Tests for the Freebox sensors."""
 from copy import deepcopy
-from datetime import timedelta
 from unittest.mock import Mock
 
-from homeassistant.components.freebox.const import DOMAIN
-from homeassistant.const import CONF_HOST, CONF_PORT
+from freezegun.api import FrozenDateTimeFactory
+
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.freebox import SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
-import homeassistant.util.dt as dt_util
 
-from .const import DATA_STORAGE_GET_RAIDS, MOCK_HOST, MOCK_PORT
+from .common import setup_platform
+from .const import DATA_STORAGE_GET_RAIDS
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import async_fire_time_changed
 
 
-async def test_raid_array_degraded(hass: HomeAssistant, router: Mock) -> None:
+async def test_raid_array_degraded(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, router: Mock
+) -> None:
     """Test raid array degraded binary sensor."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT},
-        unique_id=MOCK_HOST,
-    )
-    entry.add_to_hass(hass)
-    assert await async_setup_component(hass, DOMAIN, {})
-    await hass.async_block_till_done()
+    await setup_platform(hass, BINARY_SENSOR_DOMAIN)
 
     assert (
         hass.states.get("binary_sensor.freebox_server_r2_raid_array_0_degraded").state
@@ -35,7 +30,8 @@ async def test_raid_array_degraded(hass: HomeAssistant, router: Mock) -> None:
     data_storage_get_raids_degraded[0]["degraded"] = True
     router().storage.get_raids.return_value = data_storage_get_raids_degraded
     # Simulate an update
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=60))
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
     # To execute the save
     await hass.async_block_till_done()
     assert (

--- a/tests/components/freebox/test_button.py
+++ b/tests/components/freebox/test_button.py
@@ -1,29 +1,19 @@
 """Tests for the Freebox config flow."""
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import ANY, AsyncMock, Mock, patch
 
 from pytest_unordered import unordered
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
-from homeassistant.components.freebox.const import DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_PORT
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
-from .const import MOCK_HOST, MOCK_PORT
-
-from tests.common import MockConfigEntry
+from .common import setup_platform
 
 
-async def test_reboot_button(hass: HomeAssistant, router: Mock) -> None:
+async def test_reboot(hass: HomeAssistant, router: Mock) -> None:
     """Test reboot button."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT},
-        unique_id=MOCK_HOST,
-    )
-    entry.add_to_hass(hass)
-    assert await async_setup_component(hass, DOMAIN, {})
-    await hass.async_block_till_done()
+    entry = await setup_platform(hass, BUTTON_DOMAIN)
+
     assert hass.config_entries.async_entries() == unordered([entry, ANY])
 
     assert router.call_count == 1
@@ -32,6 +22,7 @@ async def test_reboot_button(hass: HomeAssistant, router: Mock) -> None:
     with patch(
         "homeassistant.components.freebox.router.FreeboxRouter.reboot"
     ) as mock_service:
+        mock_service.assert_not_called()
         await hass.services.async_call(
             BUTTON_DOMAIN,
             SERVICE_PRESS,
@@ -42,3 +33,29 @@ async def test_reboot_button(hass: HomeAssistant, router: Mock) -> None:
         )
         await hass.async_block_till_done()
         mock_service.assert_called_once()
+
+
+async def test_mark_calls_as_read(hass: HomeAssistant, router: Mock) -> None:
+    """Test mark calls as read button."""
+    entry = await setup_platform(hass, BUTTON_DOMAIN)
+
+    assert hass.config_entries.async_entries() == unordered([entry, ANY])
+
+    assert router.call_count == 1
+    assert router().open.call_count == 1
+
+    with patch(
+        "homeassistant.components.freebox.router.FreeboxRouter.call"
+    ) as mock_service:
+        mock_service.mark_calls_log_as_read = AsyncMock()
+        mock_service.mark_calls_log_as_read.assert_not_called()
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            service_data={
+                ATTR_ENTITY_ID: "button.mark_calls_as_read",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        mock_service.mark_calls_log_as_read.assert_called_once()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Split of #99365

Add some tests to improve coverage, and use freezegun for tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
