### PR TITLE
Revert "Cache entity properties that are never expected to change in the base class"

### DIFF
--- a/homeassistant/backports/functools.py
+++ b/homeassistant/backports/functools.py
@@ -5,18 +5,18 @@ from collections.abc import Callable
 from types import GenericAlias
 from typing import Any, Generic, Self, TypeVar, overload
 
-_T_co = TypeVar("_T_co", covariant=True)
+_T = TypeVar("_T")
 
 
-class cached_property(Generic[_T_co]):  # pylint: disable=invalid-name
+class cached_property(Generic[_T]):
     """Backport of Python 3.12's cached_property.
 
     Includes https://github.com/python/cpython/pull/101890/files
     """
 
-    def __init__(self, func: Callable[[Any], _T_co]) -> None:
+    def __init__(self, func: Callable[[Any], _T]) -> None:
         """Initialize."""
-        self.func: Callable[[Any], _T_co] = func
+        self.func: Callable[[Any], _T] = func
         self.attrname: str | None = None
         self.__doc__ = func.__doc__
 
@@ -35,12 +35,12 @@ class cached_property(Generic[_T_co]):  # pylint: disable=invalid-name
         ...
 
     @overload
-    def __get__(self, instance: Any, owner: type[Any] | None = None) -> _T_co:
+    def __get__(self, instance: Any, owner: type[Any] | None = None) -> _T:
         ...
 
     def __get__(
         self, instance: Any | None, owner: type[Any] | None = None
-    ) -> _T_co | Self:
+    ) -> _T | Self:
         """Get."""
         if instance is None:
             return self

--- a/homeassistant/components/abode/binary_sensor.py
+++ b/homeassistant/components/abode/binary_sensor.py
@@ -50,9 +50,7 @@ class AbodeBinarySensor(AbodeDevice, BinarySensorEntity):
         """Return True if the binary sensor is on."""
         return cast(bool, self._device.is_on)
 
-    @property  # type: ignore[override]
-    # We don't know if the class may be set late here
-    # so we need to override the property to disable the cache.
+    @property
     def device_class(self) -> BinarySensorDeviceClass | None:
         """Return the class of the binary sensor."""
         if self._device.get_value("is_window") == "1":

--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -9,7 +9,6 @@ from typing import Literal, final
 
 import voluptuous as vol
 
-from homeassistant.backports.functools import cached_property
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
@@ -198,7 +197,7 @@ class BinarySensorEntity(Entity):
         """
         return self.device_class is not None
 
-    @cached_property
+    @property
     def device_class(self) -> BinarySensorDeviceClass | None:
         """Return the class of this entity."""
         if hasattr(self, "_attr_device_class"):

--- a/homeassistant/components/button/__init__.py
+++ b/homeassistant/components/button/__init__.py
@@ -9,7 +9,6 @@ from typing import final
 
 import voluptuous as vol
 
-from homeassistant.backports.functools import cached_property
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.config_validation import (  # noqa: F401
@@ -97,7 +96,7 @@ class ButtonEntity(RestoreEntity):
         """
         return self.device_class is not None
 
-    @cached_property
+    @property
     def device_class(self) -> ButtonDeviceClass | None:
         """Return the class of this entity."""
         if hasattr(self, "_attr_device_class"):

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -11,7 +11,6 @@ from typing import Any, ParamSpec, TypeVar, final
 
 import voluptuous as vol
 
