### PR TITLE
Restore state of trend sensor

### DIFF
--- a/homeassistant/components/trend/binary_sensor.py
+++ b/homeassistant/components/trend/binary_sensor.py
@@ -25,6 +25,7 @@ from homeassistant.const import (
     CONF_ENTITY_ID,
     CONF_FRIENDLY_NAME,
     CONF_SENSORS,
+    STATE_ON,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
@@ -37,6 +38,7 @@ from homeassistant.helpers.event import (
     async_track_state_change_event,
 )
 from homeassistant.helpers.reload import async_setup_reload_service
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, EventType
 from homeassistant.util.dt import utcnow
 
@@ -116,7 +118,7 @@ async def async_setup_platform(
     async_add_entities(sensors)
 
 
-class SensorTrend(BinarySensorEntity):
+class SensorTrend(BinarySensorEntity, RestoreEntity):
     """Representation of a trend Sensor."""
 
     _attr_should_poll = False
@@ -193,6 +195,10 @@ class SensorTrend(BinarySensorEntity):
                 self.hass, [self._entity_id], trend_sensor_state_listener
             )
         )
+
+        if not (state := await self.async_get_last_state()):
+            return
+        self._state = state.state == STATE_ON
 
     async def async_update(self) -> None:
         """Get the latest data and update the states."""

--- a/homeassistant/components/trend/binary_sensor.py
+++ b/homeassistant/components/trend/binary_sensor.py
@@ -198,6 +198,8 @@ class SensorTrend(BinarySensorEntity, RestoreEntity):
 
         if not (state := await self.async_get_last_state()):
             return
+        if state.state == STATE_UNKNOWN:
+            return
         self._state = state.state == STATE_ON
 
     async def async_update(self) -> None:

--- a/tests/components/trend/test_binary_sensor.py
+++ b/tests/components/trend/test_binary_sensor.py
@@ -5,13 +5,14 @@ from unittest.mock import patch
 from homeassistant import config as hass_config, setup
 from homeassistant.components.trend.const import DOMAIN
 from homeassistant.const import SERVICE_RELOAD, STATE_UNKNOWN
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
     assert_setup_component,
     get_fixture_path,
     get_test_home_assistant,
+    mock_restore_cache,
 )
 
 
@@ -413,3 +414,22 @@ async def test_reload(hass: HomeAssistant) -> None:
 
     assert hass.states.get("binary_sensor.test_trend_sensor") is None
     assert hass.states.get("binary_sensor.second_test_trend_sensor")
+
+
+async def test_restore_state(hass: HomeAssistant) -> None:
+    """Test we restore the trend state."""
+    mock_restore_cache(hass, (State("binary_sensor.test_trend_sensor", "on"),))
+
+    assert await setup.async_setup_component(
+        hass,
+        "binary_sensor",
+        {
+            "binary_sensor": {
+                "platform": "trend",
+                "sensors": {"test_trend_sensor": {"entity_id": "sensor.test_state"}},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("binary_sensor.test_trend_sensor").state == "on"

--- a/tests/components/trend/test_binary_sensor.py
+++ b/tests/components/trend/test_binary_sensor.py
@@ -2,6 +2,8 @@
 from datetime import timedelta
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant import config as hass_config, setup
 from homeassistant.components.trend.const import DOMAIN
 from homeassistant.const import SERVICE_RELOAD, STATE_UNKNOWN
@@ -416,9 +418,15 @@ async def test_reload(hass: HomeAssistant) -> None:
     assert hass.states.get("binary_sensor.second_test_trend_sensor")
 
 
-async def test_restore_state(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    ("saved_state", "restored_state"),
+    [("on", "on"), ("off", "off"), ("unknown", "unknown")],
+)
+async def test_restore_state(
+    hass: HomeAssistant, saved_state: str, restored_state: str
+) -> None:
     """Test we restore the trend state."""
-    mock_restore_cache(hass, (State("binary_sensor.test_trend_sensor", "on"),))
+    mock_restore_cache(hass, (State("binary_sensor.test_trend_sensor", saved_state),))
 
     assert await setup.async_setup_component(
         hass,
@@ -432,4 +440,4 @@ async def test_restore_state(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert hass.states.get("binary_sensor.test_trend_sensor").state == "on"
+    assert hass.states.get("binary_sensor.test_trend_sensor").state == restored_state


### PR DESCRIPTION
## Proposed change
Implement `RestoreEntity` in the `trend` integration. Restore the state of the `binary_sensor` after a restart.

I think this solves #39179 because the sensor restores its state from before the reboot instead of recalculating it with missing data.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #39179 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
