### PR TITLE
Make homekit RTP/RTCP source ports more deterministic

### DIFF
--- a/homeassistant/components/homekit/type_cameras.py
+++ b/homeassistant/components/homekit/type_cameras.py
@@ -79,7 +79,7 @@ VIDEO_OUTPUT = (
     "-ssrc {v_ssrc} -f rtp "
     "-srtp_out_suite AES_CM_128_HMAC_SHA1_80 -srtp_out_params {v_srtp_key} "
     "srtp://{address}:{v_port}?rtcpport={v_port}&"
-    "localrtcpport={v_port}&pkt_size={v_pkt_size}"
+    "localrtpport={v_port}&pkt_size={v_pkt_size}"
 )
 
 AUDIO_OUTPUT = (
@@ -92,7 +92,7 @@ AUDIO_OUTPUT = (
     "-ssrc {a_ssrc} -f rtp "
     "-srtp_out_suite AES_CM_128_HMAC_SHA1_80 -srtp_out_params {a_srtp_key} "
     "srtp://{address}:{a_port}?rtcpport={a_port}&"
-    "localrtcpport={a_port}&pkt_size={a_pkt_size}"
+    "localrtpport={a_port}&pkt_size={a_pkt_size}"
 )
 
 SLOW_RESOLUTIONS = [

--- a/tests/components/homekit/test_type_cameras.py
+++ b/tests/components/homekit/test_type_cameras.py
@@ -187,11 +187,11 @@ async def test_camera_stream_source_configured(
         "yuv420p -r 30 -b:v 299k -bufsize 1196k -maxrate 299k -payload_type 99 -ssrc {v_ssrc} -f "
         "rtp -srtp_out_suite AES_CM_128_HMAC_SHA1_80 -srtp_out_params "
         "zdPmNLWeI86DtLJHvVLI6YPvqhVeeiLsNtrAgbgL "
-        "srtp://192.168.208.5:51246?rtcpport=51246&localrtcpport=51246&pkt_size=1316 -map 0:a:0 "
+        "srtp://192.168.208.5:51246?rtcpport=51246&localrtpport=51246&pkt_size=1316 -map 0:a:0 "
         "-vn -c:a libopus -application lowdelay -ac 1 -ar 24k -b:a 24k -bufsize 96k -payload_type "
         "110 -ssrc {a_ssrc} -f rtp -srtp_out_suite AES_CM_128_HMAC_SHA1_80 -srtp_out_params "
         "shnETgfD+7xUQ8zRdsaytY11wu6CO73IJ+RZVJpU "
-        "srtp://192.168.208.5:51108?rtcpport=51108&localrtcpport=51108&pkt_size=188"
+        "srtp://192.168.208.5:51108?rtcpport=51108&localrtpport=51108&pkt_size=188"
     )
 
     working_ffmpeg.open.assert_called_with(
@@ -344,7 +344,7 @@ async def test_camera_stream_source_found(
         "yuv420p -r 30 -b:v 299k -bufsize 1196k -maxrate 299k -payload_type 99 -ssrc {v_ssrc} -f "
         "rtp -srtp_out_suite AES_CM_128_HMAC_SHA1_80 -srtp_out_params "
         "zdPmNLWeI86DtLJHvVLI6YPvqhVeeiLsNtrAgbgL "
-        "srtp://192.168.208.5:51246?rtcpport=51246&localrtcpport=51246&pkt_size=1316"
+        "srtp://192.168.208.5:51246?rtcpport=51246&localrtpport=51246&pkt_size=1316"
     )
 
     working_ffmpeg.open.assert_called_with(
@@ -507,11 +507,11 @@ async def test_camera_stream_source_configured_and_copy_codec(
         "-map 0:v:0 -an -c:v copy -tune zerolatency -pix_fmt yuv420p -r 30 -b:v 299k "
         "-bufsize 1196k -maxrate 299k -payload_type 99 -ssrc {v_ssrc} -f rtp -srtp_out_suite "
         "AES_CM_128_HMAC_SHA1_80 -srtp_out_params zdPmNLWeI86DtLJHvVLI6YPvqhVeeiLsNtrAgbgL "
-        "srtp://192.168.208.5:51246?rtcpport=51246&localrtcpport=51246&pkt_size=1316 -map 0:a:0 "
+        "srtp://192.168.208.5:51246?rtcpport=51246&localrtpport=51246&pkt_size=1316 -map 0:a:0 "
         "-vn -c:a copy -ac 1 -ar 24k -b:a 24k -bufsize 96k -payload_type 110 -ssrc {a_ssrc} "
         "-f rtp -srtp_out_suite AES_CM_128_HMAC_SHA1_80 -srtp_out_params "
         "shnETgfD+7xUQ8zRdsaytY11wu6CO73IJ+RZVJpU "
-        "srtp://192.168.208.5:51108?rtcpport=51108&localrtcpport=51108&pkt_size=188"
+        "srtp://192.168.208.5:51108?rtcpport=51108&localrtpport=51108&pkt_size=188"
     )
 
     working_ffmpeg.open.assert_called_with(
@@ -580,11 +580,11 @@ async def test_camera_stream_source_configured_and_override_profile_names(
         "-map 0:v:0 -an -c:v h264_v4l2m2m -profile:v 4 -tune zerolatency -pix_fmt yuv420p -r 30 -b:v 299k "
         "-bufsize 1196k -maxrate 299k -payload_type 99 -ssrc {v_ssrc} -f rtp -srtp_out_suite "
         "AES_CM_128_HMAC_SHA1_80 -srtp_out_params zdPmNLWeI86DtLJHvVLI6YPvqhVeeiLsNtrAgbgL "
-        "srtp://192.168.208.5:51246?rtcpport=51246&localrtcpport=51246&pkt_size=1316 -map 0:a:0 "
+        "srtp://192.168.208.5:51246?rtcpport=51246&localrtpport=51246&pkt_size=1316 -map 0:a:0 "
         "-vn -c:a copy -ac 1 -ar 24k -b:a 24k -bufsize 96k -payload_type 110 -ssrc {a_ssrc} "
         "-f rtp -srtp_out_suite AES_CM_128_HMAC_SHA1_80 -srtp_out_params "
         "shnETgfD+7xUQ8zRdsaytY11wu6CO73IJ+RZVJpU "
-        "srtp://192.168.208.5:51108?rtcpport=51108&localrtcpport=51108&pkt_size=188"
+        "srtp://192.168.208.5:51108?rtcpport=51108&localrtpport=51108&pkt_size=188"
     )
 
     working_ffmpeg.open.assert_called_with(
@@ -654,11 +654,11 @@ async def test_camera_streaming_fails_after_starting_ffmpeg(
         "-map 0:v:0 -an -c:v h264_omx -profile:v high -tune zerolatency -pix_fmt yuv420p -r 30 -b:v 299k "
         "-bufsize 1196k -maxrate 299k -payload_type 99 -ssrc {v_ssrc} -f rtp -srtp_out_suite "
         "AES_CM_128_HMAC_SHA1_80 -srtp_out_params zdPmNLWeI86DtLJHvVLI6YPvqhVeeiLsNtrAgbgL "
-        "srtp://192.168.208.5:51246?rtcpport=51246&localrtcpport=51246&pkt_size=1316 -map 0:a:0 "
+        "srtp://192.168.208.5:51246?rtcpport=51246&localrtpport=51246&pkt_size=1316 -map 0:a:0 "
         "-vn -c:a copy -ac 1 -ar 24k -b:a 24k -bufsize 96k -payload_type 110 -ssrc {a_ssrc} "
         "-f rtp -srtp_out_suite AES_CM_128_HMAC_SHA1_80 -srtp_out_params "
         "shnETgfD+7xUQ8zRdsaytY11wu6CO73IJ+RZVJpU "
-        "srtp://192.168.208.5:51108?rtcpport=51108&localrtcpport=51108&pkt_size=188"
+        "srtp://192.168.208.5:51108?rtcpport=51108&localrtpport=51108&pkt_size=188"
     )
 
     ffmpeg_with_invalid_pid.open.assert_called_with(


### PR DESCRIPTION
Currently when a HomeKit controller starts a new streaming session, the following URI is used to configure ffmpeg to stream the requested video/audio:

```
srtp://{address}:{v_port}?rtcpport={v_port}&localrtcpport={v_port}&pkt_size={v_pkt_size}
```

With this URI, ffmpeg sends RTCP datagrams using (source: v_port, destination: v_port) ports while sends RTP datagrams using (source: random, destination: v_port) ports. Note the HomeKit controller receives RTP and RTCP through a single multiplexed port.

https://ffmpeg.org/ffmpeg-protocols.html#rtp says:
> - If localrtpport (the local RTP port) is not set any available port will be used for the local RTP and RTCP ports.
> - If localrtcpport (the local RTCP port) is not set it will be set to the local RTP port value plus 1.

Using a randomized RTP port makes it harder to setup firewall for Home Assistant.

This PR changes the URI option to explicitly specify the source RTP port for ffmpeg to use. Then the source RTCP port will always be the source RTP port value plus 1. This will make firewall configuration easier. In the future we can introduce a new config option to customize the port range for RTP/RTCP to use.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
