### PR TITLE
Avoid writing unifiprotect state when nothing has changed

### DIFF
--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -626,7 +626,7 @@ class ProtectEventBinarySensor(EventEntityMixin, BinarySensorEntity):
     def _async_updated_event(self, device: ProtectModelWithId) -> None:
         """Call back for incoming data that only writes when state has changed.
 
-        Only the is_on, _attr_extra_state_attributes, and available are every
+        Only the is_on, _attr_extra_state_attributes, and available are ever
         updated for these entities, and since the websocket update for the
         device will trigger an update for all entities connected to the device,
         we want to avoid writing state unless something has actually changed.
@@ -636,9 +636,8 @@ class ProtectEventBinarySensor(EventEntityMixin, BinarySensorEntity):
         previous_extra_state_attributes = self._attr_extra_state_attributes
         self._async_update_device_from_protect(device)
         if (
-            self._attr_is_on == previous_is_on
-            and self._attr_extra_state_attributes == previous_extra_state_attributes
-            and self._attr_available == previous_available
+            self._attr_is_on != previous_is_on
+            or self._attr_extra_state_attributes != previous_extra_state_attributes
+            or self._attr_available != previous_available
         ):
-            return
-        self.async_write_ha_state()
+            self.async_write_ha_state()

--- a/homeassistant/components/unifiprotect/button.py
+++ b/homeassistant/components/unifiprotect/button.py
@@ -193,3 +193,17 @@ class ProtectButton(ProtectDeviceEntity, ButtonEntity):
 
         if self.entity_description.ufp_press is not None:
             await getattr(self.device, self.entity_description.ufp_press)()
+
+    @callback
+    def _async_updated_event(self, device: ProtectModelWithId) -> None:
+        """Call back for incoming data that only writes when state has changed.
+
+        Only available is updated for these entities, and since the websocket
+        update for the device will trigger an update for all entities connected
+        to the device, we want to avoid writing state unless something has
+        actually changed.
+        """
+        previous_available = self._attr_available
+        self._async_update_device_from_protect(device)
+        if self._attr_available != previous_available:
+            self.async_write_ha_state()

--- a/homeassistant/components/unifiprotect/media_player.py
+++ b/homeassistant/components/unifiprotect/media_player.py
@@ -115,6 +115,26 @@ class ProtectMediaPlayer(ProtectDeviceEntity, MediaPlayerEntity):
         )
         self._attr_available = is_connected and updated_device.feature_flags.has_speaker
 
+    @callback
+    def _async_updated_event(self, device: ProtectModelWithId) -> None:
+        """Call back for incoming data that only writes when state has changed.
+
+        Only the state, volume, and available are ever updated for these
+        entities, and since the websocket update for the device will trigger
+        an update for all entities connected to the device, we want to avoid
+        writing state unless something has actually changed.
+        """
+        previous_state = self._attr_state
+        previous_available = self._attr_available
+        previous_volume_level = self._attr_volume_level
+        self._async_update_device_from_protect(device)
+        if (
+            self._attr_state != previous_state
+            or self._attr_volume_level != previous_volume_level
+            or self._attr_available != previous_available
+        ):
+            self.async_write_ha_state()
+
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
 

--- a/homeassistant/components/unifiprotect/number.py
+++ b/homeassistant/components/unifiprotect/number.py
@@ -268,3 +268,21 @@ class ProtectNumbers(ProtectDeviceEntity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
         await self.entity_description.ufp_set(self.device, value)
+
+    @callback
+    def _async_updated_event(self, device: ProtectModelWithId) -> None:
+        """Call back for incoming data that only writes when state has changed.
+
+        Only the native value and available are ever updated for these
+        entities, and since the websocket update for the device will trigger
+        an update for all entities connected to the device, we want to avoid
+        writing state unless something has actually changed.
+        """
+        previous_value = self._attr_native_value
+        previous_available = self._attr_available
+        self._async_update_device_from_protect(device)
+        if (
+            self._attr_native_value != previous_value
+            or self._attr_available != previous_available
+        ):
+            self.async_write_ha_state()

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -718,7 +718,7 @@ class ProtectDeviceSensor(ProtectDeviceEntity, SensorEntity):
     def _async_updated_event(self, device: ProtectModelWithId) -> None:
         """Call back for incoming data that only writes when state has changed.
 
-        Only the native value and available are every updated for these
+        Only the native value and available are ever updated for these
         entities, and since the websocket update for the device will trigger
         an update for all entities connected to the device, we want to avoid
         writing state unless something has actually changed.
@@ -727,11 +727,10 @@ class ProtectDeviceSensor(ProtectDeviceEntity, SensorEntity):
         previous_available = self._attr_available
         self._async_update_device_from_protect(device)
         if (
-            self._attr_native_value == previous_value
-            and self._attr_available == previous_available
+            self._attr_native_value != previous_value
+            or self._attr_available != previous_available
         ):
