### PR TITLE
Deprecate CLOSE_COMM_ON_ERROR

### DIFF
--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -266,6 +266,9 @@ class ModbusHub:
                 severity=IssueSeverity.WARNING,
                 translation_key="deprecated_close_comm_config",
             )
+            _LOGGER.warning(
+                "`close_comm_on_error`: is deprecated and will be remove in version 2024.4"
+            )
         # generic configuration
         self._client: ModbusBaseClient | None = None
         self._async_cancel_listener: Callable[[], None] | None = None

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -34,6 +34,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.typing import ConfigType
 
@@ -256,8 +257,14 @@ class ModbusHub:
         """Initialize the Modbus hub."""
 
         if CONF_CLOSE_COMM_ON_ERROR in client_config:
-            _LOGGER.warning(
-                "CLOSE_COMM_ON_ERROR is deprecated since 2023.10.0 and will be removed in 2024.3"
+            async_create_issue(  # pragma: no cover
+                hass,
+                DOMAIN,
+                "deprecated_close_comm_config",
+                breaks_in_ha_version="2024.4.0",
+                is_fixable=False,
+                severity=IssueSeverity.WARNING,
+                translation_key="deprecated_close_comm_config",
             )
         # generic configuration
         self._client: ModbusBaseClient | None = None

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -255,6 +255,10 @@ class ModbusHub:
     def __init__(self, hass: HomeAssistant, client_config: dict[str, Any]) -> None:
         """Initialize the Modbus hub."""
 
+        if CONF_CLOSE_COMM_ON_ERROR in client_config:
+            _LOGGER.warning(
+                "CLOSE_COMM_ON_ERROR is deprecated since 2023.10.0 and will be removed in 2024.3"
+            )
         # generic configuration
         self._client: ModbusBaseClient | None = None
         self._async_cancel_listener: Callable[[], None] | None = None
@@ -274,7 +278,6 @@ class ModbusHub:
         self._pb_params = {
             "port": client_config[CONF_PORT],
             "timeout": client_config[CONF_TIMEOUT],
-            "reset_socket": client_config[CONF_CLOSE_COMM_ON_ERROR],
             "retries": client_config[CONF_RETRIES],
             "retry_on_empty": client_config[CONF_RETRY_ON_EMPTY],
         }

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -265,6 +265,11 @@ class ModbusHub:
                 is_fixable=False,
                 severity=IssueSeverity.WARNING,
                 translation_key="deprecated_close_comm_config",
+                translation_placeholders={
+                    "config_key": "close_comm_on_error",
+                    "integration": DOMAIN,
+                    "url": "https://www.home-assistant.io/integrations/modbus",
+                },
             )
             _LOGGER.warning(
                 "`close_comm_on_error`: is deprecated and will be remove in version 2024.4"

--- a/homeassistant/components/modbus/strings.json
+++ b/homeassistant/components/modbus/strings.json
@@ -71,8 +71,8 @@
   },
   "issues": {
     "deprecated_close_comm_config": {
-      "title": "\"close_comm_on_error:\" is deprecated",
-      "description": "Please remove parameter \"close_comm_on_error:\" from the modus entry in configuration.yaml.\nCommunication is automatically closed on errors. Please review the other parameters for error handling."
+      "title": "`close_comm_on_error:` is deprecated",
+      "description": "Please remove parameter `close_comm_on_error`: from the modus entry in configuration.yaml and restart Home Assistant to fix this issue.\nCommunication is automatically closed on errors. Please review the other parameters for error handling."
     }
   }
 }

--- a/homeassistant/components/modbus/strings.json
+++ b/homeassistant/components/modbus/strings.json
@@ -72,7 +72,7 @@
   "issues": {
     "deprecated_close_comm_config": {
       "title": "`{config_key}` configuration key is being removed",
-      "description": "Please remove the `{config_key}` key from the {integration} entry in your configuration.yaml file and restart Home Assistant to fix this issue.\n\nCommunication is automatically closed on errors, please review the other parameters for error handling, please see [the documentation]({url})."
+      "description": "Please remove the `{config_key}` key from the {integration} entry in your configuration.yaml file and restart Home Assistant to fix this issue.\n\nCommunication is automatically closed on errors, see [the documentation]({url}) for other error handling parameters."
     }
   }
 }

