### PR TITLE
Fix Freebox disk free space sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -417,7 +417,6 @@ omit =
     homeassistant/components/freebox/device_tracker.py
     homeassistant/components/freebox/home_base.py
     homeassistant/components/freebox/router.py
-    homeassistant/components/freebox/sensor.py
     homeassistant/components/freebox/switch.py
     homeassistant/components/fritz/common.py
     homeassistant/components/fritz/device_tracker.py

--- a/homeassistant/components/freebox/router.py
+++ b/homeassistant/components/freebox/router.py
@@ -156,7 +156,12 @@ class FreeboxRouter:
         fbx_disks: list[dict[str, Any]] = await self._api.storage.get_disks() or []
 
         for fbx_disk in fbx_disks:
-            self.disks[fbx_disk["id"]] = fbx_disk
+            disk: dict[str, Any] = {**fbx_disk}
+            disk_part: dict[int, dict[str, Any]] = {}
+            for fbx_disk_part in fbx_disk["partitions"]:
+                disk_part[fbx_disk_part["id"]] = fbx_disk_part
+            disk["partitions"] = disk_part
+            self.disks[fbx_disk["id"]] = disk
 
     async def _update_raids_sensors(self) -> None:
         """Update Freebox raids."""

--- a/homeassistant/components/freebox/sensor.py
+++ b/homeassistant/components/freebox/sensor.py
@@ -95,7 +95,7 @@ async def async_setup_entry(
     entities.extend(
         FreeboxDiskSensor(router, disk, partition, description)
         for disk in router.disks.values()
-        for partition in disk["partitions"]
+        for partition in disk["partitions"].values()
         for description in DISK_PARTITION_SENSORS
     )
 
@@ -197,7 +197,8 @@ class FreeboxDiskSensor(FreeboxSensor):
     ) -> None:
         """Initialize a Freebox disk sensor."""
         super().__init__(router, description)
-        self._partition = partition
+        self._disk_id = disk["id"]
+        self._partition_id = partition["id"]
         self._attr_name = f"{partition['label']} {description.name}"
         self._attr_unique_id = (
             f"{router.mac} {description.key} {disk['id']} {partition['id']}"
@@ -218,10 +219,10 @@ class FreeboxDiskSensor(FreeboxSensor):
     def async_update_state(self) -> None:
         """Update the Freebox disk sensor."""
         value = None
-        if self._partition.get("total_bytes"):
-            value = round(
-                self._partition["free_bytes"] * 100 / self._partition["total_bytes"], 2
-            )
+        disk: dict[str, Any] = self._router.disks[self._disk_id]
+        partition: dict[str, Any] = disk["partitions"][self._partition_id]
+        if partition.get("total_bytes"):
+            value = round(partition["free_bytes"] * 100 / partition["total_bytes"], 2)
         self._attr_native_value = value
 
 

--- a/tests/components/freebox/common.py
+++ b/tests/components/freebox/common.py
@@ -1,0 +1,27 @@
+"""Common methods used across tests for Freebox."""
+from unittest.mock import patch
+
+from homeassistant.components.freebox.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from .const import MOCK_HOST, MOCK_PORT
+
+from tests.common import MockConfigEntry
+
+
+async def setup_platform(hass: HomeAssistant, platform: str) -> MockConfigEntry:
+    """Set up the Freebox platform."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT},
+        unique_id=MOCK_HOST,
+    )
+    mock_entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.freebox.PLATFORMS", [platform]):
+        assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    return mock_entry

--- a/tests/components/freebox/test_sensor.py
+++ b/tests/components/freebox/test_sensor.py
@@ -20,6 +20,17 @@ async def test_disk(
     """Test disk sensor."""
     await setup_platform(hass, SENSOR_DOMAIN)
 
+    # Initial state
+    assert (
+        router().storage.get_disks.return_value[2]["partitions"][0]["total_bytes"]
+        == 1960000000000
+    )
+
+    assert (
+        router().storage.get_disks.return_value[2]["partitions"][0]["free_bytes"]
+        == 1730000000000
+    )
+
     assert hass.states.get("sensor.freebox_free_space").state == "88.27"
 
     # Simulate a changed storage size

--- a/tests/components/freebox/test_sensor.py
+++ b/tests/components/freebox/test_sensor.py
@@ -1,0 +1,34 @@
+"""Tests for the Freebox sensors."""
+from copy import deepcopy
+from unittest.mock import Mock
+
+from freezegun.api import FrozenDateTimeFactory
+
+from homeassistant.components.freebox import SCAN_INTERVAL
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.core import HomeAssistant
+
+from .common import setup_platform
+from .const import DATA_STORAGE_GET_DISKS
+
+from tests.common import async_fire_time_changed
+
+
+async def test_disk(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, router: Mock
+) -> None:
+    """Test disk sensor."""
+    await setup_platform(hass, SENSOR_DOMAIN)
+
+    assert hass.states.get("sensor.freebox_free_space").state == "88.27"
+
+    # Simulate a changed storage size
+    data_storage_get_disks_changed = deepcopy(DATA_STORAGE_GET_DISKS)
+    data_storage_get_disks_changed[2]["partitions"][0]["free_bytes"] = 880000000000
+    router().storage.get_disks.return_value = data_storage_get_disks_changed
+    # Simulate an update
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    # To execute the save
+    await hass.async_block_till_done()
+    assert hass.states.get("sensor.freebox_free_space").state == "44.9"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Split of #99365

fix bugs:
- disk free space sensor got created and populated but never updated: issue from #46689 in **2021.4**

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
