### PR TITLE
Add fan modes in Lyric integration

### DIFF
--- a/homeassistant/components/lyric/__init__.py
+++ b/homeassistant/components/lyric/__init__.py
@@ -133,6 +133,7 @@ class LyricEntity(CoordinatorEntity[DataUpdateCoordinator[Lyric]]):
         self._location = location
         self._mac_id = device.macID
         self._update_thermostat = coordinator.data.update_thermostat
+        self._update_fan = coordinator.data.update_fan
 
     @property
     def unique_id(self) -> str:

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -181,8 +181,19 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
 
         # Setup supported fan modes
         self._attr_fan_modes = device.settings.attributes.get("fan", {}).get(
-            "allowedModes", []
+            "allowedModes"
         )
+
+        # Setup supported features
+        if device.changeableValues.thermostatSetpointStatus:
+            self._attr_supported_features = SUPPORT_FLAGS_LCC
+        else:
+            self._attr_supported_features = SUPPORT_FLAGS_TCC
+
+        if self._attr_fan_modes:
+            self._attr_supported_features = (
+                self._attr_supported_features | ClimateEntityFeature.FAN_MODE
+            )
 
         super().__init__(
             coordinator,
@@ -191,19 +202,6 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
             f"{device.macID}_thermostat",
         )
         self.entity_description = description
-
-    @property
-    def supported_features(self) -> ClimateEntityFeature:
-        """Return the list of supported features."""
-        if self.device.changeableValues.thermostatSetpointStatus:
-            supported_flags = SUPPORT_FLAGS_LCC
-        else:
-            supported_flags = SUPPORT_FLAGS_TCC
-
-        if self._attr_fan_modes:
-            supported_flags = supported_flags | ClimateEntityFeature.FAN_MODE
-
-        return supported_flags
 
     @property
     def current_temperature(self) -> float | None:

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -52,12 +52,10 @@ SUPPORT_FLAGS_LCC = (
     ClimateEntityFeature.TARGET_TEMPERATURE
     | ClimateEntityFeature.PRESET_MODE
     | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
-    | ClimateEntityFeature.FAN_MODE
 )
 SUPPORT_FLAGS_TCC = (
     ClimateEntityFeature.TARGET_TEMPERATURE
     | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
-    | ClimateEntityFeature.FAN_MODE
 )
 
 LYRIC_HVAC_ACTION_OFF = "EquipmentOff"
@@ -198,8 +196,14 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
     def supported_features(self) -> ClimateEntityFeature:
         """Return the list of supported features."""
         if self.device.changeableValues.thermostatSetpointStatus:
-            return SUPPORT_FLAGS_LCC
-        return SUPPORT_FLAGS_TCC
+            supported_flags = SUPPORT_FLAGS_LCC
+        else:
+            supported_flags = SUPPORT_FLAGS_TCC
+
+        if self._attr_fan_modes:
+            supported_flags = supported_flags | ClimateEntityFeature.FAN_MODE
+
+        return supported_flags
 
     @property
     def current_temperature(self) -> float | None:
@@ -410,7 +414,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set fan (On, Auto, Circulate) mode."""
-        _LOGGER.debug("Set preset mode: %s", fan_mode)
+        _LOGGER.debug("Set fan mode: %s", fan_mode)
         try:
             await self._update_fan(self.location, self.device, mode=fan_mode)
         except LYRIC_EXCEPTIONS as exception:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Add fan modes in Honeywell Lyric integration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #96969 
- This PR is related to issue: 
- Link to documentation pull request: 
- *Note: I also proposed [a pending PR](https://github.com/timmo001/aiolyric/pull/62) in aiolyric to make the syntax cleaner. There's currently some typos in aiolyric fan mode implementations.*

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
