### PR TITLE
Cache device trigger info during ZHA startup

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -159,6 +159,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                 get_device_automation_triggers(dev),
             )
 
+    _LOGGER.debug("Trigger cache: %s", zha_data[DATA_ZHA_DEVICE_TRIGGER_CACHE])
+
     zha_gateway = ZHAGateway(hass, config, config_entry)
 
     async def async_zha_shutdown():

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -162,6 +162,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     if (zha_gateway := zha_data.get(DATA_ZHA_GATEWAY)) is None:
         zha_gateway = ZHAGateway(hass, config, config_entry)
 
+    config_entry.async_on_unload(zha_gateway.shutdown)
+
     try:
         await zha_gateway.async_initialize()
     except Exception:  # pylint: disable=broad-except
@@ -178,8 +180,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         raise
 
     repairs.async_delete_blocking_issues(hass)
-
-    config_entry.async_on_unload(zha_gateway.shutdown)
 
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -158,10 +158,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                 get_device_automation_triggers(dev),
             )
 
-    # Re-use the gateway object between ZHA reloads
-    if (zha_gateway := zha_data.get(DATA_ZHA_GATEWAY)) is None:
-        zha_gateway = ZHAGateway(hass, config, config_entry)
-
+    zha_gateway = ZHAGateway(hass, config, config_entry)
     config_entry.async_on_unload(zha_gateway.shutdown)
 
     try:

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -186,6 +186,7 @@ DATA_ZHA = "zha"
 DATA_ZHA_CONFIG = "config"
 DATA_ZHA_BRIDGE_ID = "zha_bridge_id"
 DATA_ZHA_CORE_EVENTS = "zha_core_events"
+DATA_ZHA_DEVICE_TRIGGER_CACHE = "zha_device_trigger_cache"
 DATA_ZHA_GATEWAY = "zha_gateway"
 
 DEBUG_COMP_BELLOWS = "bellows"

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -93,6 +93,16 @@ _UPDATE_ALIVE_INTERVAL = (60, 90)
 _CHECKIN_GRACE_PERIODS = 2
 
 
+def get_device_automation_triggers(
+    device: zigpy.device.Device,
+) -> dict[tuple[str, str], dict[str, str]]:
+    """Get the supported device automation triggers for a zigpy device."""
+    return {
+        ("device_offline", "device_offline"): {"device_event_type": "device_offline"},
+        **getattr(device, "device_automation_triggers", {}),
+    }
+
+
 class DeviceStatus(Enum):
     """Status of a device."""
 
@@ -311,16 +321,7 @@ class ZHADevice(LogMixin):
     @cached_property
     def device_automation_triggers(self) -> dict[tuple[str, str], dict[str, str]]:
         """Return the device automation triggers for this device."""
-        triggers = {
-            ("device_offline", "device_offline"): {
-                "device_event_type": "device_offline"
-            }
-        }
-
-        if hasattr(self._zigpy_device, "device_automation_triggers"):
-            triggers.update(self._zigpy_device.device_automation_triggers)
-
-        return triggers
+        return get_device_automation_triggers(self._zigpy_device)
 
     @property
     def available_signal(self) -> str:

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -48,6 +48,7 @@ from .const import (
     CONF_ZIGPY,
     DATA_ZHA,
     DATA_ZHA_BRIDGE_ID,
+    DATA_ZHA_CONFIG,
     DATA_ZHA_GATEWAY,
     DEBUG_COMP_BELLOWS,
     DEBUG_COMP_ZHA,
@@ -771,7 +772,13 @@ class ZHAGateway:
             and self.application_controller is not None
         ):
             await self.application_controller.shutdown()
