### PR TITLE
Make core States use cached_property

### DIFF
--- a/homeassistant/components/api/__init__.py
+++ b/homeassistant/components/api/__init__.py
@@ -202,11 +202,11 @@ class APIStatesView(HomeAssistantView):
         user: User = request["hass_user"]
         hass: HomeAssistant = request.app["hass"]
         if user.is_admin:
-            states = (state.as_dict_json() for state in hass.states.async_all())
+            states = (state.as_dict_json for state in hass.states.async_all())
         else:
             entity_perm = user.permissions.check_entity
             states = (
-                state.as_dict_json()
+                state.as_dict_json
                 for state in hass.states.async_all()
                 if entity_perm(state.entity_id, "read")
             )
@@ -233,7 +233,7 @@ class APIEntityStateView(HomeAssistantView):
 
         if state := hass.states.get(entity_id):
             return web.Response(
-                body=state.as_dict_json(),
+                body=state.as_dict_json,
                 content_type=CONTENT_TYPE_JSON,
             )
         return self.json_message("Entity not found.", HTTPStatus.NOT_FOUND)

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -270,7 +270,7 @@ def handle_get_states(
     states = _async_get_allowed_states(hass, connection)
 
     try:
-        serialized_states = [state.as_dict_json() for state in states]
+        serialized_states = [state.as_dict_json for state in states]
     except (ValueError, TypeError):
         pass
     else:
@@ -281,7 +281,7 @@ def handle_get_states(
     serialized_states = []
     for state in states:
         try:
-            serialized_states.append(state.as_dict_json())
+            serialized_states.append(state.as_dict_json)
         except (ValueError, TypeError):
             connection.logger.error(
                 "Unable to serialize to JSON. Bad data found at %s",
@@ -358,7 +358,7 @@ def handle_subscribe_entities(
     # to succeed for the UI to show.
     try:
         serialized_states = [
-            state.as_compressed_state_json()
+            state.as_compressed_state_json
             for state in states
             if not entity_ids or state.entity_id in entity_ids
         ]
@@ -371,7 +371,7 @@ def handle_subscribe_entities(
     serialized_states = []
     for state in states:
         try:
-            serialized_states.append(state.as_compressed_state_json())
+            serialized_states.append(state.as_compressed_state_json)
         except (ValueError, TypeError):
             connection.logger.error(
                 "Unable to serialize to JSON. Bad data found at %s",

--- a/homeassistant/components/websocket_api/messages.py
+++ b/homeassistant/components/websocket_api/messages.py
@@ -141,7 +141,7 @@ def _state_diff_event(event: Event) -> dict:
     if (event_old_state := event.data["old_state"]) is None:
         return {
             ENTITY_EVENT_ADD: {
-                event_new_state.entity_id: event_new_state.as_compressed_state()
+                event_new_state.entity_id: event_new_state.as_compressed_state
             }
         }
     if TYPE_CHECKING:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -929,8 +929,6 @@ class DomainStates:
 class TemplateStateBase(State):
     """Class to represent a state object in a template."""
 
-    __slots__ = ("_hass", "_collect", "_entity_id", "__dict__")
-
     _state: State
 
     __setitem__ = _readonly

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -670,11 +670,11 @@ def test_state_as_dict_json() -> None:
         '"last_changed":"1984-12-08T12:00:00","last_updated":"1984-12-08T12:00:00",'
         '"context":{"id":"01H0D6K3RFJAYAV2093ZW30PCW","parent_id":null,"user_id":null}}'
     )
-    as_dict_json_1 = state.as_dict_json()
+    as_dict_json_1 = state.as_dict_json
     assert as_dict_json_1 == expected
     # 2nd time to verify cache
-    assert state.as_dict_json() == expected
-    assert state.as_dict_json() is as_dict_json_1
+    assert state.as_dict_json == expected
+    assert state.as_dict_json is as_dict_json_1
 
 
 def test_state_as_compressed_state() -> None:
@@ -693,12 +693,12 @@ def test_state_as_compressed_state() -> None:
         "lc": last_time.timestamp(),
         "s": "on",
     }
-    as_compressed_state = state.as_compressed_state()
+    as_compressed_state = state.as_compressed_state
     # We are not too concerned about these being ReadOnlyDict
     # since we don't expect them to be called by external callers
     assert as_compressed_state == expected
     # 2nd time to verify cache
-    assert state.as_compressed_state() == expected
+    assert state.as_compressed_state == expected
 
 
 def test_state_as_compressed_state_unique_last_updated() -> None:
@@ -719,12 +719,12 @@ def test_state_as_compressed_state_unique_last_updated() -> None:
         "lu": last_updated.timestamp(),
         "s": "on",
     }
-    as_compressed_state = state.as_compressed_state()
+    as_compressed_state = state.as_compressed_state
     # We are not too concerned about these being ReadOnlyDict
     # since we don't expect them to be called by external callers
     assert as_compressed_state == expected
     # 2nd time to verify cache
-    assert state.as_compressed_state() == expected
+    assert state.as_compressed_state == expected
 
 
 def test_state_as_compressed_state_json() -> None:
@@ -739,13 +739,13 @@ def test_state_as_compressed_state_json() -> None:
         context=ha.Context(id="01H0D6H5K3SZJ3XGDHED1TJ79N"),
     )
     expected = '"happy.happy":{"s":"on","a":{"pig":"dog"},"c":"01H0D6H5K3SZJ3XGDHED1TJ79N","lc":471355200.0}'
-    as_compressed_state = state.as_compressed_state_json()
+    as_compressed_state = state.as_compressed_state_json
     # We are not too concerned about these being ReadOnlyDict
     # since we don't expect them to be called by external callers
     assert as_compressed_state == expected
     # 2nd time to verify cache
-    assert state.as_compressed_state_json() == expected
-    assert state.as_compressed_state_json() is as_compressed_state
+    assert state.as_compressed_state_json == expected
+    assert state.as_compressed_state_json is as_compressed_state
 
 
 async def test_eventbus_add_remove_listener(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
~~DRAFT since need to validate the tradeoff of removing `__slots__` is worth it since these flux a lot more than the registries~~
Edit: trade off seems worth it.

Discovered this while testing #100302

I did not mark this as a breaking change since I expect these calls are only used internally.

~68% speed up building the list of states when subscribing to entities.

before
![core](https://github.com/home-assistant/core/assets/663432/cb456042-315f-4aae-8414-bdbe46ba8028)

after
![after](https://github.com/home-assistant/core/assets/663432/171194f7-bcb4-4e46-bc35-31c77cf5a9e8)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
