### PR TITLE
Fix Spotify media position update value

### DIFF
--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -27,7 +27,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util.dt import utc_from_timestamp, utcnow
+from homeassistant.util.dt import utcnow
 
 from . import HomeAssistantSpotifyData
 from .browse_media import async_browse_media_internal
@@ -203,7 +203,7 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
     @property
     def media_position_updated_at(self) -> dt.datetime | None:
         """When was the position of the current playing media valid."""
-        if not self._currently_playing or self._currently_playing_updated is None:
+        if not self._currently_playing:
             return None
         return self._currently_playing_updated
 

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from asyncio import run_coroutine_threadsafe
-import datetime as dt
 from datetime import timedelta
 import logging
 from typing import Any

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -134,7 +134,6 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
             SPOTIFY_SCOPES
         )
         self._currently_playing: dict | None = {}
-        self._currently_playing_updated: dt.datetime | None = None
         self._playlist: dict | None = None
         self._restricted_device: bool = False
 
@@ -199,13 +198,6 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
         ):
             return None
         return self._currently_playing["progress_ms"] / 1000
-
-    @property
-    def media_position_updated_at(self) -> dt.datetime | None:
-        """When was the position of the current playing media valid."""
-        if not self._currently_playing:
-            return None
-        return self._currently_playing_updated
 
     @property
     def media_image_url(self) -> str | None:
@@ -416,7 +408,7 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
         self._currently_playing = current or {}
         # Record the last updated time, because Spotify's timestamp property is unreliable
         # and doesn't actually return the fetch time as is mentioned in the API description
-        self._currently_playing_updated = utcnow() if current is not None else None
+        self._attr_media_position_updated_at = utcnow() if current is not None else None
 
         context = self._currently_playing.get("context") or {}
 

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -134,7 +134,7 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
             SPOTIFY_SCOPES
         )
         self._currently_playing: dict | None = {}
-        self._currently_playing_updated: int
+        self._currently_playing_updated: dt.datetime | None = None
         self._playlist: dict | None = None
         self._restricted_device: bool = False
 
@@ -203,7 +203,7 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
     @property
     def media_position_updated_at(self) -> dt.datetime | None:
         """When was the position of the current playing media valid."""
-        if not self._currently_playing:
+        if not self._currently_playing or self._currently_playing_updated is None:
             return None
         return self._currently_playing_updated
 
@@ -416,7 +416,7 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
         self._currently_playing = current or {}
         # Record the last updated time, because Spotify's timestamp property is unreliable
         # and doesn't actually return the fetch time as is mentioned in the API description
-        self._currently_playing_updated = utcnow()
+        self._currently_playing_updated = utcnow() if current is not None else None
 
         context = self._currently_playing.get("context") or {}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This fixes the track position of the Spotify media player, which is currently not accurate as it seems to shift an additional 30 seconds forward every 30 seconds.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #86931
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
