### PR TITLE
Add DataUpdateCoordinator to Minecraft Server

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -732,6 +732,7 @@ omit =
     homeassistant/components/mill/sensor.py
     homeassistant/components/minecraft_server/__init__.py
     homeassistant/components/minecraft_server/binary_sensor.py
+    homeassistant/components/minecraft_server/coordinator.py
     homeassistant/components/minecraft_server/entity.py
     homeassistant/components/minecraft_server/sensor.py
     homeassistant/components/minio/minio_helper.py

--- a/homeassistant/components/minecraft_server/__init__.py
+++ b/homeassistant/components/minecraft_server/__init__.py
@@ -1,31 +1,17 @@
 """The Minecraft Server integration."""
 from __future__ import annotations
 
-from collections.abc import Mapping
-from dataclasses import dataclass
-from datetime import datetime, timedelta
 import logging
 from typing import Any
 
-import aiodns
-from mcstatus.server import JavaServer
-
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, Platform
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.const import CONF_HOST, CONF_NAME, Platform
+from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.device_registry as dr
-from homeassistant.helpers.dispatcher import async_dispatcher_send
 import homeassistant.helpers.entity_registry as er
-from homeassistant.helpers.event import async_track_time_interval
 
-from .const import (
-    DOMAIN,
-    KEY_LATENCY,
-    KEY_MOTD,
-    SCAN_INTERVAL,
-    SIGNAL_NAME_PREFIX,
-    SRV_RECORD_PREFIX,
-)
+from .const import DOMAIN, KEY_LATENCY, KEY_MOTD
+from .coordinator import MinecraftServerCoordinator
 
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
@@ -36,17 +22,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Minecraft Server from a config entry."""
     domain_data = hass.data.setdefault(DOMAIN, {})
 
-    # Create and store server instance.
+    # Create and store coordinator instance.
     config_entry_id = entry.entry_id
     _LOGGER.debug(
-        "Creating server instance for '%s' (%s)",
+        "Creating coordinator instance for '%s' (%s)",
         entry.data[CONF_NAME],
         entry.data[CONF_HOST],
     )
-    server = MinecraftServer(hass, config_entry_id, entry.data)
-    domain_data[config_entry_id] = server
-    await server.async_update()
-    server.start_periodic_update()
+    coordinator = MinecraftServerCoordinator(hass, config_entry_id, entry.data)
+    domain_data[config_entry_id] = coordinator
+    await coordinator.async_config_entry_first_refresh()
 
     # Set up platforms.
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -57,7 +42,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Unload Minecraft Server config entry."""
     config_entry_id = config_entry.entry_id
-    server = hass.data[DOMAIN][config_entry_id]
 
     # Unload platforms.
     unload_ok = await hass.config_entries.async_unload_platforms(
@@ -65,7 +49,6 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     )
 
     # Clean up.
-    server.stop_periodic_update()
     hass.data[DOMAIN].pop(config_entry_id)
 
     return unload_ok
@@ -165,181 +148,3 @@ def _migrate_entity_unique_id(entity_entry: er.RegistryEntry) -> dict[str, Any]:
     )
 
     return {"new_unique_id": new_unique_id}
