### PR TITLE
Add configuration flow to Todoist integration

### DIFF
--- a/homeassistant/components/todoist/__init__.py
+++ b/homeassistant/components/todoist/__init__.py
@@ -1,1 +1,44 @@
-"""The todoist component."""
+"""The todoist integration."""
+
+import datetime
+import logging
+
+from todoist_api_python.api_async import TodoistAPIAsync
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_TOKEN, Platform
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .coordinator import TodoistCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = datetime.timedelta(minutes=1)
+
+
+PLATFORMS: list[Platform] = [Platform.CALENDAR]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up todoist from a config entry."""
+
+    token = entry.data[CONF_TOKEN]
+    api = TodoistAPIAsync(token)
+    coordinator = TodoistCoordinator(hass, _LOGGER, SCAN_INTERVAL, api)
+    await coordinator.async_config_entry_first_refresh()
+
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = coordinator
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/todoist/__init__.py
+++ b/homeassistant/components/todoist/__init__.py
@@ -25,7 +25,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     token = entry.data[CONF_TOKEN]
     api = TodoistAPIAsync(token)
-    coordinator = TodoistCoordinator(hass, _LOGGER, SCAN_INTERVAL, api)
+    coordinator = TodoistCoordinator(hass, _LOGGER, SCAN_INTERVAL, api, token)
     await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})

--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -121,7 +121,7 @@ async def async_setup_entry(
         project_data: ProjectData = {CONF_NAME: project.name, CONF_ID: project.id}
         entities.append(TodoistProjectEntity(coordinator, project_data, labels))
 
-    async_add_entities(entities, update_before_add=True)
+    async_add_entities(entities)
     async_register_services(hass, coordinator)
 
 

--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -17,6 +17,7 @@ from homeassistant.components.calendar import (
     CalendarEntity,
     CalendarEvent,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ID, CONF_NAME, CONF_TOKEN, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, ServiceCall, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -104,6 +105,22 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 SCAN_INTERVAL = timedelta(minutes=1)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the Todoist calendar platform config entry."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    projects = await coordinator.async_get_projects()
+    labels = await coordinator.async_get_labels()
+
+    entities = []
+    for project in projects:
+        project_data: ProjectData = {CONF_NAME: project.name, CONF_ID: project.id}
+        entities.append(TodoistProjectEntity(coordinator, project_data, labels))
+
+    async_add_entities(entities, update_before_add=True)
 
 
 async def async_setup_platform(

--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -20,6 +20,7 @@ from homeassistant.components.calendar import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ID, CONF_NAME, CONF_TOKEN, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -121,6 +122,7 @@ async def async_setup_entry(
         entities.append(TodoistProjectEntity(coordinator, project_data, labels))
 
     async_add_entities(entities, update_before_add=True)
+    async_register_services(hass, coordinator)
 
 
 async def async_setup_platform(
@@ -136,7 +138,7 @@ async def async_setup_platform(
     project_id_lookup = {}
 
     api = TodoistAPIAsync(token)
-    coordinator = TodoistCoordinator(hass, _LOGGER, SCAN_INTERVAL, api)
+    coordinator = TodoistCoordinator(hass, _LOGGER, SCAN_INTERVAL, api, token)
     await coordinator.async_refresh()
 
     async def _shutdown_coordinator(_: Event) -> None:
@@ -194,12 +196,29 @@ async def async_setup_platform(
 
     async_add_entities(project_devices, update_before_add=True)
 
+    async_register_services(hass, coordinator)
+
+
+def async_register_services(
+    hass: HomeAssistant, coordinator: TodoistCoordinator
+) -> None:
+    """Register services."""
+
+    if hass.services.has_service(DOMAIN, SERVICE_NEW_TASK):
+        return
+
     session = async_get_clientsession(hass)
 
     async def handle_new_task(call: ServiceCall) -> None:
         """Call when a user creates a new Todoist Task from Home Assistant."""
-        project_name = call.data[PROJECT_NAME]
-        project_id = project_id_lookup[project_name]
+        project_name = call.data[PROJECT_NAME].lower()
+        projects = await coordinator.async_get_projects()
+        project_id: str | None = None
+        for project in projects:
+            if project_name == project.name.lower():
+                project_id = project.id
+        if project_id is None:
+            raise HomeAssistantError(f"Invalid project name '{project_name}'")
 
         # Create the task
         content = call.data[CONTENT]
@@ -209,7 +228,7 @@ async def async_setup_platform(
             data["labels"] = task_labels
 
         if ASSIGNEE in call.data:
-            collaborators = await api.get_collaborators(project_id)
+            collaborators = await coordinator.api.get_collaborators(project_id)
             collaborator_id_lookup = {
                 collab.name.lower(): collab.id for collab in collaborators
             }
@@ -242,7 +261,7 @@ async def async_setup_platform(
             date_format = "%Y-%m-%dT%H:%M:%S"
             data["due_datetime"] = datetime.strftime(due_date, date_format)
 
-        api_task = await api.add_task(content, **data)
+        api_task = await coordinator.api.add_task(content, **data)
 
         # @NOTE: The rest-api doesn't support reminders, this works manually using
         # the sync api, in order to keep functional parity with the component.
@@ -280,7 +299,7 @@ async def async_setup_platform(
                     }
                 ]
             }
-            headers = create_headers(token=token, with_content=True)
+            headers = create_headers(token=coordinator.token, with_content=True)
             return await session.post(sync_url, headers=headers, json=reminder_data)
 
         if _reminder_due:

--- a/homeassistant/components/todoist/config_flow.py
+++ b/homeassistant/components/todoist/config_flow.py
@@ -11,7 +11,6 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_TOKEN
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN
 
@@ -35,6 +34,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the initial step."""
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
         errors: dict[str, str] = {}
         if user_input is not None:
             api = TodoistAPIAsync(user_input[CONF_TOKEN])