--- a/homeassistant/components/modbus/strings.json
+++ b/homeassistant/components/modbus/strings.json
@@ -71,7 +71,7 @@
   },
   "issues": {
     "deprecated_close_comm_config": {
-      "title": "CLOSE_COMM_ON_ERROR is deprecated",
+      "title": "\"close_comm_on_error:\" is deprecated",
       "description": "Please remove parameter \"close_comm_on_error:\" from the modus entry in configuration.yaml."
     }
   }

--- a/homeassistant/components/modbus/strings.json
+++ b/homeassistant/components/modbus/strings.json
@@ -72,7 +72,7 @@
   "issues": {
     "deprecated_close_comm_config": {
       "title": "`close_comm_on_error` configuration key is being removed",
-      "description": "Please remove the `close_comm_on_error` key from the modbus entry in your configuration.yaml file and restart Home Assistant to fix this issue.\n\nCommunication is automatically closed on errors. Please review the other parameters for error handling."
+      "description": "Please remove the `close_comm_on_error` key from the modbus entry in your configuration.yaml file and restart Home Assistant to fix this issue.\n\nCommunication is automatically closed on errors. Please review the other parameters for error handling, please see https://www.home-assistant.io/integrations/modbus"
     }
   }
 }

--- a/homeassistant/components/modbus/strings.json
+++ b/homeassistant/components/modbus/strings.json
@@ -71,8 +71,8 @@
   },
   "issues": {
     "deprecated_close_comm_config": {
-      "title": "`close_comm_on_error` configuration key is being removed",
-      "description": "Please remove the `close_comm_on_error` key from the modbus entry in your configuration.yaml file and restart Home Assistant to fix this issue.\n\nCommunication is automatically closed on errors. Please review the other parameters for error handling, please see https://www.home-assistant.io/integrations/modbus"
+      "title": "`{config_key}` configuration key is being removed",
+      "description": "Please remove the `{config_key}` key from the {integration} entry in your configuration.yaml file and restart Home Assistant to fix this issue.\n\nCommunication is automatically closed on errors, please review the other parameters for error handling, please see [the documentation]({url})."
     }
   }
 }

--- a/homeassistant/components/modbus/strings.json
+++ b/homeassistant/components/modbus/strings.json
@@ -72,7 +72,7 @@
   "issues": {
     "deprecated_close_comm_config": {
       "title": "\"close_comm_on_error:\" is deprecated",
-      "description": "Please remove parameter \"close_comm_on_error:\" from the modus entry in configuration.yaml."
+      "description": "Please remove parameter \"close_comm_on_error:\" from the modus entry in configuration.yaml.\nCommunication is automatically closed on errors. Please review the other parameters for error handling."
     }
   }
 }

--- a/homeassistant/components/modbus/strings.json
+++ b/homeassistant/components/modbus/strings.json
@@ -71,8 +71,8 @@
   },
   "issues": {
     "deprecated_close_comm_config": {
-      "title": "`close_comm_on_error:` is deprecated",
-      "description": "Please remove parameter `close_comm_on_error`: from the modus entry in configuration.yaml and restart Home Assistant to fix this issue.\nCommunication is automatically closed on errors. Please review the other parameters for error handling."
+      "title": "`close_comm_on_error` configuration key is being removed",
+      "description": "Please remove the `close_comm_on_error` key from the modbus entry in your configuration.yaml file and restart Home Assistant to fix this issue.\n\nCommunication is automatically closed on errors. Please review the other parameters for error handling."
     }
   }
 }

--- a/homeassistant/components/modbus/strings.json
+++ b/homeassistant/components/modbus/strings.json
@@ -68,5 +68,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "deprecated_close_comm_config": {
+      "title": "CLOSE_COMM_ON_ERROR is deprecated",
+      "description": "Please remove parameter \"close_comm_on_error:\" from the modus entry in configuration.yaml."
+    }
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
"close_comm_on_error:" is no optional, sockets will always be closed on error, therefor it is now deprecated, and will be removed in 2024.3.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
https://github.com/home-assistant/home-assistant.io/pull/28853

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