-
-
-@dataclass
-class MinecraftServerData:
-    """Representation of Minecraft server data."""
-
-    latency: float | None = None
-    motd: str | None = None
-    players_max: int | None = None
-    players_online: int | None = None
-    players_list: list[str] | None = None
-    protocol_version: int | None = None
-    version: str | None = None
-
-
-class MinecraftServer:
-    """Representation of a Minecraft server."""
-
-    def __init__(
-        self, hass: HomeAssistant, unique_id: str, config_data: Mapping[str, Any]
-    ) -> None:
-        """Initialize server instance."""
-        self._hass = hass
-
-        # Server data
-        self.unique_id = unique_id
-        self.name = config_data[CONF_NAME]
-        self.host = config_data[CONF_HOST]
-        self.port = config_data[CONF_PORT]
-        self.online = False
-        self._last_status_request_failed = False
-        self.srv_record_checked = False
-
-        # 3rd party library instance
-        self._server = JavaServer(self.host, self.port)
-
-        # Data provided by 3rd party library
-        self.data: MinecraftServerData = MinecraftServerData()
-
-        # Dispatcher signal name
-        self.signal_name = f"{SIGNAL_NAME_PREFIX}_{self.unique_id}"
-
-        # Callback for stopping periodic update.
-        self._stop_periodic_update: CALLBACK_TYPE | None = None
-
-    def start_periodic_update(self) -> None:
-        """Start periodic execution of update method."""
-        self._stop_periodic_update = async_track_time_interval(
-            self._hass, self.async_update, timedelta(seconds=SCAN_INTERVAL)
-        )
-
-    def stop_periodic_update(self) -> None:
-        """Stop periodic execution of update method."""
-        if self._stop_periodic_update:
-            self._stop_periodic_update()
-
-    async def async_check_connection(self) -> None:
-        """Check server connection using a 'status' request and store connection status."""
-        # Check if host is a valid SRV record, if not already done.
-        if not self.srv_record_checked:
-            self.srv_record_checked = True
-            srv_record = await self._async_check_srv_record(self.host)
-            if srv_record is not None:
-                _LOGGER.debug(
-                    "'%s' is a valid Minecraft SRV record ('%s:%s')",
-                    self.host,
-                    srv_record[CONF_HOST],
-                    srv_record[CONF_PORT],
-                )
-                # Overwrite host, port and 3rd party library instance
-                # with data extracted out of SRV record.
-                self.host = srv_record[CONF_HOST]
-                self.port = srv_record[CONF_PORT]
-                self._server = JavaServer(self.host, self.port)
-
-        # Ping the server with a status request.
-        try:
-            await self._server.async_status()
-            self.online = True
-        except OSError as error:
-            _LOGGER.debug(
-                (
-                    "Error occurred while trying to check the connection to '%s:%s' -"
-                    " OSError: %s"
-                ),
-                self.host,
-                self.port,
-                error,
-            )
-            self.online = False
-
-    async def _async_check_srv_record(self, host: str) -> dict[str, Any] | None:
-        """Check if the given host is a valid Minecraft SRV record."""
-        srv_record = None
-        srv_query = None
-
-        try:
-            srv_query = await aiodns.DNSResolver().query(
-                host=f"{SRV_RECORD_PREFIX}.{host}", qtype="SRV"
-            )
-        except aiodns.error.DNSError:
-            # 'host' is not a SRV record.
-            pass
-        else:
-            # 'host' is a valid SRV record, extract the data.
-            srv_record = {
-                CONF_HOST: srv_query[0].host,
-                CONF_PORT: srv_query[0].port,
-            }
-
-        return srv_record
-
-    async def async_update(self, now: datetime | None = None) -> None:
-        """Get server data from 3rd party library and update properties."""
-        # Check connection status.
-        server_online_old = self.online
-        await self.async_check_connection()
-        server_online = self.online
-
-        # Inform user once about connection state changes if necessary.
-        if server_online_old and not server_online:
-            _LOGGER.warning("Connection to '%s:%s' lost", self.host, self.port)
-        elif not server_online_old and server_online:
-            _LOGGER.info("Connection to '%s:%s' (re-)established", self.host, self.port)
-
-        # Update the server properties if server is online.
-        if server_online:
-            await self._async_status_request()
-
-        # Notify sensors about new data.
-        async_dispatcher_send(self._hass, self.signal_name)
-
-    async def _async_status_request(self) -> None:
-        """Request server status and update properties."""
-        try:
-            status_response = await self._server.async_status()
-
-            # Got answer to request, update properties.
-            self.data.version = status_response.version.name
-            self.data.protocol_version = status_response.version.protocol
-            self.data.players_online = status_response.players.online
-            self.data.players_max = status_response.players.max
-            self.data.latency = status_response.latency
-            self.data.motd = status_response.motd.to_plain()
-
-            self.data.players_list = []
-            if status_response.players.sample is not None:
-                for player in status_response.players.sample:
-                    self.data.players_list.append(player.name)
-                self.data.players_list.sort()
-
-            # Inform user once about successful update if necessary.
-            if self._last_status_request_failed:
-                _LOGGER.info(
-                    "Updating the properties of '%s:%s' succeeded again",
-                    self.host,
-                    self.port,
-                )
-            self._last_status_request_failed = False
-        except OSError as error:
-            # No answer to request, set all properties to unknown.
-            self.data.version = None
-            self.data.protocol_version = None
-            self.data.players_online = None
-            self.data.players_max = None
-            self.data.latency = None
-            self.data.players_list = None
-            self.data.motd = None
-
-            # Inform user once about failed update if necessary.
-            if not self._last_status_request_failed:
-                _LOGGER.warning(
-                    "Updating the properties of '%s:%s' failed - OSError: %s",
-                    self.host,
-                    self.port,
-                    error,
-                )
-            self._last_status_request_failed = True