@@ -59,11 +61,3 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
             description_placeholders={"settings_url": SETTINGS_URL},
         )
-
-
-class CannotConnect(HomeAssistantError):
-    """Error to indicate we cannot connect."""
-
-
-class InvalidAuth(HomeAssistantError):
-    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/todoist/config_flow.py
+++ b/homeassistant/components/todoist/config_flow.py
@@ -1,0 +1,69 @@
+"""Config flow for todoist integration."""
+
+from http import HTTPStatus
+import logging
+from typing import Any
+
+from requests.exceptions import HTTPError
+from todoist_api_python.api_async import TodoistAPIAsync
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_TOKEN
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.exceptions import HomeAssistantError
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+SETTINGS_URL = "https://todoist.com/app/settings/integrations"
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_TOKEN): str,
+    }
+)
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for todoist."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            api = TodoistAPIAsync(user_input[CONF_TOKEN])
+            try:
+                await api.get_tasks()
+            except HTTPError as err:
+                if err.response.status_code == HTTPStatus.UNAUTHORIZED:
+                    errors["base"] = "invalid_access_token"
+                else:
+                    errors["base"] = "cannot_connect"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                await self.async_set_unique_id(user_input[CONF_TOKEN])
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(title="Todoist", data=user_input)
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+            description_placeholders={"settings_url": SETTINGS_URL},
+        )
+
+
+class CannotConnect(HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/todoist/coordinator.py
+++ b/homeassistant/components/todoist/coordinator.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 import logging
 
 from todoist_api_python.api_async import TodoistAPIAsync
-from todoist_api_python.models import Task
+from todoist_api_python.models import Label, Project, Task
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -21,11 +21,25 @@ class TodoistCoordinator(DataUpdateCoordinator[list[Task]]):
     ) -> None:
         """Initialize the Todoist coordinator."""
         super().__init__(hass, logger, name="Todoist", update_interval=update_interval)
-        self.api = api
+        self._api = api
+        self._projects: list[Project] | None = None
+        self._labels: list[Label] | None = None
 
     async def _async_update_data(self) -> list[Task]:
         """Fetch tasks from the Todoist API."""
         try:
-            return await self.api.get_tasks()
+            return await self._api.get_tasks()
         except Exception as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
