### PR TITLE
Test VIRTUAL_COUNT parameter

### DIFF
--- a/tests/components/modbus/test_binary_sensor.py
+++ b/tests/components/modbus/test_binary_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.modbus.const import (
     CONF_INPUT_TYPE,
     CONF_LAZY_ERROR,
     CONF_SLAVE_COUNT,
+    CONF_VIRTUAL_COUNT,
     MODBUS_DOMAIN,
 )
 from homeassistant.const import (
@@ -265,7 +266,7 @@ ENTITY_ID2 = f"{ENTITY_ID}_1"
                     CONF_NAME: TEST_ENTITY_NAME,
                     CONF_ADDRESS: 51,
                     CONF_SCAN_INTERVAL: 0,
-                    CONF_SLAVE_COUNT: 1,
+                    CONF_VIRTUAL_COUNT: 1,
                 }
             ]
         },
@@ -294,9 +295,18 @@ TEST_NAME = "test_sensor"
                 }
             ]
         },
+        {
+            CONF_BINARY_SENSORS: [
+                {
+                    CONF_NAME: TEST_ENTITY_NAME,
+                    CONF_ADDRESS: 51,
+                    CONF_VIRTUAL_COUNT: 3,
+                }
+            ]
+        },
     ],
 )
-async def test_config_slave_binary_sensor(hass: HomeAssistant, mock_modbus) -> None:
+async def test_config_virtual_binary_sensor(hass: HomeAssistant, mock_modbus) -> None:
     """Run config test for binary sensor."""
     assert SENSOR_DOMAIN in hass.config.components
 
@@ -356,7 +366,19 @@ async def test_config_slave_binary_sensor(hass: HomeAssistant, mock_modbus) -> N
             [STATE_OFF],
         ),
         (
+            {CONF_VIRTUAL_COUNT: 1, CONF_UNIQUE_ID: SLAVE_UNIQUE_ID},
+            [False] * 8,
+            STATE_OFF,
+            [STATE_OFF],
+        ),
+        (
             {CONF_SLAVE_COUNT: 1, CONF_UNIQUE_ID: SLAVE_UNIQUE_ID},
+            [True] + [False] * 7,
+            STATE_ON,
+            [STATE_OFF],
+        ),
+        (
+            {CONF_VIRTUAL_COUNT: 1, CONF_UNIQUE_ID: SLAVE_UNIQUE_ID},
             [True] + [False] * 7,
             STATE_ON,
             [STATE_OFF],
@@ -368,7 +390,19 @@ async def test_config_slave_binary_sensor(hass: HomeAssistant, mock_modbus) -> N
             [STATE_ON],
         ),
         (
+            {CONF_VIRTUAL_COUNT: 1, CONF_UNIQUE_ID: SLAVE_UNIQUE_ID},
+            [False, True] + [False] * 6,
+            STATE_OFF,
+            [STATE_ON],
+        ),
+        (
             {CONF_SLAVE_COUNT: 7, CONF_UNIQUE_ID: SLAVE_UNIQUE_ID},
+            [True, False] * 4,
+            STATE_ON,
+            [STATE_OFF, STATE_ON] * 3 + [STATE_OFF],
+        ),
+        (
+            {CONF_VIRTUAL_COUNT: 7, CONF_UNIQUE_ID: SLAVE_UNIQUE_ID},
             [True, False] * 4,
             STATE_ON,
             [STATE_OFF, STATE_ON] * 3 + [STATE_OFF],
@@ -379,9 +413,15 @@ async def test_config_slave_binary_sensor(hass: HomeAssistant, mock_modbus) -> N
             STATE_ON,
             [STATE_OFF, STATE_ON] * 15 + [STATE_OFF],
         ),
+        (
+            {CONF_VIRTUAL_COUNT: 31, CONF_UNIQUE_ID: SLAVE_UNIQUE_ID},
+            [True, False] * 16,
+            STATE_ON,
+            [STATE_OFF, STATE_ON] * 15 + [STATE_OFF],
+        ),
     ],
 )
