### PR TITLE
Improve handling of roon media players with fixed and incremental volume

### DIFF
--- a/homeassistant/components/roon/media_player.py
+++ b/homeassistant/components/roon/media_player.py
@@ -92,7 +92,6 @@ class RoonDevice(MediaPlayerEntity):
         MediaPlayerEntityFeature.BROWSE_MEDIA
         | MediaPlayerEntityFeature.GROUPING
         | MediaPlayerEntityFeature.PAUSE
-        | MediaPlayerEntityFeature.VOLUME_SET
         | MediaPlayerEntityFeature.STOP
         | MediaPlayerEntityFeature.PREVIOUS_TRACK
         | MediaPlayerEntityFeature.NEXT_TRACK
@@ -104,7 +103,6 @@ class RoonDevice(MediaPlayerEntity):
         | MediaPlayerEntityFeature.VOLUME_MUTE
         | MediaPlayerEntityFeature.PLAY
         | MediaPlayerEntityFeature.PLAY_MEDIA
-        | MediaPlayerEntityFeature.VOLUME_STEP
     )
 
     def __init__(self, server, player_data):
@@ -124,6 +122,8 @@ class RoonDevice(MediaPlayerEntity):
         self._attr_shuffle = False
         self._attr_media_image_url = None
         self._attr_volume_level = 0
+        self._attr_volume_fixed = True
+        self._attr_volume_incremental = False
         self.update_data(player_data)
 
     async def async_added_to_hass(self) -> None:
@@ -190,21 +190,32 @@ class RoonDevice(MediaPlayerEntity):
             "level": 0,
             "step": 0,
             "muted": False,
+            "fixed": True,
+            "incremental": False,
         }
 
         try:
             volume_data = player_data["volume"]
-            volume_muted = volume_data["is_muted"]
-            volume_step = convert(volume_data["step"], int, 0)
-            volume_max = volume_data["max"]
-            volume_min = volume_data["min"]
-            raw_level = convert(volume_data["value"], float, 0)
 
-            volume_range = volume_max - volume_min
-            volume_percentage_factor = volume_range / 100
+            volume_fixed = False
+            volume_incremental = volume_data["type"] == "incremental"
+            volume_muted = volume_data.get("is_muted", False)
 
-            level = (raw_level - volume_min) / volume_percentage_factor
-            volume_level = convert(level, int, 0) / 100
+            try:
+                volume_step = convert(volume_data["step"], int, 0)
+
+                volume_max = volume_data["max"]
+                volume_min = volume_data["min"]
+                raw_level = convert(volume_data["value"], float, 0)
+
+                volume_range = volume_max - volume_min
+                volume_percentage_factor = volume_range / 100
+
+                level = (raw_level - volume_min) / volume_percentage_factor
+                volume_level = convert(level, int, 0) / 100
+            except KeyError:
+                volume_step = 0
+                volume_level = 0
 
         except KeyError:
             # catch KeyError
@@ -213,6 +224,8 @@ class RoonDevice(MediaPlayerEntity):
             volume["muted"] = volume_muted
             volume["step"] = volume_step
             volume["level"] = volume_level
+            volume["fixed"] = volume_fixed
+            volume["incremental"] = volume_incremental
 
         return volume
 
@@ -288,6 +301,16 @@ class RoonDevice(MediaPlayerEntity):
         self._attr_is_volume_muted = volume["muted"]
         self._attr_volume_step = volume["step"]
         self._attr_volume_level = volume["level"]
+        self._attr_volume_fixed = volume["fixed"]
+        self._attr_volume_incremental = volume["incremental"]
+        if not self._attr_volume_fixed:
+            self._attr_supported_features = (
+                self._attr_supported_features | MediaPlayerEntityFeature.VOLUME_STEP
+            )
+            if not self._attr_volume_incremental:
+                self._attr_supported_features = (
+                    self._attr_supported_features | MediaPlayerEntityFeature.VOLUME_SET
+                )
 
         now_playing = self._parse_now_playing(self.player_data)
         self._attr_media_title = now_playing["title"]
@@ -350,6 +373,11 @@ class RoonDevice(MediaPlayerEntity):
 
     def set_volume_level(self, volume: float) -> None:
         """Send new volume_level to device."""
