### PR TITLE
Add "full" and "empty" device classes to binary sensors

### DIFF
--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -49,6 +49,12 @@ class BinarySensorDeviceClass(StrEnum):
     # On means open, Off means closed
     DOOR = "door"
 
+    # On means empty, Off means not empty
+    EMPTY = "empty"
+
+    # On means full, Off means not full
+    FULL = "full"
+
     # On means open, Off means closed
     GARAGE_DOOR = "garage_door"
 
@@ -127,6 +133,8 @@ DEVICE_CLASS_CO = BinarySensorDeviceClass.CO.value
 DEVICE_CLASS_COLD = BinarySensorDeviceClass.COLD.value
 DEVICE_CLASS_CONNECTIVITY = BinarySensorDeviceClass.CONNECTIVITY.value
 DEVICE_CLASS_DOOR = BinarySensorDeviceClass.DOOR.value
+DEVICE_CLASS_EMPTY = BinarySensorDeviceClass.EMPTY.value
+DEVICE_CLASS_FULL = BinarySensorDeviceClass.FULL.value
 DEVICE_CLASS_GARAGE_DOOR = BinarySensorDeviceClass.GARAGE_DOOR.value
 DEVICE_CLASS_GAS = BinarySensorDeviceClass.GAS.value
 DEVICE_CLASS_HEAT = BinarySensorDeviceClass.HEAT.value

--- a/homeassistant/components/binary_sensor/device_condition.py
+++ b/homeassistant/components/binary_sensor/device_condition.py
@@ -36,6 +36,10 @@ CONF_IS_COLD = "is_cold"
 CONF_IS_NOT_COLD = "is_not_cold"
 CONF_IS_CONNECTED = "is_connected"
 CONF_IS_NOT_CONNECTED = "is_not_connected"
+CONF_IS_EMPTY = "is_empty"
+CONF_IS_NOT_EMPTY = "is_not_empty"
+CONF_IS_FULL = "is_full"
+CONF_IS_NOT_FULL = "is_not_full"
 CONF_IS_GAS = "is_gas"
 CONF_IS_NO_GAS = "is_no_gas"
 CONF_IS_HOT = "is_hot"
