### PR TITLE
Avoid redundant calls to `async_ha_write_state` in MQTT (binary) sensor

### DIFF
--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -221,7 +221,7 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity, RestoreEntity):
                     self._config.get(CONF_VALUE_TEMPLATE),
                 )
                 return
-
+            last_is_on_state = self._attr_is_on
             if payload == self._config[CONF_PAYLOAD_ON]:
                 self._attr_is_on = True
             elif payload == self._config[CONF_PAYLOAD_OFF]:
@@ -257,6 +257,8 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity, RestoreEntity):
                     self.hass, off_delay, off_delay_listener
                 )
 
+            if last_is_on_state == self._attr_is_on and not self._attr_force_update:
+                return
             get_mqtt_data(self.hass).state_write_requests.write_state_request(self)
 
         self._sub_state = subscription.async_prepare_subscribe_topics(

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -43,7 +43,7 @@ from .mixins import (
     MqttAvailability,
     MqttEntity,
     async_setup_entry_helper,
-    track_state_attribute_writes,
+    write_state_on_attr_change,
 )
 from .models import MqttValueTemplate, ReceiveMessage
 
@@ -191,7 +191,7 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity, RestoreEntity):
 
         @callback
         @log_messages(self.hass, self.entity_id)
-        @track_state_attribute_writes(self, {"_attr_is_on"})
+        @write_state_on_attr_change(self, {"_attr_is_on"})
         def state_message_received(msg: ReceiveMessage) -> None:
             """Handle a new received MQTT state message."""
             # auto-expire enabled?

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -44,7 +44,7 @@ from .mixins import (
     MqttEntity,
     async_setup_entry_helper,
 )
-from .models import MqttValueTemplate, ReceiveMessage
+from .models import EntityMonitor, MqttValueTemplate, ReceiveMessage
 from .util import get_mqtt_data
 
 _LOGGER = logging.getLogger(__name__)
@@ -221,7 +221,7 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity, RestoreEntity):
                     self._config.get(CONF_VALUE_TEMPLATE),
                 )
                 return
-            last_is_on_state = self._attr_is_on
+            monitor = EntityMonitor(self, {"_attr_is_on"})
             if payload == self._config[CONF_PAYLOAD_ON]:
                 self._attr_is_on = True
             elif payload == self._config[CONF_PAYLOAD_OFF]:
@@ -257,9 +257,9 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity, RestoreEntity):
                     self.hass, off_delay, off_delay_listener
                 )
 
-            if last_is_on_state == self._attr_is_on and not self._attr_force_update:
-                return
-            get_mqtt_data(self.hass).state_write_requests.write_state_request(self)
+            get_mqtt_data(self.hass).state_write_requests.write_state_request(
+                self, monitor
+            )
 
         self._sub_state = subscription.async_prepare_subscribe_topics(
             self.hass,

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -44,7 +44,7 @@ from .mixins import (
     MqttEntity,
     async_setup_entry_helper,
 )
-from .models import EntityMonitor, MqttValueTemplate, ReceiveMessage
+from .models import MqttValueTemplate, ReceiveMessage
 from .util import get_mqtt_data
 
 _LOGGER = logging.getLogger(__name__)
@@ -221,7 +221,7 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity, RestoreEntity):
                     self._config.get(CONF_VALUE_TEMPLATE),
                 )
                 return
-            monitor = EntityMonitor(self, {"_attr_is_on"})
+            self.monitor.track({"_attr_is_on"})
             if payload == self._config[CONF_PAYLOAD_ON]:
                 self._attr_is_on = True
             elif payload == self._config[CONF_PAYLOAD_OFF]:
@@ -257,9 +257,7 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity, RestoreEntity):
                     self.hass, off_delay, off_delay_listener
                 )
 
-            get_mqtt_data(self.hass).state_write_requests.write_state_request(
-                self, monitor
-            )
+            get_mqtt_data(self.hass).state_write_requests.write_state_request(self)
 
         self._sub_state = subscription.async_prepare_subscribe_topics(
             self.hass,

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -43,9 +43,9 @@ from .mixins import (
     MqttAvailability,
     MqttEntity,
     async_setup_entry_helper,
+    track_state_attribute_writes,
 )
 from .models import MqttValueTemplate, ReceiveMessage
-from .util import get_mqtt_data
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -191,6 +191,7 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity, RestoreEntity):
 
         @callback
         @log_messages(self.hass, self.entity_id)
