### PR TITLE
Move sms coordinators to their own file

### DIFF
--- a/homeassistant/components/sms/__init__.py
+++ b/homeassistant/components/sms/__init__.py
@@ -1,9 +1,6 @@
 """The sms component."""
-import asyncio
-from datetime import timedelta
 import logging
 
-import gammu
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
@@ -12,12 +9,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, discovery
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
     CONF_BAUD_SPEED,
     DEFAULT_BAUD_SPEED,
-    DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     GATEWAY,
     HASS_CONFIG,
@@ -25,6 +20,7 @@ from .const import (
     SIGNAL_COORDINATOR,
     SMS_GATEWAY,
 )
+from .coordinator import NetworkCoordinator, SignalCoordinator
 from .gateway import create_sms_gateway
 
 _LOGGER = logging.getLogger(__name__)
@@ -44,8 +40,6 @@ CONFIG_SCHEMA = vol.Schema(
     },
     extra=vol.ALLOW_EXTRA,
 )
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -107,47 +101,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await gateway.terminate_async()
 
     return unload_ok
-
-
-class SignalCoordinator(DataUpdateCoordinator):
-    """Signal strength coordinator."""
-
-    def __init__(self, hass, gateway):
-        """Initialize signal strength coordinator."""
-        super().__init__(
-            hass,
-            _LOGGER,
-            name="Device signal state",
-            update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL),
-        )
-        self._gateway = gateway
-
-    async def _async_update_data(self):
-        """Fetch device signal quality."""
-        try:
-            async with asyncio.timeout(10):
-                return await self._gateway.get_signal_quality_async()
-        except gammu.GSMError as exc:
-            raise UpdateFailed(f"Error communicating with device: {exc}") from exc
-
-
-class NetworkCoordinator(DataUpdateCoordinator):
-    """Network info coordinator."""
-
-    def __init__(self, hass, gateway):
-        """Initialize network info coordinator."""
-        super().__init__(
-            hass,
-            _LOGGER,
-            name="Device network state",
-            update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL),
-        )
-        self._gateway = gateway
-
-    async def _async_update_data(self):
-        """Fetch device network info."""
-        try:
-            async with asyncio.timeout(10):
-                return await self._gateway.get_network_info_async()
-        except gammu.GSMError as exc:
-            raise UpdateFailed(f"Error communicating with device: {exc}") from exc

--- a/homeassistant/components/sms/coordinator.py
+++ b/homeassistant/components/sms/coordinator.py
@@ -1,0 +1,56 @@
+"""DataUpdateCoordinators for the sms integration."""
+import asyncio
+from datetime import timedelta
+import logging
+
+import gammu
+
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DEFAULT_SCAN_INTERVAL
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SignalCoordinator(DataUpdateCoordinator):
+    """Signal strength coordinator."""
+
+    def __init__(self, hass, gateway):
+        """Initialize signal strength coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="Device signal state",
+            update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL),
+        )
+        self._gateway = gateway
+
+    async def _async_update_data(self):
+        """Fetch device signal quality."""
+        try:
+            async with asyncio.timeout(10):
+                return await self._gateway.get_signal_quality_async()
+        except gammu.GSMError as exc:
+            raise UpdateFailed(f"Error communicating with device: {exc}") from exc
+
+
+class NetworkCoordinator(DataUpdateCoordinator):
+    """Network info coordinator."""
+
+    def __init__(self, hass, gateway):
+        """Initialize network info coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="Device network state",
+            update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL),
+        )
+        self._gateway = gateway
+
+    async def _async_update_data(self):
+        """Fetch device network info."""
+        try:
+            async with asyncio.timeout(10):
+                return await self._gateway.get_network_info_async()
+        except gammu.GSMError as exc:
+            raise UpdateFailed(f"Error communicating with device: {exc}") from exc


### PR DESCRIPTION
## Proposed change
SSIA, also remove double declaration of `_LOGGER` in `__init__.py`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