@@ -83,6 +87,8 @@ IS_ON = [
     CONF_IS_CO,
     CONF_IS_COLD,
     CONF_IS_CONNECTED,
+    CONF_IS_EMPTY,
+    CONF_IS_FULL,
     CONF_IS_GAS,
     CONF_IS_HOT,
     CONF_IS_LIGHT,
@@ -111,6 +117,8 @@ IS_OFF = [
     CONF_IS_NOT_CHARGING,
     CONF_IS_NOT_COLD,
     CONF_IS_NOT_CONNECTED,
+    CONF_IS_NOT_EMPTY,
+    CONF_IS_NOT_FULL,
     CONF_IS_NOT_HOT,
     CONF_IS_LOCKED,
     CONF_IS_NOT_MOIST,
@@ -159,6 +167,14 @@ ENTITY_CONDITIONS = {
     BinarySensorDeviceClass.DOOR: [
         {CONF_TYPE: CONF_IS_OPEN},
         {CONF_TYPE: CONF_IS_NOT_OPEN},
+    ],
+    BinarySensorDeviceClass.EMPTY: [
+        {CONF_TYPE: CONF_IS_EMPTY},
+        {CONF_TYPE: CONF_IS_NOT_EMPTY},
+    ],
+    BinarySensorDeviceClass.FULL: [
+        {CONF_TYPE: CONF_IS_FULL},
+        {CONF_TYPE: CONF_IS_NOT_FULL},
     ],
     BinarySensorDeviceClass.GARAGE_DOOR: [
         {CONF_TYPE: CONF_IS_OPEN},

--- a/homeassistant/components/binary_sensor/device_trigger.py
+++ b/homeassistant/components/binary_sensor/device_trigger.py
@@ -28,6 +28,10 @@ CONF_COLD = "cold"
 CONF_NOT_COLD = "not_cold"
 CONF_CONNECTED = "connected"
 CONF_NOT_CONNECTED = "not_connected"
+CONF_EMPTY = "empty"
+CONF_NOT_EMPTY = "not_empty"
+CONF_FULL = "full"
+CONF_NOT_FULL = "not_full"
 CONF_GAS = "gas"
 CONF_NO_GAS = "no_gas"
 CONF_HOT = "hot"
@@ -94,6 +98,14 @@ ENTITY_TRIGGERS = {
     BinarySensorDeviceClass.DOOR: [
         {CONF_TYPE: CONF_OPENED},
         {CONF_TYPE: CONF_NOT_OPENED},
+    ],
+    BinarySensorDeviceClass.EMPTY: [
+        {CONF_TYPE: CONF_EMPTY},
+        {CONF_TYPE: CONF_NOT_EMPTY},
+    ],
+    BinarySensorDeviceClass.FULL: [
+        {CONF_TYPE: CONF_FULL},
+        {CONF_TYPE: CONF_NOT_FULL},
     ],
     BinarySensorDeviceClass.GARAGE_DOOR: [
         {CONF_TYPE: CONF_OPENED},

--- a/homeassistant/components/binary_sensor/strings.json
+++ b/homeassistant/components/binary_sensor/strings.json
@@ -12,6 +12,10 @@
       "is_not_cold": "{entity_name} is not cold",
       "is_connected": "{entity_name} is connected",
       "is_not_connected": "{entity_name} is disconnected",
+      "is_empty": "{entity_name} is empty",
+      "is_not_empty": "{entity_name} is not empty",
+      "is_full": "{entity_name} is full",
+      "is_not_full": "{entity_name} is not full",
       "is_gas": "{entity_name} is detecting gas",
       "is_no_gas": "{entity_name} is not detecting gas",
       "is_hot": "{entity_name} is hot",
@@ -66,6 +70,10 @@
       "not_cold": "{entity_name} became not cold",
       "connected": "{entity_name} connected",
       "not_connected": "{entity_name} disconnected",
+      "empty": "{entity_name} became empty",
+      "not_empty": "{entity_name} became not empty",
+      "full": "{entity_name} became full",
+      "not_full": "{entity_name} became not full",
       "gas": "{entity_name} started detecting gas",
       "no_gas": "{entity_name} stopped detecting gas",
       "hot": "{entity_name} became hot",
@@ -158,6 +166,20 @@
       "state": {
         "off": "[%key:common::state::closed%]",
         "on": "[%key:common::state::open%]"
+      }
+    },
+    "empty": {
+      "name": "Empty",
+      "state": {
+        "off": "Not empty",
+        "on": "Empty"
+      }
+    },
+    "full": {
+      "name": "Full",
+      "state": {
+        "off": "Not Full",
+        "on": "Full"
       }
     },
     "garage_door": {

--- a/homeassistant/components/roomba/binary_sensor.py
+++ b/homeassistant/components/roomba/binary_sensor.py
@@ -1,5 +1,8 @@
 """Roomba binary sensor entities."""
-from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -29,6 +32,7 @@ class RoombaBinStatus(IRobotEntity, BinarySensorEntity):
 
     _attr_icon = "mdi:delete-variant"
     _attr_translation_key = "bin_full"
+    _attr_device_class = BinarySensorDeviceClass.FULL
 
     @property
     def unique_id(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
I don't _think_ this would be a breaking change, but for the Roomba integration, I have added a "full" device class to the bin entity, to demonstrate it in action.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It occurred to me that binary sensors showing the status of bins and tanks tend to be used only for two possible statuses, empty, or full, but never as opposites.  This means folk have naturally avoided creating anything like a "container" entity because something not being full doesn't necessarily mean it's empty, and likewise the otherway round.

But that doesn't mean these statuses are any less used.  The prime example would be a robot vacuum or lawn mower with a bin collecting dust or grass.  The user doesn't want to be told it's empty when it's half full, but they do want to know when it's full so they can empty it.
The inverse would be true for a robot mop, or a steaming device, in this situation when binary sensors are used, they inform us if the tank is empty so we know to top it up, but when a tank is not empty, it doesn't necessarily mean it's full.

We currently represent these binary sensors with things like "robot vacuum bin full" with a status of "on" or "off", which isn't really semantically correct.

This change introduces statuses of "full" vs "not full" and "empty" vs "not empty".

I believe this will prove useful to a wide variety of devices aside from the aforementioned robot cleaners and mowers.  Automated animal feeders, rainwater fed irrigation system tanks, swimming pool filters, even battery systems with only binary outputs for full and empty could take advantage of these new device classes.

Analogue sensors do often provide a solution for these devices, as is the case with iRobot's mop providing a water level indication, but regularly simple binary sensors are used.

This change takes the liberty of adding the new "full" device class to the Roomba integration's bin binary sensor, to demonstrate one such usage of this work.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
_Sorry, I'm your least favourite kind of contributor without a proper dev environment set up 😅_

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
  - I will create PRs for this if the reception to this PR appears positive :) 

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
