### PR TITLE
Fix addon slug validation

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -6,6 +6,7 @@ from contextlib import suppress
 from datetime import datetime, timedelta
 import logging
 import os
+from re import compile
 from typing import Any, NamedTuple
 
 import voluptuous as vol
@@ -149,10 +150,12 @@ SERVICE_BACKUP_PARTIAL = "backup_partial"
 SERVICE_RESTORE_FULL = "restore_full"
 SERVICE_RESTORE_PARTIAL = "restore_partial"
 
+VALID_ADDON_SLUG = vol.Match(compile(r"^[-_.A-Za-z0-9]+$"))
+
 
 def valid_addon(value: Any) -> str:
     """Validate value is a valid addon slug."""
-    value = cv.slug(value)
+    value = VALID_ADDON_SLUG(value)
 
     hass: HomeAssistant | None = None
     with suppress(HomeAssistantError):

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -6,7 +6,7 @@ from contextlib import suppress
 from datetime import datetime, timedelta
 import logging
 import os
-from re import compile
+import re
 from typing import Any, NamedTuple
 
 import voluptuous as vol
@@ -150,7 +150,7 @@ SERVICE_BACKUP_PARTIAL = "backup_partial"
 SERVICE_RESTORE_FULL = "restore_full"
 SERVICE_RESTORE_PARTIAL = "restore_partial"
 
-VALID_ADDON_SLUG = vol.Match(compile(r"^[-_.A-Za-z0-9]+$"))
+VALID_ADDON_SLUG = vol.Match(re.compile(r"^[-_.A-Za-z0-9]+$"))
 
 
 def valid_addon(value: Any) -> str:

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -633,6 +633,41 @@ async def test_invalid_service_calls(
         )
 
 
+async def test_addon_service_call_with_complex_slug(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Addon slugs can have ., - and _, confirm that passes validation."""
+    supervisor_mock_data = {
+        "version_latest": "1.0.0",
+        "version": "1.0.0",
+        "auto_update": True,
+        "addons": [
+            {
+                "name": "test.a_1-2",
+                "slug": "test.a_1-2",
+                "state": "stopped",
+                "update_available": False,
+                "version": "1.0.0",
+                "version_latest": "1.0.0",
+                "repository": "core",
+                "icon": False,
+            },
+        ],
+    }
+    with patch.dict(os.environ, MOCK_ENVIRON), patch(
+        "homeassistant.components.hassio.HassIO.is_connected",
+        return_value=None,
+    ), patch(
+        "homeassistant.components.hassio.HassIO.get_supervisor_info",
+        return_value=supervisor_mock_data,
+    ):
+        assert await async_setup_component(hass, "hassio", {})
+        await hass.async_block_till_done()
+
+    await hass.services.async_call("hassio", "addon_start", {"addon": "test.a_1-2"})
+
+
 async def test_service_calls_core(
     hassio_env, hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

#99232 used an incorrect validator for addon slugs. It only allowed slugs which contained alphanumeric characters and underscores. Addon slugs can also contain `-` and `.`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #99912
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
