### PR TITLE
Fix inverse naming of function in Reolink

### DIFF
--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.device_registry import format_mac
 from .const import CONF_PROTOCOL, CONF_USE_HTTPS, DOMAIN
 from .exceptions import ReolinkException, ReolinkWebhookException, UserNotAdmin
 from .host import ReolinkHost
-from .util import has_connection_problem
+from .util import is_connected
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -103,7 +103,7 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             and CONF_PASSWORD in existing_entry.data
             and existing_entry.data[CONF_HOST] != discovery_info.ip
         ):
-            if has_connection_problem(self.hass, existing_entry):
+            if is_connected(self.hass, existing_entry):
                 _LOGGER.debug(
                     "Reolink DHCP reported new IP '%s', "
                     "but connection to camera seems to be okay, so sticking to IP '%s'",

--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.device_registry import format_mac
 from .const import CONF_PROTOCOL, CONF_USE_HTTPS, DOMAIN
 from .exceptions import ReolinkException, ReolinkWebhookException, UserNotAdmin
 from .host import ReolinkHost
-from .util import is_connected
+from .util import reolink_is_connected
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -103,7 +103,7 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             and CONF_PASSWORD in existing_entry.data
             and existing_entry.data[CONF_HOST] != discovery_info.ip
         ):
-            if is_connected(self.hass, existing_entry):
+            if reolink_is_connected(self.hass, existing_entry):
                 _LOGGER.debug(
                     "Reolink DHCP reported new IP '%s', "
                     "but connection to camera seems to be okay, so sticking to IP '%s'",

--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.device_registry import format_mac
 from .const import CONF_PROTOCOL, CONF_USE_HTTPS, DOMAIN
 from .exceptions import ReolinkException, ReolinkWebhookException, UserNotAdmin
 from .host import ReolinkHost
-from .util import reolink_is_connected
+from .util import is_connected
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -103,7 +103,7 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             and CONF_PASSWORD in existing_entry.data
             and existing_entry.data[CONF_HOST] != discovery_info.ip
         ):
-            if reolink_is_connected(self.hass, existing_entry):
+            if is_connected(self.hass, existing_entry):
                 _LOGGER.debug(
                     "Reolink DHCP reported new IP '%s', "
                     "but connection to camera seems to be okay, so sticking to IP '%s'",

--- a/homeassistant/components/reolink/util.py
+++ b/homeassistant/components/reolink/util.py
@@ -9,7 +9,7 @@ from .const import DOMAIN
 
 
 def is_connected(hass: HomeAssistant, config_entry: config_entries.ConfigEntry) -> bool:
-    """Check if a existing entry has a proper connection."""
+    """Check if an existing entry has a proper connection."""
     reolink_data: ReolinkData | None = hass.data.get(DOMAIN, {}).get(
         config_entry.entry_id
     )

--- a/homeassistant/components/reolink/util.py
+++ b/homeassistant/components/reolink/util.py
@@ -13,9 +13,8 @@ def is_connected(hass: HomeAssistant, config_entry: config_entries.ConfigEntry) 
     reolink_data: ReolinkData | None = hass.data.get(DOMAIN, {}).get(
         config_entry.entry_id
     )
-    connected = (
+    return (
         reolink_data is not None
         and config_entry.state == config_entries.ConfigEntryState.LOADED
         and reolink_data.device_coordinator.last_update_success
     )
-    return connected

--- a/homeassistant/components/reolink/util.py
+++ b/homeassistant/components/reolink/util.py
@@ -8,16 +8,16 @@ from . import ReolinkData
 from .const import DOMAIN
 
 
-def has_connection_problem(
+def is_connected(
     hass: HomeAssistant, config_entry: config_entries.ConfigEntry
 ) -> bool:
-    """Check if a existing entry has a connection problem."""
+    """Check if a existing entry has a proper connection."""
     reolink_data: ReolinkData | None = hass.data.get(DOMAIN, {}).get(
         config_entry.entry_id
     )
-    connection_problem = (
+    is_connected = (
         reolink_data is not None
         and config_entry.state == config_entries.ConfigEntryState.LOADED
         and reolink_data.device_coordinator.last_update_success
     )
-    return connection_problem
+    return is_connected

--- a/homeassistant/components/reolink/util.py
+++ b/homeassistant/components/reolink/util.py
@@ -8,16 +8,14 @@ from . import ReolinkData
 from .const import DOMAIN
 
 
-def reolink_is_connected(
-    hass: HomeAssistant, config_entry: config_entries.ConfigEntry
-) -> bool:
+def is_connected(hass: HomeAssistant, config_entry: config_entries.ConfigEntry) -> bool:
     """Check if a existing entry has a proper connection."""
     reolink_data: ReolinkData | None = hass.data.get(DOMAIN, {}).get(
         config_entry.entry_id
     )
-    reolink_is_connected = (
+    connected = (
         reolink_data is not None
         and config_entry.state == config_entries.ConfigEntryState.LOADED
         and reolink_data.device_coordinator.last_update_success
     )
-    return reolink_is_connected
+    return connected

--- a/homeassistant/components/reolink/util.py
+++ b/homeassistant/components/reolink/util.py
@@ -8,16 +8,16 @@ from . import ReolinkData
 from .const import DOMAIN
 
 
-def is_connected(
+def reolink_is_connected(
     hass: HomeAssistant, config_entry: config_entries.ConfigEntry
 ) -> bool:
     """Check if a existing entry has a proper connection."""
     reolink_data: ReolinkData | None = hass.data.get(DOMAIN, {}).get(
         config_entry.entry_id
     )
-    is_connected = (
+    reolink_is_connected = (
         reolink_data is not None
         and config_entry.state == config_entries.ConfigEntryState.LOADED
         and reolink_data.device_coordinator.last_update_success
     )
-    return is_connected
+    return reolink_is_connected


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix inverse naming of function in Reolink
Thanks for spotting this @MartinHjelmare in [this comment](https://github.com/home-assistant/core/pull/99381/files#diff-66be0f5d6b3d8c85521a377befcbe8bc7aee699555b7e764629d1d8206b95b88)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