--- a/homeassistant/components/minecraft_server/__init__.py
+++ b/homeassistant/components/minecraft_server/__init__.py
@@ -20,18 +20,20 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Minecraft Server from a config entry."""
-    domain_data = hass.data.setdefault(DOMAIN, {})
-
-    # Create and store coordinator instance.
-    config_entry_id = entry.entry_id
     _LOGGER.debug(
         "Creating coordinator instance for '%s' (%s)",
         entry.data[CONF_NAME],
         entry.data[CONF_HOST],
     )
+
+    # Create coordinator instance.
+    config_entry_id = entry.entry_id
     coordinator = MinecraftServerCoordinator(hass, config_entry_id, entry.data)
-    domain_data[config_entry_id] = coordinator
     await coordinator.async_config_entry_first_refresh()
+
+    # Store coordinator instance.
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    domain_data[config_entry_id] = coordinator
 
     # Set up platforms.
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/minecraft_server/binary_sensor.py
+++ b/homeassistant/components/minecraft_server/binary_sensor.py
@@ -71,4 +71,4 @@ class MinecraftServerBinarySensorEntity(MinecraftServerEntity, BinarySensorEntit
     @property
     def is_on(self) -> bool:
         """Return binary sensor state."""
-        return self._coordinator.last_update_success
+        return self.coordinator.last_update_success

--- a/homeassistant/components/minecraft_server/binary_sensor.py
+++ b/homeassistant/components/minecraft_server/binary_sensor.py
@@ -10,8 +10,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import MinecraftServer
 from .const import DOMAIN, ICON_STATUS, KEY_STATUS
+from .coordinator import MinecraftServerCoordinator
 from .entity import MinecraftServerEntity
 
 
@@ -36,15 +36,14 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Minecraft Server binary sensor platform."""
-    server = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
     # Add binary sensor entities.
     async_add_entities(
         [
-            MinecraftServerBinarySensorEntity(server, description)
+            MinecraftServerBinarySensorEntity(coordinator, description)
             for description in BINARY_SENSOR_DESCRIPTIONS
-        ],
-        True,
+        ]
     )
 
 
