### PR TITLE
Upgrade bluetooth deps to fix timeout behavior on py3.11

### DIFF
--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -15,7 +15,7 @@
   "quality_scale": "internal",
   "requirements": [
     "bleak==0.21.0",
-    "bleak-retry-connector==3.1.2",
+    "bleak-retry-connector==3.1.3",
     "bluetooth-adapters==0.16.0",
     "bluetooth-auto-recovery==1.2.1",
     "bluetooth-data-tools==1.11.0",

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -16,8 +16,8 @@
   "requirements": [
     "bleak==0.21.0",
     "bleak-retry-connector==3.1.3",
-    "bluetooth-adapters==0.16.0",
-    "bluetooth-auto-recovery==1.2.1",
+    "bluetooth-adapters==0.16.1",
+    "bluetooth-auto-recovery==1.2.2",
     "bluetooth-data-tools==1.11.0",
     "dbus-fast==1.95.2"
   ]

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -10,8 +10,8 @@ awesomeversion==22.9.0
 bcrypt==4.0.1
 bleak-retry-connector==3.1.3
 bleak==0.21.0
-bluetooth-adapters==0.16.0
-bluetooth-auto-recovery==1.2.1
+bluetooth-adapters==0.16.1
+bluetooth-auto-recovery==1.2.2
 bluetooth-data-tools==1.11.0
 certifi>=2021.5.30
 ciso8601==2.3.0

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -8,7 +8,7 @@ atomicwrites-homeassistant==1.4.1
 attrs==23.1.0
 awesomeversion==22.9.0
 bcrypt==4.0.1
-bleak-retry-connector==3.1.2
+bleak-retry-connector==3.1.3
 bleak==0.21.0
 bluetooth-adapters==0.16.0
 bluetooth-auto-recovery==1.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -519,7 +519,7 @@ bimmer-connected==0.14.0
 bizkaibus==0.1.1
 
 # homeassistant.components.bluetooth
-bleak-retry-connector==3.1.2
+bleak-retry-connector==3.1.3
 
 # homeassistant.components.bluetooth
 bleak==0.21.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -541,10 +541,10 @@ bluemaestro-ble==0.2.3
 # bluepy==1.3.0
 
 # homeassistant.components.bluetooth
-bluetooth-adapters==0.16.0
+bluetooth-adapters==0.16.1
 
 # homeassistant.components.bluetooth
-bluetooth-auto-recovery==1.2.1
+bluetooth-auto-recovery==1.2.2
 
 # homeassistant.components.bluetooth
 # homeassistant.components.esphome

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -452,10 +452,10 @@ blinkpy==0.21.0
 bluemaestro-ble==0.2.3
 
 # homeassistant.components.bluetooth
-bluetooth-adapters==0.16.0
+bluetooth-adapters==0.16.1
 
 # homeassistant.components.bluetooth
-bluetooth-auto-recovery==1.2.1
+bluetooth-auto-recovery==1.2.2
 
 # homeassistant.components.bluetooth
 # homeassistant.components.esphome

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -437,7 +437,7 @@ bellows==0.36.3
 bimmer-connected==0.14.0
 
 # homeassistant.components.bluetooth
-bleak-retry-connector==3.1.2
+bleak-retry-connector==3.1.3
 
 # homeassistant.components.bluetooth
 bleak==0.21.0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Switch usage of `async_timeout` to `asyncio.timeout` on py3.11 since it better handles cancelation of the inner code when a timeout happens. We already did this in core, but I forgot to do it in these deps.

changelog: https://github.com/Bluetooth-Devices/bleak-retry-connector/compare/v3.1.2...v3.1.3
changelog: https://github.com/Bluetooth-Devices/bluetooth-adapters/compare/v0.16.0...v0.16.1
changelog: https://github.com/Bluetooth-Devices/bluetooth-auto-recovery/compare/v1.2.1...v1.2.2


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
