### PR TITLE
Switch ESPHome Bluetooth to use loop.create_future()

### DIFF
--- a/homeassistant/components/esphome/bluetooth/client.py
+++ b/homeassistant/components/esphome/bluetooth/client.py
@@ -318,8 +318,7 @@ class ESPHomeClient(BaseBleakClient):
         Returns:
             Boolean representing connection status.
         """
-        if not self._bluetooth_device.ble_connections_free:
-            await self._wait_for_free_connection_slot(CONNECT_FREE_SLOT_TIMEOUT)
+        await self._wait_for_free_connection_slot(CONNECT_FREE_SLOT_TIMEOUT)
         cache = self._cache
 
         self._mtu = cache.get_gatt_mtu_cache(self._address_as_int)
@@ -392,12 +391,14 @@ class ESPHomeClient(BaseBleakClient):
     async def _disconnect(self) -> bool:
         self._async_disconnected_cleanup()
         await self._client.bluetooth_device_disconnect(self._address_as_int)
-        if not self._bluetooth_device.ble_connections_free:
-            await self._wait_for_free_connection_slot(DISCONNECT_TIMEOUT)
+        await self._wait_for_free_connection_slot(DISCONNECT_TIMEOUT)
         return True
 
     async def _wait_for_free_connection_slot(self, timeout: float) -> None:
         """Wait for a free connection slot."""
+        bluetooth_device = self._bluetooth_device
+        if bluetooth_device.ble_connections_free:
+            return
         _LOGGER.debug(
             "%s: %s - %s: Out of connection slots, waiting for a free one",
             self._source_name,
@@ -405,7 +406,7 @@ class ESPHomeClient(BaseBleakClient):
             self._ble_device.address,
         )
         async with asyncio.timeout(timeout):
-            await self._bluetooth_device.wait_for_ble_connections_free()
+            await bluetooth_device.wait_for_ble_connections_free()
 
     @property
     def is_connected(self) -> bool:

--- a/homeassistant/components/esphome/bluetooth/device.py
+++ b/homeassistant/components/esphome/bluetooth/device.py
@@ -21,6 +21,7 @@ class ESPHomeBluetoothDevice:
     _ble_connection_free_futures: list[asyncio.Future[int]] = field(
         default_factory=list
     )
+    loop: asyncio.AbstractEventLoop = field(default_factory=asyncio.get_running_loop)
 
     @callback
     def async_update_ble_connection_limits(self, free: int, limit: int) -> None:
@@ -49,6 +50,6 @@ class ESPHomeBluetoothDevice:
         """Wait until there are free BLE connections."""
         if self.ble_connections_free > 0:
             return self.ble_connections_free
-        fut: asyncio.Future[int] = asyncio.Future()
+        fut: asyncio.Future[int] = self.loop.create_future()
         self._ble_connection_free_futures.append(fut)
         return await fut


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://docs.python.org/3/library/asyncio-future.html#asyncio.Future

> The rule of thumb is to never expose Future objects in user-facing APIs, and the recommended way to create a Future object is to call loop.create_future(). This way alternative event loop implementations can inject their own optimized implementations of a Future object.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
