### PR TITLE
Fix AVM Fritz!Tools update entity

### DIFF
--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -1096,7 +1096,7 @@ class FritzBoxBaseEntity:
 class FritzRequireKeysMixin:
     """Fritz entity description mix in."""
 
-    value_fn: Callable[[FritzStatus, Any], Any]
+    value_fn: Callable[[FritzStatus, Any], Any] | None
 
 
 @dataclass
@@ -1118,9 +1118,12 @@ class FritzBoxBaseCoordinatorEntity(update_coordinator.CoordinatorEntity[AvmWrap
     ) -> None:
         """Init device info class."""
         super().__init__(avm_wrapper)
-        self.async_on_remove(
-            avm_wrapper.register_entity_updates(description.key, description.value_fn)
-        )
+        if description.value_fn is not None:
+            self.async_on_remove(
+                avm_wrapper.register_entity_updates(
+                    description.key, description.value_fn
+                )
+            )
         self.entity_description = description
         self._device_name = device_name
         self._attr_unique_id = f"{avm_wrapper.unique_id}-{description.key}"

--- a/homeassistant/components/fritz/update.py
+++ b/homeassistant/components/fritz/update.py
@@ -1,18 +1,29 @@
 """Support for AVM FRITZ!Box update platform."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 import logging
 from typing import Any
 
-from homeassistant.components.update import UpdateEntity, UpdateEntityFeature
+from homeassistant.components.update import (
+    UpdateEntity,
+    UpdateEntityDescription,
+    UpdateEntityFeature,
+)
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .common import AvmWrapper, FritzBoxBaseEntity
+from .common import AvmWrapper, FritzBoxBaseCoordinatorEntity, FritzEntityDescription
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class FritzUpdateEntityDescription(UpdateEntityDescription, FritzEntityDescription):
+    """Describes Fritz update entity."""
 
 
 async def async_setup_entry(
@@ -27,11 +38,13 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class FritzBoxUpdateEntity(FritzBoxBaseEntity, UpdateEntity):
+class FritzBoxUpdateEntity(FritzBoxBaseCoordinatorEntity, UpdateEntity):
     """Mixin for update entity specific attributes."""
 
+    _attr_entity_category = EntityCategory.CONFIG
     _attr_supported_features = UpdateEntityFeature.INSTALL
     _attr_title = "FRITZ!OS"
+    entity_description: FritzUpdateEntityDescription
 
     def __init__(
         self,
@@ -39,29 +52,30 @@ class FritzBoxUpdateEntity(FritzBoxBaseEntity, UpdateEntity):
         device_friendly_name: str,
     ) -> None:
         """Init FRITZ!Box connectivity class."""
-        self._attr_name = f"{device_friendly_name} FRITZ!OS"
-        self._attr_unique_id = f"{avm_wrapper.unique_id}-update"
-        super().__init__(avm_wrapper, device_friendly_name)
+        description = FritzUpdateEntityDescription(
+            key="update", name="FRITZ!OS", value_fn=None
+        )
+        super().__init__(avm_wrapper, device_friendly_name, description)
 
     @property
     def installed_version(self) -> str | None:
         """Version currently in use."""
-        return self._avm_wrapper.current_firmware
+        return self.coordinator.current_firmware
 
     @property
     def latest_version(self) -> str | None:
         """Latest version available for install."""
-        if self._avm_wrapper.update_available:
-            return self._avm_wrapper.latest_firmware
-        return self._avm_wrapper.current_firmware
+        if self.coordinator.update_available:
+            return self.coordinator.latest_firmware
+        return self.coordinator.current_firmware
 
     @property
     def release_url(self) -> str | None:
         """URL to the full release notes of the latest version available."""
-        return self._avm_wrapper.release_url
+        return self.coordinator.release_url
 
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
         """Install an update."""
-        await self._avm_wrapper.async_trigger_firmware_update()
+        await self.coordinator.async_trigger_firmware_update()

--- a/tests/components/fritz/test_update.py
+++ b/tests/components/fritz/test_update.py
@@ -8,10 +8,24 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from .const import MOCK_FIRMWARE_AVAILABLE, MOCK_FIRMWARE_RELEASE_URL, MOCK_USER_DATA
+from .const import (
+    MOCK_FB_SERVICES,
+    MOCK_FIRMWARE_AVAILABLE,
+    MOCK_FIRMWARE_RELEASE_URL,
+    MOCK_USER_DATA,
+)
 
 from tests.common import MockConfigEntry
 from tests.typing import ClientSessionGenerator
+
+AVAILABLE_UPDATE = {
+    "UserInterface1": {
+        "GetInfo": {
+            "NewX_AVM-DE_Version": MOCK_FIRMWARE_AVAILABLE,
+            "NewX_AVM-DE_InfoURL": MOCK_FIRMWARE_RELEASE_URL,
+        },
+    }
+}
 
 
 async def test_update_entities_initialized(
@@ -41,23 +55,21 @@ async def test_update_available(
 ) -> None:
     """Test update entities."""
 
-    with patch(
-        "homeassistant.components.fritz.common.FritzBoxTools._update_device_info",
-        return_value=(True, MOCK_FIRMWARE_AVAILABLE, MOCK_FIRMWARE_RELEASE_URL),
-    ):
-        entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
-        entry.add_to_hass(hass)
+    fc_class_mock().override_services({**MOCK_FB_SERVICES, **AVAILABLE_UPDATE})
 
-        assert await async_setup_component(hass, DOMAIN, {})
-        await hass.async_block_till_done()
-        assert entry.state == ConfigEntryState.LOADED
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    entry.add_to_hass(hass)
 
-        update = hass.states.get("update.mock_title_fritz_os")
-        assert update is not None
-        assert update.state == "on"
-        assert update.attributes.get("installed_version") == "7.29"
-        assert update.attributes.get("latest_version") == MOCK_FIRMWARE_AVAILABLE
-        assert update.attributes.get("release_url") == MOCK_FIRMWARE_RELEASE_URL
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+    assert entry.state == ConfigEntryState.LOADED
+
+    update = hass.states.get("update.mock_title_fritz_os")
+    assert update is not None
+    assert update.state == "on"
+    assert update.attributes.get("installed_version") == "7.29"
+    assert update.attributes.get("latest_version") == MOCK_FIRMWARE_AVAILABLE
+    assert update.attributes.get("release_url") == MOCK_FIRMWARE_RELEASE_URL
 
 
 async def test_no_update_available(
@@ -90,10 +102,9 @@ async def test_available_update_can_be_installed(
 ) -> None:
     """Test update entities."""
 
+    fc_class_mock().override_services({**MOCK_FB_SERVICES, **AVAILABLE_UPDATE})
+
     with patch(
-        "homeassistant.components.fritz.common.FritzBoxTools._update_device_info",
-        return_value=(True, MOCK_FIRMWARE_AVAILABLE, MOCK_FIRMWARE_RELEASE_URL),
-    ), patch(
         "homeassistant.components.fritz.common.FritzBoxTools.async_trigger_firmware_update",
         return_value=True,
     ) as mocked_update_call:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As the update entity uses properties from the coordinator (_`avm_wrapper` class_), but is not inherited from a coordinator entity, it never get's updated when new data are available. This is now fixed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #83718
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
