### PR TITLE
Also handle DiscovergyClientError as UpdateFailed

### DIFF
--- a/homeassistant/components/discovergy/config_flow.py
+++ b/homeassistant/components/discovergy/config_flow.py
@@ -85,7 +85,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     httpx_client=get_async_client(self.hass),
                     authentication=BasicAuth(),
                 ).meters()
-            except discovergyError.HTTPError:
+            except (discovergyError.HTTPError, discovergyError.DiscovergyClientError):
                 errors["base"] = "cannot_connect"
             except discovergyError.InvalidLogin:
                 errors["base"] = "invalid_auth"

--- a/homeassistant/components/discovergy/coordinator.py
+++ b/homeassistant/components/discovergy/coordinator.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 import logging
 
 from pydiscovergy import Discovergy
-from pydiscovergy.error import AccessTokenExpired, DiscovergyClientError, HTTPError
+from pydiscovergy.error import DiscovergyClientError, HTTPError, InvalidLogin
 from pydiscovergy.models import Meter, Reading
 
 from homeassistant.core import HomeAssistant
@@ -44,7 +44,7 @@ class DiscovergyUpdateCoordinator(DataUpdateCoordinator[Reading]):
         """Get last reading for meter."""
         try:
             return await self.discovergy_client.meter_last_reading(self.meter.meter_id)
-        except AccessTokenExpired as err:
+        except InvalidLogin as err:
             raise ConfigEntryAuthFailed(
                 f"Auth expired while fetching last reading for meter {self.meter.meter_id}"
             ) from err

--- a/homeassistant/components/discovergy/coordinator.py
+++ b/homeassistant/components/discovergy/coordinator.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 import logging
 
 from pydiscovergy import Discovergy
-from pydiscovergy.error import AccessTokenExpired, HTTPError
+from pydiscovergy.error import AccessTokenExpired, DiscovergyClientError, HTTPError
 from pydiscovergy.models import Meter, Reading
 
 from homeassistant.core import HomeAssistant
@@ -48,7 +48,7 @@ class DiscovergyUpdateCoordinator(DataUpdateCoordinator[Reading]):
             raise ConfigEntryAuthFailed(
                 f"Auth expired while fetching last reading for meter {self.meter.meter_id}"
             ) from err
-        except HTTPError as err:
+        except (HTTPError, DiscovergyClientError) as err:
             raise UpdateFailed(
                 f"Error while fetching last reading for meter {self.meter.meter_id}"
             ) from err

--- a/tests/components/discovergy/test_config_flow.py
+++ b/tests/components/discovergy/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the Discovergy config flow."""
 from unittest.mock import Mock, patch
 
-from pydiscovergy.error import HTTPError, InvalidLogin
+from pydiscovergy.error import DiscovergyClientError, HTTPError, InvalidLogin
 
 from homeassistant import data_entry_flow
 from homeassistant.components.discovergy.const import DOMAIN
@@ -102,6 +102,25 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     )
 
     with patch("pydiscovergy.Discovergy.meters", side_effect=HTTPError):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_EMAIL: "test@example.com",
+                CONF_PASSWORD: "test-password",
+            },
+        )
+
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
+    assert result2["errors"] == {"base": "cannot_connect"}
+
+
+async def test_form_client_error(hass: HomeAssistant) -> None:
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with patch("pydiscovergy.Discovergy.meters", side_effect=DiscovergyClientError):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {


### PR DESCRIPTION
## Proposed change
SSIA, avoids log spam when HA can't reach the Discovergy API.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