-from homeassistant.backports.functools import cached_property
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     SERVICE_CLOSE_COVER,
@@ -251,7 +250,7 @@ class CoverEntity(Entity):
         """
         return self._attr_current_cover_tilt_position
 
-    @cached_property
+    @property
     def device_class(self) -> CoverDeviceClass | None:
         """Return the class of this entity."""
         if hasattr(self, "_attr_device_class"):

--- a/homeassistant/components/date/__init__.py
+++ b/homeassistant/components/date/__init__.py
@@ -8,7 +8,6 @@ from typing import final
 
 import voluptuous as vol
 
-from homeassistant.backports.functools import cached_property
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_DATE
 from homeassistant.core import HomeAssistant, ServiceCall
@@ -76,7 +75,7 @@ class DateEntity(Entity):
     _attr_native_value: date | None
     _attr_state: None = None
 
-    @cached_property
+    @property
     @final
     def device_class(self) -> None:
         """Return the device class for the entity."""

--- a/homeassistant/components/datetime/__init__.py
+++ b/homeassistant/components/datetime/__init__.py
@@ -8,7 +8,6 @@ from typing import final
 
 import voluptuous as vol
 
-from homeassistant.backports.functools import cached_property
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
@@ -87,7 +86,7 @@ class DateTimeEntity(Entity):
     _attr_state: None = None
     _attr_native_value: datetime | None
 
-    @cached_property
+    @property
     @final
     def device_class(self) -> None:
         """Return entity device class."""

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -592,10 +592,7 @@ class DSMREntity(SensorEntity):
         """Entity is only available if there is a telegram."""
         return self.telegram is not None
 
-    @property  # type: ignore[override]
-    # The device class can change at runtime from GAS to ENERGY
-    # when new data is received. This should be remembered and restored
-    # at startup, but the integration currently doesn't support that.
+    @property
     def device_class(self) -> SensorDeviceClass | None:
         """Return the device class of this entity."""
         device_class = super().device_class

--- a/homeassistant/components/event/__init__.py
+++ b/homeassistant/components/event/__init__.py
@@ -7,7 +7,6 @@ from enum import StrEnum
 import logging
 from typing import Any, Self, final
 
-from homeassistant.backports.functools import cached_property
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.config_validation import (  # noqa: F401
@@ -115,7 +114,7 @@ class EventEntity(RestoreEntity):
     __last_event_type: str | None = None
     __last_event_attributes: dict[str, Any] | None = None
 
-    @cached_property
+    @property
     def device_class(self) -> EventDeviceClass | None:
         """Return the class of this entity."""
         if hasattr(self, "_attr_device_class"):

--- a/homeassistant/components/filter/sensor.py
+++ b/homeassistant/components/filter/sensor.py
@@ -220,16 +220,9 @@ class SensorFilter(SensorEntity):
         self._state: StateType = None
         self._filters = filters
         self._attr_icon = None
-        self._device_class = None
+        self._attr_device_class = None
         self._attr_state_class = None
         self._attr_extra_state_attributes = {ATTR_ENTITY_ID: entity_id}
-
-    @property
-    # This property is not cached because the underlying source may
-    # not always be available.
-    def device_class(self) -> SensorDeviceClass | None:  # type: ignore[override]
-        """Return the device class of the sensor."""
-        return self._device_class
 
     @callback
     def _update_filter_sensor_state_event(
@@ -290,7 +283,7 @@ class SensorFilter(SensorEntity):
         self._state = temp_state.state
 
         self._attr_icon = new_state.attributes.get(ATTR_ICON, ICON)
-        self._device_class = new_state.attributes.get(ATTR_DEVICE_CLASS)
+        self._attr_device_class = new_state.attributes.get(ATTR_DEVICE_CLASS)
         self._attr_state_class = new_state.attributes.get(ATTR_STATE_CLASS)
 
         if self._attr_native_unit_of_measurement != new_state.attributes.get(

--- a/homeassistant/components/group/binary_sensor.py
+++ b/homeassistant/components/group/binary_sensor.py
@@ -5,7 +5,6 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.backports.functools import cached_property
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASSES_SCHEMA,
     DOMAIN as BINARY_SENSOR_DOMAIN,
@@ -148,7 +147,7 @@ class BinarySensorGroup(GroupEntity, BinarySensorEntity):
             # Set as ON if any / all member is ON
             self._attr_is_on = self.mode(state == STATE_ON for state in states)
 
-    @cached_property
+    @property
     def device_class(self) -> BinarySensorDeviceClass | None:
         """Return the sensor class of the binary sensor."""
         return self._device_class

--- a/homeassistant/components/group/sensor.py
+++ b/homeassistant/components/group/sensor.py
@@ -360,10 +360,7 @@ class SensorGroup(GroupEntity, SensorEntity):
         """Return the state attributes of the sensor."""
         return {ATTR_ENTITY_ID: self._entity_ids, **self._extra_state_attribute}
 
-    @property  # type: ignore[override]
-    # Because the device class is calculated, there is no guarantee that the
-    # sensors will be available when the entity is created so we do not want to
-    # cache the value.
+    @property
     def device_class(self) -> SensorDeviceClass | None:
         """Return device class."""
         if self._attr_device_class is not None:

--- a/homeassistant/components/here_travel_time/sensor.py
+++ b/homeassistant/components/here_travel_time/sensor.py
@@ -154,10 +154,7 @@ class HERETravelTimeSensor(
             )
             self.async_write_ha_state()
 
-    @property  # type: ignore[override]
-    # This property is not cached because the attribute can change
-    # at run time. This is not expected, but it is currently how
-    # the HERE integration works.
+    @property
     def attribution(self) -> str | None:
         """Return the attribution."""
         if self.coordinator.data is not None:

--- a/homeassistant/components/huawei_lte/sensor.py
+++ b/homeassistant/components/huawei_lte/sensor.py
@@ -760,9 +760,7 @@ class HuaweiLteSensor(HuaweiLteBaseEntityWithDevice, SensorEntity):
             return self.entity_description.icon_fn(self.state)
         return self.entity_description.icon
 
-    @property  # type: ignore[override]
-    # The device class might change at run time of the signal
-    # is not a number, so we override here.
+    @property
     def device_class(self) -> SensorDeviceClass | None:
         """Return device class for sensor."""
         if self.entity_description.device_class_fn:

--- a/homeassistant/components/humidifier/__init__.py
+++ b/homeassistant/components/humidifier/__init__.py
@@ -9,7 +9,6 @@ from typing import Any, final
 
 import voluptuous as vol
 
-from homeassistant.backports.functools import cached_property
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_MODE,
@@ -159,7 +158,7 @@ class HumidifierEntity(ToggleEntity):
 
         return data
 
-    @cached_property
+    @property
     def device_class(self) -> HumidifierDeviceClass | None:
         """Return the class of this entity."""
         if hasattr(self, "_attr_device_class"):

--- a/homeassistant/components/image_processing/__init__.py
+++ b/homeassistant/components/image_processing/__init__.py
@@ -10,7 +10,6 @@ from typing import Any, Final, TypedDict, final
 
 import voluptuous as vol
 
-from homeassistant.backports.functools import cached_property
 from homeassistant.components.camera import Image
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -157,7 +156,7 @@ class ImageProcessingEntity(Entity):
             return self.entity_description.confidence
         return None
 
-    @cached_property
+    @property
     def device_class(self) -> ImageProcessingDeviceClass | None:
         """Return the class of this entity."""
         if hasattr(self, "_attr_device_class"):

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -242,14 +242,6 @@ class IntegrationSensor(RestoreSensor):
         self._source_entity: str = source_entity
         self._last_valid_state: Decimal | None = None
         self._attr_device_info = device_info
-        self._device_class: SensorDeviceClass | None = None
-
-    @property  # type: ignore[override]
-    # The underlying source data may be unavailable at startup, so the device
-    # class may be set late so we need to override the property to disable the cache.
-    def device_class(self) -> SensorDeviceClass | None:
-        """Return the device class of the sensor."""
-        return self._device_class
 
     def _unit(self, source_unit: str) -> str:
         """Derive unit from the source sensor, SI prefix and time unit."""
@@ -296,7 +288,7 @@ class IntegrationSensor(RestoreSensor):
                         err,
                     )
 
-            self._device_class = state.attributes.get(ATTR_DEVICE_CLASS)
+            self._attr_device_class = state.attributes.get(ATTR_DEVICE_CLASS)
             self._unit_of_measurement = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
 
         @callback
@@ -327,7 +319,7 @@ class IntegrationSensor(RestoreSensor):
                 and new_state.attributes.get(ATTR_DEVICE_CLASS)
                 == SensorDeviceClass.POWER
             ):
-                self._device_class = SensorDeviceClass.ENERGY
+                self._attr_device_class = SensorDeviceClass.ENERGY
                 self._attr_icon = None
 
             self.async_write_ha_state()

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -22,7 +22,6 @@ from aiohttp.typedefs import LooseHeaders
 import voluptuous as vol
 from yarl import URL
 
-from homeassistant.backports.functools import cached_property
 from homeassistant.components import websocket_api
 from homeassistant.components.http import KEY_AUTHENTICATED, HomeAssistantView
 from homeassistant.components.websocket_api import ERR_NOT_SUPPORTED, ERR_UNKNOWN_ERROR
@@ -496,7 +495,7 @@ class MediaPlayerEntity(Entity):
     _attr_volume_level: float | None = None
 
     # Implement these for your media player
-    @cached_property
+    @property
     def device_class(self) -> MediaPlayerDeviceClass | None:
         """Return the class of this entity."""
         if hasattr(self, "_attr_device_class"):

--- a/homeassistant/components/mobile_app/binary_sensor.py
+++ b/homeassistant/components/mobile_app/binary_sensor.py
@@ -67,7 +67,7 @@ async def async_setup_entry(
     )
 
 
-class MobileAppBinarySensor(MobileAppEntity, BinarySensorEntity):  # type: ignore[misc]
+class MobileAppBinarySensor(MobileAppEntity, BinarySensorEntity):
     """Representation of an mobile app binary sensor."""
 
     @property

--- a/homeassistant/components/mobile_app/entity.py
+++ b/homeassistant/components/mobile_app/entity.py
@@ -69,9 +69,7 @@ class MobileAppEntity(RestoreEntity):
         """Return if entity should be enabled by default."""
         return not self._config.get(ATTR_SENSOR_DISABLED)
 
-    @property  # type: ignore[override,unused-ignore]
-    # Because the device class is received later from the mobile app
-    # we do not want to cache the property
+    @property
     def device_class(self):
         """Return the device class."""
         return self._config.get(ATTR_SENSOR_DEVICE_CLASS)

--- a/homeassistant/components/mobile_app/sensor.py
+++ b/homeassistant/components/mobile_app/sensor.py
@@ -76,7 +76,7 @@ async def async_setup_entry(
     )
 
 
-class MobileAppSensor(MobileAppEntity, RestoreSensor):  # type: ignore[misc]
+class MobileAppSensor(MobileAppEntity, RestoreSensor):
     """Representation of an mobile app sensor."""
 
     async def async_restore_last_state(self, last_state):

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -12,7 +12,6 @@ from typing import Any, Self, final
 
 import voluptuous as vol
 
-from homeassistant.backports.functools import cached_property
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_MODE, CONF_UNIT_OF_MEASUREMENT, UnitOfTemperature
 from homeassistant.core import HomeAssistant, ServiceCall, callback
@@ -232,7 +231,7 @@ class NumberEntity(Entity):
         """
         return self.device_class is not None
 
