### PR TITLE
Add entity option to invert a cover's state

### DIFF
--- a/tests/components/cover/test_init.py
+++ b/tests/components/cover/test_init.py
@@ -1,8 +1,13 @@
 """The tests for Cover."""
+from unittest.mock import patch
+
 import homeassistant.components.cover as cover
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_PLATFORM,
+    SERVICE_CLOSE_COVER,
+    SERVICE_OPEN_COVER,
+    SERVICE_SET_COVER_POSITION,
     SERVICE_TOGGLE,
     STATE_CLOSED,
     STATE_CLOSING,
@@ -10,7 +15,10 @@ from homeassistant.const import (
     STATE_OPENING,
 )
 from homeassistant.core import HomeAssistant
+import homeassistant.helpers.entity_registry as er
 from homeassistant.setup import async_setup_component
+
+from tests.testing_config.custom_components.test.cover import MockCover
 
 
 async def test_services(hass: HomeAssistant, enable_custom_integrations: None) -> None:
@@ -112,3 +120,122 @@ def is_closed(hass, ent):
 def is_closing(hass, ent):
     """Return if the cover is closed based on the statemachine."""
     return hass.states.is_state(ent.entity_id, STATE_CLOSING)
+
+
+async def test_invert_cover_state(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    enable_custom_integrations: None,
+) -> None:
+    """Test invert cover state entity option."""
+    entry = entity_registry.async_get_or_create("cover", "test", "very_unique")
+    entity_id = entry.entity_id
+    await hass.async_block_till_done()
+
+    platform = getattr(hass.components, "test.cover")
+    platform.init(empty=True)
+    platform.ENTITIES.append(
+        MockCover(
+            name="test",
+            is_on=True,
+            unique_id="very_unique",
+            current_cover_position=10,
+            supported_features=cover.CoverEntityFeature.OPEN
+            | cover.CoverEntityFeature.CLOSE
+            | cover.CoverEntityFeature.STOP
+            | cover.CoverEntityFeature.SET_POSITION,
+        ),
+    )
+
+    assert await async_setup_component(hass, "cover", {"cover": {"platform": "test"}})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_OPEN
+    assert state.attributes["current_position"] == 10
+
+    entity_registry.async_update_entity_options(
+        entry.entity_id, "cover", {"invert_cover_state": True}
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_CLOSED
+    assert state.attributes["current_position"] == 90
+
+    entity0: MockCover = platform.ENTITIES[0]
+    with patch.object(entity0, "async_close_cover") as close_cover_mock, patch.object(
+        entity0, "async_open_cover"
+    ) as open_cover_mock:
+        await hass.services.async_call(
+            cover.DOMAIN,
+            SERVICE_CLOSE_COVER,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+        close_cover_mock.assert_not_called()
+        open_cover_mock.assert_called_once()
+
+        close_cover_mock.reset_mock()
+        open_cover_mock.reset_mock()
+        await hass.services.async_call(
+            cover.DOMAIN, SERVICE_OPEN_COVER, {ATTR_ENTITY_ID: entity_id}, blocking=True
+        )
+        close_cover_mock.assert_called_once()
+        open_cover_mock.assert_not_called()
+
+    with patch.object(entity0, "async_set_cover_position") as set_cover_position_mock:
+        await hass.services.async_call(
+            cover.DOMAIN,
+            SERVICE_SET_COVER_POSITION,
+            {ATTR_ENTITY_ID: entity_id, cover.ATTR_POSITION: 20},
+            blocking=True,
+        )
+        set_cover_position_mock.assert_called_once_with(position=80)
+
+    # TODO: Test toggle behavior
+
+
+async def test_invert_cover_state_update(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    enable_custom_integrations: None,
+) -> None:
+    """Test invert cover state entity option is updated."""
+    entry = entity_registry.async_get_or_create("cover", "test", "very_unique")
+    entity_id = entry.entity_id
+    entity_registry.async_update_entity_options(
+        entity_id, "cover", {"invert_cover_state": True}
+    )
+    await hass.async_block_till_done()
+
+    platform = getattr(hass.components, "test.cover")
+    platform.init(empty=True)
+    platform.ENTITIES.append(
+        MockCover(
+            name="test",
+            is_on=True,
+            unique_id="very_unique",
+            current_cover_position=10,
+            supported_features=cover.CoverEntityFeature.OPEN
+            | cover.CoverEntityFeature.CLOSE
+            | cover.CoverEntityFeature.STOP
+            | cover.CoverEntityFeature.SET_POSITION,
+        ),
+    )
+
+    assert await async_setup_component(hass, "cover", {"cover": {"platform": "test"}})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_CLOSED
+    assert state.attributes["current_position"] == 90
+
+    entity_registry.async_update_entity_options(
+        entity_id, "cover", {"invert_cover_state": False}
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_OPEN
+    assert state.attributes["current_position"] == 10

--- a/tests/testing_config/custom_components/test/cover.py
+++ b/tests/testing_config/custom_components/test/cover.py
@@ -30,13 +30,11 @@ def init(empty=False):
         else [
             MockCover(
                 name="Simple cover",
-                is_on=True,
                 unique_id="unique_cover",
                 supported_features=SUPPORT_OPEN | SUPPORT_CLOSE,
             ),
             MockCover(
                 name="Set position cover",
-                is_on=True,
                 unique_id="unique_set_pos_cover",
                 current_cover_position=50,
                 supported_features=SUPPORT_OPEN
@@ -46,7 +44,6 @@ def init(empty=False):
             ),
             MockCover(
                 name="Simple tilt cover",
-                is_on=True,
                 unique_id="unique_tilt_cover",
                 supported_features=SUPPORT_OPEN
                 | SUPPORT_CLOSE
@@ -55,7 +52,6 @@ def init(empty=False):
             ),
             MockCover(
                 name="Set tilt position cover",
-                is_on=True,
                 unique_id="unique_set_pos_tilt_cover",
                 current_cover_tilt_position=50,
                 supported_features=SUPPORT_OPEN
@@ -67,7 +63,6 @@ def init(empty=False):
             ),
             MockCover(
                 name="All functions cover",
-                is_on=True,
                 unique_id="unique_all_functions_cover",
                 current_cover_position=50,
                 current_cover_tilt_position=50,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add entity option to invert a cover's state

Work in progress, not finished:
- The toggle service does not yet check the invert option
- The cover entity model defines position 0 as closed, 1..100 as open, by just inverting the logic position 0 mean open, 1..100 means closed, which may not be acceptable

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