+
+    async def async_get_projects(self) -> list[Project]:
+        """Return todoist projects fetched at most once."""
+        if self._projects is None:
+            self._projects = await self._api.get_projects()
+        return self._projects
+
+    async def async_get_labels(self) -> list[Label]:
+        """Return todoist labels fetched at most once."""
+        if self._labels is None:
+            self._labels = await self._api.get_labels()
+        return self._labels

--- a/homeassistant/components/todoist/coordinator.py
+++ b/homeassistant/components/todoist/coordinator.py
@@ -18,28 +18,30 @@ class TodoistCoordinator(DataUpdateCoordinator[list[Task]]):
         logger: logging.Logger,
         update_interval: timedelta,
         api: TodoistAPIAsync,
+        token: str,
     ) -> None:
         """Initialize the Todoist coordinator."""
         super().__init__(hass, logger, name="Todoist", update_interval=update_interval)
-        self._api = api
+        self.api = api
         self._projects: list[Project] | None = None
         self._labels: list[Label] | None = None
+        self.token = token
 
     async def _async_update_data(self) -> list[Task]:
         """Fetch tasks from the Todoist API."""
         try:
-            return await self._api.get_tasks()
+            return await self.api.get_tasks()
         except Exception as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
 
     async def async_get_projects(self) -> list[Project]:
         """Return todoist projects fetched at most once."""
         if self._projects is None:
-            self._projects = await self._api.get_projects()
+            self._projects = await self.api.get_projects()
         return self._projects
 
     async def async_get_labels(self) -> list[Label]:
         """Return todoist labels fetched at most once."""
         if self._labels is None:
-            self._labels = await self._api.get_labels()
+            self._labels = await self.api.get_labels()
         return self._labels

--- a/homeassistant/components/todoist/manifest.json
+++ b/homeassistant/components/todoist/manifest.json
@@ -2,6 +2,7 @@
   "domain": "todoist",
   "name": "Todoist",
   "codeowners": ["@boralyl"],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/todoist",
   "iot_class": "cloud_polling",
   "loggers": ["todoist"],