-        self._hass.data[DATA_ZHA] = {}
+
+        # save a reference to configuration.yaml config since it is not reloaded
+        # when a config entry is reloaded
+        config = {}
+        if DATA_ZHA_CONFIG in self._hass.data[DATA_ZHA]:
+            config[DATA_ZHA_CONFIG] = self._hass.data[DATA_ZHA][DATA_ZHA_CONFIG]
+        self._hass.data[DATA_ZHA] = config
 
     def handle_message(
         self,

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -149,12 +149,6 @@ class ZHAGateway:
         self.config_entry = config_entry
         self._unsubs: list[Callable[[], None]] = []
 
-        discovery.PROBE.initialize(self._hass)
-        discovery.GROUP_PROBE.initialize(self._hass)
-
-        self.ha_device_registry = dr.async_get(self._hass)
-        self.ha_entity_registry = er.async_get(self._hass)
-
     def get_application_controller_data(self) -> tuple[ControllerApplication, dict]:
         """Get an uninitialized instance of a zigpy `ControllerApplication`."""
         radio_type = self.config_entry.data[CONF_RADIO_TYPE]
@@ -197,6 +191,12 @@ class ZHAGateway:
 
     async def async_initialize(self) -> None:
         """Initialize controller and connect radio."""
+        discovery.PROBE.initialize(self._hass)
+        discovery.GROUP_PROBE.initialize(self._hass)
+
+        self.ha_device_registry = dr.async_get(self._hass)
+        self.ha_entity_registry = er.async_get(self._hass)
+
         app_controller_cls, app_config = self.get_application_controller_data()
         self.application_controller = await app_controller_cls.new(
             config=app_config,
@@ -766,7 +766,12 @@ class ZHAGateway:
             unsubscribe()
         for device in self.devices.values():
             device.async_cleanup_handles()
-        await self.application_controller.shutdown()
+        if (
+            hasattr(self, "application_controller")
+            and self.application_controller is not None
+        ):
+            await self.application_controller.shutdown()
+        self._hass.data[DATA_ZHA] = {}
 
     def handle_message(
         self,

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -48,7 +48,6 @@ from .const import (
     CONF_ZIGPY,
     DATA_ZHA,
     DATA_ZHA_BRIDGE_ID,
-    DATA_ZHA_CONFIG,
     DATA_ZHA_GATEWAY,
     DEBUG_COMP_BELLOWS,
     DEBUG_COMP_ZHA,
@@ -767,18 +766,15 @@ class ZHAGateway:
             unsubscribe()
         for device in self.devices.values():
             device.async_cleanup_handles()
+        # shutdown is called when the config entry unloads are processed
+        # there are cases where unloads are processed because of a failure of
+        # some sort and the application controller may not have been
+        # created yet
         if (
             hasattr(self, "application_controller")
             and self.application_controller is not None
         ):
             await self.application_controller.shutdown()
-
-        # save a reference to configuration.yaml config since it is not reloaded
-        # when a config entry is reloaded
-        config = {}
-        if DATA_ZHA_CONFIG in self._hass.data[DATA_ZHA]:
-            config[DATA_ZHA_CONFIG] = self._hass.data[DATA_ZHA][DATA_ZHA_CONFIG]
-        self._hass.data[DATA_ZHA] = config
 
     def handle_message(
         self,

--- a/homeassistant/components/zha/device_trigger.py
+++ b/homeassistant/components/zha/device_trigger.py
@@ -9,12 +9,12 @@ from homeassistant.components.device_automation.exceptions import (
 from homeassistant.components.homeassistant.triggers import event as event_trigger
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
-from homeassistant.exceptions import HomeAssistantError, IntegrationError
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
 
 from . import DOMAIN as ZHA_DOMAIN
-from .core.const import ZHA_EVENT
+from .core.const import DATA_ZHA, DATA_ZHA_DEVICE_TRIGGER_CACHE, ZHA_EVENT
 from .core.helpers import async_get_zha_device
 
 CONF_SUBTYPE = "subtype"
@@ -26,21 +26,34 @@ TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
 )
 
 
+def _get_device_trigger_data(hass: HomeAssistant, device_id: str) -> tuple[str, dict]:
+    """Get device trigger data for a device, falling back to the cache if possible."""
+
+    # First, try checking to see if the device itself is accessible
+    try:
+        zha_device = async_get_zha_device(hass, device_id)
+    except KeyError:
+        pass
+    else:
+        return str(zha_device.ieee), zha_device.device_automation_triggers
+
+    # If not, check the trigger cache but allow any `KeyError`s to propagate
+    return hass.data[DATA_ZHA][DATA_ZHA_DEVICE_TRIGGER_CACHE][device_id]
+
+
 async def async_validate_trigger_config(
     hass: HomeAssistant, config: ConfigType
 ) -> ConfigType:
     """Validate config."""
     config = TRIGGER_SCHEMA(config)
 
-    trigger = (config[CONF_TYPE], config[CONF_SUBTYPE])
     try:
-        zha_device = async_get_zha_device(hass, config[CONF_DEVICE_ID])
-    except (KeyError, AttributeError, IntegrationError) as err:
+        _, triggers = _get_device_trigger_data(hass, config[CONF_DEVICE_ID])
+    except KeyError as err:
         raise InvalidDeviceAutomationConfig from err
-    if (
-        zha_device.device_automation_triggers is None
-        or trigger not in zha_device.device_automation_triggers
-    ):
+
+    trigger = (config[CONF_TYPE], config[CONF_SUBTYPE])
+    if trigger not in triggers:
         raise InvalidDeviceAutomationConfig(f"device does not have trigger {trigger}")
 
     return config
@@ -53,26 +66,26 @@ async def async_attach_trigger(
     trigger_info: TriggerInfo,
 ) -> CALLBACK_TYPE:
     """Listen for state changes based on configuration."""
-    trigger_key: tuple[str, str] = (config[CONF_TYPE], config[CONF_SUBTYPE])
+
     try:
-        zha_device = async_get_zha_device(hass, config[CONF_DEVICE_ID])
-    except (KeyError, AttributeError) as err:
+        ieee, triggers = _get_device_trigger_data(hass, config[CONF_DEVICE_ID])
+    except KeyError as err:
         raise HomeAssistantError(
             f"Unable to get zha device {config[CONF_DEVICE_ID]}"
         ) from err
 
-    if trigger_key not in zha_device.device_automation_triggers:
+    trigger_key: tuple[str, str] = (config[CONF_TYPE], config[CONF_SUBTYPE])
+
+    if trigger_key not in triggers:
         raise HomeAssistantError(f"Unable to find trigger {trigger_key}")
 
-    trigger = zha_device.device_automation_triggers[trigger_key]
-
-    event_config = {
-        event_trigger.CONF_PLATFORM: "event",
-        event_trigger.CONF_EVENT_TYPE: ZHA_EVENT,
-        event_trigger.CONF_EVENT_DATA: {DEVICE_IEEE: str(zha_device.ieee), **trigger},
-    }
-
-    event_config = event_trigger.TRIGGER_SCHEMA(event_config)
+    event_config = event_trigger.TRIGGER_SCHEMA(
+        {
+            event_trigger.CONF_PLATFORM: "event",
+            event_trigger.CONF_EVENT_TYPE: ZHA_EVENT,
+            event_trigger.CONF_EVENT_DATA: {DEVICE_IEEE: ieee, **triggers[trigger_key]},
+        }
+    )
     return await event_trigger.async_attach_trigger(
         hass, event_config, action, trigger_info, platform_type="device"
     )
@@ -83,24 +96,17 @@ async def async_get_triggers(
 ) -> list[dict[str, str]]:
     """List device triggers.
 
-    Make sure the device supports device automations and
-    if it does return the trigger list.
+    Make sure the device supports device automations and return the trigger list.
     """
-    zha_device = async_get_zha_device(hass, device_id)
+    _, triggers = _get_device_trigger_data(hass, device_id)
 
-    if not zha_device.device_automation_triggers:
-        return []
-
-    triggers = []
-    for trigger, subtype in zha_device.device_automation_triggers:
-        triggers.append(
-            {
-                CONF_DEVICE_ID: device_id,
-                CONF_DOMAIN: ZHA_DOMAIN,
-                CONF_PLATFORM: DEVICE,
-                CONF_TYPE: trigger,
-                CONF_SUBTYPE: subtype,
-            }
-        )
-
-    return triggers
+    return [
+        {
+            CONF_DEVICE_ID: device_id,
+            CONF_DOMAIN: ZHA_DOMAIN,
+            CONF_PLATFORM: DEVICE,
+            CONF_TYPE: trigger,
+            CONF_SUBTYPE: subtype,
+        }
+        for trigger, subtype in triggers
+    ]

--- a/homeassistant/components/zha/device_trigger.py
+++ b/homeassistant/components/zha/device_trigger.py
@@ -47,10 +47,8 @@ async def async_validate_trigger_config(
     """Validate config."""
     config = TRIGGER_SCHEMA(config)
 
-    try:
-        _, triggers = _get_device_trigger_data(hass, config[CONF_DEVICE_ID])
-    except KeyError as err:
-        raise InvalidDeviceAutomationConfig from err
+    # Trigger validation will not occur if the config entry is not loaded
+    _, triggers = _get_device_trigger_data(hass, config[CONF_DEVICE_ID])
 
     trigger = (config[CONF_TYPE], config[CONF_SUBTYPE])
     if trigger not in triggers:
@@ -98,7 +96,10 @@ async def async_get_triggers(
 
     Make sure the device supports device automations and return the trigger list.
     """
-    _, triggers = _get_device_trigger_data(hass, device_id)
+    try:
+        _, triggers = _get_device_trigger_data(hass, device_id)
+    except KeyError as err:
+        raise InvalidDeviceAutomationConfig from err
 
     return [
         {

--- a/homeassistant/components/zha/radio_manager.py
+++ b/homeassistant/components/zha/radio_manager.py
@@ -170,7 +170,7 @@ class ZhaRadioManager:
         try:
             yield app
         finally:
-            await app.disconnect()
+            await app.shutdown()
             await asyncio.sleep(CONNECT_DELAY_S)
 
     async def restore_backup(

--- a/homeassistant/components/zha/radio_manager.py
+++ b/homeassistant/components/zha/radio_manager.py
@@ -8,7 +8,7 @@ import copy
 import enum
 import logging
 import os
-from typing import Any
+from typing import Any, Self
 
 from bellows.config import CONF_USE_THREAD
 import voluptuous as vol
@@ -126,6 +126,19 @@ class ZhaRadioManager:
         self.current_settings: zigpy.backups.NetworkBackup | None = None
         self.backups: list[zigpy.backups.NetworkBackup] = []
         self.chosen_backup: zigpy.backups.NetworkBackup | None = None
+
+    @classmethod
+    def from_config_entry(
+        cls, hass: HomeAssistant, config_entry: config_entries.ConfigEntry
+    ) -> Self:
+        """Create an instance from a config entry."""
+        mgr = cls()
+        mgr.hass = hass
+        mgr.device_path = config_entry.data[CONF_DEVICE][CONF_DEVICE_PATH]
+        mgr.device_settings = config_entry.data[CONF_DEVICE]
+        mgr.radio_type = RadioType[config_entry.data[CONF_RADIO_TYPE]]
+
+        return mgr
 
     @contextlib.asynccontextmanager
     async def connect_zigpy_app(self) -> ControllerApplication:

--- a/homeassistant/components/zha/radio_manager.py
+++ b/homeassistant/components/zha/radio_manager.py
@@ -155,7 +155,6 @@ class ZhaRadioManager:
         )
 
         try:
-            await app.connect()
             yield app
         finally:
             await app.disconnect()
@@ -171,6 +170,7 @@ class ZhaRadioManager:
             return
 
         async with self._connect_zigpy_app() as app:
+            await app.connect()
             await app.backups.restore_backup(backup, **kwargs)
 
     @staticmethod
@@ -219,6 +219,8 @@ class ZhaRadioManager:
         backup = None
 
         async with self._connect_zigpy_app() as app:
+            await app.connect()
+
             # Check if the stick has any settings and load them
             try:
                 await app.load_network_info()
@@ -242,11 +244,13 @@ class ZhaRadioManager:
     async def async_form_network(self) -> None:
         """Form a brand-new network."""
         async with self._connect_zigpy_app() as app:
+            await app.connect()
             await app.form_network()
 
     async def async_reset_adapter(self) -> None:
         """Reset the current adapter."""
         async with self._connect_zigpy_app() as app:
+            await app.connect()
             await app.reset_network_info()
 
     async def async_restore_backup_step_1(self) -> bool:

--- a/homeassistant/components/zha/radio_manager.py
+++ b/homeassistant/components/zha/radio_manager.py
@@ -128,7 +128,7 @@ class ZhaRadioManager:
         self.chosen_backup: zigpy.backups.NetworkBackup | None = None
 
     @contextlib.asynccontextmanager
-    async def _connect_zigpy_app(self) -> ControllerApplication:
+    async def connect_zigpy_app(self) -> ControllerApplication:
         """Connect to the radio with the current config and then clean up."""
         assert self.radio_type is not None
 
@@ -169,7 +169,7 @@ class ZhaRadioManager:
         ):
             return
 
-        async with self._connect_zigpy_app() as app:
+        async with self.connect_zigpy_app() as app:
             await app.connect()
             await app.backups.restore_backup(backup, **kwargs)
 
@@ -218,7 +218,7 @@ class ZhaRadioManager:
         """Connect to the radio and load its current network settings."""
         backup = None
 
-        async with self._connect_zigpy_app() as app:
+        async with self.connect_zigpy_app() as app:
             await app.connect()
 
             # Check if the stick has any settings and load them
@@ -243,13 +243,13 @@ class ZhaRadioManager:
 
     async def async_form_network(self) -> None:
         """Form a brand-new network."""
-        async with self._connect_zigpy_app() as app:
+        async with self.connect_zigpy_app() as app:
             await app.connect()
             await app.form_network()
 
     async def async_reset_adapter(self) -> None:
         """Reset the current adapter."""
-        async with self._connect_zigpy_app() as app:
+        async with self.connect_zigpy_app() as app:
             await app.connect()
             await app.reset_network_info()
 

--- a/tests/components/homeassistant_hardware/conftest.py
+++ b/tests/components/homeassistant_hardware/conftest.py
@@ -23,7 +23,7 @@ def mock_zha_config_flow_setup() -> Generator[None, None, None]:
     with patch(
         "bellows.zigbee.application.ControllerApplication.probe", side_effect=mock_probe
     ), patch(
-        "homeassistant.components.zha.radio_manager.ZhaRadioManager._connect_zigpy_app",
+        "homeassistant.components.zha.radio_manager.ZhaRadioManager.connect_zigpy_app",
         return_value=mock_connect_app,
     ), patch(
         "homeassistant.components.zha.async_setup_entry",

--- a/tests/components/homeassistant_sky_connect/conftest.py
+++ b/tests/components/homeassistant_sky_connect/conftest.py
@@ -25,7 +25,7 @@ def mock_zha():
     )
 
     with patch(
-        "homeassistant.components.zha.radio_manager.ZhaRadioManager._connect_zigpy_app",
+        "homeassistant.components.zha.radio_manager.ZhaRadioManager.connect_zigpy_app",
         return_value=mock_connect_app,
     ), patch(
         "homeassistant.components.zha.async_setup_entry",

--- a/tests/components/homeassistant_sky_connect/test_init.py
+++ b/tests/components/homeassistant_sky_connect/test_init.py
@@ -45,7 +45,7 @@ def mock_zha_config_flow_setup() -> Generator[None, None, None]:
     with patch(
         "bellows.zigbee.application.ControllerApplication.probe", side_effect=mock_probe
     ), patch(
-        "homeassistant.components.zha.radio_manager.ZhaRadioManager._connect_zigpy_app",
+        "homeassistant.components.zha.radio_manager.ZhaRadioManager.connect_zigpy_app",
         return_value=mock_connect_app,
     ):
         yield

--- a/tests/components/homeassistant_yellow/conftest.py
+++ b/tests/components/homeassistant_yellow/conftest.py
@@ -23,7 +23,7 @@ def mock_zha_config_flow_setup() -> Generator[None, None, None]:
     with patch(
         "bellows.zigbee.application.ControllerApplication.probe", side_effect=mock_probe
     ), patch(
-        "homeassistant.components.zha.radio_manager.ZhaRadioManager._connect_zigpy_app",
+        "homeassistant.components.zha.radio_manager.ZhaRadioManager.connect_zigpy_app",
         return_value=mock_connect_app,
     ), patch(
         "homeassistant.components.zha.async_setup_entry",

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -376,3 +376,10 @@ def hass_disable_services(hass):
         hass, "services", MagicMock(has_service=MagicMock(return_value=True))
     ):
         yield hass
+
+
+@pytest.fixture(autouse=True)
+def speed_up_radio_mgr():
+    """Speed up the radio manager connection time by removing delays."""
+    with patch("homeassistant.components.zha.radio_manager.CONNECT_DELAY_S", 0.00001):
+        yield

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -293,14 +293,20 @@ def zigpy_device_mock(zigpy_app_controller):
     return _mock_dev
 
 
+@patch("homeassistant.components.zha.setup_quirks", MagicMock(return_value=True))
 @pytest.fixture
 def zha_device_joined(hass, setup_zha):
     """Return a newly joined ZHA device."""
+    setup_zha_fixture = setup_zha
 
-    async def _zha_device(zigpy_dev):
+    async def _zha_device(zigpy_dev, *, setup_zha: bool = True):
         zigpy_dev.last_seen = time.time()
-        await setup_zha()
+
+        if setup_zha:
+            await setup_zha_fixture()
+
         zha_gateway = common.get_zha_gateway(hass)
+        zha_gateway.application_controller.devices[zigpy_dev.ieee] = zigpy_dev
         await zha_gateway.async_device_initialized(zigpy_dev)
         await hass.async_block_till_done()
         return zha_gateway.get_device(zigpy_dev.ieee)
@@ -308,17 +314,21 @@ def zha_device_joined(hass, setup_zha):
     return _zha_device
 
 
+@patch("homeassistant.components.zha.setup_quirks", MagicMock(return_value=True))
 @pytest.fixture
 def zha_device_restored(hass, zigpy_app_controller, setup_zha):
     """Return a restored ZHA device."""
+    setup_zha_fixture = setup_zha
 
-    async def _zha_device(zigpy_dev, last_seen=None):
+    async def _zha_device(zigpy_dev, *, last_seen=None, setup_zha: bool = True):
         zigpy_app_controller.devices[zigpy_dev.ieee] = zigpy_dev
 
         if last_seen is not None:
             zigpy_dev.last_seen = last_seen
 
-        await setup_zha()
+        if setup_zha:
+            await setup_zha_fixture()
+
         zha_gateway = hass.data[zha_const.DATA_ZHA][zha_const.DATA_ZHA_GATEWAY]
         return zha_gateway.get_device(zigpy_dev.ieee)
 

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -64,13 +64,6 @@ def mock_multipan_platform():
 
 
 @pytest.fixture(autouse=True)
-def reduce_reconnect_timeout():
-    """Reduces reconnect timeout to speed up tests."""
-    with patch("homeassistant.components.zha.radio_manager.CONNECT_DELAY_S", 0.01):
-        yield
-
-
-@pytest.fixture(autouse=True)
 def mock_app():
     """Mock zigpy app interface."""
     mock_app = AsyncMock()

--- a/tests/components/zha/test_device_trigger.py
+++ b/tests/components/zha/test_device_trigger.py
@@ -9,6 +9,9 @@ import zigpy.zcl.clusters.general as general
 
 import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
+from homeassistant.components.device_automation.exceptions import (
+    InvalidDeviceAutomationConfig,
+)
 from homeassistant.components.zha.core.const import ATTR_ENDPOINT_ID
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -20,6 +23,7 @@ from .common import async_enable_traffic
 from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 
 from tests.common import (
+    MockConfigEntry,
     async_fire_time_changed,
     async_get_device_automations,
     async_mock_service,
@@ -43,6 +47,16 @@ DOUBLE_PRESS = "remote_button_double_press"
 SHORT_PRESS = "remote_button_short_press"
 LONG_PRESS = "remote_button_long_press"
 LONG_RELEASE = "remote_button_long_release"
+
+
+SWITCH_SIGNATURE = {
+    1: {
+        SIG_EP_INPUT: [general.Basic.cluster_id],
+        SIG_EP_OUTPUT: [general.OnOff.cluster_id],
+        SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.ON_OFF_SWITCH,
+        SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
+    }
+}
 
 
 @pytest.fixture(autouse=True)
@@ -72,16 +86,7 @@ def calls(hass):
 async def mock_devices(hass, zigpy_device_mock, zha_device_joined_restored):
     """IAS device fixture."""
 
-    zigpy_device = zigpy_device_mock(
-        {
-            1: {
-                SIG_EP_INPUT: [general.Basic.cluster_id],
-                SIG_EP_OUTPUT: [general.OnOff.cluster_id],
-                SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.ON_OFF_SWITCH,
-                SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
-            }
-        }
-    )
+    zigpy_device = zigpy_device_mock(SWITCH_SIGNATURE)
 
     zha_device = await zha_device_joined_restored(zigpy_device)
     zha_device.update_available(True)
@@ -397,3 +402,108 @@ async def test_exception_bad_trigger(
         "Unnamed automation failed to setup triggers and has been disabled: "
         "device does not have trigger ('junk', 'junk')" in caplog.text
     )
+
+
+async def test_validate_trigger_config_missing_info(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    zigpy_device_mock,
+    mock_zigpy_connect,
+    zha_device_joined,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test device triggers referring to a missing device."""
+
+    # Join a device
+    switch = zigpy_device_mock(SWITCH_SIGNATURE)
+    await zha_device_joined(switch)
+
+    # After we unload the config entry, trigger info was not cached on startup, nor can
+    # it be pulled from the current device, making it impossible to validate triggers
+    await hass.config_entries.async_unload(config_entry.entry_id)
+
+    ha_device_registry = dr.async_get(hass)
+    reg_device = ha_device_registry.async_get_device(
+        identifiers={("zha", str(switch.ieee))}
+    )
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "device_id": reg_device.id,
+                        "domain": "zha",
+                        "platform": "device",
+                        "type": "junk",
+                        "subtype": "junk",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data": {"message": "service called"},
+                    },
+                }
+            ]
+        },
+    )
+
+    assert "Unable to get zha device" in caplog.text
+
+    with pytest.raises(InvalidDeviceAutomationConfig):
+        await async_get_device_automations(
+            hass, DeviceAutomationType.TRIGGER, reg_device.id
+        )
+
+
+async def test_validate_trigger_config_unloaded_bad_info(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    zigpy_device_mock,
+    mock_zigpy_connect,
+    zha_device_joined,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test device triggers referring to a missing device."""
+
+    # Join a device
+    switch = zigpy_device_mock(SWITCH_SIGNATURE)
+    await zha_device_joined(switch)
+
+    # After we unload the config entry, trigger info was not cached on startup, nor can
+    # it be pulled from the current device, making it impossible to validate triggers
+    await hass.config_entries.async_unload(config_entry.entry_id)
+
+    # Reload ZHA to persist the device info in the cache
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.config_entries.async_unload(config_entry.entry_id)
+
+    ha_device_registry = dr.async_get(hass)
+    reg_device = ha_device_registry.async_get_device(
+        identifiers={("zha", str(switch.ieee))}
+    )
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "device_id": reg_device.id,
+                        "domain": "zha",
+                        "platform": "device",
+                        "type": "junk",
+                        "subtype": "junk",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data": {"message": "service called"},
+                    },
+                }
+            ]
+        },
+    )
+
+    assert "Unable to find trigger" in caplog.text

--- a/tests/components/zha/test_radio_manager.py
+++ b/tests/components/zha/test_radio_manager.py
@@ -99,7 +99,7 @@ def mock_connect_zigpy_app() -> Generator[MagicMock, None, None]:
     )
 
     with patch(
-        "homeassistant.components.zha.radio_manager.ZhaRadioManager._connect_zigpy_app",
+        "homeassistant.components.zha.radio_manager.ZhaRadioManager.connect_zigpy_app",
         return_value=mock_connect_app,
     ):
         yield mock_connect_app

--- a/tests/components/zha/test_radio_manager.py
+++ b/tests/components/zha/test_radio_manager.py
@@ -32,9 +32,7 @@ def disable_platform_only():
 @pytest.fixture(autouse=True)
 def reduce_reconnect_timeout():
     """Reduces reconnect timeout to speed up tests."""
-    with patch(
-        "homeassistant.components.zha.radio_manager.CONNECT_DELAY_S", 0.0001
-    ), patch("homeassistant.components.zha.radio_manager.RETRY_DELAY_S", 0.0001):
+    with patch("homeassistant.components.zha.radio_manager.RETRY_DELAY_S", 0.0001):
         yield
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR supersedes #99694 and reverts #99679. Instead of persisting the ZHA gateway object across loads, we instead preemptively cache device trigger information on startup and use this cache as a fallback for loading device trigger data, when the ZHA integration is not ready yet automations continue loading.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #99750, fixes #99966, fixes #99750
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
