### PR TITLE
Add virtual_count == slave_count in modbus configuration

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -105,6 +105,7 @@ from .const import (  # noqa: F401
     CONF_TARGET_TEMP,
     CONF_TARGET_TEMP_WRITE_REGISTERS,
     CONF_VERIFY,
+    CONF_VIRTUAL_COUNT,
     CONF_WRITE_REGISTERS,
     CONF_WRITE_TYPE,
     CONF_ZERO_SUPPRESS,
@@ -308,7 +309,8 @@ SENSOR_SCHEMA = vol.All(
             vol.Optional(CONF_DEVICE_CLASS): SENSOR_DEVICE_CLASSES_SCHEMA,
             vol.Optional(CONF_STATE_CLASS): SENSOR_STATE_CLASSES_SCHEMA,
             vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
-            vol.Optional(CONF_SLAVE_COUNT, default=0): cv.positive_int,
+            vol.Exclusive(CONF_VIRTUAL_COUNT, "vir_sen_count"): cv.positive_int,
+            vol.Optional(CONF_SLAVE_COUNT, "vir_sen_count"): cv.positive_int,
             vol.Optional(CONF_MIN_VALUE): number_validator,
             vol.Optional(CONF_MAX_VALUE): number_validator,
             vol.Optional(CONF_NAN_VALUE): nan_validator,
@@ -328,7 +330,8 @@ BINARY_SENSOR_SCHEMA = BASE_COMPONENT_SCHEMA.extend(
                 CALL_TYPE_REGISTER_INPUT,
             ]
         ),
-        vol.Optional(CONF_SLAVE_COUNT, default=0): cv.positive_int,
+        vol.Exclusive(CONF_VIRTUAL_COUNT, "vir_bin_count"): cv.positive_int,
+        vol.Exclusive(CONF_SLAVE_COUNT, "vir_bin_count"): cv.positive_int,
     }
 )
 

--- a/homeassistant/components/modbus/base_platform.py
+++ b/homeassistant/components/modbus/base_platform.py
@@ -166,8 +166,8 @@ class BaseStructPlatform(BasePlatform, RestoreEntity):
         if self._scale < 1 and not self._precision:
             self._precision = 2
         self._offset = config[CONF_OFFSET]