@@ -55,15 +54,21 @@ class MinecraftServerBinarySensorEntity(MinecraftServerEntity, BinarySensorEntit
 
     def __init__(
         self,
-        server: MinecraftServer,
+        coordinator: MinecraftServerCoordinator,
         description: MinecraftServerBinarySensorEntityDescription,
     ) -> None:
         """Initialize binary sensor base entity."""
-        super().__init__(server=server)
+        super().__init__(coordinator=coordinator)
         self.entity_description = description
-        self._attr_unique_id = f"{server.unique_id}-{description.key}"
+        self._attr_unique_id = f"{coordinator.unique_id}-{description.key}"
         self._attr_is_on = False
 
-    async def async_update(self) -> None:
-        """Update binary sensor state."""
-        self._attr_is_on = self._server.online
+    @property
+    def available(self) -> bool:
+        """Return binary sensor availability."""
+        return True
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return binary sensor state."""
+        return self._coordinator.last_update_success

--- a/homeassistant/components/minecraft_server/binary_sensor.py
+++ b/homeassistant/components/minecraft_server/binary_sensor.py
@@ -58,7 +58,7 @@ class MinecraftServerBinarySensorEntity(MinecraftServerEntity, BinarySensorEntit
         description: MinecraftServerBinarySensorEntityDescription,
     ) -> None:
         """Initialize binary sensor base entity."""
-        super().__init__(coordinator=coordinator)
+        super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.unique_id}-{description.key}"
         self._attr_is_on = False
@@ -69,6 +69,6 @@ class MinecraftServerBinarySensorEntity(MinecraftServerEntity, BinarySensorEntit
         return True
 
     @property
-    def is_on(self) -> bool | None:
+    def is_on(self) -> bool:
         """Return binary sensor state."""
         return self._coordinator.last_update_success

--- a/homeassistant/components/minecraft_server/config_flow.py
+++ b/homeassistant/components/minecraft_server/config_flow.py
@@ -1,7 +1,6 @@
 """Config flow for Minecraft Server integration."""
 from contextlib import suppress
 import logging
-from typing import Any
 
 from mcstatus import JavaServer
 import voluptuous as vol
@@ -57,14 +56,13 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
                     CONF_HOST: host,
                     CONF_PORT: port,
                 }
-                server_online = await self.async_is_server_online(config_data)
-                if not server_online:
-                    # Host or port invalid or server not reachable.
-                    errors["base"] = "cannot_connect"
-                else:
+                if await self._async_is_server_online(host, port):
                     # Configuration data are available and no error was detected,
                     # create configuration entry.
                     return self.async_create_entry(title=title, data=config_data)
+
+                # Host or port invalid or server not reachable.
+                errors["base"] = "cannot_connect"
 
         # Show configuration form (default form in case of no user_input,
         # form filled with user_input and eventually with errors otherwise).
@@ -90,26 +88,22 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_is_server_online(self, config_data: dict[str, Any]) -> bool:
+    async def _async_is_server_online(self, host: str, port: int) -> bool:
         """Check server connection using a 'status' request and return result."""
-        server_online = False
 
         # Check if host is a SRV record. If so, update server data.
-        srv_record = await helpers.async_check_srv_record(config_data[CONF_HOST])
+        srv_record = await helpers.async_check_srv_record(host)
 
         if srv_record is not None:
             # Use extracted host and port from SRV record.
             host = srv_record[CONF_HOST]
             port = srv_record[CONF_PORT]
-        else:
-            # Use host and port from user input.
-            host = config_data[CONF_HOST]
-            port = config_data[CONF_PORT]
 
         # Send a status request to the server.
         server = JavaServer(host, port)
         try:
             await server.async_status()
+            return True
         except OSError as error:
             _LOGGER.debug(
                 (
@@ -120,7 +114,5 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
                 port,
                 error,
             )
-        else:
-            server_online = True
 
-        return server_online
+        return False

--- a/homeassistant/components/minecraft_server/config_flow.py
+++ b/homeassistant/components/minecraft_server/config_flow.py
@@ -7,8 +7,8 @@ from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.data_entry_flow import FlowResult
 
-from . import MinecraftServer
 from .const import DEFAULT_HOST, DEFAULT_NAME, DEFAULT_PORT, DOMAIN
+from .coordinator import MinecraftServerCoordinator
 
 
 class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -52,9 +52,11 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
                     CONF_HOST: host,
                     CONF_PORT: port,
                 }
-                server = MinecraftServer(self.hass, "dummy_unique_id", config_data)
-                await server.async_check_connection()
-                if not server.online:
+                coordinator = MinecraftServerCoordinator(
+                    self.hass, "dummy_unique_id", config_data
+                )
+                server_online = await coordinator.async_is_server_online()
+                if not server_online:
                     # Host or port invalid or server not reachable.
                     errors["base"] = "cannot_connect"
                 else:

--- a/homeassistant/components/minecraft_server/config_flow.py
+++ b/homeassistant/components/minecraft_server/config_flow.py
@@ -92,9 +92,7 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
         """Check server connection using a 'status' request and return result."""
 
         # Check if host is a SRV record. If so, update server data.
-        srv_record = await helpers.async_check_srv_record(host)
-
-        if srv_record is not None:
+        if srv_record := await helpers.async_check_srv_record(host):
             # Use extracted host and port from SRV record.
             host = srv_record[CONF_HOST]
             port = srv_record[CONF_PORT]

--- a/homeassistant/components/minecraft_server/const.py
+++ b/homeassistant/components/minecraft_server/const.py
@@ -28,8 +28,6 @@ MANUFACTURER = "Mojang AB"
 
 SCAN_INTERVAL = 60
 
-SIGNAL_NAME_PREFIX = f"signal_{DOMAIN}"
-
 SRV_RECORD_PREFIX = "_minecraft._tcp"
 
 UNIT_PLAYERS_MAX = "players"

--- a/homeassistant/components/minecraft_server/coordinator.py
+++ b/homeassistant/components/minecraft_server/coordinator.py
@@ -45,7 +45,6 @@ class MinecraftServerCoordinator(DataUpdateCoordinator[MinecraftServerData]):
             logger=_LOGGER,
             update_interval=timedelta(seconds=SCAN_INTERVAL),
         )
-        self._hass = hass
 
         # Server data
         self.unique_id = unique_id

--- a/homeassistant/components/minecraft_server/coordinator.py
+++ b/homeassistant/components/minecraft_server/coordinator.py
@@ -1,0 +1,146 @@
+"""The Minecraft Server integration."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import timedelta
+import logging
+from typing import Any
+
+import aiodns
+from mcstatus.server import JavaServer
+
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import SCAN_INTERVAL, SRV_RECORD_PREFIX
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class MinecraftServerData:
+    """Representation of Minecraft Server data."""
+
+    latency: float
+    motd: str
+    players_max: int
+    players_online: int
+    players_list: list[str]
+    protocol_version: int
+    version: str
+
+
+class MinecraftServerCoordinator(DataUpdateCoordinator[MinecraftServerData]):
+    """Minecraft Server data update coordinator."""
+
+    def __init__(
+        self, hass: HomeAssistant, unique_id: str, config_data: Mapping[str, Any]
+    ) -> None:
+        """Initialize coordinator instance."""
+        super().__init__(
+            hass=hass,
+            name=config_data[CONF_NAME],
+            logger=_LOGGER,
+            update_interval=timedelta(seconds=SCAN_INTERVAL),
+        )
+        self._hass = hass
+
+        # Server data
+        self.unique_id = unique_id
+        self.name = config_data[CONF_NAME]
+        self.host = config_data[CONF_HOST]
+        self.port = config_data[CONF_PORT]
+        self.srv_record_checked = False
+
+        # 3rd party library instance
+        self._server = JavaServer(self.host, self.port)
+
+    async def async_is_server_online(self) -> bool:
+        """Check server connection using a 'status' request and return result."""
+        server_online = False
+
+        # Check once if host is a SRV record. If so, update server data.
+        if not self.srv_record_checked:
+            await self._async_check_srv_record()
+
+        # Send a status request to the server.
+        try:
+            await self._server.async_status()
+            server_online = True
+        except OSError as error:
+            _LOGGER.debug(
+                (
+                    "Error occurred while trying to check the connection to '%s:%s' -"
+                    " OSError: %s"
+                ),
+                self.host,
+                self.port,
+                error,
+            )
+
+        return server_online
+
+    async def _async_check_srv_record(self) -> None:
+        """Check if the given host is a valid Minecraft SRV record."""
+        self.srv_record_checked = True
+        srv_record = None
+        srv_query = None
+
+        try:
+            srv_query = await aiodns.DNSResolver().query(
+                host=f"{SRV_RECORD_PREFIX}.{self.host}", qtype="SRV"
+            )
+        except aiodns.error.DNSError:
+            # 'host' is not a SRV record.
+            pass
+        else:
+            # 'host' is a valid SRV record, extract the data.
+            srv_record = {
+                CONF_HOST: srv_query[0].host,
+                CONF_PORT: srv_query[0].port,
+            }
+
+            if srv_record is not None:
+                _LOGGER.debug(
+                    "'%s' is a valid Minecraft SRV record ('%s:%s')",
+                    self.host,
+                    srv_record[CONF_HOST],
+                    srv_record[CONF_PORT],
+                )
+                # Overwrite host, port and 3rd party library instance
+                # with data extracted out of SRV record.
+                self.host = srv_record[CONF_HOST]
+                self.port = srv_record[CONF_PORT]
+                self._server = JavaServer(self.host, self.port)
+
+    async def _async_update_data(self) -> MinecraftServerData:
+        """Get server data from 3rd party library and update properties."""
+
+        # Check once if host is a SRV record. If so, update server data.
+        if not self.srv_record_checked:
+            await self._async_check_srv_record()
+
+        # Send status request to the server.
+        try:
+            status_response = await self._server.async_status()
+        except OSError as error:
+            raise UpdateFailed(error) from error
+
+        # Got answer to request, update properties.
+        players_list = []
+        if status_response.players.sample is not None:
+            for player in status_response.players.sample:
+                players_list.append(player.name)
+            players_list.sort()
+
+        return MinecraftServerData(
+            version=status_response.version.name,
+            protocol_version=status_response.version.protocol,
+            players_online=status_response.players.online,
+            players_max=status_response.players.max,
+            players_list=players_list,
+            latency=status_response.latency,
+            motd=status_response.motd.to_plain(),
+        )

--- a/homeassistant/components/minecraft_server/entity.py
+++ b/homeassistant/components/minecraft_server/entity.py
@@ -1,52 +1,28 @@
 """Base entity for the Minecraft Server integration."""
 
-
-from homeassistant.core import CALLBACK_TYPE, callback
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import MinecraftServer
 from .const import DOMAIN, MANUFACTURER
+from .coordinator import MinecraftServerCoordinator
 
 
-class MinecraftServerEntity(Entity):
+class MinecraftServerEntity(CoordinatorEntity[MinecraftServerCoordinator]):
     """Representation of a Minecraft Server base entity."""
 
     _attr_has_entity_name = True
-    _attr_should_poll = False
 
     def __init__(
         self,
-        server: MinecraftServer,
+        coordinator: MinecraftServerCoordinator,
     ) -> None:
         """Initialize base entity."""
-        self._server = server
+        super().__init__(coordinator=coordinator)
+        self._coordinator = coordinator
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, server.unique_id)},
+            identifiers={(DOMAIN, coordinator.unique_id)},
             manufacturer=MANUFACTURER,
