### PR TITLE
Log warning at debug level when load_default_certs is called in the event loop

### DIFF
--- a/homeassistant/block_async_io.py
+++ b/homeassistant/block_async_io.py
@@ -21,5 +21,5 @@ def enable() -> None:
     # builtins.open = protect_loop(builtins.open)
 
     SSLContext.load_default_certs = protect_loop(  # type: ignore[method-assign]
-        SSLContext.load_default_certs, strict=False
+        SSLContext.load_default_certs, strict=False, debug=True
     )

--- a/homeassistant/block_async_io.py
+++ b/homeassistant/block_async_io.py
@@ -1,5 +1,6 @@
 """Block blocking calls being done in asyncio."""
 from http.client import HTTPConnection
+from ssl import SSLContext
 import time
 
 from .util.async_ import protect_loop
@@ -18,3 +19,7 @@ def enable() -> None:
     # Currently disabled. pytz doing I/O when getting timezone.
     # Prevent files being opened inside the event loop
     # builtins.open = protect_loop(builtins.open)
+
+    SSLContext.load_default_certs = protect_loop(  # type: ignore[method-assign]
+        SSLContext.load_default_certs, strict=False
+    )

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -75,7 +75,10 @@ def run_callback_threadsafe(
 
 
 def check_loop(
-    func: Callable[..., Any], strict: bool = True, advise_msg: str | None = None
+    func: Callable[..., Any],
+    strict: bool = True,
+    advise_msg: str | None = None,
+    debug: bool = False,
 ) -> None:
     """Warn if called inside the event loop. Raise if `strict` is True.
 
@@ -134,7 +137,8 @@ def check_loop(
     else:
         extra = ""
 
-    _LOGGER.warning(
+    _LOGGER.log(
+        logging.DEBUG if debug else logging.WARNING,
         (
             "Detected blocking call to %s inside the event loop. This is causing"
             " stability issues. Please report issue%s for %s doing blocking calls at"
@@ -156,12 +160,14 @@ def check_loop(
         )
 
 
-def protect_loop(func: Callable[_P, _R], strict: bool = True) -> Callable[_P, _R]:
+def protect_loop(
+    func: Callable[_P, _R], strict: bool = True, debug: bool = False
+) -> Callable[_P, _R]:
     """Protect function from running in event loop."""
 
     @functools.wraps(func)
     def protected_loop_func(*args: _P.args, **kwargs: _P.kwargs) -> _R:
-        check_loop(func, strict=strict)
+        check_loop(func, strict=strict, debug=debug)
         return func(*args, **kwargs)
 
     return protected_loop_func


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This one keep coming up over and over in profiles and since it does blocking I/O we should avoid calling it in the event loop. The solution is usually to put it behind an LRU and only do it once, or use `homeassistant.util.ssl`

This logs at debug level since there are a lot of places that still do this that need to be cleaned up.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
