### PR TITLE
Try Reolink ONVIF long polling if ONVIF push not supported

### DIFF
--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -61,7 +61,8 @@ class ReolinkHost:
         )
 
         self.webhook_id: str | None = None
-        self._onvif_supported: bool = True
+        self._onvif_push_supported: bool = True
+        self._onvif_long_poll_supported: bool = True
         self._base_url: str = ""
         self._webhook_url: str = ""
         self._webhook_reachable: bool = False
@@ -97,7 +98,8 @@ class ReolinkHost:
                 f"'{self._api.user_level}', only admin users can change camera settings"
             )
 
-        self._onvif_supported = self._api.supported(None, "ONVIF")
+        self._onvif_push_supported = self._api.supported(None, "ONVIF")
+        self._onvif_long_poll_supported = self._api.supported(None, "ONVIF")
 
         enable_rtsp = None
         enable_onvif = None
@@ -109,7 +111,7 @@ class ReolinkHost:
             )
             enable_rtsp = True
 
-        if not self._api.onvif_enabled and self._onvif_supported:
+        if not self._api.onvif_enabled and (self._onvif_push_supported or self._onvif_long_poll_supported):
             _LOGGER.debug(
                 "ONVIF is disabled on %s, trying to enable it", self._api.nvr_name
             )
@@ -157,11 +159,11 @@ class ReolinkHost:
 
         self._unique_id = format_mac(self._api.mac_address)
 
-        if self._onvif_supported:
+        if self._onvif_push_supported:
             try:
                 await self.subscribe()
             except NotSupportedError:
-                self._onvif_supported = False
+                self._onvif_push_supported = False
                 self.unregister_webhook()
                 await self._api.unsubscribe()
             else:
@@ -179,12 +181,25 @@ class ReolinkHost:
                 self._cancel_onvif_check = async_call_later(
                     self._hass, FIRST_ONVIF_TIMEOUT, self._async_check_onvif
                 )
-        if not self._onvif_supported:
+        if not self._onvif_push_supported:
             _LOGGER.debug(
-                "Camera model %s does not support ONVIF, using fast polling instead",
+                "Camera model %s does not support ONVIF push, using ONVIF long polling instead",
                 self._api.model,
             )
-            await self._async_poll_all_motion()
+            try:
+                await self._async_start_long_polling(initial=True)
+            except NotSupportedError:
+                _LOGGER.debug(
+                    "Camera model %s does not support ONVIF long polling, using fast polling instead",
+                    self._api.model,
+                )
+                self._onvif_long_poll_supported = False
+                await self._api.unsubscribe()
+                await self._async_poll_all_motion()
+            else:
+                self._cancel_long_poll_check = async_call_later(
+                    self._hass, FIRST_ONVIF_LONG_POLL_TIMEOUT, self._async_check_onvif_long_poll
+                )
 
         if self._api.sw_version_update_required:
             ir.async_create_issue(
@@ -317,11 +332,22 @@ class ReolinkHost:
                 str(err),
             )
 
-    async def _async_start_long_polling(self):
+    async def _async_start_long_polling(self, initial=False):
         """Start ONVIF long polling task."""
         if self._long_poll_task is None:
             try:
                 await self._api.subscribe(sub_type=SubType.long_poll)
+            except NotSupportedError as err:
+                if initial:
+                    raise err
+                # make sure the long_poll_task is always created to try again later
+                if not self._lost_subscription:
+                    self._lost_subscription = True
+                    _LOGGER.error(
+                        "Reolink %s event long polling subscription lost: %s",
+                        self._api.nvr_name,
+                        str(err),
+                    )
             except ReolinkError as err:
                 # make sure the long_poll_task is always created to try again later
                 if not self._lost_subscription:
@@ -381,12 +407,11 @@ class ReolinkHost:
 
     async def renew(self) -> None:
         """Renew the subscription of motion events (lease time is 15 minutes)."""
-        if not self._onvif_supported:
-            return
-
         try:
-            await self._renew(SubType.push)
-            if self._long_poll_task is not None:
+            if self._onvif_push_supported:
+                await self._renew(SubType.push)
+
+            if self._onvif_long_poll_supported and self._long_poll_task is not None:
                 if not self._api.subscribed(SubType.long_poll):
                     _LOGGER.debug("restarting long polling task")
                     # To prevent 5 minute request timeout

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -111,7 +111,9 @@ class ReolinkHost:
             )
             enable_rtsp = True
 
-        if not self._api.onvif_enabled and (self._onvif_push_supported or self._onvif_long_poll_supported):
+        if not self._api.onvif_enabled and (
+            self._onvif_push_supported or self._onvif_long_poll_supported
+        ):
             _LOGGER.debug(
                 "ONVIF is disabled on %s, trying to enable it", self._api.nvr_name
             )
@@ -198,7 +200,9 @@ class ReolinkHost:
                 await self._async_poll_all_motion()
             else:
                 self._cancel_long_poll_check = async_call_later(
-                    self._hass, FIRST_ONVIF_LONG_POLL_TIMEOUT, self._async_check_onvif_long_poll
+                    self._hass,
+                    FIRST_ONVIF_LONG_POLL_TIMEOUT,
+                    self._async_check_onvif_long_poll,
                 )
 
         if self._api.sw_version_update_required:

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -98,8 +98,9 @@ class ReolinkHost:
                 f"'{self._api.user_level}', only admin users can change camera settings"
             )
 
-        self._onvif_push_supported = self._api.supported(None, "ONVIF")
-        self._onvif_long_poll_supported = self._api.supported(None, "ONVIF")
+        onvif_supported = self._api.supported(None, "ONVIF")
+        self._onvif_push_supported = onvif_supported
+        self._onvif_long_poll_supported = onvif_supported
 
         enable_rtsp = None
         enable_onvif = None
@@ -111,9 +112,7 @@ class ReolinkHost:
             )
             enable_rtsp = True
 
-        if not self._api.onvif_enabled and (
-            self._onvif_push_supported or self._onvif_long_poll_supported
-        ):
+        if not self._api.onvif_enabled and onvif_supported:
             _LOGGER.debug(
                 "ONVIF is disabled on %s, trying to enable it", self._api.nvr_name
             )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If a (old) Reolink camera does not support ONVIF WS base subscriptions (push), then first try ONVIF PullPoint subscribtion (long polling) before reverting to fast polling.
In the case of the RLC-410-5MP with hardware version IPC_51516M5M, this is the case: ONVIF push does not work but ONVIF PullPoint does work.
See https://github.com/home-assistant/core/issues/100181

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/100181
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
