### PR TITLE
Bump sensirion-ble to 0.1.1

### DIFF
--- a/homeassistant/components/sensirion_ble/manifest.json
+++ b/homeassistant/components/sensirion_ble/manifest.json
@@ -16,5 +16,5 @@
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/sensirion_ble",
   "iot_class": "local_push",
-  "requirements": ["sensirion-ble==0.1.0"]
+  "requirements": ["sensirion-ble==0.1.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2379,7 +2379,7 @@ sense-energy==0.12.1
 sense_energy==0.12.1
 
 # homeassistant.components.sensirion_ble
-sensirion-ble==0.1.0
+sensirion-ble==0.1.1
 
 # homeassistant.components.sensorpro
 sensorpro-ble==0.5.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1745,7 +1745,7 @@ sense-energy==0.12.1
 sense_energy==0.12.1
 
 # homeassistant.components.sensirion_ble
-sensirion-ble==0.1.0
+sensirion-ble==0.1.1
 
 # homeassistant.components.sensorpro
 sensorpro-ble==0.5.3


### PR DESCRIPTION

## Proposed change

Bumps the Sensirion comms library to fix a signedness bug: https://github.com/akx/sensirion-ble/compare/v0.1.0...v0.1.1

Fixes akx/sensirion-ble#6
Refs https://github.com/home-assistant/core/issues/93678#issuecomment-1694522112

## Type of change

- [x] Dependency upgrade

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
