### PR TITLE
Add intial property to imap_content event data

### DIFF
--- a/homeassistant/components/imap/coordinator.py
+++ b/homeassistant/components/imap/coordinator.py
@@ -113,6 +113,7 @@ class ImapMessage:
     @property
     def message_id(self) -> str | None:
         """Get the message ID."""
+        value: str
         for header, value in self.email_message.items():
             if header == "Message-ID":
                 return value

--- a/homeassistant/components/imap/coordinator.py
+++ b/homeassistant/components/imap/coordinator.py
@@ -111,6 +111,16 @@ class ImapMessage:
         return header_base
 
     @property
+    def message_id(self) -> str | None:
+        """Get the message ID."""
+        id_header: list[str] = [
+            value
+            for header, value in self.email_message.items()
+            if header == "Message-ID"
+        ]
+        return id_header[0] if id_header else None
+
+    @property
     def date(self) -> datetime | None:
         """Get the date the email was sent."""
         # See https://www.rfc-editor.org/rfc/rfc2822#section-3.3
@@ -189,6 +199,7 @@ class ImapDataUpdateCoordinator(DataUpdateCoordinator[int | None]):
         """Initiate imap client."""
         self.imap_client = imap_client
         self.auth_errors: int = 0
+        self._last_message_uid: str | None = None
         self._last_message_id: str | None = None
         self.custom_event_template = None
         _custom_event_template = entry.data.get(CONF_CUSTOM_EVENT_DATA_TEMPLATE)
@@ -209,16 +220,22 @@ class ImapDataUpdateCoordinator(DataUpdateCoordinator[int | None]):
         if self.imap_client is None:
             self.imap_client = await connect_to_server(self.config_entry.data)
 
-    async def _async_process_event(self, last_message_id: str) -> None:
+    async def _async_process_event(self, last_message_uid: str) -> None:
         """Send a event for the last message if the last message was changed."""
-        response = await self.imap_client.fetch(last_message_id, "BODY.PEEK[]")
+        response = await self.imap_client.fetch(last_message_uid, "BODY.PEEK[]")
         if response.result == "OK":
             message = ImapMessage(response.lines[1])
+            # Set `initial` to `False` if the last message is triggered again
+            initial: bool = True
+            if (message_id := message.message_id) == self._last_message_id:
+                initial = False
+            self._last_message_id = message_id
             data = {
                 "server": self.config_entry.data[CONF_SERVER],
                 "username": self.config_entry.data[CONF_USERNAME],
                 "search": self.config_entry.data[CONF_SEARCH],
                 "folder": self.config_entry.data[CONF_FOLDER],
+                "initial": initial,
                 "date": message.date,
                 "text": message.text,
                 "sender": message.sender,
@@ -231,18 +248,20 @@ class ImapDataUpdateCoordinator(DataUpdateCoordinator[int | None]):
                         data, parse_result=True
                     )
                     _LOGGER.debug(
-                        "imap custom template (%s) for msgid %s rendered to: %s",
+                        "IMAP custom template (%s) for msguid %s (%s) rendered to: %s, initial: %s",
                         self.custom_event_template,
-                        last_message_id,
+                        last_message_uid,
+                        message_id,
                         data["custom"],
+                        initial,
                     )
                 except TemplateError as err:
                     data["custom"] = None
                     _LOGGER.error(
-                        "Error rendering imap custom template (%s) for msgid %s "
+                        "Error rendering IMAP custom template (%s) for msguid %s "
                         "failed with message: %s",
                         self.custom_event_template,
-                        last_message_id,
+                        last_message_uid,
                         err,
                     )
             data["text"] = message.text[
@@ -263,10 +282,12 @@ class ImapDataUpdateCoordinator(DataUpdateCoordinator[int | None]):
 
             self.hass.bus.fire(EVENT_IMAP, data)
             _LOGGER.debug(
-                "Message with id %s processed, sender: %s, subject: %s",
-                last_message_id,
+                "Message with id %s (%s) processed, sender: %s, subject: %s, initial: %s",
+                last_message_uid,
+                message_id,
                 message.sender,
                 message.subject,
+                initial,
             )
 
     async def _async_fetch_number_of_messages(self) -> int | None:
@@ -282,20 +303,20 @@ class ImapDataUpdateCoordinator(DataUpdateCoordinator[int | None]):
                 f"Invalid response for search '{self.config_entry.data[CONF_SEARCH]}': {result} / {lines[0]}"
             )
         if not (count := len(message_ids := lines[0].split())):
-            self._last_message_id = None
+            self._last_message_uid = None
             return 0
-        last_message_id = (
+        last_message_uid = (
             str(message_ids[-1:][0], encoding=self.config_entry.data[CONF_CHARSET])
             if count
             else None
         )
         if (
             count
-            and last_message_id is not None
-            and self._last_message_id != last_message_id
+            and last_message_uid is not None
+            and self._last_message_uid != last_message_uid
         ):
-            self._last_message_id = last_message_id
-            await self._async_process_event(last_message_id)
+            self._last_message_uid = last_message_uid
+            await self._async_process_event(last_message_uid)
 
         return count
 

--- a/homeassistant/components/imap/coordinator.py
+++ b/homeassistant/components/imap/coordinator.py
@@ -113,12 +113,10 @@ class ImapMessage:
     @property
     def message_id(self) -> str | None:
         """Get the message ID."""
-        id_header: list[str] = [
-            value
-            for header, value in self.email_message.items()
-            if header == "Message-ID"
-        ]
-        return id_header[0] if id_header else None
+        for header, value in self.email_message.items():
+            if header == "Message-ID":
+                return value
+        return None
 
     @property
     def date(self) -> datetime | None:

--- a/tests/components/imap/const.py
+++ b/tests/components/imap/const.py
@@ -22,6 +22,7 @@ TEST_MESSAGE_HEADERS2 = (
     b"To: notify@example.com\r\n"
     b"From: John Doe <john.doe@example.com>\r\n"
     b"Subject: Test subject\r\n"
+    b"Message-ID: <N753P9hLvLw3lYGan11ji9WggPjxtLSpKvFOYgdnE@example.com>"
 )
 
 TEST_MESSAGE_HEADERS3 = b""

--- a/tests/components/imap/test_init.py
+++ b/tests/components/imap/test_init.py
@@ -512,6 +512,7 @@ async def test_reset_last_message(
     assert data["sender"] == "john.doe@example.com"
     assert data["subject"] == "Test subject"
     assert data["text"]
+    assert data["initial"]
     assert (
         valid_date
         and isinstance(data["date"], datetime)
@@ -628,7 +629,7 @@ async def test_message_is_truncated(
     [
         ("{{ subject }}", "Test subject", None),
         ('{{ "@example.com" in sender }}', True, None),
-        ("{% bad template }}", None, "Error rendering imap custom template"),
+        ("{% bad template }}", None, "Error rendering IMAP custom template"),
     ],
     ids=["subject_test", "sender_filter", "template_error"],
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
An `imap_content` event is triggered when something changes withing the imap search context.
If a message within the search context is removed the message UID of the last message received might change.
For automation's the extra event might be experienced as duplicate if it is used to render the email content.
An extra attribute `initial` was added to be able to detect the first occurrence of the last message received.
Note this initial flag relies on the availability of the `Message-ID` header in the email that triggers the event, conformant to https://datatracker.ietf.org/doc/html/rfc2392.
Strictly this `Message-ID` header is optional, but under common conditions this header is always set. If the header is not set, then the `intial` property will always be set to `True`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes
- This PR is related to issue:  #100155
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28882

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
