### PR TITLE
Harden modbus against lib errors

### DIFF
--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -425,7 +425,7 @@ class ModbusHub:
         if not hasattr(result, entry.attr):
             self._log_error(str(result))
             return None
-        if not result:
+        if not result.isError():  # type: ignore[no-untyped-call]
             self._log_error("Error: pymodbus returned isError True")
             return None
         self._in_error = False

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -425,7 +425,7 @@ class ModbusHub:
         if not hasattr(result, entry.attr):
             self._log_error(str(result))
             return None
-        if not result.isError():  # type: ignore[no-untyped-call]
+        if result.isError():  # type: ignore[no-untyped-call]
             self._log_error("Error: pymodbus returned isError True")
             return None
         self._in_error = False

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -419,8 +419,14 @@ class ModbusHub:
         except ModbusException as exception_error:
             self._log_error(str(exception_error))
             return None
+        if not result:
+            self._log_error("Error: pymodbus returned None")
+            return None
         if not hasattr(result, entry.attr):
             self._log_error(str(result))
+            return None
+        if not result:
+            self._log_error("Error: pymodbus returned isError True")
             return None
         self._in_error = False
         return result

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -32,6 +32,11 @@ class ReadResult:
         """Init."""
         self.registers = register_words
         self.bits = register_words
+        self.value = register_words
+
+    def isError(self):
+        """Set error state."""
+        return False
 
 
 @pytest.fixture(name="mock_pymodbus")
@@ -136,6 +141,10 @@ async def mock_pymodbus_return_fixture(hass, register_words, mock_modbus):
     mock_modbus.read_discrete_inputs.return_value = read_result
     mock_modbus.read_input_registers.return_value = read_result
     mock_modbus.read_holding_registers.return_value = read_result
+    mock_modbus.write_register.return_value = read_result
+    mock_modbus.write_registers.return_value = read_result
+    mock_modbus.write_coil.return_value = read_result
+    mock_modbus.write_coils.return_value = read_result
 
 
 @pytest.fixture(name="mock_do_cycle")

--- a/tests/components/modbus/test_fan.py
+++ b/tests/components/modbus/test_fan.py
@@ -261,7 +261,10 @@ async def test_restore_state_fan(
     ],
 )
 async def test_fan_service_turn(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_modbus
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    mock_modbus,
+    mock_pymodbus_return,
 ) -> None:
     """Run test for service turn_on/turn_off."""
 

--- a/tests/components/modbus/test_light.py
+++ b/tests/components/modbus/test_light.py
@@ -260,7 +260,10 @@ async def test_restore_state_light(
     ],
 )
 async def test_light_service_turn(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_modbus
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    mock_modbus,
+    mock_pymodbus_return,
 ) -> None:
     """Run test for service turn_on/turn_off."""
 

--- a/tests/components/modbus/test_switch.py
+++ b/tests/components/modbus/test_switch.py
@@ -316,7 +316,10 @@ async def test_restore_state_switch(
     ],
 )
 async def test_switch_service_turn(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_modbus
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    mock_modbus,
+    mock_pymodbus_return,
 ) -> None:
     """Run test for service turn_on/turn_off."""
     assert MODBUS_DOMAIN in hass.config.components
@@ -407,7 +410,9 @@ async def test_service_switch_update(hass: HomeAssistant, mock_modbus, mock_ha) 
         },
     ],
 )
-async def test_delay_switch(hass: HomeAssistant, mock_modbus) -> None:
+async def test_delay_switch(
+    hass: HomeAssistant, mock_modbus, mock_pymodbus_return
+) -> None:
     """Run test for switch verify delay."""
     mock_modbus.read_holding_registers.return_value = ReadResult([0x01])
     now = dt_util.utcnow()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After pymodbus was updated to v3.5.1, a couple of new returns are possible, which is catched with this PR.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
