### PR TITLE
Fix error is measurement is not sent by AirNow

### DIFF
--- a/homeassistant/components/airnow/sensor.py
+++ b/homeassistant/components/airnow/sensor.py
@@ -58,6 +58,16 @@ class AirNowEntityDescription(SensorEntityDescription, AirNowEntityDescriptionMi
     """Describes Airnow sensor entity."""
 
 
+def station_extra_attrs(data: dict[str, Any]) -> dict[str, Any]:
+    """Process extra attributes for station location (if available)."""
+    if ATTR_API_STATION in data:
+        return {
+            "lat": data.get(ATTR_API_STATION_LATITUDE),
+            "long": data.get(ATTR_API_STATION_LONGITUDE),
+        }
+    return {}
+
+
 SENSOR_TYPES: tuple[AirNowEntityDescription, ...] = (
     AirNowEntityDescription(
         key=ATTR_API_AQI,
@@ -93,10 +103,7 @@ SENSOR_TYPES: tuple[AirNowEntityDescription, ...] = (
         translation_key="station",
         icon="mdi:blur",
         value_fn=lambda data: data.get(ATTR_API_STATION),
-        extra_state_attributes_fn=lambda data: {
-            "lat": data.get(ATTR_API_STATION_LATITUDE),
-            "long": data.get(ATTR_API_STATION_LONGITUDE),
-        },
+        extra_state_attributes_fn=station_extra_attrs,
     ),
 )
 

--- a/homeassistant/components/airnow/sensor.py
+++ b/homeassistant/components/airnow/sensor.py
@@ -94,8 +94,8 @@ SENSOR_TYPES: tuple[AirNowEntityDescription, ...] = (
         icon="mdi:blur",
         value_fn=lambda data: data.get(ATTR_API_STATION),
         extra_state_attributes_fn=lambda data: {
-            "lat": data[ATTR_API_STATION_LATITUDE],
-            "long": data[ATTR_API_STATION_LONGITUDE],
+            "lat": data.get(ATTR_API_STATION_LATITUDE),
+            "long": data.get(ATTR_API_STATION_LONGITUDE),
         },
     ),
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Fix error when station latitude or longitude is not set because AirNow does not send a PM2.5 measurement.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
In #97273 we used the PM2.5 measurement to set the reporting station sensor, but if there is no PM2.5 measurement sent back by the API, the station latitude and longitude will be unset and the dict lookup fails.  Should use `.get()` as in the reporting station sensor value getter to avoid this error.

- This PR fixes or closes issue: fixes #100003

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
