### PR TITLE
Fix circular dependency detection

### DIFF
--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -1137,7 +1137,7 @@ async def _async_component_dependencies(
     loaded = set()
 
     async def component_dependencies_impl(integration: Integration) -> None:
-        """Recursive async impl to get component dependencies."""
+        """Recursively get component dependencies."""
         domain = integration.domain
         loading.add(domain)
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -777,9 +777,7 @@ class Integration:
             return self._all_dependencies_resolved
 
         try:
-            dependencies = await _async_component_dependencies(
-                self.hass, self.domain, self, set(), set()
-            )
+            dependencies = await _async_component_dependencies(self.hass, self)
             dependencies.discard(self.domain)
             self._all_dependencies = dependencies
             self._all_dependencies_resolved = True
@@ -1132,43 +1130,39 @@ def bind_hass(func: _CallableT) -> _CallableT:
 
 async def _async_component_dependencies(
     hass: HomeAssistant,
-    start_domain: str,
     integration: Integration,
-    loaded: set[str],
-    loading: set[str],
 ) -> set[str]:
-    """Recursive function to get component dependencies.
+    """Async function to get component dependencies."""
+    loading = set()
+    loaded = set()
 
-    Async friendly.
-    """
-    domain = integration.domain
-    loading.add(domain)
+    async def helper(integration: Integration) -> None:
+        """Recursive async helper to get component dependencies."""
+        domain = integration.domain
+        loading.add(domain)
 
-    for dependency_domain in integration.dependencies:
-        # Check not already loaded
-        if dependency_domain in loaded:
-            continue
+        for dependency_domain in integration.dependencies:
+            dep_integration = await async_get_integration(hass, dependency_domain)
 
-        # If we are already loading it, we have a circular dependency.
-        if dependency_domain in loading:
-            raise CircularDependency(domain, dependency_domain)
+            # If we are already loading it, we have a circular dependency.
+            # We have to check it here, because we need to cover all possible dependants.
+            if conflict := loading.intersection(dep_integration.after_dependencies):
+                raise CircularDependency(conflict.pop(), dependency_domain)
 
-        loaded.add(dependency_domain)
+            # If we have already loaded it, no point doing it again.
+            if dependency_domain in loaded:
+                continue
 
-        dep_integration = await async_get_integration(hass, dependency_domain)
+            # If we are already loading it, we have a circular dependency.
+            if dependency_domain in loading:
+                raise CircularDependency(dependency_domain, domain)
 
-        if start_domain in dep_integration.after_dependencies:
-            raise CircularDependency(start_domain, dependency_domain)
+            await helper(dep_integration)
 
-        if dep_integration.dependencies:
-            dep_loaded = await _async_component_dependencies(
-                hass, start_domain, dep_integration, loaded, loading
-            )
+        loading.remove(domain)
+        loaded.add(domain)
 
-            loaded.update(dep_loaded)
-
-    loaded.add(domain)
-    loading.remove(domain)
+    await helper(integration)
 
     return loaded
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -996,7 +996,7 @@ class IntegrationNotLoaded(LoaderError):
 class CircularDependency(LoaderError):
     """Raised when a circular dependency is found when resolving components."""
 
-    def __init__(self, from_domain: str, to_domain: str) -> None:
+    def __init__(self, from_domain: str | set[str], to_domain: str) -> None:
         """Initialize circular dependency error."""
         super().__init__(f"Circular dependency detected: {from_domain} -> {to_domain}.")
         self.from_domain = from_domain
@@ -1148,7 +1148,7 @@ async def _async_component_dependencies(
             # We have to check it here to make sure that every integration that
             # depends on us, does not appear in our own after_dependencies.
             if conflict := loading.intersection(dep_integration.after_dependencies):
-                raise CircularDependency(conflict.pop(), dependency_domain)
+                raise CircularDependency(conflict, dependency_domain)
 
             # If we have already loaded it, no point doing it again.
             if dependency_domain in loaded:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
### Fix bug with circular dependency detection
- In some cases the loop was being exited too early, and as a result some circular dependencies were not being detected
- This problem is now fixed and properly covered by the new tests
### Fix bug with circular after_dependency detection
- after_dependencies were not being checked properly, being compared only with starting integration
- Now they are properly compared with all the integrations in the dependency chain
- This problem is now also properly covered by the tests
### Simplify interface and make the code more readable

Additionally there was a problem with the tests themselves, where due to some small typos they were not behaving entirely correctly. This was also fixed. Details on this are below in this thread.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
