### PR TITLE
Avoid probing ipp printers for unique_id when it is available via mdns

### DIFF
--- a/homeassistant/components/ipp/config_flow.py
+++ b/homeassistant/components/ipp/config_flow.py
@@ -134,13 +134,7 @@ class IPPFlowHandler(ConfigFlow, domain=DOMAIN):
             # If we already have the unique id, try to set it now
             # so we can avoid probing the device if its already
             # configured or ignored
-            await self.async_set_unique_id(unique_id)
-            self._abort_if_unique_id_configured(
-                updates={
-                    CONF_HOST: self.discovery_info[CONF_HOST],
-                    CONF_NAME: self.discovery_info[CONF_NAME],
-                },
-            )
+            await self._async_set_unique_id_and_abort_if_already_configured(unique_id)
 
         self.context.update({"title_placeholders": {"name": name}})
 
@@ -177,16 +171,22 @@ class IPPFlowHandler(ConfigFlow, domain=DOMAIN):
             )
 
         if unique_id and self.unique_id != unique_id:
-            await self.async_set_unique_id(unique_id)
-            self._abort_if_unique_id_configured(
-                updates={
-                    CONF_HOST: self.discovery_info[CONF_HOST],
-                    CONF_NAME: self.discovery_info[CONF_NAME],
-                },
-            )
+            await self._async_set_unique_id_and_abort_if_already_configured(unique_id)
 
         await self._async_handle_discovery_without_unique_id()
         return await self.async_step_zeroconf_confirm()
+
+    async def _async_set_unique_id_and_abort_if_already_configured(
+        self, unique_id: str
+    ) -> None:
+        """Set the unique ID and abort if already configured."""
+        await self.async_set_unique_id(unique_id)
+        self._abort_if_unique_id_configured(
+            updates={
+                CONF_HOST: self.discovery_info[CONF_HOST],
+                CONF_NAME: self.discovery_info[CONF_NAME],
+            },
+        )
 
     async def async_step_zeroconf_confirm(
         self, user_input: dict[str, Any] | None = None

--- a/tests/components/ipp/fixtures/printer_without_uuid.json
+++ b/tests/components/ipp/fixtures/printer_without_uuid.json
@@ -1,0 +1,36 @@
+{
+  "SN": "1234",
+  "printer-state": "idle",
+  "printer-name": "Test Printer",
+  "printer-location": null,
+  "printer-make-and-model": "Test HA-1000 Series",
+  "printer-device-id": "MFG:TEST;CMD:ESCPL2,BDC,D4,D4PX,ESCPR7,END4,GENEP,URF;MDL:HA-1000 Series;CLS:PRINTER;DES:TEST HA-1000 Series;CID:EpsonRGB;FID:FXN,DPA,WFA,ETN,AFN,DAN,WRA;RID:20;DDS:022500;ELG:1000;SN:555534593035345555;URF:CP1,PQ4-5,OB9,OFU0,RS360,SRGB24,W8,DM3,IS1-7-6,V1.4,MT1-3-7-8-10-11-12;",
+  "printer-uri-supported": [
+    "ipps://192.168.1.31:631/ipp/print",
+    "ipp://192.168.1.31:631/ipp/print"
+  ],
+  "uri-authentication-supported": ["none", "none"],
+  "uri-security-supported": ["tls", "none"],
+  "printer-info": "Test HA-1000 Series",
+  "printer-up-time": 30,
+  "printer-firmware-string-version": "20.23.06HA",
+  "printer-more-info": "http://192.168.1.31:80/PRESENTATION/BONJOUR",
+  "marker-names": [
+    "Black ink",
+    "Photo black ink",
+    "Cyan ink",
+    "Yellow ink",
+    "Magenta ink"
+  ],
+  "marker-types": [
+    "ink-cartridge",
+    "ink-cartridge",
+    "ink-cartridge",
+    "ink-cartridge",
+    "ink-cartridge"
+  ],
+  "marker-colors": ["#000000", "#000000", "#00FFFF", "#FFFF00", "#FF00FF"],
+  "marker-levels": [58, 98, 91, 95, 73],
+  "marker-low-levels": [10, 10, 10, 10, 10],
+  "marker-high-levels": [100, 100, 100, 100, 100]
+}

--- a/tests/components/ipp/fixtures/printer_without_uuid.json
+++ b/tests/components/ipp/fixtures/printer_without_uuid.json
@@ -1,5 +1,4 @@
 {
-  "SN": "1234",
   "printer-state": "idle",
   "printer-name": "Test Printer",
   "printer-location": null,

--- a/tests/components/ipp/test_config_flow.py
+++ b/tests/components/ipp/test_config_flow.py
@@ -318,6 +318,31 @@ async def test_zeroconf_with_uuid_device_exists_abort(
     assert result["reason"] == "already_configured"
 
 
+async def test_zeroconf_with_uuid_device_exists_abort_new_host(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_ipp_config_flow: MagicMock,
+) -> None:
+    """Test we abort zeroconf flow if printer already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    discovery_info = dataclasses.replace(MOCK_ZEROCONF_IPP_SERVICE_INFO, host="1.2.3.9")
+    discovery_info.properties = {
+        **MOCK_ZEROCONF_IPP_SERVICE_INFO.properties,
+        "UUID": "cfe92100-67c4-11d4-a45f-f8d027761251",
+    }
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=discovery_info,
+    )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert mock_config_entry.data[CONF_HOST] == "1.2.3.9"
+
+
 async def test_zeroconf_empty_unique_id(
     hass: HomeAssistant,
     mock_ipp_config_flow: MagicMock,


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We would always probe the device in the ipp flow and than abort if it was already configured. We avoid the probe for most printers.

This can cause some printers to lock up when there are many HA instances on the network.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