-            return
-        self.async_write_ha_state()
+            self.async_write_ha_state()
 
 
 class ProtectNVRSensor(ProtectNVREntity, SensorEntity):
@@ -747,7 +746,7 @@ class ProtectNVRSensor(ProtectNVREntity, SensorEntity):
     def _async_updated_event(self, device: ProtectModelWithId) -> None:
         """Call back for incoming data that only writes when state has changed.
 
-        Only the native value and available are every updated for these
+        Only the native value and available are ever updated for these
         entities, and since the websocket update for the device will trigger
         an update for all entities connected to the device, we want to avoid
         writing state unless something has actually changed.
@@ -756,11 +755,10 @@ class ProtectNVRSensor(ProtectNVREntity, SensorEntity):
         previous_available = self._attr_available
         self._async_update_device_from_protect(device)
         if (
-            self._attr_native_value == previous_value
-            and self._attr_available == previous_available
+            self._attr_native_value != previous_value
+            or self._attr_available != previous_available
         ):
-            return
-        self.async_write_ha_state()
+            self.async_write_ha_state()
 
 
 class ProtectEventSensor(EventEntityMixin, SensorEntity):

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -726,10 +726,9 @@ class ProtectDeviceSensor(ProtectDeviceEntity, SensorEntity):
         previous_value = self._attr_native_value
         previous_available = self._attr_available
         self._async_update_device_from_protect(device)
-        new_available = self._attr_available
         if (
             self._attr_native_value == previous_value
-            and new_available == previous_available
+            and self._attr_available == previous_available
         ):
             return
         self.async_write_ha_state()
@@ -756,10 +755,9 @@ class ProtectNVRSensor(ProtectNVREntity, SensorEntity):
         previous_value = self._attr_native_value
         previous_available = self._attr_available
         self._async_update_device_from_protect(device)
-        new_available = self._attr_available
         if (
             self._attr_native_value == previous_value
-            and new_available == previous_available
+            and self._attr_available == previous_available
         ):
             return
         self.async_write_ha_state()

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -710,10 +710,29 @@ class ProtectDeviceSensor(ProtectDeviceEntity, SensorEntity):
 
     entity_description: ProtectSensorEntityDescription
 
-    @callback
     def _async_update_device_from_protect(self, device: ProtectModelWithId) -> None:
         super()._async_update_device_from_protect(device)
         self._attr_native_value = self.entity_description.get_ufp_value(self.device)
+
+    @callback
+    def _async_updated_event(self, device: ProtectModelWithId) -> None:
+        """Call back for incoming data that only writes when state has changed.
+
+        Only the native value and available are every updated for these
+        entity and since the websocket update for the device will trigger
+        an update for all entities connected to the device, we want to avoid
+        writing state unless something has actually changed.
+        """
+        previous_value = self._attr_native_value
+        previous_available = self._attr_available
+        self._async_update_device_from_protect(device)
+        new_available = self._attr_available
+        if (
+            self._attr_native_value == previous_value
+            and new_available == previous_available
+        ):
+            return
+        self.async_write_ha_state()
 
 
 class ProtectNVRSensor(ProtectNVREntity, SensorEntity):
@@ -721,10 +740,29 @@ class ProtectNVRSensor(ProtectNVREntity, SensorEntity):
 
     entity_description: ProtectSensorEntityDescription
 
-    @callback
     def _async_update_device_from_protect(self, device: ProtectModelWithId) -> None:
         super()._async_update_device_from_protect(device)
         self._attr_native_value = self.entity_description.get_ufp_value(self.device)
+
+    @callback
+    def _async_updated_event(self, device: ProtectModelWithId) -> None:
+        """Call back for incoming data that only writes when state has changed.
+
+        Only the native value and available are every updated for these
+        entity and since the websocket update for the device will trigger
+        an update for all entities connected to the device, we want to avoid
+        writing state unless something has actually changed.
+        """
+        previous_value = self._attr_native_value
+        previous_available = self._attr_available
+        self._async_update_device_from_protect(device)
+        new_available = self._attr_available
+        if (
+            self._attr_native_value == previous_value
+            and new_available == previous_available
+        ):
+            return
+        self.async_write_ha_state()
 
 
 class ProtectEventSensor(EventEntityMixin, SensorEntity):

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -719,7 +719,7 @@ class ProtectDeviceSensor(ProtectDeviceEntity, SensorEntity):
         """Call back for incoming data that only writes when state has changed.
 
         Only the native value and available are every updated for these
-        entity and since the websocket update for the device will trigger
+        entities, and since the websocket update for the device will trigger
         an update for all entities connected to the device, we want to avoid
         writing state unless something has actually changed.
         """
@@ -749,7 +749,7 @@ class ProtectNVRSensor(ProtectNVREntity, SensorEntity):
         """Call back for incoming data that only writes when state has changed.
 
         Only the native value and available are every updated for these