-        self._slave_count = config.get(
-            CONF_SLAVE_COUNT, config.get(CONF_VIRTUAL_COUNT, 0)
+        self._slave_count = config.get(CONF_SLAVE_COUNT, None) or config.get(
+            CONF_VIRTUAL_COUNT, 0
         )
         self._slave_size = self._count = config[CONF_COUNT]
 

--- a/homeassistant/components/modbus/base_platform.py
+++ b/homeassistant/components/modbus/base_platform.py
@@ -58,6 +58,7 @@ from .const import (
     CONF_SWAP_WORD,
     CONF_SWAP_WORD_BYTE,
     CONF_VERIFY,
+    CONF_VIRTUAL_COUNT,
     CONF_WRITE_TYPE,
     CONF_ZERO_SUPPRESS,
     SIGNAL_START_ENTITY,
@@ -165,7 +166,9 @@ class BaseStructPlatform(BasePlatform, RestoreEntity):
         if self._scale < 1 and not self._precision:
             self._precision = 2
         self._offset = config[CONF_OFFSET]
-        self._slave_count = config.get(CONF_SLAVE_COUNT, 0)
+        self._slave_count = config.get(CONF_SLAVE_COUNT, None)
+        if not self._slave_count:
+            self._slave_count = config.get(CONF_VIRTUAL_COUNT, 0)
         self._slave_size = self._count = config[CONF_COUNT]
 
     def _swap_registers(self, registers: list[int], slave_count: int) -> list[int]:

--- a/homeassistant/components/modbus/base_platform.py
+++ b/homeassistant/components/modbus/base_platform.py
@@ -166,9 +166,9 @@ class BaseStructPlatform(BasePlatform, RestoreEntity):
         if self._scale < 1 and not self._precision:
             self._precision = 2
         self._offset = config[CONF_OFFSET]
-        self._slave_count = config.get(CONF_SLAVE_COUNT, None)
-        if not self._slave_count:
-            self._slave_count = config.get(CONF_VIRTUAL_COUNT, 0)
+        self._slave_count = config.get(
+            CONF_SLAVE_COUNT, config.get(CONF_VIRTUAL_COUNT, 0)
+        )
         self._slave_size = self._count = config[CONF_COUNT]
 
     def _swap_registers(self, registers: list[int], slave_count: int) -> list[int]:

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -51,7 +51,9 @@ async def async_setup_platform(
     sensors: list[ModbusBinarySensor | SlaveSensor] = []
     hub = get_hub(hass, discovery_info[CONF_NAME])
     for entry in discovery_info[CONF_BINARY_SENSORS]:
-        slave_count = entry.get(CONF_SLAVE_COUNT, entry.get(CONF_VIRTUAL_COUNT, 0))
+        slave_count = entry.get(CONF_SLAVE_COUNT, None) or entry.get(
+            CONF_VIRTUAL_COUNT, 0
+        )
         sensor = ModbusBinarySensor(hub, entry, slave_count)
         if slave_count > 0:
             sensors.extend(await sensor.async_setup_slaves(hass, slave_count, entry))

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -51,9 +51,7 @@ async def async_setup_platform(
     sensors: list[ModbusBinarySensor | SlaveSensor] = []
     hub = get_hub(hass, discovery_info[CONF_NAME])
     for entry in discovery_info[CONF_BINARY_SENSORS]:
-        slave_count = entry.get(CONF_SLAVE_COUNT, None)
-        if not slave_count:
-            slave_count = entry.get(CONF_VIRTUAL_COUNT, 0)
+        slave_count = entry.get(CONF_SLAVE_COUNT, entry.get(CONF_VIRTUAL_COUNT, 0))
         sensor = ModbusBinarySensor(hub, entry, slave_count)
         if slave_count > 0:
             sensors.extend(await sensor.async_setup_slaves(hass, slave_count, entry))

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -24,7 +24,12 @@ from homeassistant.helpers.update_coordinator import (
 
 from . import get_hub
 from .base_platform import BasePlatform
-from .const import CALL_TYPE_COIL, CALL_TYPE_DISCRETE, CONF_SLAVE_COUNT
+from .const import (
+    CALL_TYPE_COIL,
+    CALL_TYPE_DISCRETE,
+    CONF_SLAVE_COUNT,
+    CONF_VIRTUAL_COUNT,
+)
 from .modbus import ModbusHub
 
 _LOGGER = logging.getLogger(__name__)
@@ -46,7 +51,9 @@ async def async_setup_platform(
     sensors: list[ModbusBinarySensor | SlaveSensor] = []
     hub = get_hub(hass, discovery_info[CONF_NAME])
     for entry in discovery_info[CONF_BINARY_SENSORS]:
-        slave_count = entry.get(CONF_SLAVE_COUNT, 0)
+        slave_count = entry.get(CONF_SLAVE_COUNT, None)
+        if not slave_count:
+            slave_count = entry.get(CONF_VIRTUAL_COUNT, 0)
         sensor = ModbusBinarySensor(hub, entry, slave_count)
         if slave_count > 0:
             sensors.extend(await sensor.async_setup_slaves(hass, slave_count, entry))

--- a/homeassistant/components/modbus/const.py
+++ b/homeassistant/components/modbus/const.py
@@ -61,6 +61,7 @@ CONF_HVAC_MODE_DRY = "state_dry"
 CONF_HVAC_MODE_FAN_ONLY = "state_fan_only"
 CONF_WRITE_REGISTERS = "write_registers"
 CONF_VERIFY = "verify"
+CONF_VIRTUAL_COUNT = "virtual_count"
 CONF_WRITE_TYPE = "write_type"
 CONF_ZERO_SUPPRESS = "zero_suppress"
 

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -50,7 +50,9 @@ async def async_setup_platform(
     sensors: list[ModbusRegisterSensor | SlaveSensor] = []
     hub = get_hub(hass, discovery_info[CONF_NAME])
     for entry in discovery_info[CONF_SENSORS]:
-        slave_count = entry.get(CONF_SLAVE_COUNT, entry.get(CONF_VIRTUAL_COUNT, 0))
+        slave_count = entry.get(CONF_SLAVE_COUNT, None) or entry.get(
+            CONF_VIRTUAL_COUNT, 0
+        )
         sensor = ModbusRegisterSensor(hub, entry, slave_count)
         if slave_count > 0:
             sensors.extend(await sensor.async_setup_slaves(hass, slave_count, entry))

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -50,9 +50,7 @@ async def async_setup_platform(
     sensors: list[ModbusRegisterSensor | SlaveSensor] = []
     hub = get_hub(hass, discovery_info[CONF_NAME])
     for entry in discovery_info[CONF_SENSORS]:
-        slave_count = entry.get(CONF_SLAVE_COUNT, None)
-        if not slave_count:
-            slave_count = entry.get(CONF_VIRTUAL_COUNT, 0)
+        slave_count = entry.get(CONF_SLAVE_COUNT, entry.get(CONF_VIRTUAL_COUNT, 0))
         sensor = ModbusRegisterSensor(hub, entry, slave_count)
         if slave_count > 0:
             sensors.extend(await sensor.async_setup_slaves(hass, slave_count, entry))

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -28,7 +28,7 @@ from homeassistant.helpers.update_coordinator import (
 
 from . import get_hub
 from .base_platform import BaseStructPlatform
-from .const import CONF_SLAVE_COUNT
+from .const import CONF_SLAVE_COUNT, CONF_VIRTUAL_COUNT
 from .modbus import ModbusHub
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,7 +50,9 @@ async def async_setup_platform(
     sensors: list[ModbusRegisterSensor | SlaveSensor] = []
     hub = get_hub(hass, discovery_info[CONF_NAME])
     for entry in discovery_info[CONF_SENSORS]:
-        slave_count = entry.get(CONF_SLAVE_COUNT, 0)
+        slave_count = entry.get(CONF_SLAVE_COUNT, None)
+        if not slave_count:
+            slave_count = entry.get(CONF_VIRTUAL_COUNT, 0)
         sensor = ModbusRegisterSensor(hub, entry, slave_count)
         if slave_count > 0:
             sensors.extend(await sensor.async_setup_slaves(hass, slave_count, entry))

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -32,6 +32,7 @@ from .const import (
     CONF_SWAP_NONE,
     CONF_SWAP_WORD,
     CONF_SWAP_WORD_BYTE,
+    CONF_VIRTUAL_COUNT,
     CONF_WRITE_TYPE,
     DEFAULT_HUB,
     DEFAULT_SCAN_INTERVAL,
@@ -97,6 +98,10 @@ def struct_validator(config: dict[str, Any]) -> dict[str, Any]:
     count = config.get(CONF_COUNT, None)
     structure = config.get(CONF_STRUCTURE, None)
     slave_count = config.get(CONF_SLAVE_COUNT, None)
+    slave_name = CONF_SLAVE_COUNT
+    if not slave_count:
+        slave_count = config.get(CONF_VIRTUAL_COUNT, 0)
+        slave_name = CONF_VIRTUAL_COUNT
     swap_type = config.get(CONF_SWAP, CONF_SWAP_NONE)
     validator = DEFAULT_STRUCT_FORMAT[data_type].validate_parm
     if count and not validator.count:
@@ -112,7 +117,7 @@ def struct_validator(config: dict[str, Any]) -> dict[str, Any]:
         error = f"{name}: `{CONF_STRUCTURE}` missing or empty, demanded with `{CONF_DATA_TYPE}: {data_type}`"
         raise vol.Invalid(error)
     if slave_count and not validator.slave_count:
-        error = f"{name}: `{CONF_SLAVE_COUNT}: {slave_count}` cannot be combined with `{CONF_DATA_TYPE}: {data_type}`"
+        error = f"{name}: `{slave_name}: {slave_count}` cannot be combined with `{CONF_DATA_TYPE}: {data_type}`"
         raise vol.Invalid(error)
     if swap_type != CONF_SWAP_NONE:
         swap_type_validator = {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is the very first part of getting rid of "slave" in Modbus.

This PR adds the possibility to use "virtual_count:" instead of "slave_count:" (which is still legal).

"*_count" is used to define virtual sensors and/or virtual binary_sensors, allowing the integration to read a number of entities with a single request.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
https://github.com/home-assistant/home-assistant.io/pull/28910

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