-            model=f"Minecraft Server ({server.data.version})",
-            name=server.name,
-            sw_version=str(server.data.protocol_version),
+            model=f"Minecraft Server ({coordinator.data.version})",
+            name=coordinator.name,
+            sw_version=str(coordinator.data.protocol_version),
         )
-        self._disconnect_dispatcher: CALLBACK_TYPE | None = None
-
-    async def async_update(self) -> None:
-        """Fetch data from the server."""
-        raise NotImplementedError()
-
-    async def async_added_to_hass(self) -> None:
-        """Connect dispatcher to signal from server."""
-        self._disconnect_dispatcher = async_dispatcher_connect(
-            self.hass, self._server.signal_name, self._update_callback
-        )
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Disconnect dispatcher before removal."""
-        if self._disconnect_dispatcher:
-            self._disconnect_dispatcher()
-
-    @callback
-    def _update_callback(self) -> None:
-        """Triggers update of properties after receiving signal from server."""
-        self.async_schedule_update_ha_state(force_refresh=True)

--- a/homeassistant/components/minecraft_server/entity.py
+++ b/homeassistant/components/minecraft_server/entity.py
@@ -17,7 +17,7 @@ class MinecraftServerEntity(CoordinatorEntity[MinecraftServerCoordinator]):
         coordinator: MinecraftServerCoordinator,
     ) -> None:
         """Initialize base entity."""
-        super().__init__(coordinator=coordinator)
+        super().__init__(coordinator)
         self._coordinator = coordinator
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.unique_id)},

--- a/homeassistant/components/minecraft_server/entity.py
+++ b/homeassistant/components/minecraft_server/entity.py
@@ -18,7 +18,6 @@ class MinecraftServerEntity(CoordinatorEntity[MinecraftServerCoordinator]):
     ) -> None:
         """Initialize base entity."""
         super().__init__(coordinator)
-        self._coordinator = coordinator
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.unique_id)},
             manufacturer=MANUFACTURER,

--- a/homeassistant/components/minecraft_server/helpers.py
+++ b/homeassistant/components/minecraft_server/helpers.py
@@ -29,7 +29,7 @@ async def async_check_srv_record(host: str) -> dict[str, Any] | None:
             CONF_PORT: srv_query[0].port,
         }
         _LOGGER.debug(
-            "'%s' is a valid SRV record ('%s:%s')",
+            "'%s' is a valid Minecraft SRV record ('%s:%s')",
             host,
             srv_record[CONF_HOST],
             srv_record[CONF_PORT],

--- a/homeassistant/components/minecraft_server/helpers.py
+++ b/homeassistant/components/minecraft_server/helpers.py
@@ -1,0 +1,38 @@
+"""Helper functions of Minecraft Server integration."""
+import logging
+from typing import Any
+
+import aiodns
+
+from homeassistant.const import CONF_HOST, CONF_PORT
+
+from .const import SRV_RECORD_PREFIX
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_check_srv_record(host: str) -> dict[str, Any] | None:
+    """Check if the given host is a valid Minecraft SRV record."""
+    srv_record = None
+
+    try:
+        srv_query = await aiodns.DNSResolver().query(
+            host=f"{SRV_RECORD_PREFIX}.{host}", qtype="SRV"
+        )
+    except aiodns.error.DNSError:
+        # 'host' is not a Minecraft SRV record.
+        pass
+    else:
+        # 'host' is a valid Minecraft SRV record, extract the data.
+        srv_record = {
+            CONF_HOST: srv_query[0].host,
+            CONF_PORT: srv_query[0].port,
+        }
+        _LOGGER.debug(
+            "'%s' is a valid SRV record ('%s:%s')",
+            host,
+            srv_record[CONF_HOST],
+            srv_record[CONF_PORT],
+        )
+
+    return srv_record

--- a/homeassistant/components/minecraft_server/sensor.py
+++ b/homeassistant/components/minecraft_server/sensor.py
@@ -147,7 +147,7 @@ class MinecraftServerSensorEntity(MinecraftServerEntity, SensorEntity):
     @property
     def native_value(self) -> StateType:
         """Return sensor value."""
-        return self.entity_description.value_fn(self._coordinator.data)
+        return self.entity_description.value_fn(self.coordinator.data)
 
     @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
@@ -155,6 +155,6 @@ class MinecraftServerSensorEntity(MinecraftServerEntity, SensorEntity):
         extra_state_attributes = None
         if self.entity_description.attributes_fn:
             extra_state_attributes = self.entity_description.attributes_fn(
-                self._coordinator.data
+                self.coordinator.data
             )
         return extra_state_attributes

--- a/homeassistant/components/minecraft_server/sensor.py
+++ b/homeassistant/components/minecraft_server/sensor.py
@@ -1,7 +1,7 @@
 """The Minecraft Server sensor platform."""
 from __future__ import annotations
 
-from collections.abc import Callable, MutableMapping
+from collections.abc import Callable, Mapping, MutableMapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -12,7 +12,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from . import MinecraftServer, MinecraftServerData
 from .const import (
     ATTR_PLAYERS_LIST,
     DOMAIN,
@@ -31,6 +30,7 @@ from .const import (
     UNIT_PLAYERS_MAX,
     UNIT_PLAYERS_ONLINE,
 )
+from .coordinator import MinecraftServerCoordinator, MinecraftServerData
 from .entity import MinecraftServerEntity
 
 
@@ -118,15 +118,14 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Minecraft Server sensor platform."""
-    server = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
     # Add sensor entities.
     async_add_entities(
         [
-            MinecraftServerSensorEntity(server, description)
+            MinecraftServerSensorEntity(coordinator, description)
             for description in SENSOR_DESCRIPTIONS
-        ],
-        True,
+        ]
     )
 
 