-        entity and since the websocket update for the device will trigger
+        entities, and since the websocket update for the device will trigger
         an update for all entities connected to the device, we want to avoid
         writing state unless something has actually changed.
         """

--- a/homeassistant/components/unifiprotect/switch.py
+++ b/homeassistant/components/unifiprotect/switch.py
@@ -436,7 +436,7 @@ class ProtectSwitch(ProtectDeviceEntity, SwitchEntity):
     def _async_updated_event(self, device: ProtectModelWithId) -> None:
         """Call back for incoming data that only writes when state has changed.
 
-        Only the is_on and available are every updated for these
+        Only the is_on and available are ever updated for these
         entities, and since the websocket update for the device will trigger
         an update for all entities connected to the device, we want to avoid
         writing state unless something has actually changed.
@@ -445,11 +445,10 @@ class ProtectSwitch(ProtectDeviceEntity, SwitchEntity):
         previous_available = self._attr_available
         self._async_update_device_from_protect(device)
         if (
-            self._attr_is_on == previous_is_on
-            and self._attr_available == previous_available
+            self._attr_is_on != previous_is_on
+            or self._attr_available != previous_available
         ):
-            return
-        self.async_write_ha_state()
+            self.async_write_ha_state()
 
 
 class ProtectNVRSwitch(ProtectNVREntity, SwitchEntity):

--- a/homeassistant/components/unifiprotect/switch.py
+++ b/homeassistant/components/unifiprotect/switch.py
@@ -438,7 +438,7 @@ class ProtectSwitch(ProtectDeviceEntity, SwitchEntity):
     def _async_updated_event(self, device: ProtectModelWithId) -> None:
         """Call back for incoming data that only writes when state has changed.
 
-        Only the native value and available are every updated for these
+        Only the is_on and available are every updated for these
         entity and since the websocket update for the device will trigger
         an update for all entities connected to the device, we want to avoid
         writing state unless something has actually changed.

--- a/homeassistant/components/unifiprotect/switch.py
+++ b/homeassistant/components/unifiprotect/switch.py
@@ -426,12 +426,10 @@ class ProtectSwitch(ProtectDeviceEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
-
         await self.entity_description.ufp_set(self.device, True)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
-
         await self.entity_description.ufp_set(self.device, False)
 
     @callback
@@ -439,7 +437,7 @@ class ProtectSwitch(ProtectDeviceEntity, SwitchEntity):
         """Call back for incoming data that only writes when state has changed.
 
         Only the is_on and available are every updated for these
-        entity and since the websocket update for the device will trigger
+        entities, and since the websocket update for the device will trigger
         an update for all entities connected to the device, we want to avoid
         writing state unless something has actually changed.
         """

--- a/homeassistant/components/unifiprotect/switch.py
+++ b/homeassistant/components/unifiprotect/switch.py
@@ -444,8 +444,10 @@ class ProtectSwitch(ProtectDeviceEntity, SwitchEntity):
         previous_is_on = self._attr_is_on
         previous_available = self._attr_available
         self._async_update_device_from_protect(device)
-        new_available = self._attr_available
-        if self._attr_is_on == previous_is_on and new_available == previous_available:
+        if (
+            self._attr_is_on == previous_is_on
+            and self._attr_available == previous_available
+        ):
             return
         self.async_write_ha_state()
 

--- a/homeassistant/components/unifiprotect/switch.py
+++ b/homeassistant/components/unifiprotect/switch.py
@@ -443,11 +443,11 @@ class ProtectSwitch(ProtectDeviceEntity, SwitchEntity):
         an update for all entities connected to the device, we want to avoid
         writing state unless something has actually changed.
         """
-        previous_value = self._attr_is_on
+        previous_is_on = self._attr_is_on
         previous_available = self._attr_available
         self._async_update_device_from_protect(device)
         new_available = self._attr_available
-        if self._attr_is_on == previous_value and new_available == previous_available:
+        if self._attr_is_on == previous_is_on and new_available == previous_available:
             return
         self.async_write_ha_state()
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
UFP generated ~37% of the state writes on my primary production instance and only 0.3% of them actually had changes.  (10 minute sample size) -- on another install it was > 50% .. but no tplink power strips on that install which is the next biggest source.

For simple sensors and switches that only have a single value, we can avoid the whole state write path when we know nothing has changed.

This reduces 91% of the `async_write_ha_state` calls that the integration was making.  Which takes it from 32% of event loop run time to 7% which is a significant drop.

I only did the high volume entities: 

- `button` we have a lot of these per camera, but they have no actual state other than available
- `number` each camera has a few of these
- `sensor` is much more expensive to write than any of the other entities
- `switch` - Each cameras has a large number of config `switch` entities
- `binary_sensor` was only partially done for the high rate devices as the nvr entities themselves don't change that often.
- `select` at least 5 per camera
- `media_player` - this one is expensive

`camera` are also expensive in terms writes so it would be good to reduce their writes as well but the current design doesn't permit that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
