### PR TITLE
Limit waze_travel_time to 1 call every 0.5s

### DIFF
--- a/homeassistant/components/waze_travel_time/sensor.py
+++ b/homeassistant/components/waze_travel_time/sensor.py
@@ -1,6 +1,7 @@
 """Support for Waze travel time sensor."""
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 import logging
 from typing import Any
@@ -47,6 +48,10 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(minutes=5)
+
+PARALLEL_UPDATES = 1
+
+MS_BETWEEN_API_CALLS = 0.5
 
 
 async def async_setup_entry(
@@ -144,6 +149,7 @@ class WazeTravelTime(SensorEntity):
         self._waze_data.origin = find_coordinates(self.hass, self._origin)
         self._waze_data.destination = find_coordinates(self.hass, self._destination)
         await self._waze_data.async_update()
+        await asyncio.sleep(MS_BETWEEN_API_CALLS)
 
 
 class WazeTravelTimeData:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Open issues #66058 #92664 #100066 show a lot of Timeout and empty response issues with Waze. With the shift to [pywaze](https://github.com/eifinger/pywaze) the issue got worse as [this](https://github.com/eifinger/pywaze/issues/11) issue shows.

I suspect it got worse because changing to pywaze also changed from using `update()` to `async_update()` which in turn lead to 'PARALLEL_UPDATES' defaulting to `0` aka "unlimited" as described in https://developers.home-assistant.io/docs/integration_fetching_data/?_highlight=parallel#request-parallelism

I took several measurements to find the best combination of wait time and parallel requests.

**1 parallel requests**: successes out of max 100 by wait time: {'0.0': 100, '0.1': 96, '0.2': 94, '0.3': 99, '0.4': 100, '0.5': 100, '0.6': 100, '0.7': 100, '0.8': 100, '0.9': 100, '1.0': 100, '1.1': 100, '1.2': 100, '1.3': 100, '1.4': 100, '1.5': 100, '1.6': 100, '1.7': 100, '1.8': 100, '1.9': 100}
**2 parallel requests**: successes out of max 200 by wait time:  {'0.0': 181, '0.1': 173, '0.2': 181, '0.3': 184, '0.4': 190, '0.5': 186, '0.6': 184, '0.7': 186, '0.8': 184, '0.9': 189, '1.0': 185, '1.1': 184, '1.2': 179, '1.3': 183, '1.4': 181, '1.5': 184, '1.6': 188, '1.7': 188, '1.8': 186, '1.9': 182}
**3 parallel requests**: successes out of max 300 by wait time:  {'0.0': 249, '0.1': 233, '0.2': 238, '0.3': 243, '0.4': 239, '0.5': 258, '0.6': 253, '0.7': 245, '0.8': 259, '0.9': 260, '1.0': 248, '1.1': 249, '1.2': 255, '1.3': 249, '1.4': 253, '1.5': 259, '1.6': 260, '1.7': 251, '1.8': 270, '1.9': 253}

This shows that having more than 1 parallel request leads to 10-20% failed requests. Moreover a timeout of 0.4s seems sufficient so I chose 0.5 to be on the save side.

Code used for getting those metrics:

```python
#!/usr/bin/env python3

import asyncio

import httpx
from pywaze import route_calculator

async def do_work(client: route_calculator.WazeRouteCalculator, start: str, end: str) -> bool:
    try:
        await client.calc_route_info(start, end)
        return True
    except Exception as e:
        #print(f"Error: {e}")
        return False


async def get_times(start: str, end: str) -> list[float]:
    """Return the travel time home."""

    repetitions = 100

    httpx_client = httpx.AsyncClient(timeout=10)
    async with route_calculator.WazeRouteCalculator(client=httpx_client) as client:
        for parallel in range(4):
            metrics = {}
            for repetition in range(repetitions):
                #print(f"Starting {repetition}/{repetitions}")
                for m in range(20):
                    sleep = m*0.1
                    futures = []
                    #print(f"Starting {parallel} parallel requests")
                    for _ in range(parallel):
                        futures.append(do_work(client, start, end))
                    results = await asyncio.gather(*futures)
                    for success in results:
                        if success:
                            metrics["%.1f" % sleep] = metrics.setdefault("%.1f" % sleep, 0) + 1
                    #print("Sleeping: %.1f" % sleep)
                    await asyncio.sleep(sleep)
            print(f"parallel[{parallel}]successes out of max {parallel*repetitions}: {metrics}")

start = "50.00332659227126,8.262322651915843"
end = "50.08414976707619,8.247836017342934"

asyncio.run(get_times(start, end))
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #66058 #92664 #100066 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