@@ -137,24 +136,25 @@ class MinecraftServerSensorEntity(MinecraftServerEntity, SensorEntity):
 
     def __init__(
         self,
-        server: MinecraftServer,
+        coordinator: MinecraftServerCoordinator,
         description: MinecraftServerSensorEntityDescription,
     ) -> None:
         """Initialize sensor base entity."""
-        super().__init__(server)
+        super().__init__(coordinator)
         self.entity_description = description
-        self._attr_unique_id = f"{server.unique_id}-{description.key}"
+        self._attr_unique_id = f"{coordinator.unique_id}-{description.key}"
 
     @property
-    def available(self) -> bool:
-        """Return sensor availability."""
-        return self._server.online
+    def native_value(self) -> StateType:
+        """Return sensor value."""
+        return self.entity_description.value_fn(self._coordinator.data)
 
-    async def async_update(self) -> None:
-        """Update sensor state."""
-        self._attr_native_value = self.entity_description.value_fn(self._server.data)
-
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        """Return sensor state attributes, if available."""
+        extra_state_attributes = None
         if self.entity_description.attributes_fn:
-            self._attr_extra_state_attributes = self.entity_description.attributes_fn(
-                self._server.data
+            extra_state_attributes = self.entity_description.attributes_fn(
+                self._coordinator.data
             )
+        return extra_state_attributes

--- a/homeassistant/components/minecraft_server/sensor.py
+++ b/homeassistant/components/minecraft_server/sensor.py
@@ -143,19 +143,20 @@ class MinecraftServerSensorEntity(MinecraftServerEntity, SensorEntity):
         super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.unique_id}-{description.key}"