+
+        if self._attr_volume_fixed:
+            _LOGGER.error("Cannot change volume for %s, volume is fixed", self.name)
+            return
+
         volume = volume * 100
         self._server.roonapi.set_volume_percent(self.output_id, volume)
 
@@ -359,11 +387,25 @@ class RoonDevice(MediaPlayerEntity):
 
     def volume_up(self) -> None:
         """Send new volume_level to device."""
-        self._server.roonapi.change_volume_percent(self.output_id, 3)
+        if self._attr_volume_fixed:
+            _LOGGER.error("Cannot change volume for %s, volume is fixed", self.name)
+            return
+
+        if self._attr_volume_incremental:
+            self._server.roonapi.change_volume_raw(self.output_id, 1, "relative_step")
+        else:
+            self._server.roonapi.change_volume_percent(self.output_id, 3)
 
     def volume_down(self) -> None:
         """Send new volume_level to device."""
-        self._server.roonapi.change_volume_percent(self.output_id, -3)
+        if self._attr_volume_fixed:
+            _LOGGER.error("Cannot change volume for %s, volume is fixed", self.name)
+            return
+
+        if self._attr_volume_incremental:
+            self._server.roonapi.change_volume_raw(self.output_id, -1, "relative_step")
+        else:
+            self._server.roonapi.change_volume_percent(self.output_id, -3)
 
     def turn_on(self) -> None:
         """Turn on device (if supported)."""

--- a/homeassistant/components/roon/media_player.py
+++ b/homeassistant/components/roon/media_player.py
@@ -122,8 +122,8 @@ class RoonDevice(MediaPlayerEntity):
         self._attr_shuffle = False
         self._attr_media_image_url = None
         self._attr_volume_level = 0
-        self.volume_fixed = True
-        self.volume_incremental = False
+        self._volume_fixed = True
+        self._volume_incremental = False
         self.update_data(player_data)
 
     async def async_added_to_hass(self) -> None:
@@ -291,13 +291,13 @@ class RoonDevice(MediaPlayerEntity):
         self._attr_is_volume_muted = volume["muted"]
         self._attr_volume_step = volume["step"]
         self._attr_volume_level = volume["level"]
-        self.volume_fixed = volume["fixed"]
-        self.volume_incremental = volume["incremental"]
-        if not self.volume_fixed:
+        self._volume_fixed = volume["fixed"]
+        self._volume_incremental = volume["incremental"]
+        if not self._volume_fixed:
             self._attr_supported_features = (
                 self._attr_supported_features | MediaPlayerEntityFeature.VOLUME_STEP
             )
-            if not self.volume_incremental:
+            if not self._volume_incremental:
                 self._attr_supported_features = (
                     self._attr_supported_features | MediaPlayerEntityFeature.VOLUME_SET
                 )
@@ -372,14 +372,14 @@ class RoonDevice(MediaPlayerEntity):
 
     def volume_up(self) -> None:
         """Send new volume_level to device."""
-        if self.volume_incremental:
+        if self._volume_incremental:
             self._server.roonapi.change_volume_raw(self.output_id, 1, "relative_step")
         else:
             self._server.roonapi.change_volume_percent(self.output_id, 3)
 
     def volume_down(self) -> None:
         """Send new volume_level to device."""
-        if self.volume_incremental:
+        if self._volume_incremental:
             self._server.roonapi.change_volume_raw(self.output_id, -1, "relative_step")
         else:
             self._server.roonapi.change_volume_percent(self.output_id, -3)

--- a/homeassistant/components/roon/media_player.py
+++ b/homeassistant/components/roon/media_player.py
@@ -122,8 +122,8 @@ class RoonDevice(MediaPlayerEntity):
         self._attr_shuffle = False
         self._attr_media_image_url = None
         self._attr_volume_level = 0
-        self._attr_volume_fixed = True
-        self._attr_volume_incremental = False
+        self.volume_fixed = True
+        self.volume_incremental = False
         self.update_data(player_data)
 
     async def async_added_to_hass(self) -> None:
@@ -301,13 +301,13 @@ class RoonDevice(MediaPlayerEntity):
         self._attr_is_volume_muted = volume["muted"]
         self._attr_volume_step = volume["step"]
         self._attr_volume_level = volume["level"]
