### PR TITLE
Fix missing dew point and humidity in tomorrowio forecasts

### DIFF
--- a/homeassistant/components/tomorrowio/__init__.py
+++ b/homeassistant/components/tomorrowio/__init__.py
@@ -302,6 +302,8 @@ class TomorrowioDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     [
                         TMRW_ATTR_TEMPERATURE_LOW,
                         TMRW_ATTR_TEMPERATURE_HIGH,
+                        TMRW_ATTR_DEW_POINT,
+                        TMRW_ATTR_HUMIDITY,
                         TMRW_ATTR_WIND_SPEED,
                         TMRW_ATTR_WIND_DIRECTION,
                         TMRW_ATTR_CONDITION,

--- a/tests/components/tomorrowio/test_weather.py
+++ b/tests/components/tomorrowio/test_weather.py
@@ -153,9 +153,66 @@ async def test_legacy_config_entry(hass: HomeAssistant) -> None:
     assert len(er.async_entries_for_config_entry(registry, entry.entry_id)) == 30
 
 
-async def test_v4_weather(hass: HomeAssistant) -> None:
+async def test_v4_weather(hass: HomeAssistant, tomorrowio_config_entry_update) -> None:
     """Test v4 weather data."""
     weather_state = await _setup(hass, API_V4_ENTRY_DATA)
+
+    tomorrowio_config_entry_update.assert_called_with(
+        [
+            "temperature",
+            "humidity",
+            "pressureSeaLevel",
+            "windSpeed",
+            "windDirection",
+            "weatherCode",
+            "visibility",
+            "pollutantO3",
+            "windGust",
+            "cloudCover",
+            "precipitationType",
+            "pollutantCO",
+            "mepIndex",
+            "mepHealthConcern",
+            "mepPrimaryPollutant",
+            "cloudBase",
+            "cloudCeiling",
+            "cloudCover",
+            "dewPoint",
+            "epaIndex",
+            "epaHealthConcern",
+            "epaPrimaryPollutant",
+            "temperatureApparent",
+            "fireIndex",
+            "pollutantNO2",
+            "pollutantO3",
+            "particulateMatter10",
+            "particulateMatter25",
+            "grassIndex",
+            "treeIndex",
+            "weedIndex",
+            "precipitationType",
+            "pressureSurfaceLevel",
+            "solarGHI",
+            "pollutantSO2",
+            "uvIndex",
+            "uvHealthConcern",
+            "windGust",
+        ],
+        [
+            "temperatureMin",
+            "temperatureMax",
+            "dewPoint",
+            "humidity",
+            "windSpeed",
+            "windDirection",
+            "weatherCode",
+            "precipitationIntensityAvg",
+            "precipitationProbability",
+        ],
+        nowcast_timestep=60,
+        location="80.0,80.0",
+    )
+
     assert weather_state.state == ATTR_CONDITION_SUNNY
     assert weather_state.attributes[ATTR_ATTRIBUTION] == ATTRIBUTION
     assert len(weather_state.attributes[ATTR_FORECAST]) == 14


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Humidity and dew point were added to the tomorrow.io forecasts in 2023.9.0 but they aren't working as two lines were missed in the original commits.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/99792
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
