### PR TITLE
Remove useless timeout guards in devolo_home_network

### DIFF
--- a/homeassistant/components/devolo_home_network/__init__.py
+++ b/homeassistant/components/devolo_home_network/__init__.py
@@ -1,7 +1,6 @@
 """The devolo Home Network integration."""
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import Any
 
@@ -74,8 +73,7 @@ async def async_setup_entry(  # noqa: C901
         """Fetch data from API endpoint."""
         assert device.device
         try:
-            async with asyncio.timeout(30):
-                return await device.device.async_check_firmware_available()
+            return await device.device.async_check_firmware_available()
         except DeviceUnavailable as err:
             raise UpdateFailed(err) from err
 
@@ -83,8 +81,7 @@ async def async_setup_entry(  # noqa: C901
         """Fetch data from API endpoint."""
         assert device.plcnet
         try:
-            async with asyncio.timeout(10):
-                return await device.plcnet.async_get_network_overview()
+            return await device.plcnet.async_get_network_overview()
         except DeviceUnavailable as err:
             raise UpdateFailed(err) from err
 
@@ -92,8 +89,7 @@ async def async_setup_entry(  # noqa: C901
         """Fetch data from API endpoint."""
         assert device.device
         try:
-            async with asyncio.timeout(10):
-                return await device.device.async_get_wifi_guest_access()
+            return await device.device.async_get_wifi_guest_access()
         except DeviceUnavailable as err:
             raise UpdateFailed(err) from err
         except DevicePasswordProtected as err:
@@ -103,8 +99,7 @@ async def async_setup_entry(  # noqa: C901
         """Fetch data from API endpoint."""
         assert device.device
         try:
-            async with asyncio.timeout(10):
-                return await device.device.async_get_led_setting()
+            return await device.device.async_get_led_setting()
         except DeviceUnavailable as err:
             raise UpdateFailed(err) from err
 
@@ -112,8 +107,7 @@ async def async_setup_entry(  # noqa: C901
         """Fetch data from API endpoint."""
         assert device.device
         try:
-            async with asyncio.timeout(10):
-                return await device.device.async_get_wifi_connected_station()
+            return await device.device.async_get_wifi_connected_station()
         except DeviceUnavailable as err:
             raise UpdateFailed(err) from err
 
@@ -121,8 +115,7 @@ async def async_setup_entry(  # noqa: C901
         """Fetch data from API endpoint."""
         assert device.device
         try:
-            async with asyncio.timeout(30):
-                return await device.device.async_get_wifi_neighbor_access_points()
+            return await device.device.async_get_wifi_neighbor_access_points()
         except DeviceUnavailable as err:
             raise UpdateFailed(err) from err
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
While fixing a bug in #100350, @MartinHjelmare correctly discovered, that asyncio.timeout guards around the coordinator updates are not needed, because the library already takes care about that. This MR removes them.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
