### PR TITLE
Disable flaky modbus test

### DIFF
--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -863,6 +863,7 @@ async def test_shutdown(
     assert caplog.text == ""
 
 
+@pytest.mark.skip(reason="disabled because the test is flapping")
 @pytest.mark.parametrize(
     "do_config",
     [
@@ -884,6 +885,7 @@ async def test_stop_restart(
 
     caplog.set_level(logging.INFO)
     entity_id = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
+    # The assert below is sometimes failing because the state is unavailable
     assert hass.states.get(entity_id).state == STATE_UNKNOWN
     hass.states.async_set(entity_id, 17)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Disable flaky modbus test

Test seen failing with this output:
```
________________________ test_stop_restart[do_config0] _________________________
[gw1] linux -- Python 3.11.5 /home/runner/work/core/core/venv/bin/python3

hass = <HomeAssistant RUNNING>
caplog = <_pytest.logging.LogCaptureFixture object at 0x7fc2bb1d1b10>
mock_modbus = <MagicMock id='140474347661072'>

    @pytest.mark.parametrize(
        "do_config",
        [
            {
                CONF_SENSORS: [
                    {
                        CONF_NAME: TEST_ENTITY_NAME,
                        CONF_ADDRESS: 51,
                        CONF_SLAVE: 0,
                    }
                ]
            },
        ],
    )
    async def test_stop_restart(
        hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_modbus
    ) -> None:
        """Run test for service stop."""
    
        caplog.set_level(logging.INFO)
        entity_id = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
>       assert hass.states.get(entity_id).state == STATE_UNKNOWN
E       AssertionError: assert 'unavailable' == 'unknown'
E         - unknown
E         + unavailable

tests/components/modbus/test_init.py:887: AssertionError
---------------------------- Captured stderr setup -----------------------------
WARNING:asyncio:Executing <Task finished name='Task-26917' coro=<EntityPlatform._async_add_entity() done, defined at /home/runner/work/core/core/homeassistant/helpers/entity_platform.py:553> result=None created at /opt/hostedtoolcache/Python/3.11.5/x64/lib/python3.11/asyncio/tasks.py:670> took 0.954 seconds
ERROR:homeassistant.components.modbus.base_platform:Received 0 bytes, unpack error unpack requires a buffer of 2 bytes
------------------------------ Captured log setup ------------------------------
2023-09-13 09:52:15.459 WARNING  MainThread asyncio:base_events.py:1917 Executing <Task finished name='Task-26917' coro=<EntityPlatform._async_add_entity() done, defined at /home/runner/work/core/core/homeassistant/helpers/entity_platform.py:553> result=None created at /opt/hostedtoolcache/Python/3.11.5/x64/lib/python3.11/asyncio/tasks.py:670> took 0.954 seconds
2023-09-13 09:52:15.465 ERROR    MainThread homeassistant.components.modbus.base_platform:base_platform.py:224 Received 0 bytes, unpack error unpack requires a buffer of 2 bytes
--------------------------- Captured stderr teardown ---------------------------
WARNING:homeassistant.components.modbus.modbus:modbus modbusTest communication closed
---------------------------- Captured log teardown -----------------------------
2023-09-13 09:52:15.521 WARNING  MainThread homeassistant.components.modbus.modbus:modbus.py:397 modbus modbusTest communication closed
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