+        @track_state_attribute_writes(self, {"_attr_is_on"})
         def state_message_received(msg: ReceiveMessage) -> None:
             """Handle a new received MQTT state message."""
             # auto-expire enabled?
@@ -221,7 +222,6 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity, RestoreEntity):
                     self._config.get(CONF_VALUE_TEMPLATE),
                 )
                 return
-            self.monitor.track({"_attr_is_on"})
             if payload == self._config[CONF_PAYLOAD_ON]:
                 self._attr_is_on = True
             elif payload == self._config[CONF_PAYLOAD_OFF]:
@@ -256,8 +256,6 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity, RestoreEntity):
                 self._delay_listener = evt.async_call_later(
                     self.hass, off_delay, off_delay_listener
                 )
-
-            get_mqtt_data(self.hass).state_write_requests.write_state_request(self)
 
         self._sub_state = subscription.async_prepare_subscribe_topics(
             self.hass,

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -222,6 +222,7 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity, RestoreEntity):
                     self._config.get(CONF_VALUE_TEMPLATE),
                 )
                 return
+
             if payload == self._config[CONF_PAYLOAD_ON]:
                 self._attr_is_on = True
             elif payload == self._config[CONF_PAYLOAD_OFF]:

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -101,6 +101,7 @@ from .discovery import (
     set_discovery_hash,
 )
 from .models import (
+    EntityMonitor,
     MqttValueTemplate,
     PublishPayloadType,
     ReceiveMessage,
@@ -392,7 +393,7 @@ class MqttAttributes(Entity):
                     }
                     self._attr_extra_state_attributes = filtered_dict
                     get_mqtt_data(self.hass).state_write_requests.write_state_request(
-                        self
+                        self  # type: ignore[arg-type]
                     )
                 else:
                     _LOGGER.warning("JSON result was not a dictionary")
@@ -500,7 +501,7 @@ class MqttAvailability(Entity):
                 self._available[topic] = False
                 self._available_latest = False
 
