### PR TITLE
Add diagnostics to Twinkly

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1324,8 +1324,8 @@ build.json @home-assistant/supervisor
 /tests/components/tuya/ @Tuya @zlinoliver @frenck
 /homeassistant/components/twentemilieu/ @frenck
 /tests/components/twentemilieu/ @frenck
-/homeassistant/components/twinkly/ @dr1rrb @Robbie1221
-/tests/components/twinkly/ @dr1rrb @Robbie1221
+/homeassistant/components/twinkly/ @dr1rrb @Robbie1221 @Olen
+/tests/components/twinkly/ @dr1rrb @Robbie1221 @Olen
 /homeassistant/components/twitch/ @joostlek
 /tests/components/twitch/ @joostlek
 /homeassistant/components/ukraine_alarm/ @PaulAnnekov

--- a/homeassistant/components/twinkly/diagnostics.py
+++ b/homeassistant/components/twinkly/diagnostics.py
@@ -4,16 +4,15 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_IP_ADDRESS, CONF_MAC
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .const import DATA_DEVICE_INFO
+from .const import DATA_DEVICE_INFO, DOMAIN
 
 TO_REDACT = [CONF_HOST, CONF_IP_ADDRESS, CONF_MAC]
-DOMAIN = "light"
-PLATFORM = "twinkly"
 
 
 async def async_get_config_entry_diagnostics(
@@ -25,16 +24,17 @@ async def async_get_config_entry_diagnostics(
     entity_registry = er.async_get(hass)
 
     entity_id = entity_registry.async_get_entity_id(
-        DOMAIN, PLATFORM, str(entry.unique_id)
+        LIGHT_DOMAIN, DOMAIN, str(entry.unique_id)
     )
     if entity_id:
         state = hass.states.get(entity_id)
     if state:
         attributes = state.attributes
-    return {
-        "entry": async_redact_data(entry.as_dict(), TO_REDACT),
-        "device_info": async_redact_data(
-            hass.data[PLATFORM][entry.entry_id][DATA_DEVICE_INFO], TO_REDACT
-        ),
-        "attributes": async_redact_data(attributes, TO_REDACT),
-    }
+    return async_redact_data(
+        {
+            "entry": entry.as_dict(),
+            "device_info": hass.data[DOMAIN][entry.entry_id][DATA_DEVICE_INFO],
+            "attributes": attributes,
+        },
+        TO_REDACT,
+    )

--- a/homeassistant/components/twinkly/diagnostics.py
+++ b/homeassistant/components/twinkly/diagnostics.py
@@ -1,0 +1,40 @@
+"""Diagnostics support for Twinkly."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_IP_ADDRESS, CONF_MAC
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .const import DATA_DEVICE_INFO
+
+TO_REDACT = [CONF_HOST, CONF_IP_ADDRESS, CONF_MAC]
+DOMAIN = "light"
+PLATFORM = "twinkly"
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a Twinkly config entry."""
+    attributes = None
+    state = None
+    entity_registry = er.async_get(hass)
+
+    entity_id = entity_registry.async_get_entity_id(
+        DOMAIN, PLATFORM, str(entry.unique_id)
+    )
+    if entity_id:
+        state = hass.states.get(entity_id)
+    if state:
+        attributes = state.attributes
+    return {
+        "entry": async_redact_data(entry.as_dict(), TO_REDACT),
+        "device_info": async_redact_data(
+            hass.data[PLATFORM][entry.entry_id][DATA_DEVICE_INFO], TO_REDACT
+        ),
+        "attributes": async_redact_data(attributes, TO_REDACT),
+    }

--- a/homeassistant/components/twinkly/light.py
+++ b/homeassistant/components/twinkly/light.py
@@ -20,9 +20,8 @@ from homeassistant.components.light import (
     LightEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_SW_VERSION, CONF_MODEL, CONF_NAME
+from homeassistant.const import CONF_MODEL
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -30,6 +29,7 @@ from .const import (
     ATTR_VERSION,
     CONF_HOST,
     CONF_ID,
+    CONF_NAME,
     DATA_CLIENT,
     DATA_DEVICE_INFO,
     DEV_LED_PROFILE,
@@ -54,9 +54,6 @@ async def async_setup_entry(
     client = hass.data[DOMAIN][config_entry.entry_id][DATA_CLIENT]
     device_info = hass.data[DOMAIN][config_entry.entry_id][DATA_DEVICE_INFO]
 
-    software_version = await client.get_firmware_version()
-    if ATTR_VERSION in software_version:
-        device_info[ATTR_SW_VERSION] = software_version[ATTR_VERSION]
     entity = TwinklyLight(config_entry, client, device_info)
 
     async_add_entities([entity], update_before_add=True)
@@ -101,7 +98,7 @@ class TwinklyLight(LightEntity):
         self._attributes: dict[Any, Any] = {}
         self._current_movie: dict[Any, Any] = {}
         self._movies: list[Any] = []
-        self._software_version = device_info.get(ATTR_SW_VERSION)
+        self._software_version = ""
         # We guess that most devices are "new" and support effects
         self._attr_supported_features = LightEntityFeature.EFFECT
 
@@ -171,15 +168,15 @@ class TwinklyLight(LightEntity):
 
     async def async_added_to_hass(self) -> None:
         """Device is added to hass."""
-        if AwesomeVersion(self._software_version) < AwesomeVersion(MIN_EFFECT_VERSION):
-            self._attr_supported_features = (
-                self.supported_features & ~LightEntityFeature.EFFECT
-            )
-            device_registry = dr.async_get(self.hass)
-            device_entry = device_registry.async_get_device({(DOMAIN, self._id)}, set())
-            if device_entry:
-                device_registry.async_update_device(
-                    device_entry.id, sw_version=self._software_version
+        software_version = await self._client.get_firmware_version()
+        if ATTR_VERSION in software_version:
+            self._software_version = software_version[ATTR_VERSION]
+
+            if AwesomeVersion(self._software_version) < AwesomeVersion(
+                MIN_EFFECT_VERSION
+            ):
+                self._attr_supported_features = (
+                    self.supported_features & ~LightEntityFeature.EFFECT
                 )
 
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/homeassistant/components/twinkly/light.py
+++ b/homeassistant/components/twinkly/light.py
@@ -20,8 +20,9 @@ from homeassistant.components.light import (
     LightEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_MODEL
+from homeassistant.const import ATTR_SW_VERSION, CONF_MODEL, CONF_NAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -29,7 +30,6 @@ from .const import (
     ATTR_VERSION,
     CONF_HOST,
     CONF_ID,
-    CONF_NAME,
     DATA_CLIENT,
     DATA_DEVICE_INFO,
     DEV_LED_PROFILE,
@@ -54,6 +54,9 @@ async def async_setup_entry(
     client = hass.data[DOMAIN][config_entry.entry_id][DATA_CLIENT]
     device_info = hass.data[DOMAIN][config_entry.entry_id][DATA_DEVICE_INFO]
 
+    software_version = await client.get_firmware_version()
+    if ATTR_VERSION in software_version:
+        device_info[ATTR_SW_VERSION] = software_version[ATTR_VERSION]
     entity = TwinklyLight(config_entry, client, device_info)
 
     async_add_entities([entity], update_before_add=True)
@@ -98,7 +101,7 @@ class TwinklyLight(LightEntity):
         self._attributes: dict[Any, Any] = {}
         self._current_movie: dict[Any, Any] = {}
         self._movies: list[Any] = []
-        self._software_version = ""
+        self._software_version = device_info.get(ATTR_SW_VERSION)
         # We guess that most devices are "new" and support effects
         self._attr_supported_features = LightEntityFeature.EFFECT
 
@@ -168,15 +171,15 @@ class TwinklyLight(LightEntity):
 
     async def async_added_to_hass(self) -> None:
         """Device is added to hass."""
-        software_version = await self._client.get_firmware_version()
-        if ATTR_VERSION in software_version:
-            self._software_version = software_version[ATTR_VERSION]
-
-            if AwesomeVersion(self._software_version) < AwesomeVersion(
-                MIN_EFFECT_VERSION
-            ):
-                self._attr_supported_features = (
-                    self.supported_features & ~LightEntityFeature.EFFECT
+        if AwesomeVersion(self._software_version) < AwesomeVersion(MIN_EFFECT_VERSION):
+            self._attr_supported_features = (
+                self.supported_features & ~LightEntityFeature.EFFECT
+            )
+            device_registry = dr.async_get(self.hass)
+            device_entry = device_registry.async_get_device({(DOMAIN, self._id)}, set())
+            if device_entry:
+                device_registry.async_update_device(
+                    device_entry.id, sw_version=self._software_version
                 )
 
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/homeassistant/components/twinkly/manifest.json
+++ b/homeassistant/components/twinkly/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "twinkly",
   "name": "Twinkly",
-  "codeowners": ["@dr1rrb", "@Robbie1221"],
+  "codeowners": ["@dr1rrb", "@Robbie1221", "@Olen"],
   "config_flow": true,
   "dhcp": [
     {

--- a/tests/components/twinkly/__init__.py
+++ b/tests/components/twinkly/__init__.py
@@ -28,7 +28,6 @@ class ClientMock:
         self.mode = None
         self.version = "2.8.10"
 
-        # self.id = str(uuid4())
         self.id = TEST_UID
         self.device_info = {
             "uuid": self.id,

--- a/tests/components/twinkly/__init__.py
+++ b/tests/components/twinkly/__init__.py
@@ -1,6 +1,5 @@
 """Constants and mock for the twkinly component tests."""
 
-from uuid import uuid4
 
 from aiohttp.client_exceptions import ClientConnectionError
 
@@ -8,6 +7,7 @@ from homeassistant.components.twinkly.const import DEV_NAME
 
 TEST_HOST = "test.twinkly.com"
 TEST_ID = "twinkly_test_device_id"
+TEST_UID = "4c8fccf5-e08a-4173-92d5-49bf479252a2"
 TEST_NAME = "twinkly_test_device_name"
 TEST_NAME_ORIGINAL = "twinkly_test_original_device_name"  # the original (deprecated) name stored in the conf
 TEST_MODEL = "twinkly_test_device_model"
@@ -28,10 +28,11 @@ class ClientMock:
         self.mode = None
         self.version = "2.8.10"
 
-        self.id = str(uuid4())
+        # self.id = str(uuid4())
+        self.id = TEST_UID
         self.device_info = {
             "uuid": self.id,
-            "device_name": self.id,  # we make sure that entity id is different for each test
+            "device_name": TEST_NAME,
             "product_code": TEST_MODEL,
             "sw_version": self.version,
         }

--- a/tests/components/twinkly/__init__.py
+++ b/tests/components/twinkly/__init__.py
@@ -33,6 +33,7 @@ class ClientMock:
             "uuid": self.id,
             "device_name": self.id,  # we make sure that entity id is different for each test
             "product_code": TEST_MODEL,
+            "sw_version": self.version,
         }
 
     @property

--- a/tests/components/twinkly/conftest.py
+++ b/tests/components/twinkly/conftest.py
@@ -1,0 +1,55 @@
+"""Configure tests for the Twinkly integration."""
+from collections.abc import Awaitable, Callable, Coroutine
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from . import TEST_MODEL, TEST_NAME, TEST_UID, ClientMock
+
+from tests.common import MockConfigEntry
+
+ComponentSetup = Callable[[], Awaitable[ClientMock]]
+
+DOMAIN = "twinkly"
+TITLE = "Twinkly"
+
+
+@pytest.fixture(name="config_entry")
+def mock_config_entry() -> MockConfigEntry:
+    """Create YouTube entry in Home Assistant."""
+    client = ClientMock()
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title=TITLE,
+        unique_id=TEST_UID,
+        entry_id=TEST_UID,
+        data={
+            "host": client.host,
+            "id": client.id,
+            "name": TEST_NAME,
+            "model": TEST_MODEL,
+            "device_name": TEST_NAME,
+        },
+    )
+
+
+@pytest.fixture(name="setup_integration")
+async def mock_setup_integration(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> Callable[[], Coroutine[Any, Any, ClientMock]]:
+    """Fixture for setting up the component."""
+    config_entry.add_to_hass(hass)
+
+    # assert await async_setup_component(hass, "application_credentials", {})
+    async def func() -> ClientMock:
+        mock = ClientMock()
+        with patch("homeassistant.components.twinkly.Twinkly", return_value=mock):
+            assert await async_setup_component(hass, DOMAIN, {})
+            await hass.async_block_till_done()
+        return mock
+
+    return func

--- a/tests/components/twinkly/conftest.py
+++ b/tests/components/twinkly/conftest.py
@@ -20,7 +20,7 @@ TITLE = "Twinkly"
 
 @pytest.fixture(name="config_entry")
 def mock_config_entry() -> MockConfigEntry:
-    """Create YouTube entry in Home Assistant."""
+    """Create Twinkly entry in Home Assistant."""
     client = ClientMock()
     return MockConfigEntry(
         domain=DOMAIN,
@@ -44,7 +44,6 @@ async def mock_setup_integration(
     """Fixture for setting up the component."""
     config_entry.add_to_hass(hass)
 
-    # assert await async_setup_component(hass, "application_credentials", {})
     async def func() -> ClientMock:
         mock = ClientMock()
         with patch("homeassistant.components.twinkly.Twinkly", return_value=mock):

--- a/tests/components/twinkly/snapshots/test_diagnostics.ambr
+++ b/tests/components/twinkly/snapshots/test_diagnostics.ambr
@@ -1,0 +1,43 @@
+# serializer version: 1
+# name: test_diagnostics
+  dict({
+    'attributes': dict({
+      'brightness': 26,
+      'color_mode': 'brightness',
+      'effect_list': list([
+      ]),
+      'friendly_name': 'twinkly_test_device_name',
+      'icon': 'mdi:string-lights',
+      'supported_color_modes': list([
+        'brightness',
+      ]),
+      'supported_features': 4,
+    }),
+    'device_info': dict({
+      'device_name': 'twinkly_test_device_name',
+      'product_code': 'twinkly_test_device_model',
+      'sw_version': '2.8.10',
+      'uuid': '4c8fccf5-e08a-4173-92d5-49bf479252a2',
+    }),
+    'entry': dict({
+      'data': dict({
+        'device_name': 'twinkly_test_device_name',
+        'host': '**REDACTED**',
+        'id': '4c8fccf5-e08a-4173-92d5-49bf479252a2',
+        'model': 'twinkly_test_device_model',
+        'name': 'twinkly_test_device_name',
+      }),
+      'disabled_by': None,
+      'domain': 'twinkly',
+      'entry_id': '4c8fccf5-e08a-4173-92d5-49bf479252a2',
+      'options': dict({
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'user',
+      'title': 'Twinkly',
+      'unique_id': '4c8fccf5-e08a-4173-92d5-49bf479252a2',
+      'version': 1,
+    }),
+  })
+# ---

--- a/tests/components/twinkly/test_config_flow.py
+++ b/tests/components/twinkly/test_config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.components.twinkly.const import (
 from homeassistant.const import CONF_MODEL
 from homeassistant.core import HomeAssistant
 
-from . import TEST_MODEL, ClientMock
+from . import TEST_MODEL, TEST_NAME, ClientMock
 
 from tests.common import MockConfigEntry
 
@@ -60,11 +60,11 @@ async def test_success_flow(hass: HomeAssistant) -> None:
         )
 
     assert result["type"] == "create_entry"
-    assert result["title"] == client.id
+    assert result["title"] == TEST_NAME
     assert result["data"] == {
         CONF_HOST: "dummy",
         CONF_ID: client.id,
-        CONF_NAME: client.id,
+        CONF_NAME: TEST_NAME,
         CONF_MODEL: TEST_MODEL,
     }
 
@@ -113,11 +113,11 @@ async def test_dhcp_success(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
     assert result["type"] == "create_entry"
-    assert result["title"] == client.id
+    assert result["title"] == TEST_NAME
     assert result["data"] == {
         CONF_HOST: "1.2.3.4",
         CONF_ID: client.id,
-        CONF_NAME: client.id,
+        CONF_NAME: TEST_NAME,
         CONF_MODEL: TEST_MODEL,
     }
 
@@ -131,7 +131,7 @@ async def test_dhcp_already_exists(hass: HomeAssistant) -> None:
         data={
             CONF_HOST: "1.2.3.4",
             CONF_ID: client.id,
-            CONF_NAME: client.id,
+            CONF_NAME: TEST_NAME,
             CONF_MODEL: TEST_MODEL,
         },
         unique_id=client.id,

--- a/tests/components/twinkly/test_diagnostics.py
+++ b/tests/components/twinkly/test_diagnostics.py
@@ -1,0 +1,24 @@
+"""Tests for the diagnostics of the twinly component."""
+from homeassistant.core import HomeAssistant
+
+from . import ClientMock
+from .test_light import _create_entries
+
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+async def test_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
+    """Test the diagnostics data."""
+    client = ClientMock()
+    entity, _, _, config_entry = await _create_entries(hass, client)
+    config_entry.unique_id = entity.unique_id
+
+    diag = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
+
+    assert diag["entry"]["title"] == "Mock Title"
+    assert diag["device_info"]["sw_version"] == "2.8.10"
+    assert diag["entry"]["data"]["host"] == "**REDACTED**"
+    assert "effect_list" in diag["attributes"]

--- a/tests/components/twinkly/test_light.py
+++ b/tests/components/twinkly/test_light.py
@@ -16,7 +16,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.entity_registry import RegistryEntry
 
-from . import TEST_MODEL, TEST_NAME_ORIGINAL, ClientMock
+from . import TEST_MODEL, TEST_NAME, TEST_NAME_ORIGINAL, ClientMock
 
 from tests.common import MockConfigEntry
 
@@ -28,16 +28,16 @@ async def test_initial_state(hass: HomeAssistant) -> None:
     state = hass.states.get(entity.entity_id)
 
     # Basic state properties
-    assert state.name == entity.unique_id
+    assert state.name == TEST_NAME
     assert state.state == "on"
     assert state.attributes[ATTR_BRIGHTNESS] == 26
-    assert state.attributes["friendly_name"] == entity.unique_id
+    assert state.attributes["friendly_name"] == TEST_NAME
     assert state.attributes["icon"] == "mdi:string-lights"
 
-    assert entity.original_name == entity.unique_id
+    assert entity.original_name == TEST_NAME
     assert entity.original_icon == "mdi:string-lights"
 
-    assert device.name == entity.unique_id
+    assert device.name == TEST_NAME
     assert device.model == TEST_MODEL
     assert device.manufacturer == "LEDWORKS"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adding Diagnostics to the twinkly integration.
This is an updated version of the one from #83204 that unforttunatly was never completed.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

Example diagnostics output:

```
{
  "home_assistant": {
    "installation_type": "Unsupported Third Party Container",
    "version": "2023.10.0.dev0",
    "dev": true,
    "hassio": false,
    "virtualenv": false,
    "python_version": "3.11.4",
    "docker": true,
    "arch": "x86_64",
    "timezone": "Europe/Oslo",
    "os_name": "Linux",
    "os_version": "6.3.8-100.fc37.x86_64",
    "run_as_root": false
  },
  "custom_components": {
  },
  "integration_manifest": {
    "domain": "twinkly",
    "name": "Twinkly",
    "codeowners": [
      "@dr1rrb",
      "@Robbie1221"
    ],
    "config_flow": true,
    "dhcp": [
      {
        "hostname": "twinkly_*"
      }
    ],
    "documentation": "https://www.home-assistant.io/integrations/twinkly",
    "iot_class": "local_polling",
    "loggers": [
      "ttls"
    ],
    "requirements": [
      "ttls==1.5.1"
    ],
    "is_built_in": true
  },
  "data": {
    "entry": {
      "entry_id": "61ecc34c8181f834cde5604527ec219f",
      "version": 1,
      "domain": "twinkly",
      "title": "Twinkly",
      "data": {
        "host": "**REDACTED**",
        "id": "9A586984-C950-4C78-A233-0DDD7009AF56",
        "name": "Twinkly",
        "model": "TWFL200STW"
      },
      "options": {},
      "pref_disable_new_entities": false,
      "pref_disable_polling": false,
      "source": "user",
      "unique_id": "9A586984-C950-4C78-A233-0DDD7009AF56",
      "disabled_by": null
    },
    "device_info": {
      "product_name": "Twinkly",
      "hardware_version": "601",
      "bytes_per_led": 3,
      "hw_id": "53d330",
      "flash_size": 64,
      "led_type": 22,
      "product_code": "TWFL200STW",
      "fw_family": "S",
      "device_name": "Twinkly",
      "uptime": "3623526457",
      "mac": "**REDACTED**",
      "uuid": "9A586984-C950-4C78-A233-0DDD7009AF56",
      "max_supported_led": 500,
      "number_of_led": 192,
      "led_profile": "RGB",
      "frame_rate": 40,
      "measured_frame_rate": 4.95,
      "movie_capacity": 7047,
      "max_movies": 55,
      "wire_type": 0,
      "copyright": "LEDWORKS 2021",
      "code": 1000
    },
    "attributes": {
      "effect_list": [
        "0 Rainbow",
        "1 Snow",
        "2 Beat",
        "3 Snake"
      ],
      "supported_color_modes": [
        "rgb"
      ],
      "icon": "mdi:string-lights",
      "friendly_name": "Twinkly",
      "supported_features": 4
    }
  }
}
```


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