-    @cached_property
+    @property
     def device_class(self) -> NumberDeviceClass | None:
         """Return the class of this entity."""
         if hasattr(self, "_attr_device_class"):

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -11,7 +11,6 @@ import logging
 from math import ceil, floor, isfinite, log10
 from typing import Any, Final, Self, cast, final
 
-from homeassistant.backports.functools import cached_property
 from homeassistant.config_entries import ConfigEntry
 
 # pylint: disable-next=hass-deprecated-import
@@ -260,7 +259,7 @@ class SensorEntity(Entity):
         """
         return self.device_class not in (None, SensorDeviceClass.ENUM)
 
-    @cached_property
+    @property
     def device_class(self) -> SensorDeviceClass | None:
         """Return the class of this entity."""
         if hasattr(self, "_attr_device_class"):

--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -393,9 +393,7 @@ class StatisticsSensor(SensorEntity):
             unit = base_unit + "/s"
         return unit
 
-    @property  # type: ignore[override]
-    # Since the underlying data source may not be available at startup
-    # we disable the caching of device_class.
+    @property
     def device_class(self) -> SensorDeviceClass | None:
         """Return the class of this device."""
         if self._state_characteristic in STATS_DATETIME:

--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -8,7 +8,6 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.backports.functools import cached_property
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     SERVICE_TOGGLE,
@@ -103,7 +102,7 @@ class SwitchEntity(ToggleEntity):
     entity_description: SwitchEntityDescription
     _attr_device_class: SwitchDeviceClass | None
 
-    @cached_property
+    @property
     def device_class(self) -> SwitchDeviceClass | None:
         """Return the class of this entity."""
         if hasattr(self, "_attr_device_class"):

--- a/homeassistant/components/template/weather.py
+++ b/homeassistant/components/template/weather.py
@@ -294,9 +294,7 @@ class WeatherTemplate(TemplateEntity, WeatherEntity):
         """Return the daily forecast in native units."""
         return self._forecast_twice_daily
 
-    @property  # type: ignore[override]
-    # Because attribution is a template, it can change at any time
-    # and we don't want to cache it.
+    @property
     def attribution(self) -> str | None:
         """Return the attribution."""
         if self._attribution is None:

--- a/homeassistant/components/time/__init__.py
+++ b/homeassistant/components/time/__init__.py
@@ -8,7 +8,6 @@ from typing import final
 
 import voluptuous as vol
 
-from homeassistant.backports.functools import cached_property
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TIME
 from homeassistant.core import HomeAssistant, ServiceCall
@@ -76,7 +75,7 @@ class TimeEntity(Entity):
     _attr_device_class: None = None
     _attr_state: None = None
 
-    @cached_property
+    @property
     @final
     def device_class(self) -> None:
         """Return the device class for the entity."""

--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -552,7 +552,6 @@ class ProtectDeviceBinarySensor(ProtectDeviceEntity, BinarySensorEntity):
 
     device: Camera | Light | Sensor
     entity_description: ProtectBinaryEntityDescription
-    _device_class: BinarySensorDeviceClass | None
 
     @callback
     def _async_update_device_from_protect(self, device: ProtectModelWithId) -> None:
@@ -562,17 +561,9 @@ class ProtectDeviceBinarySensor(ProtectDeviceEntity, BinarySensorEntity):
         self._attr_is_on = entity_description.get_ufp_value(updated_device)
         # UP Sense can be any of the 3 contact sensor device classes
         if entity_description.key == _KEY_DOOR and isinstance(updated_device, Sensor):
-            self._device_class = MOUNT_DEVICE_CLASS_MAP.get(
-                self.device.mount_type, BinarySensorDeviceClass.DOOR
+            entity_description.device_class = MOUNT_DEVICE_CLASS_MAP.get(
+                updated_device.mount_type, BinarySensorDeviceClass.DOOR
             )
-        else:
-            self._device_class = self.entity_description.device_class
-
-    @property  # type: ignore[override]
-    # UFP smart sensors can change device class at runtime
-    def device_class(self) -> BinarySensorDeviceClass | None:
-        """Return the class of this sensor."""
-        return self._device_class
 
 
 class ProtectDiskBinarySensor(ProtectNVREntity, BinarySensorEntity):

--- a/homeassistant/components/update/__init__.py
+++ b/homeassistant/components/update/__init__.py
@@ -11,7 +11,6 @@ from typing import Any, Final, final
 from awesomeversion import AwesomeVersion, AwesomeVersionCompareException
 import voluptuous as vol
 
-from homeassistant.backports.functools import cached_property
 from homeassistant.components import websocket_api
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF, STATE_ON, EntityCategory
@@ -224,7 +223,7 @@ class UpdateEntity(RestoreEntity):
         """
         return self.device_class is not None
 