-        self._attr_volume_fixed = volume["fixed"]
-        self._attr_volume_incremental = volume["incremental"]
-        if not self._attr_volume_fixed:
+        self.volume_fixed = volume["fixed"]
+        self.volume_incremental = volume["incremental"]
+        if not self.volume_fixed:
             self._attr_supported_features = (
                 self._attr_supported_features | MediaPlayerEntityFeature.VOLUME_STEP
             )
-            if not self._attr_volume_incremental:
+            if not self.volume_incremental:
                 self._attr_supported_features = (
                     self._attr_supported_features | MediaPlayerEntityFeature.VOLUME_SET
                 )
@@ -373,11 +373,6 @@ class RoonDevice(MediaPlayerEntity):
 
     def set_volume_level(self, volume: float) -> None:
         """Send new volume_level to device."""
-
-        if self._attr_volume_fixed:
-            _LOGGER.error("Cannot change volume for %s, volume is fixed", self.name)
-            return
-
         volume = volume * 100
         self._server.roonapi.set_volume_percent(self.output_id, volume)
 
@@ -387,22 +382,14 @@ class RoonDevice(MediaPlayerEntity):
 
     def volume_up(self) -> None:
         """Send new volume_level to device."""
-        if self._attr_volume_fixed:
-            _LOGGER.error("Cannot change volume for %s, volume is fixed", self.name)
-            return
-
-        if self._attr_volume_incremental:
+        if self.volume_incremental:
             self._server.roonapi.change_volume_raw(self.output_id, 1, "relative_step")
         else:
             self._server.roonapi.change_volume_percent(self.output_id, 3)
 
     def volume_down(self) -> None:
         """Send new volume_level to device."""
-        if self._attr_volume_fixed:
-            _LOGGER.error("Cannot change volume for %s, volume is fixed", self.name)
-            return
-
-        if self._attr_volume_incremental:
+        if self.volume_incremental:
             self._server.roonapi.change_volume_raw(self.output_id, -1, "relative_step")
         else:
             self._server.roonapi.change_volume_percent(self.output_id, -3)

--- a/homeassistant/components/roon/media_player.py
+++ b/homeassistant/components/roon/media_player.py
@@ -196,36 +196,26 @@ class RoonDevice(MediaPlayerEntity):
 
         try:
             volume_data = player_data["volume"]
-
-            volume_fixed = False
-            volume_incremental = volume_data["type"] == "incremental"
-            volume_muted = volume_data.get("is_muted", False)
-
-            try:
-                volume_step = convert(volume_data["step"], int, 0)
-
-                volume_max = volume_data["max"]
-                volume_min = volume_data["min"]
-                raw_level = convert(volume_data["value"], float, 0)
-
-                volume_range = volume_max - volume_min
-                volume_percentage_factor = volume_range / 100
-
-                level = (raw_level - volume_min) / volume_percentage_factor
-                volume_level = convert(level, int, 0) / 100
-            except KeyError:
-                volume_step = 0
-                volume_level = 0
-
         except KeyError:
-            # catch KeyError
+            return volume
+
+        volume["fixed"] = False
+        volume["incremental"] = volume_data["type"] == "incremental"
+        volume["muted"] = volume_data.get("is_muted", False)
+        volume["step"] = convert(volume_data.get("step"), int, 0)
+
+        try:
+            volume_max = volume_data["max"]
+            volume_min = volume_data["min"]
+            raw_level = convert(volume_data["value"], float, 0)
+
+            volume_range = volume_max - volume_min
+            volume_percentage_factor = volume_range / 100
+
+            level = (raw_level - volume_min) / volume_percentage_factor
+            volume["level"] = convert(level, int, 0) / 100
+        except KeyError:
             pass
-        else:
-            volume["muted"] = volume_muted
-            volume["step"] = volume_step
-            volume["level"] = volume_level
-            volume["fixed"] = volume_fixed
-            volume["incremental"] = volume_incremental
 
         return volume
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current HA roon integration assumes that roon media players have the ability to set volume, and increment volume (up and down). However in fact roon has endpoints with fixed volume, and incremental only volume, as well as more conventional volume.

This PR does two things:

- Set the _supported features_ correctly based on the abilities of the roon endpoint
- Fix bugs when using incremental only roon endpoints

Incremental endpoints are not common (which is why the bugs haven't been reported) - but will be used if https://github.com/home-assistant/core/pull/99684 is merged.

This PR should be merged regardless of the PR above (as it fixes bugs). But it is required to release the PR above.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
