### PR TITLE
Improve Entity._suggest_report_issue

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from abc import ABC
 import asyncio
 from collections.abc import Coroutine, Iterable, Mapping, MutableMapping
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum, auto
@@ -40,7 +41,11 @@ from homeassistant.exceptions import (
     InvalidStateError,
     NoEntitySpecifiedError,
 )
-from homeassistant.loader import bind_hass
+from homeassistant.loader import (
+    IntegrationNotLoaded,
+    async_get_loaded_integration,
+    bind_hass,
+)
 from homeassistant.util import ensure_unique_string, slugify
 
 from . import device_registry as dr, entity_registry as er
@@ -1203,8 +1208,21 @@ class Entity(ABC):
     def _suggest_report_issue(self) -> str:
         """Suggest to report an issue."""
         report_issue = ""
+
+        integration = None
+        # The check for self.platform guards against integrations not using an
+        # EntityComponent and can be removed in HA Core 2024.1
+        if self.platform:
+            with suppress(IntegrationNotLoaded):
+                integration = async_get_loaded_integration(
+                    self.hass, self.platform.platform_name
+                )
+
         if "custom_components" in type(self).__module__:
-            report_issue = "report it to the custom integration author."
+            if integration and integration.issue_tracker:
+                report_issue = f"create a bug report at {integration.issue_tracker}"
+            else:
+                report_issue = "report it to the custom integration author"
         else:
             report_issue = (
                 "create a bug report at "

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -164,7 +164,7 @@ async def test_deprecated_last_reset(
         f"with state_class {state_class} has set last_reset. Setting last_reset for "
         "entities with state_class other than 'total' is not supported. Please update "
         "your configuration if state_class is manually configured, otherwise report it "
-        "to the custom integration author."
+        "to the custom integration author"
     ) in caplog.text
 
     state = hass.states.get("sensor.test")

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -27,8 +27,10 @@ from tests.common import (
     MockConfigEntry,
     MockEntity,
     MockEntityPlatform,
+    MockModule,
     MockPlatform,
     get_test_home_assistant,
+    mock_integration,
     mock_registry,
 )
 
@@ -776,7 +778,7 @@ async def test_warn_slow_write_state_custom_component(
     assert (
         "Updating state for comp_test.test_entity "
         "(<class 'custom_components.bla.sensor.test_warn_slow_write_state_custom_component.<locals>.CustomComponentEntity'>) "
-        "took 10.000 seconds. Please report it to the custom integration author."
+        "took 10.000 seconds. Please report it to the custom integration author"
     ) in caplog.text
 
 
@@ -1505,3 +1507,57 @@ async def test_invalid_state(
     ent._attr_state = "x" * 255
     ent.async_write_ha_state()
     assert hass.states.get("test.test").state == "x" * 255
+
+
+async def test_suggest_report_issue_built_in(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test _suggest_report_issue for an entity from a built-in integration."""
+    mock_entity = entity.Entity()
+    mock_entity.entity_id = "comp_test.test_entity"
+
+    suggestion = mock_entity._suggest_report_issue()
+    assert suggestion == (
+        "create a bug report at https://github.com/home-assistant/core/issues"
+        "?q=is%3Aopen+is%3Aissue"
+    )
+
+    mock_integration(hass, MockModule(domain="test"), built_in=True)
+    platform = MockEntityPlatform(hass, domain="comp_test", platform_name="test")
+    await platform.async_add_entities([mock_entity])
+
+    suggestion = mock_entity._suggest_report_issue()
+    assert suggestion == (
+        "create a bug report at https://github.com/home-assistant/core/issues"
+        "?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+test%22"
+    )
+
+
+async def test_suggest_report_issue_custom_component(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test _suggest_report_issue for an entity from a custom component."""
+
+    class CustomComponentEntity(entity.Entity):
+        """Custom component entity."""
+
+        __module__ = "custom_components.bla.sensor"
+
+    mock_entity = CustomComponentEntity()
+    mock_entity.entity_id = "comp_test.test_entity"
+
+    suggestion = mock_entity._suggest_report_issue()
+    assert suggestion == "report it to the custom integration author"
+
+    mock_integration(
+        hass,
+        MockModule(
+            domain="test", partial_manifest={"issue_tracker": "httpts://some_url"}
+        ),
+        built_in=False,
+    )
+    platform = MockEntityPlatform(hass, domain="comp_test", platform_name="test")
+    await platform.async_add_entities([mock_entity])
+
+    suggestion = mock_entity._suggest_report_issue()
+    assert suggestion == "create a bug report at httpts://some_url"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Improve `Entity._suggest_report_issue` by including the link to the custom component issue tracker if the misbehaving entity is from a custom component

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