-    @cached_property
+    @property
     def device_class(self) -> UpdateDeviceClass | None:
         """Return the class of this entity."""
         if hasattr(self, "_attr_device_class"):

--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -8,7 +8,6 @@ import zigpy.types as t
 from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.clusters.security import IasZone
 
-from homeassistant.backports.functools import cached_property
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -196,7 +195,7 @@ class IASZone(BinarySensor):
         zone_type = self._cluster_handler.cluster.get("zone_type")
         return IAS_ZONE_NAME_MAPPING.get(zone_type, "iaszone")
 
-    @cached_property
+    @property
     def device_class(self) -> BinarySensorDeviceClass | None:
         """Return device class from component DEVICE_CLASSES."""
         zone_type = self._cluster_handler.cluster.get("zone_type")

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -645,13 +645,6 @@ class ZwaveSensor(ZWaveBaseEntity, SensorEntity):
             return None
         return str(self.info.primary_value.metadata.unit)
 
-    @property  # type: ignore[override]
-    # fget is used in the child classes which is not compatible with cached_property
-    # mypy also doesn't know about fget: https://github.com/python/mypy/issues/6185
-    def device_class(self) -> SensorDeviceClass | None:
-        """Return device class of sensor."""
-        return super().device_class
-
 
 class ZWaveNumericSensor(ZwaveSensor):
     """Representation of a Z-Wave Numeric sensor."""