-async def test_slave_binary_sensor(
+async def test_virtual_binary_sensor(
     hass: HomeAssistant, expected, slaves, mock_do_cycle
 ) -> None:
     """Run test for given config."""

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -50,6 +50,7 @@ from homeassistant.components.modbus.const import (
     CONF_SWAP_BYTE,
     CONF_SWAP_WORD,
     CONF_SWAP_WORD_BYTE,
+    CONF_VIRTUAL_COUNT,
     DEFAULT_SCAN_INTERVAL,
     MODBUS_DOMAIN as DOMAIN,
     RTUOVERTCP,
@@ -265,8 +266,20 @@ async def test_ok_struct_validator(do_config) -> None:
         },
         {
             CONF_NAME: TEST_ENTITY_NAME,
+            CONF_COUNT: 2,
+            CONF_DATA_TYPE: DataType.CUSTOM,
+            CONF_STRUCTURE: ">f",
+            CONF_VIRTUAL_COUNT: 5,
+        },
+        {
+            CONF_NAME: TEST_ENTITY_NAME,
             CONF_DATA_TYPE: DataType.STRING,
             CONF_SLAVE_COUNT: 2,
+        },
+        {
+            CONF_NAME: TEST_ENTITY_NAME,
+            CONF_DATA_TYPE: DataType.STRING,
+            CONF_VIRTUAL_COUNT: 2,
         },
         {
             CONF_NAME: TEST_ENTITY_NAME,
@@ -277,6 +290,12 @@ async def test_ok_struct_validator(do_config) -> None:
             CONF_NAME: TEST_ENTITY_NAME,
             CONF_COUNT: 2,
             CONF_SLAVE_COUNT: 2,
+            CONF_DATA_TYPE: DataType.INT32,
+        },
+        {
+            CONF_NAME: TEST_ENTITY_NAME,
+            CONF_COUNT: 2,
+            CONF_VIRTUAL_COUNT: 2,
             CONF_DATA_TYPE: DataType.INT32,
         },
         {

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -21,6 +21,7 @@ from homeassistant.components.modbus.const import (
     CONF_SWAP_NONE,
     CONF_SWAP_WORD,
     CONF_SWAP_WORD_BYTE,
+    CONF_VIRTUAL_COUNT,
     CONF_ZERO_SUPPRESS,
     MODBUS_DOMAIN,
     DataType,
@@ -147,6 +148,16 @@ SLAVE_UNIQUE_ID = "ground_floor_sensor"
                     CONF_ADDRESS: 51,
                     CONF_DATA_TYPE: DataType.INT32,
                     CONF_SLAVE_COUNT: 5,
+                }
+            ]
+        },
+        {
+            CONF_SENSORS: [
+                {
+                    CONF_NAME: TEST_ENTITY_NAME,
+                    CONF_ADDRESS: 51,
+                    CONF_DATA_TYPE: DataType.INT32,
+                    CONF_VIRTUAL_COUNT: 5,
                 }
             ]
         },
@@ -673,6 +684,21 @@ async def test_all_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> None:
         ),
         (
             {
+                CONF_VIRTUAL_COUNT: 1,
+                CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
+                CONF_DATA_TYPE: DataType.FLOAT32,
+            },
+            [
+                0x5102,
+                0x0304,
+                int.from_bytes(struct.pack(">f", float("nan"))[0:2]),
+                int.from_bytes(struct.pack(">f", float("nan"))[2:4]),
+            ],
+            False,
+            ["34899771392", "0"],
+        ),
+        (
+            {
                 CONF_SLAVE_COUNT: 0,
                 CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
             },
@@ -682,7 +708,25 @@ async def test_all_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> None:
         ),
         (
             {
+                CONF_VIRTUAL_COUNT: 0,
+                CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
+            },
+            [0x0102, 0x0304],
+            False,
+            ["16909060"],
+        ),
+        (
+            {
                 CONF_SLAVE_COUNT: 1,
+                CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
+            },
+            [0x0102, 0x0304, 0x0403, 0x0201],
+            False,
+            ["16909060", "67305985"],
+        ),
+        (
+            {
+                CONF_VIRTUAL_COUNT: 1,
                 CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
             },
             [0x0102, 0x0304, 0x0403, 0x0201],
@@ -714,7 +758,39 @@ async def test_all_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> None:
         ),
         (
             {
+                CONF_VIRTUAL_COUNT: 3,
+                CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
+            },
+            [
+                0x0102,
+                0x0304,
+                0x0506,
+                0x0708,
+                0x090A,
+                0x0B0C,
+                0x0D0E,
+                0x0F00,
+            ],
+            False,
+            [
+                "16909060",
+                "84281096",
+                "151653132",
+                "219025152",
+            ],
+        ),
+        (
+            {
                 CONF_SLAVE_COUNT: 1,
+                CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
+            },
+            [0x0102, 0x0304, 0x0403, 0x0201],
+            True,
+            [STATE_UNAVAILABLE, STATE_UNKNOWN],
+        ),
+        (
+            {
+                CONF_VIRTUAL_COUNT: 1,
                 CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
             },
             [0x0102, 0x0304, 0x0403, 0x0201],
@@ -730,9 +806,18 @@ async def test_all_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> None:
             False,
             [STATE_UNAVAILABLE, STATE_UNKNOWN],
         ),
