### PR TITLE
Netgear catch no info error

### DIFF
--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -190,6 +190,7 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             )
         except CannotLoginException:
             errors["base"] = "config"
+            return await self._show_setup_form(user_input, errors)
 
         config_data = {
             CONF_USERNAME: username,
@@ -203,8 +204,6 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         info = await self.hass.async_add_executor_job(api.get_info)
         if info is None:
             errors["base"] = "info"
-
-        if errors:
             return await self._show_setup_form(user_input, errors)
 
         await self.async_set_unique_id(info["SerialNumber"], raise_on_progress=False)

--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -191,9 +191,6 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         except CannotLoginException:
             errors["base"] = "config"
 
-        if errors:
-            return await self._show_setup_form(user_input, errors)
-
         config_data = {
             CONF_USERNAME: username,
             CONF_PASSWORD: password,
@@ -204,6 +201,12 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         # Check if already configured
         info = await self.hass.async_add_executor_job(api.get_info)
+        if info is None:
+            errors["base"] = "info"
+
+        if errors:
+            return await self._show_setup_form(user_input, errors)
+
         await self.async_set_unique_id(info["SerialNumber"], raise_on_progress=False)
         self._abort_if_unique_id_configured(updates=config_data)
 

--- a/homeassistant/components/netgear/strings.json
+++ b/homeassistant/components/netgear/strings.json
@@ -11,7 +11,8 @@
       }
     },
     "error": {
-      "config": "Connection or login error: please check your configuration"
+      "config": "Connection or login error: please check your configuration",
+      "info": "Failed to get info from router"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/tests/components/netgear/test_config_flow.py
+++ b/tests/components/netgear/test_config_flow.py
@@ -76,41 +76,6 @@ def mock_controller_service():
         yield service_mock
 
 
-@pytest.fixture(name="service_5555")
-def mock_controller_service_5555():
-    """Mock a successful service."""
-    with patch(
-        "homeassistant.components.netgear.async_setup_entry", return_value=True
-    ), patch("homeassistant.components.netgear.router.Netgear") as service_mock:
-        service_mock.return_value.get_info = Mock(return_value=ROUTER_INFOS)
-        service_mock.return_value.port = 5555
-        service_mock.return_value.ssl = True
-        yield service_mock
-
-
-@pytest.fixture(name="service_incomplete")
-def mock_controller_service_incomplete():
-    """Mock a successful service."""
-    router_infos = ROUTER_INFOS.copy()
-    router_infos.pop("DeviceName")
-    with patch(
-        "homeassistant.components.netgear.async_setup_entry", return_value=True
-    ), patch("homeassistant.components.netgear.router.Netgear") as service_mock:
-        service_mock.return_value.get_info = Mock(return_value=router_infos)
-        service_mock.return_value.port = 80
-        service_mock.return_value.ssl = False
-        yield service_mock
-
-
-@pytest.fixture(name="service_failed")
-def mock_controller_service_failed():
-    """Mock a failed service."""
-    with patch("homeassistant.components.netgear.router.Netgear") as service_mock:
-        service_mock.return_value.login_try_port = Mock(return_value=None)
-        service_mock.return_value.get_info = Mock(return_value=None)
-        yield service_mock
-
-
 async def test_user(hass: HomeAssistant, service) -> None:
     """Test user step."""
     result = await hass.config_entries.flow.async_init(
@@ -138,13 +103,15 @@ async def test_user(hass: HomeAssistant, service) -> None:
     assert result["data"][CONF_PASSWORD] == PASSWORD
 
 
-async def test_user_connect_error(hass: HomeAssistant, service_failed) -> None:
+async def test_user_connect_error(hass: HomeAssistant, service) -> None:
     """Test user step with connection failure."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
+
+    service.return_value.get_info = Mock(return_value=None)
 
     # Have to provide all config
     result = await hass.config_entries.flow.async_configure(
@@ -157,9 +124,9 @@ async def test_user_connect_error(hass: HomeAssistant, service_failed) -> None:
     )
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
-    assert result["errors"] == {"base": "config"}
+    assert result["errors"] == {"base": "info"}
 
-    service_failed.return_value.login_try_port = Mock(return_value=True)
+    service.return_value.login_try_port = Mock(return_value=None)
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -171,16 +138,20 @@ async def test_user_connect_error(hass: HomeAssistant, service_failed) -> None:
     )
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
-    assert result["errors"] == {"base": "info"}
+    assert result["errors"] == {"base": "config"}
 
 
-async def test_user_incomplete_info(hass: HomeAssistant, service_incomplete) -> None:
+async def test_user_incomplete_info(hass: HomeAssistant, service) -> None:
     """Test user step with incomplete device info."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
+
+    router_infos = ROUTER_INFOS.copy()
+    router_infos.pop("DeviceName")
+    service.return_value.get_info = Mock(return_value=router_infos)
 
     # Have to provide all config
     result = await hass.config_entries.flow.async_configure(
@@ -327,7 +298,7 @@ async def test_ssdp(hass: HomeAssistant, service) -> None:
     assert result["data"][CONF_PASSWORD] == PASSWORD
 
 
-async def test_ssdp_port_5555(hass: HomeAssistant, service_5555) -> None:
+async def test_ssdp_port_5555(hass: HomeAssistant, service) -> None:
     """Test ssdp step with port 5555."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -345,6 +316,9 @@ async def test_ssdp_port_5555(hass: HomeAssistant, service_5555) -> None:
     )
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
+
+    service.return_value.port = 5555
+    service.return_value.ssl = True
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_PASSWORD: PASSWORD}

--- a/tests/components/netgear/test_config_flow.py
+++ b/tests/components/netgear/test_config_flow.py
@@ -159,6 +159,19 @@ async def test_user_connect_error(hass: HomeAssistant, service_failed) -> None:
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "config"}
 
+    service_mock.return_value.login_try_port = Mock(return_value=True)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_HOST: HOST,
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+        },
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "info"}
 
 async def test_user_incomplete_info(hass: HomeAssistant, service_incomplete) -> None:
     """Test user step with incomplete device info."""

--- a/tests/components/netgear/test_config_flow.py
+++ b/tests/components/netgear/test_config_flow.py
@@ -173,6 +173,7 @@ async def test_user_connect_error(hass: HomeAssistant, service_failed) -> None:
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "info"}
 
+
 async def test_user_incomplete_info(hass: HomeAssistant, service_incomplete) -> None:
     """Test user step with incomplete device info."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/netgear/test_config_flow.py
+++ b/tests/components/netgear/test_config_flow.py
@@ -159,7 +159,7 @@ async def test_user_connect_error(hass: HomeAssistant, service_failed) -> None:
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "config"}
 
-    service_mock.return_value.login_try_port = Mock(return_value=True)
+    service_failed.return_value.login_try_port = Mock(return_value=True)
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Catch no info returned during config flow of the netgear integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/98227
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