-            get_mqtt_data(self.hass).state_write_requests.write_state_request(self)
+            get_mqtt_data(self.hass).state_write_requests.write_state_request(self)  # type: ignore[arg-type]
 
         self._available = {
             topic: (self._available[topic] if topic in self._available else False)
@@ -1030,6 +1031,7 @@ class MqttEntity(
         """Init the MQTT Entity."""
         self.hass = hass
         self._config: ConfigType = config
+        self.monitor = EntityMonitor(self)
         self._attr_unique_id = config.get(CONF_UNIQUE_ID)
         self._sub_state: dict[str, EntitySubscription] = {}
         self._discovery = discovery_data is not None

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -347,7 +347,7 @@ def init_entity_id_from_config(
         )
 
 
-def track_state_attribute_writes(
+def write_state_on_attr_change(
     entity: Entity, attributes: set[str]
 ) -> Callable[[MessageCallbackType], MessageCallbackType]:
     """Wrap an MQTT message callback to track state attribute changes."""
@@ -415,7 +415,7 @@ class MqttAttributes(Entity):
 
         @callback
         @log_messages(self.hass, self.entity_id)
-        @track_state_attribute_writes(self, {"_attr_extra_state_attributes"})
+        @write_state_on_attr_change(self, {"_attr_extra_state_attributes"})
         def attributes_message_received(msg: ReceiveMessage) -> None:
             try:
                 payload = attr_tpl(msg.payload)
@@ -522,7 +522,7 @@ class MqttAvailability(Entity):
 
         @callback
         @log_messages(self.hass, self.entity_id)
-        @track_state_attribute_writes(self, {"available"})
+        @write_state_on_attr_change(self, {"available"})
         def availability_message_received(msg: ReceiveMessage) -> None:
             """Handle a new received MQTT availability message."""
             topic = msg.topic

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -354,13 +354,13 @@ def write_state_on_attr_change(
 
     def _attrs_have_changed(tracked_attrs: dict[str, Any]) -> bool:
         """Return True if attributes on entity changed or if update is forced."""
-        if not (assume_has_changed := (getattr(entity, "_attr_force_update", False))):
+        if not (write_state := (getattr(entity, "_attr_force_update", False))):
             for attribute, last_value in tracked_attrs.items():
                 if getattr(entity, attribute, UNDEFINED) != last_value:
-                    assume_has_changed = True
+                    write_state = True
                     break
 
-        return assume_has_changed
+        return write_state
 
     def _decorator(msg_callback: MessageCallbackType) -> MessageCallbackType:
         @wraps(msg_callback)

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -381,6 +381,7 @@ class MqttAttributes(Entity):
         @callback
         @log_messages(self.hass, self.entity_id)
         def attributes_message_received(msg: ReceiveMessage) -> None:
+            self.monitor.track({"_attr_extra_state_attributes"})  # type: ignore[attr-defined]
             try:
                 payload = attr_tpl(msg.payload)
                 json_dict = json_loads(payload) if isinstance(payload, str) else None
@@ -494,6 +495,7 @@ class MqttAvailability(Entity):
             topic = msg.topic
             payload: ReceivePayloadType
             payload = self._avail_topics[topic][CONF_AVAILABILITY_TEMPLATE](msg.payload)
+            self.monitor.track({"available"})  # type: ignore[attr-defined]
             if payload == self._avail_topics[topic][CONF_PAYLOAD_AVAILABLE]:
                 self._available[topic] = True
                 self._available_latest = True

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -351,6 +351,7 @@ class MqttAttributes(Entity):
     """Mixin used for platforms that support JSON attributes."""
 
     _attributes_extra_blocked: frozenset[str] = frozenset()
+    monitor: EntityMonitor
 
     def __init__(self, config: ConfigType) -> None:
         """Initialize the JSON attributes mixin."""
@@ -381,7 +382,7 @@ class MqttAttributes(Entity):
         @callback
         @log_messages(self.hass, self.entity_id)
         def attributes_message_received(msg: ReceiveMessage) -> None:
-            self.monitor.track({"_attr_extra_state_attributes"})  # type: ignore[attr-defined]
+            self.monitor.track({"_attr_extra_state_attributes"})
             try:
                 payload = attr_tpl(msg.payload)
                 json_dict = json_loads(payload) if isinstance(payload, str) else None
@@ -427,6 +428,8 @@ class MqttAttributes(Entity):
 
 class MqttAvailability(Entity):
     """Mixin used for platforms that report availability."""
+
+    monitor: EntityMonitor
 
     def __init__(self, config: ConfigType) -> None:
         """Initialize the availability mixin."""
@@ -495,7 +498,7 @@ class MqttAvailability(Entity):
             topic = msg.topic
             payload: ReceivePayloadType
             payload = self._avail_topics[topic][CONF_AVAILABILITY_TEMPLATE](msg.payload)
-            self.monitor.track({"available"})  # type: ignore[attr-defined]
+            self.monitor.track({"available"})
             if payload == self._avail_topics[topic][CONF_PAYLOAD_AVAILABLE]:
                 self._available[topic] = True
                 self._available_latest = True

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -18,7 +18,13 @@ from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers import template
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.service_info.mqtt import ReceivePayloadType
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, TemplateVarsType
+from homeassistant.helpers.typing import (
+    UNDEFINED,
+    ConfigType,
+    DiscoveryInfoType,
+    TemplateVarsType,
+    UndefinedType,
+)
 
 if TYPE_CHECKING:
     from paho.mqtt.client import MQTTMessage
@@ -292,7 +298,7 @@ class MqttValueTemplate:
 class EntityMonitor:
     """Monitors entity state changes."""
 
-    _singleton: object = object()
+    _singleton: UndefinedType = UNDEFINED
 
     def __init__(self, entity: Entity, attributes: set[str]) -> None:
         """Initialize entity monitor."""

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from .debug_info import TimestampedPublishMessage
     from .device_trigger import Trigger
     from .discovery import MQTTDiscoveryPayload
-    from .mixins import MqttEntity
+    from .mixins import MqttMonitorEntity
     from .tag import MQTTTagScanner
 
 
@@ -339,7 +339,7 @@ class EntityTopicState:
 
     def __init__(self) -> None:
         """Register topic."""
-        self.subscribe_calls: dict[str, MqttEntity] = {}
+        self.subscribe_calls: dict[str, MqttMonitorEntity] = {}
 
     @callback
     def process_write_state_requests(self, msg: MQTTMessage) -> None:
@@ -358,7 +358,7 @@ class EntityTopicState:
                 )
 
     @callback
-    def write_state_request(self, entity: MqttEntity) -> None:
+    def write_state_request(self, entity: MqttMonitorEntity) -> None:
         """Register write state request."""
         if not entity.monitor.assume_has_changed:
             # no change detected skip state write request

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -295,7 +295,7 @@ class MqttValueTemplate:
         return rendered_payload
 
 
-class EntityMonitor:
+class EntityAttributeTracker:
     """Monitors entity state changes."""
 
     __slots__ = ("_entity", "_attributes")
@@ -306,15 +306,7 @@ class EntityMonitor:
         self._attributes: dict[str, Any] = {}
 
     def track(self, attributes: set[str]) -> None:
-        """Start tracking attributes.
-
-        Only requests a write state request for the MQTT entity
-        if one or more of the passed properties had changes.
-        If MqttMonitorEntity.write_state_request is called without
-        `MqttMonitorEntity.monitor.track`, the state write request is passed
-        and Entity.async_ha_write_state will be triggered
-        to check all properties for changes.
-        """
+        """Start tracking attributes."""
         self._attributes = {
             attribute: getattr(self._entity, attribute, UNDEFINED)
             for attribute in attributes
@@ -368,9 +360,6 @@ class EntityTopicState:
     @callback
     def write_state_request(self, entity: MqttMonitorEntity) -> None:
         """Register write state request."""
-        if not entity.monitor.attrs_have_changed:
-            # no change detected skip state write request
-            return
         self.subscribe_calls[entity.entity_id] = entity
 
 

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -298,7 +298,7 @@ class MqttValueTemplate:
 class EntityMonitor:
     """Monitors entity state changes."""
 
-    __slots__ = ["_entity", "_attributes"]
+    __slots__ = ("_entity", "_attributes")
 
     def __init__(self, entity: Entity) -> None:
         """Initialize entity monitor."""

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -298,6 +298,8 @@ class MqttValueTemplate:
 class EntityMonitor:
     """Monitors entity state changes."""
 
+    __slots__ = ["_entity", "_attributes"]
+
     def __init__(self, entity: Entity) -> None:
         """Initialize entity monitor."""
         self._entity: Entity = entity

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -318,15 +318,19 @@ class EntityMonitor:
 
         Stops tracking attribute changes.
         """
-        assume_has_changed = (
-            getattr(self._entity, "_attr_force_update", False)
-            or not self._attributes
-            or any(
-                getattr(self._entity, attribute, UNDEFINED) != last_value
-                for attribute, last_value in self._attributes.items()
+        entity = self._entity
+        attributes = self._attributes
+        if not (
+            assume_has_changed := (
+                getattr(entity, "_attr_force_update", False) or not attributes
             )
-        )
-        self._attributes = {}
+        ):
+            for attribute, last_value in attributes.items():
+                if getattr(entity, attribute, UNDEFINED) != last_value:
+                    assume_has_changed = True
+                    break
+
+        attributes.clear()
         return assume_has_changed
 
 

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -308,7 +308,7 @@ class EntityMonitor:
     def track(self, attributes: set[str]) -> None:
         """Start tracking attributes.
 
-        Only requests a MqttMonitorEntity.write_state_request()
+        Only requests a write state request for the MQTT entity
         if one or more of the passed properties had changes.
         If MqttMonitorEntity.write_state_request is called without
         `MqttMonitorEntity.monitor.track`, the state write request is passed

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -350,7 +350,6 @@ class EntityTopicState:
         if monitor and not monitor.changed:
             # no change detected skip state write request
             return
-        del monitor
         self.subscribe_calls[entity.entity_id] = entity
 
 

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -45,6 +45,7 @@ from .mixins import (
     MqttAvailability,
     MqttEntity,
     async_setup_entry_helper,
+    track_state_attribute_writes,
 )
 from .models import (
     MqttValueTemplate,
@@ -52,7 +53,6 @@ from .models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
-from .util import get_mqtt_data
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -287,14 +287,13 @@ class MqttSensor(MqttEntity, RestoreSensor):
                 )
 
         @callback
+        @track_state_attribute_writes(self, {"_attr_native_value", "_attr_last_reset"})
         @log_messages(self.hass, self.entity_id)
         def message_received(msg: ReceiveMessage) -> None:
             """Handle new MQTT messages."""
-            self.monitor.track({"_attr_native_value", "_attr_last_reset"})
             _update_state(msg)
             if CONF_LAST_RESET_VALUE_TEMPLATE in self._config:
                 _update_last_reset(msg)
-            get_mqtt_data(self.hass).state_write_requests.write_state_request(self)
 
         topics["state_topic"] = {
             "topic": self._config[CONF_STATE_TOPIC],

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -290,9 +290,17 @@ class MqttSensor(MqttEntity, RestoreSensor):
         @log_messages(self.hass, self.entity_id)
         def message_received(msg: ReceiveMessage) -> None:
             """Handle new MQTT messages."""
+            last_native_value = self._attr_native_value
+            last_last_reset = self._attr_last_reset
             _update_state(msg)
             if CONF_LAST_RESET_VALUE_TEMPLATE in self._config:
                 _update_last_reset(msg)
+            if (
+                last_native_value == self._attr_native_value
+                and last_last_reset == self._attr_last_reset
+                and not self._attr_force_update
+            ):
+                return
             get_mqtt_data(self.hass).state_write_requests.write_state_request(self)
 
         topics["state_topic"] = {

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -45,7 +45,7 @@ from .mixins import (
     MqttAvailability,
     MqttEntity,
     async_setup_entry_helper,
-    track_state_attribute_writes,
+    write_state_on_attr_change,
 )
 from .models import (
     MqttValueTemplate,
@@ -287,7 +287,7 @@ class MqttSensor(MqttEntity, RestoreSensor):
                 )
 
         @callback
-        @track_state_attribute_writes(self, {"_attr_native_value", "_attr_last_reset"})
+        @write_state_on_attr_change(self, {"_attr_native_value", "_attr_last_reset"})
         @log_messages(self.hass, self.entity_id)
         def message_received(msg: ReceiveMessage) -> None:
             """Handle new MQTT messages."""

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -47,7 +47,6 @@ from .mixins import (
     async_setup_entry_helper,
 )
 from .models import (
-    EntityMonitor,
     MqttValueTemplate,
     PayloadSentinel,
     ReceiveMessage,
@@ -291,13 +290,11 @@ class MqttSensor(MqttEntity, RestoreSensor):
         @log_messages(self.hass, self.entity_id)
         def message_received(msg: ReceiveMessage) -> None:
             """Handle new MQTT messages."""
-            monitor = EntityMonitor(self, {"_attr_native_value", "_attr_last_reset"})
+            self.monitor.track({"_attr_native_value", "_attr_last_reset"})
             _update_state(msg)
             if CONF_LAST_RESET_VALUE_TEMPLATE in self._config:
                 _update_last_reset(msg)
-            get_mqtt_data(self.hass).state_write_requests.write_state_request(
-                self, monitor
-            )
+            get_mqtt_data(self.hass).state_write_requests.write_state_request(self)
 
         topics["state_topic"] = {
             "topic": self._config[CONF_STATE_TOPIC],

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -47,6 +47,7 @@ from .mixins import (
     async_setup_entry_helper,
 )
 from .models import (
+    EntityMonitor,
     MqttValueTemplate,
     PayloadSentinel,
     ReceiveMessage,
@@ -290,18 +291,13 @@ class MqttSensor(MqttEntity, RestoreSensor):
         @log_messages(self.hass, self.entity_id)
         def message_received(msg: ReceiveMessage) -> None:
             """Handle new MQTT messages."""
-            last_native_value = self._attr_native_value
-            last_last_reset = self._attr_last_reset
+            monitor = EntityMonitor(self, {"_attr_native_value", "_attr_last_reset"})
             _update_state(msg)
             if CONF_LAST_RESET_VALUE_TEMPLATE in self._config:
                 _update_last_reset(msg)
-            if (
-                last_native_value == self._attr_native_value
-                and last_last_reset == self._attr_last_reset
-                and not self._attr_force_update
-            ):
-                return
-            get_mqtt_data(self.hass).state_write_requests.write_state_request(self)
+            get_mqtt_data(self.hass).state_write_requests.write_state_request(
+                self, monitor
+            )
 
         topics["state_topic"] = {
             "topic": self._config[CONF_STATE_TOPIC],

--- a/tests/components/mqtt/test_common.py
+++ b/tests/components/mqtt/test_common.py
@@ -1925,3 +1925,28 @@ async def help_test_discovery_setup(
     await hass.async_block_till_done()
     state = hass.states.get(f"{domain}.{name}")
     assert state and state.state is not None
+
+
+async def help_test_skipped_async_ha_write_state(
+    hass: HomeAssistant, topic: str, payload1: str, payload2: str
+) -> None:
+    """Test entity.async_ha_write_state is only called on changes."""
+    with patch(
+        "homeassistant.components.mqtt.mixins.MqttEntity.async_write_ha_state"
+    ) as mock_async_ha_write_state:
+        assert len(mock_async_ha_write_state.mock_calls) == 0
+        async_fire_mqtt_message(hass, topic, payload1)
+        await hass.async_block_till_done()
+        assert len(mock_async_ha_write_state.mock_calls) == 1
+
+        async_fire_mqtt_message(hass, topic, payload1)
+        await hass.async_block_till_done()
+        assert len(mock_async_ha_write_state.mock_calls) == 1
+
+        async_fire_mqtt_message(hass, topic, payload2)
+        await hass.async_block_till_done()
+        assert len(mock_async_ha_write_state.mock_calls) == 2
+
+        async_fire_mqtt_message(hass, topic, payload2)
+        await hass.async_block_till_done()
+        assert len(mock_async_ha_write_state.mock_calls) == 2

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -60,6 +60,7 @@ from .test_common import (
     help_test_setting_attribute_via_mqtt_json_message,
     help_test_setting_attribute_with_template,
     help_test_setting_blocked_attribute_via_mqtt_json_message,
+    help_test_skipped_async_ha_write_state,
     help_test_unique_id,
     help_test_unload_config_entry_with_platform,
     help_test_update_with_json_attrs_bad_json,
@@ -1437,3 +1438,38 @@ async def test_entity_name(
     await help_test_entity_name(
         hass, mqtt_mock_entry, domain, config, expected_friendly_name, device_class
     )
+
+
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        help_custom_config(
+            sensor.DOMAIN,
+            DEFAULT_CONFIG,
+            (
+                {
+                    "availability_topic": "availability-topic",
+                    "json_attributes_topic": "json-attributes-topic",
+                },
+            ),
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    ("topic", "payload1", "payload2"),
+    [
+        ("test-topic", "val1", "val2"),
+        ("availability-topic", "online", "offline"),
+        ("json-attributes-topic", '{"attr1": "val1"}', '{"attr1": "val2"}'),
+    ],
+)
+async def test_skipped_async_ha_write_state(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    topic: str,
+    payload1: str,
+    payload2: str,
+) -> None:
+    """Test a write state command is only called when there is change."""
+    await mqtt_mock_entry()
+    await help_test_skipped_async_ha_write_state(hass, topic, payload1, payload2)

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -1450,6 +1450,8 @@ async def test_entity_name(
                 {
                     "availability_topic": "availability-topic",
                     "json_attributes_topic": "json-attributes-topic",
+                    "value_template": "{{ value_json.state }}",
+                    "last_reset_value_template": "{{ value_json.last_reset }}",
                 },
             ),
         )
@@ -1458,7 +1460,12 @@ async def test_entity_name(
 @pytest.mark.parametrize(
     ("topic", "payload1", "payload2"),
     [
-        ("test-topic", "val1", "val2"),
+        ("test-topic", '{"state":"val1"}', '{"state":"val2"}'),
+        (
+            "test-topic",
+            '{"last_reset":"2023-09-15 15:11:03"}',
+            '{"last_reset":"2023-09-16 15:11:02"}',
+        ),
         ("availability-topic", "online", "offline"),
         ("json-attributes-topic", '{"attr1": "val1"}', '{"attr1": "val2"}'),
     ],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Only call `async_ha_write_state` on state changes.

The PR adds a decorator `track_state_attribute_writes` to simplify monitoring attribute changes and triggering state writes. This decocrator tracks changes to state attributes passed as an argument and and will only call trigger state writes using `get_mqtt_data(self.hass).state_write_requests.write_state_request(self)` when needed.

Without the decorator, it is still required to call  `get_mqtt_data(self.hass).state_write_requests.write_state_request(self)` and then the changes are detected at core level asking more performance. In followup PR's all message handling will be refactored using the new decorator.

This PR handles the `sensor`'s state and `last_reset` and `binary_sensor` state.
The `availability` and `extra_state_attributes` are handled for all MQTT entities.
A common test helper has been added to make it easy to extend the tests to test all decorator usage.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