@@ -744,9 +737,7 @@ class ZWaveListSensor(ZwaveSensor):
             return list(self.info.primary_value.metadata.states.values())
         return None
 
-    @property  # type: ignore[override]
-    # fget is used which is not compatible with cached_property
-    # mypy also doesn't know about fget: https://github.com/python/mypy/issues/6185
+    @property
     def device_class(self) -> SensorDeviceClass | None:
         """Return sensor device class."""
         if (device_class := super().device_class) is not None:
@@ -790,7 +781,7 @@ class ZWaveConfigParameterSensor(ZWaveListSensor):
             additional_info=[property_key_name] if property_key_name else None,
         )
 
-    @property  # type: ignore[override]
+    @property
     def device_class(self) -> SensorDeviceClass | None:
         """Return sensor device class."""
         # mypy doesn't know about fget: https://github.com/python/mypy/issues/6185

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -550,7 +550,7 @@ class Entity(ABC):
         """
         return self._attr_device_info
 
-    @cached_property
+    @property
     def device_class(self) -> str | None:
         """Return the class of this device, from component DEVICE_CLASSES."""
         if hasattr(self, "_attr_device_class"):
@@ -639,7 +639,7 @@ class Entity(ABC):
             return self.entity_description.entity_registry_visible_default
         return True
 
-    @cached_property
+    @property
     def attribution(self) -> str | None:
         """Return the attribution."""
         return self._attr_attribution
@@ -653,7 +653,7 @@ class Entity(ABC):
             return self.entity_description.entity_category
         return None
 
-    @cached_property
+    @property
     def translation_key(self) -> str | None:
         """Return the translation key to translate the entity's states."""
         if hasattr(self, "_attr_translation_key"):

