### PR TITLE
Handle disconnects in zwave_js repair flow

### DIFF
--- a/homeassistant/components/zwave_js/repairs.py
+++ b/homeassistant/components/zwave_js/repairs.py
@@ -22,13 +22,6 @@ class DeviceConfigFileChangedFlow(RepairsFlow):
         self, user_input: dict[str, str] | None = None
     ) -> data_entry_flow.FlowResult:
         """Handle the first step of a fix flow."""
-        try:
-            async_get_node_from_device_id(self.hass, self.device_id)
-        except ValueError:
-            return self.async_abort(
-                reason="cannot_connect",
-                description_placeholders={"device_name": self.device_name},
-            )
         return await self.async_step_confirm()
 
     async def async_step_confirm(

--- a/homeassistant/components/zwave_js/repairs.py
+++ b/homeassistant/components/zwave_js/repairs.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import voluptuous as vol
-from zwave_js_server.model.node import Node
 
 from homeassistant import data_entry_flow
 from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
@@ -14,15 +13,22 @@ from .helpers import async_get_node_from_device_id
 class DeviceConfigFileChangedFlow(RepairsFlow):
     """Handler for an issue fixing flow."""
 
-    def __init__(self, node: Node, device_name: str) -> None:
+    def __init__(self, data: dict[str, str]) -> None:
         """Initialize."""
-        self.node = node
-        self.device_name = device_name
+        self.device_name: str = data["device_name"]
+        self.device_id: str = data["device_id"]
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
     ) -> data_entry_flow.FlowResult:
         """Handle the first step of a fix flow."""
+        try:
+            async_get_node_from_device_id(self.hass, self.device_id)
+        except ValueError:
+            return self.async_abort(
+                reason="cannot_connect",
+                description_placeholders={"device_name": self.device_name},
+            )
         return await self.async_step_confirm()
 
     async def async_step_confirm(
@@ -30,7 +36,14 @@ class DeviceConfigFileChangedFlow(RepairsFlow):
     ) -> data_entry_flow.FlowResult:
         """Handle the confirm step of a fix flow."""
         if user_input is not None:
-            self.hass.async_create_task(self.node.async_refresh_info())
+            try:
+                node = async_get_node_from_device_id(self.hass, self.device_id)
+            except ValueError:
+                return self.async_abort(
+                    reason="cannot_connect",
+                    description_placeholders={"device_name": self.device_name},
+                )
+            self.hass.async_create_task(node.async_refresh_info())
             return self.async_create_entry(title="", data={})
 
         return self.async_show_form(
@@ -41,15 +54,11 @@ class DeviceConfigFileChangedFlow(RepairsFlow):
 
 
 async def async_create_fix_flow(
-    hass: HomeAssistant,
-    issue_id: str,
-    data: dict[str, str] | None,
+    hass: HomeAssistant, issue_id: str, data: dict[str, str] | None
 ) -> RepairsFlow:
     """Create flow."""
 
     if issue_id.split(".")[0] == "device_config_file_changed":
         assert data
-        return DeviceConfigFileChangedFlow(
-            async_get_node_from_device_id(hass, data["device_id"]), data["device_name"]
-        )
+        return DeviceConfigFileChangedFlow(data)
     return ConfirmRepairFlow()

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -170,6 +170,9 @@
             "title": "Z-Wave device configuration file changed: {device_name}",
             "description": "Z-Wave JS discovers a lot of device metadata by interviewing the device. However, some of the information has to be loaded from a configuration file. Some of this information is only evaluated once, during the device interview.\n\nWhen a device config file is updated, this information may be stale and and the device must be re-interviewed to pick up the changes.\n\n This is not a required operation and device functionality will be impacted during the re-interview process, but you may see improvements for your device once it is complete.\n\nIf you'd like to proceed, click on SUBMIT below. The re-interview will take place in the background."
           }
+        },
+        "abort": {
+          "cannot_connect": "Cannot connect to {device_name}. Please try again later after confirming that your Z-Wave network is up and connected to Home Assistant."
         }
       }
     }


### PR DESCRIPTION
## Proposed change
Per https://github.com/home-assistant/core/issues/99639, if we can't connect to a node, the repair flow raises an exception. With this change we will instead abort the flow gracefully when this happens.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/99639
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