+        (
+            {
+                CONF_VIRTUAL_COUNT: 1,
+                CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
+            },
+            [],
+            False,
+            [STATE_UNAVAILABLE, STATE_UNKNOWN],
+        ),
     ],
 )
-async def test_slave_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> None:
+async def test_virtual_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> None:
     """Run test for sensor."""
     entity_registry = er.async_get(hass)
     for i in range(0, len(expected)):
@@ -766,7 +851,7 @@ async def test_slave_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> Non
     [
         (
             {
-                CONF_SLAVE_COUNT: 0,
+                CONF_VIRTUAL_COUNT: 0,
                 CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
                 CONF_SWAP: CONF_SWAP_BYTE,
                 CONF_DATA_TYPE: DataType.UINT16,
@@ -777,7 +862,7 @@ async def test_slave_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> Non
         ),
         (
             {
-                CONF_SLAVE_COUNT: 0,
+                CONF_VIRTUAL_COUNT: 0,
                 CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
                 CONF_SWAP: CONF_SWAP_WORD,
                 CONF_DATA_TYPE: DataType.UINT32,
@@ -788,7 +873,7 @@ async def test_slave_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> Non
         ),
         (
             {
-                CONF_SLAVE_COUNT: 0,
+                CONF_VIRTUAL_COUNT: 0,
                 CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
                 CONF_SWAP: CONF_SWAP_WORD,
                 CONF_DATA_TYPE: DataType.UINT64,
@@ -799,7 +884,7 @@ async def test_slave_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> Non
         ),
         (
             {
-                CONF_SLAVE_COUNT: 1,
+                CONF_VIRTUAL_COUNT: 1,
                 CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
                 CONF_DATA_TYPE: DataType.UINT16,
                 CONF_SWAP: CONF_SWAP_BYTE,
@@ -810,7 +895,7 @@ async def test_slave_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> Non
         ),
         (
             {
-                CONF_SLAVE_COUNT: 1,
+                CONF_VIRTUAL_COUNT: 1,
                 CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
                 CONF_DATA_TYPE: DataType.UINT32,
                 CONF_SWAP: CONF_SWAP_WORD,
@@ -821,7 +906,7 @@ async def test_slave_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> Non
         ),
         (
             {
-                CONF_SLAVE_COUNT: 1,
+                CONF_VIRTUAL_COUNT: 1,
                 CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
                 CONF_DATA_TYPE: DataType.UINT64,
                 CONF_SWAP: CONF_SWAP_WORD,
@@ -832,7 +917,7 @@ async def test_slave_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> Non
         ),
         (
             {
-                CONF_SLAVE_COUNT: 3,
+                CONF_VIRTUAL_COUNT: 3,
                 CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
                 CONF_DATA_TYPE: DataType.UINT16,
                 CONF_SWAP: CONF_SWAP_BYTE,
@@ -843,7 +928,7 @@ async def test_slave_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> Non
         ),
         (
             {
-                CONF_SLAVE_COUNT: 3,
+                CONF_VIRTUAL_COUNT: 3,
                 CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
                 CONF_DATA_TYPE: DataType.UINT32,
                 CONF_SWAP: CONF_SWAP_WORD,
@@ -868,7 +953,7 @@ async def test_slave_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> Non
         ),
         (
             {
-                CONF_SLAVE_COUNT: 3,
+                CONF_VIRTUAL_COUNT: 3,
                 CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
                 CONF_DATA_TYPE: DataType.UINT64,
                 CONF_SWAP: CONF_SWAP_WORD,
@@ -901,7 +986,9 @@ async def test_slave_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> Non
         ),
     ],
 )
-async def test_slave_swap_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> None:
+async def test_virtual_swap_sensor(
+    hass: HomeAssistant, mock_do_cycle, expected
+) -> None:
     """Run test for sensor."""
     for i in range(0, len(expected)):
         entity_id = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
@@ -1230,7 +1317,7 @@ async def mock_restore(hass):
                     CONF_NAME: TEST_ENTITY_NAME,
                     CONF_ADDRESS: 51,
                     CONF_SCAN_INTERVAL: 0,
-                    CONF_SLAVE_COUNT: 1,
+                    CONF_VIRTUAL_COUNT: 1,
                 }
             ]
         },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added tests for the newly added VIRTUAL_COUNT parameter.

Basically all tests with SLAVE_COUNT have been duplicated with VIRTUAL_COUNT,
that way it is secured that all corner cases are covered (since it was the case with SLAVE_COUNT alone).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