-        self._attr_native_value = description.value_fn(coordinator.data)
-
-        if func := description.attributes_fn:
-            self._attr_extra_state_attributes = func(coordinator.data)
+        self._update_properties()
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+        self._update_properties()
+        self.async_write_ha_state()
+
+    @callback
+    def _update_properties(self) -> None:
+        """Update sensor properties."""
         self._attr_native_value = self.entity_description.value_fn(
             self.coordinator.data
         )
 
         if func := self.entity_description.attributes_fn:
             self._attr_extra_state_attributes = func(self.coordinator.data)
-
-        self.async_write_ha_state()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Minecraft Server integration periodically reads data from the server centrally and informs all sensor entities via dispatcher signals that new data is available, so that they can update their states. In this PR this manual handling is replaced by switching to the [DataUpdateCoordinator](https://developers.home-assistant.io/docs/integration_fetching_data/#coordinated-single-api-poll-for-data-for-all-entities). This simplifies the code and adds better handling with HA core (like automatic retry of loading the integration, if it fails).

I tried to keep code changes as minimal as I could to keep this PR as small as possible, but some changes were required to adapt to the DataUpdateCoordinator.
I am aware that the code (especially the coordinator) has potential for optimization/simplification. One examples is:
- Moving SRV handling to the API.

I will tackle optimizations/simplification after this PR.

Tested with my own server and some open ones from the web.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: n.a.
- This PR is related to issue: n.a.
- Link to documentation pull request: n.a.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