--- a/homeassistant/components/todoist/strings.json
+++ b/homeassistant/components/todoist/strings.json
@@ -1,4 +1,23 @@
 {
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "token": "[%key:common::config_flow::data::api_token%]"
+        },
+        "description": "Please entry your API token from your [Todoist Settings page]({settings_url})"
+      }
+    },
+    "error": {
+      "invalid_api_key": "[%key:common::config_flow::error::invalid_api_key%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
+    },
+    "create_entry": {
+      "default": "[%key:common::config_flow::create_entry::authenticated%]"
+    }
+  },
   "services": {
     "new_task": {
       "name": "New task",

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -473,6 +473,7 @@ FLOWS = {
         "tibber",
         "tile",
         "tilt_ble",
+        "todoist",
         "tolo",
         "tomorrowio",
         "toon",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -5802,7 +5802,7 @@
     "todoist": {
       "name": "Todoist",
       "integration_type": "hub",
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "cloud_polling"
     },
     "tolo": {

--- a/tests/components/todoist/conftest.py
+++ b/tests/components/todoist/conftest.py
@@ -1,0 +1,135 @@
+"""Common fixtures for the todoist tests."""
+from collections.abc import Generator
+from http import HTTPStatus
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from requests.exceptions import HTTPError
+from requests.models import Response
+from todoist_api_python.models import Collaborator, Due, Label, Project, Task
+
+from homeassistant.components.todoist import DOMAIN
+from homeassistant.const import CONF_TOKEN
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+from tests.common import MockConfigEntry
+
+SUMMARY = "A task"
+TOKEN = "some-token"
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.todoist.PLATFORMS", return_value=[]
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+@pytest.fixture(name="due")
+def mock_due() -> Due:
+    """Mock a todoist Task Due date/time."""
+    return Due(
+        is_recurring=False, date=dt_util.now().strftime("%Y-%m-%d"), string="today"
+    )
+
+
+@pytest.fixture(name="task")
+def mock_task(due: Due) -> Task:
+    """Mock a todoist Task instance."""
+    return Task(
+        assignee_id="1",
+        assigner_id="1",
+        comment_count=0,
+        is_completed=False,
+        content=SUMMARY,
+        created_at="2021-10-01T00:00:00",
+        creator_id="1",
+        description="A task",
+        due=due,
+        id="1",
+        labels=["Label1"],
+        order=1,
+        parent_id=None,
+        priority=1,
+        project_id="12345",
+        section_id=None,
+        url="https://todoist.com",
+        sync_id=None,
+    )
+
+
+@pytest.fixture(name="api")
+def mock_api(task) -> AsyncMock:
+    """Mock the api state."""
+    api = AsyncMock()
+    api.get_projects.return_value = [
+        Project(
+            id="12345",
+            color="blue",
+            comment_count=0,
+            is_favorite=False,
+            name="Name",
+            is_shared=False,
+            url="",
+            is_inbox_project=False,
+            is_team_inbox=False,
+            order=1,
+            parent_id=None,
+            view_style="list",
+        )
+    ]
+    api.get_labels.return_value = [
+        Label(id="1", name="Label1", color="1", order=1, is_favorite=False)
+    ]
+    api.get_collaborators.return_value = [
+        Collaborator(email="user@gmail.com", id="1", name="user")
+    ]
+    api.get_tasks.return_value = [task]
+    return api
+
+
+@pytest.fixture(name="todoist_api_status")
+def mock_api_status() -> HTTPStatus | None:
+    """Fixture to inject an http status error."""
+    return None
+
+
+@pytest.fixture(autouse=True)
+def mock_api_side_effect(
+    api: AsyncMock, todoist_api_status: HTTPStatus | None
+) -> MockConfigEntry:
+    """Mock todoist configuration."""
+    if todoist_api_status:
+        response = Response()
+        response.status_code = todoist_api_status
+        api.get_tasks.side_effect = HTTPError(response=response)
+
+
+@pytest.fixture(name="todoist_config_entry")
+def mock_todoist_config_entry() -> MockConfigEntry:
+    """Mock todoist configuration."""
+    return MockConfigEntry(domain=DOMAIN, unique_id=TOKEN, data={CONF_TOKEN: TOKEN})
+
+
+@pytest.fixture(name="todoist_domain")
+def mock_todoist_domain() -> str:
+    """Mock todoist configuration."""
+    return DOMAIN
+
+
+@pytest.fixture(name="setup_integration")
+async def mock_setup_integration(
+    hass: HomeAssistant,
+    api: AsyncMock,
+    todoist_config_entry: MockConfigEntry | None,
+) -> None:
+    """Mock setup of the todoist integration."""
+    if todoist_config_entry is not None:
+        todoist_config_entry.add_to_hass(hass)
+    with patch("homeassistant.components.todoist.TodoistAPIAsync", return_value=api):
+        assert await async_setup_component(hass, DOMAIN, {})
+        yield

--- a/tests/components/todoist/conftest.py
+++ b/tests/components/todoist/conftest.py
@@ -24,7 +24,7 @@ TOKEN = "some-token"
 def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""
     with patch(
-        "homeassistant.components.todoist.PLATFORMS", return_value=[]
+        "homeassistant.components.todoist.async_setup_entry", return_value=True
     ) as mock_setup_entry:
         yield mock_setup_entry
 

--- a/tests/components/todoist/test_calendar.py
+++ b/tests/components/todoist/test_calendar.py
@@ -7,7 +7,7 @@ import urllib
 import zoneinfo
 
 import pytest
-from todoist_api_python.models import Collaborator, Due, Label, Project, Task
+from todoist_api_python.models import Due
 
 from homeassistant import setup
 from homeassistant.components.todoist.const import (
@@ -24,9 +24,10 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.util import dt as dt_util
 
+from .conftest import SUMMARY
+
 from tests.typing import ClientSessionGenerator
 
-SUMMARY = "A task"
 # Set our timezone to CST/Regina so we can check calculations
 # This keeps UTC-6 all year round
 TZ_NAME = "America/Regina"
@@ -37,69 +38,6 @@ TIMEZONE = zoneinfo.ZoneInfo(TZ_NAME)
 def set_time_zone(hass: HomeAssistant):
     """Set the time zone for the tests."""
     hass.config.set_time_zone(TZ_NAME)
-
-
-@pytest.fixture(name="due")
-def mock_due() -> Due:
-    """Mock a todoist Task Due date/time."""
-    return Due(
-        is_recurring=False, date=dt_util.now().strftime("%Y-%m-%d"), string="today"
-    )
-
-
-@pytest.fixture(name="task")
-def mock_task(due: Due) -> Task:
-    """Mock a todoist Task instance."""
-    return Task(
-        assignee_id="1",
-        assigner_id="1",
-        comment_count=0,
-        is_completed=False,
-        content=SUMMARY,
-        created_at="2021-10-01T00:00:00",
-        creator_id="1",
-        description="A task",
-        due=due,
-        id="1",
-        labels=["Label1"],
-        order=1,
-        parent_id=None,
-        priority=1,
-        project_id="12345",
-        section_id=None,
-        url="https://todoist.com",
-        sync_id=None,
-    )
-
-
-@pytest.fixture(name="api")
-def mock_api(task) -> AsyncMock:
-    """Mock the api state."""
-    api = AsyncMock()
-    api.get_projects.return_value = [
-        Project(
-            id="12345",
-            color="blue",
-            comment_count=0,
-            is_favorite=False,
-            name="Name",
-            is_shared=False,
-            url="",
-            is_inbox_project=False,
-            is_team_inbox=False,
-            order=1,
-            parent_id=None,
-            view_style="list",
-        )
-    ]
-    api.get_labels.return_value = [
-        Label(id="1", name="Label1", color="1", order=1, is_favorite=False)
-    ]
-    api.get_collaborators.return_value = [
-        Collaborator(email="user@gmail.com", id="1", name="user")
-    ]
-    api.get_tasks.return_value = [task]
-    return api
 
 
 def get_events_url(entity: str, start: str, end: str) -> str:
@@ -417,3 +355,39 @@ async def test_task_due_datetime(
     )
     assert response.status == HTTPStatus.OK
     assert await response.json() == []
+
+
+@pytest.mark.parametrize(
+    ("due", "todoist_config"),
+    [
+        (
+            Due(
+                date="2023-03-30",
+                is_recurring=False,
+                string="Mar 30 6:00 PM",
+                datetime="2023-03-31T00:00:00Z",
+                timezone="America/Regina",
+            ),
+            {},
+        )
+    ],
+)
+async def test_config_entry(
+    hass: HomeAssistant,
+    setup_integration: None,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test for a calendar created with a config entry."""
+    client = await hass_client()
+    response = await client.get(
+        get_events_url(
+            "calendar.name", "2023-03-30T08:00:00.000Z", "2023-03-31T08:00:00.000Z"
+        ),
+    )
+    assert response.status == HTTPStatus.OK
+    assert await response.json() == [
+        get_events_response(
+            {"dateTime": "2023-03-30T18:00:00-06:00"},
+            {"dateTime": "2023-03-31T18:00:00-06:00"},
+        )
+    ]

--- a/tests/components/todoist/test_calendar.py
+++ b/tests/components/todoist/test_calendar.py
@@ -65,8 +65,8 @@ def mock_todoist_config() -> dict[str, Any]:
     return {}
 
 
-@pytest.fixture(name="setup_integration", autouse=True)
-async def mock_setup_integration(
+@pytest.fixture(name="setup_platform", autouse=True)
+async def mock_setup_platform(
     hass: HomeAssistant,
     api: AsyncMock,
     todoist_config: dict[str, Any],
@@ -153,7 +153,7 @@ async def test_update_entity_for_calendar_with_due_date_in_the_future(
     assert state.attributes["end_time"] == expected_end_time
 
 
-@pytest.mark.parametrize("setup_integration", [None])
+@pytest.mark.parametrize("setup_platform", [None])
 async def test_failed_coordinator_update(hass: HomeAssistant, api: AsyncMock) -> None:
     """Test a failed data coordinator update is handled correctly."""
     api.get_tasks.side_effect = Exception("API error")
@@ -358,7 +358,7 @@ async def test_task_due_datetime(
 
 
 @pytest.mark.parametrize(
-    ("due", "todoist_config"),
+    ("due", "setup_platform"),
     [
         (
             Due(
@@ -368,7 +368,7 @@ async def test_task_due_datetime(
                 datetime="2023-03-31T00:00:00Z",
                 timezone="America/Regina",
             ),
-            {},
+            None,
         )
     ],
 )
@@ -378,6 +378,11 @@ async def test_config_entry(
     hass_client: ClientSessionGenerator,
 ) -> None:
     """Test for a calendar created with a config entry."""
+
+    await async_update_entity(hass, "calendar.name")
+    state = hass.states.get("calendar.name")
+    assert state
+
     client = await hass_client()
     response = await client.get(
         get_events_url(

--- a/tests/components/todoist/test_config_flow.py
+++ b/tests/components/todoist/test_config_flow.py
@@ -55,7 +55,7 @@ async def test_form(
 
 
 @pytest.mark.parametrize("todoist_api_status", [HTTPStatus.UNAUTHORIZED])
-async def test_form_invalid_auth(hass: HomeAssistant, api: AsyncMock) -> None:
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -73,7 +73,7 @@ async def test_form_invalid_auth(hass: HomeAssistant, api: AsyncMock) -> None:
 
 
 @pytest.mark.parametrize("todoist_api_status", [HTTPStatus.INTERNAL_SERVER_ERROR])
-async def test_form_cannot_connect(hass: HomeAssistant, api: AsyncMock) -> None:
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -88,6 +88,26 @@ async def test_form_cannot_connect(hass: HomeAssistant, api: AsyncMock) -> None:
 
     assert result2.get("type") == FlowResultType.FORM
     assert result2.get("errors") == {"base": "cannot_connect"}
+
+
+@pytest.mark.parametrize("todoist_api_status", [HTTPStatus.UNAUTHORIZED])
+async def test_unknown_error(hass: HomeAssistant, api: AsyncMock) -> None:
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    api.get_tasks.side_effect = ValueError("unexpected")
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_TOKEN: TOKEN,
+        },
+    )
+
+    assert result2.get("type") == FlowResultType.FORM
+    assert result2.get("errors") == {"base": "unknown"}
 
 
 async def test_already_configured(hass: HomeAssistant, setup_integration: None) -> None:

--- a/tests/components/todoist/test_config_flow.py
+++ b/tests/components/todoist/test_config_flow.py
@@ -1,0 +1,109 @@
+"""Test the todoist config flow."""
+
+from http import HTTPStatus
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.todoist.const import DOMAIN
+from homeassistant.const import CONF_TOKEN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from .conftest import TOKEN
+
+pytestmark = pytest.mark.usefixtures("mock_setup_entry")
+
+
+@pytest.fixture(autouse=True)
+async def patch_api(
+    api: AsyncMock,
+) -> None:
+    """Mock setup of the todoist integration."""
+    with patch(
+        "homeassistant.components.todoist.config_flow.TodoistAPIAsync", return_value=api
+    ):
+        yield
+
+
+async def test_form(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test we get the form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result.get("type") == FlowResultType.FORM
+    assert not result.get("errors")
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_TOKEN: TOKEN,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result2.get("type") == FlowResultType.CREATE_ENTRY
+    assert result2.get("title") == "Todoist"
+    assert result2.get("data") == {
+        CONF_TOKEN: TOKEN,
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+@pytest.mark.parametrize("todoist_api_status", [HTTPStatus.UNAUTHORIZED])
+async def test_form_invalid_auth(hass: HomeAssistant, api: AsyncMock) -> None:
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_TOKEN: TOKEN,
+        },
+    )
+
+    assert result2.get("type") == FlowResultType.FORM
+    assert result2.get("errors") == {"base": "invalid_access_token"}
+
+
+@pytest.mark.parametrize("todoist_api_status", [HTTPStatus.INTERNAL_SERVER_ERROR])
+async def test_form_cannot_connect(hass: HomeAssistant, api: AsyncMock) -> None:
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_TOKEN: TOKEN,
+        },
+    )
+
+    assert result2.get("type") == FlowResultType.FORM
+    assert result2.get("errors") == {"base": "cannot_connect"}
+
+
+async def test_already_configured(hass: HomeAssistant, setup_integration: None) -> None:
+    """Test handling the case where the API key is already used."""
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_TOKEN: TOKEN,
+        },
+    )
+    assert result2.get("type") == FlowResultType.ABORT
+    assert result2.get("reason") == "already_configured"

--- a/tests/components/todoist/test_config_flow.py
+++ b/tests/components/todoist/test_config_flow.py
@@ -91,7 +91,7 @@ async def test_form_cannot_connect(hass: HomeAssistant, api: AsyncMock) -> None:
 
 
 async def test_already_configured(hass: HomeAssistant, setup_integration: None) -> None:
-    """Test handling the case where the API key is already used."""
+    """Test that only a single instance can be configured."""
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -99,11 +99,5 @@ async def test_already_configured(hass: HomeAssistant, setup_integration: None) 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            CONF_TOKEN: TOKEN,
-        },
-    )
-    assert result2.get("type") == FlowResultType.ABORT
-    assert result2.get("reason") == "already_configured"
+    assert result.get("type") == FlowResultType.ABORT
+    assert result.get("reason") == "single_instance_allowed"

--- a/tests/components/todoist/test_init.py
+++ b/tests/components/todoist/test_init.py
@@ -1,0 +1,40 @@
+"""Unit tests for the Todoist integration."""
+from http import HTTPStatus
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from homeassistant.components.todoist.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_load_unload(
+    hass: HomeAssistant,
+    mock_setup_entry: Any,
+    setup_integration: None,
+    todoist_config_entry: MockConfigEntry | None,
+) -> None:
+    """Test loading and unloading of the config entry."""
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+
+    assert todoist_config_entry.state == ConfigEntryState.LOADED
+
+    assert await hass.config_entries.async_unload(todoist_config_entry.entry_id)
+    assert todoist_config_entry.state == ConfigEntryState.NOT_LOADED
+
+
+@pytest.mark.parametrize("todoist_api_status", [HTTPStatus.INTERNAL_SERVER_ERROR])
+async def test_init_failure(
+    hass: HomeAssistant,
+    mock_setup_entry: Any,
+    setup_integration: None,
+    api: AsyncMock,
+    todoist_config_entry: MockConfigEntry | None,
+) -> None:
+    """Test an initialization error on integration load."""
+    assert todoist_config_entry.state == ConfigEntryState.SETUP_RETRY

--- a/tests/components/todoist/test_init.py
+++ b/tests/components/todoist/test_init.py
@@ -1,7 +1,7 @@
 """Unit tests for the Todoist integration."""
+from collections.abc import Generator
 from http import HTTPStatus
-from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -12,9 +12,17 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry
 
 
+@pytest.fixture(autouse=True)
+def mock_platforms() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.todoist.PLATFORMS", return_value=[]
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
 async def test_load_unload(
     hass: HomeAssistant,
-    mock_setup_entry: Any,
     setup_integration: None,
     todoist_config_entry: MockConfigEntry | None,
 ) -> None:
@@ -31,7 +39,6 @@ async def test_load_unload(
 @pytest.mark.parametrize("todoist_api_status", [HTTPStatus.INTERNAL_SERVER_ERROR])
 async def test_init_failure(
     hass: HomeAssistant,
-    mock_setup_entry: Any,
     setup_integration: None,
     api: AsyncMock,
     todoist_config_entry: MockConfigEntry | None,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a config flow to the Todoist integration. The motivation for doing this is to prepare for adding more platforms. (todo platform [proposal](https://github.com/home-assistant/architecture/discussions/962))

The existing yaml configuration supports many options that are not supported in the config flow. The platform yaml configuration will remain, and those cannot be imported.

The service that creates new tasks currently does not support multiple configurations. Therefore, the new configuration flow only allows one instance.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28886

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