--- a/tests/components/event/test_init.py
+++ b/tests/components/event/test_init.py
@@ -51,7 +51,6 @@ async def test_event() -> None:
         event.event_types
 
     # Test retrieving data from entity description
-    del event.device_class
     event.entity_description = EventEntityDescription(
         key="test_event",
         event_types=["short_press", "long_press"],
@@ -64,7 +63,6 @@ async def test_event() -> None:
     event._attr_event_types = ["short_press", "long_press", "double_press"]
     assert event.event_types == ["short_press", "long_press", "double_press"]
     event._attr_device_class = EventDeviceClass.BUTTON
-    del event.device_class
     assert event.device_class == EventDeviceClass.BUTTON
 
     # Test triggering an event

--- a/tests/components/update/test_init.py
+++ b/tests/components/update/test_init.py
@@ -59,26 +59,17 @@ class MockUpdateEntity(UpdateEntity):
     """Mock UpdateEntity to use in tests."""
 
 
-def _create_mock_update_entity(
-    hass: HomeAssistant,
-) -> MockUpdateEntity:
-    mock_platform = MockEntityPlatform(hass)
+async def test_update(hass: HomeAssistant) -> None:
+    """Test getting data from the mocked update entity."""
     update = MockUpdateEntity()
     update.hass = hass
-    update.platform = mock_platform
+    update.platform = MockEntityPlatform(hass)
 
     update._attr_installed_version = "1.0.0"
     update._attr_latest_version = "1.0.1"
     update._attr_release_summary = "Summary"
     update._attr_release_url = "https://example.com"
     update._attr_title = "Title"
-
-    return update
-
-
-async def test_update(hass: HomeAssistant) -> None:
-    """Test getting data from the mocked update entity."""
-    update = _create_mock_update_entity(hass)
 
     assert update.entity_category is EntityCategory.DIAGNOSTIC
     assert (
@@ -102,6 +93,7 @@ async def test_update(hass: HomeAssistant) -> None:
         ATTR_SKIPPED_VERSION: None,
         ATTR_TITLE: "Title",
     }
+
     # Test no update available
     update._attr_installed_version = "1.0.0"
     update._attr_latest_version = "1.0.0"
@@ -128,19 +120,14 @@ async def test_update(hass: HomeAssistant) -> None:
     assert update.state is STATE_ON
 
     # Test entity category becomes config when its possible to install
-    update = _create_mock_update_entity(hass)
     update._attr_supported_features = UpdateEntityFeature.INSTALL
     assert update.entity_category is EntityCategory.CONFIG
 
     # UpdateEntityDescription was set
-    update = _create_mock_update_entity(hass)
     update._attr_supported_features = 0
     update.entity_description = UpdateEntityDescription(key="F5 - Its very refreshing")
     assert update.device_class is None
     assert update.entity_category is EntityCategory.CONFIG
-
-    update = _create_mock_update_entity(hass)
-    update._attr_supported_features = 0
     update.entity_description = UpdateEntityDescription(
         key="F5 - Its very refreshing",
         device_class=UpdateDeviceClass.FIRMWARE,
@@ -150,24 +137,14 @@ async def test_update(hass: HomeAssistant) -> None:
     assert update.entity_category is None
 
     # Device class via attribute (override entity description)
-    update = _create_mock_update_entity(hass)
-    update._attr_supported_features = 0
     update._attr_device_class = None
     assert update.device_class is None
-
-    update = _create_mock_update_entity(hass)
-    update._attr_supported_features = 0
     update._attr_device_class = UpdateDeviceClass.FIRMWARE
     assert update.device_class is UpdateDeviceClass.FIRMWARE
 
     # Entity Attribute via attribute (override entity description)
-    update = _create_mock_update_entity(hass)
-    update._attr_supported_features = 0
     update._attr_entity_category = None
     assert update.entity_category is None
-
-    update = _create_mock_update_entity(hass)
-    update._attr_supported_features = 0
     update._attr_entity_category = EntityCategory.DIAGNOSTIC
     assert update.entity_category is EntityCategory.DIAGNOSTIC
 

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -98,13 +98,9 @@ class TestHelpersEntity:
 
     def setup_method(self, method):
         """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self._create_entity()
-
-    def _create_entity(self) -> None:
         self.entity = entity.Entity()
         self.entity.entity_id = "test.overwrite_hidden_true"
-        self.entity.hass = self.hass
+        self.hass = self.entity.hass = get_test_home_assistant()
         self.entity.schedule_update_ha_state()
         self.hass.block_till_done()
 
@@ -127,7 +123,6 @@ class TestHelpersEntity:
         with patch(
             "homeassistant.helpers.entity.Entity.device_class", new="test_class"
         ):
-            self._create_entity()
             self.entity.schedule_update_ha_state()
             self.hass.block_till_done()
         state = self.hass.states.get(self.entity.entity_id)


### PR DESCRIPTION
Reverts home-assistant/core#95315

We don't forbid entities from changing `attribution`, `device_class`, or `translation_key`, meaning the PR breaks integrations which currently do so.
As an example, it breaks MQTT which allows changing device class without destroying the entity object.

The end goal of improving performance is good, but we should discuss the means in an architecture issue.
Maybe we can find a way for integrations to opt-in to frozen attributes?