### PR TITLE
Revert "Set roku media player device class in constructor"

### DIFF
--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -122,20 +122,20 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         | MediaPlayerEntityFeature.BROWSE_MEDIA
     )
 
-    def __init__(self, coordinator: RokuDataUpdateCoordinator) -> None:
-        """Initialize the Roku device."""
-        super().__init__(coordinator=coordinator)
-        if coordinator.data.info.device_type == "tv":
-            self._attr_device_class = MediaPlayerDeviceClass.TV
-        else:
-            self._attr_device_class = MediaPlayerDeviceClass.RECEIVER
-
     def _media_playback_trackable(self) -> bool:
         """Detect if we have enough media data to track playback."""
         if self.coordinator.data.media is None or self.coordinator.data.media.live:
             return False
 
         return self.coordinator.data.media.duration > 0
+
+    @property
+    def device_class(self) -> MediaPlayerDeviceClass:
+        """Return the class of this device."""
+        if self.coordinator.data.info.device_type == "tv":
+            return MediaPlayerDeviceClass.TV
+
+        return MediaPlayerDeviceClass.RECEIVER
 
     @property
     def state(self) -> MediaPlayerState | None:


### PR DESCRIPTION
Reverts home-assistant/core#100225

CC @joostlek @bdraco 

The upstream PR was merged without codeowner approval, which is required for that integration. A CI check is in place as well, which was overridden.

This PR reverts the merge for that reason.


../Frenck