### PR TITLE
Add reload to rest_command integration

### DIFF
--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -70,7 +70,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         if conf is None or DOMAIN not in conf:
             return
 
-        existing = hass.services.async_services().get(DOMAIN, {}).keys()
+        existing = hass.services.async_services().get(DOMAIN, {})
         for existing_service in existing:
             if existing_service == SERVICE_RELOAD:
                 continue

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -1,7 +1,7 @@
 """Support for exposing regular REST commands as services."""
 import asyncio
-from http import HTTPStatus
 import contextlib
+from http import HTTPStatus
 import logging
 
 import aiohttp

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -19,7 +19,6 @@ from homeassistant.const import (
     SERVICE_RELOAD,
 )
 from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.reload import async_integration_yaml_config

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -62,7 +62,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async def reload_service_handler(service: ServiceCall) -> None:
         """Remove all rest_commands and load new ones from config."""
-        conf = await async_integration_yaml_config(hass, DOMAIN) or {}
+        conf = await async_integration_yaml_config(hass, DOMAIN)
+        
+        # conf will be None if the configuration can't be parsed
+        if conf is None:
+            return
 
         existing = hass.services.async_services().get(DOMAIN, {})
         for existing_service in existing:

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -1,6 +1,5 @@
 """Support for exposing regular REST commands as services."""
 import asyncio
-import contextlib
 from http import HTTPStatus
 import logging
 
@@ -64,7 +63,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async def reload_service_handler(service: ServiceCall) -> None:
         """Remove all rest_commands and load new ones from config."""
-        conf = await async_integration_yaml_config(hass, DOMAIN)
+        conf = await async_integration_yaml_config(hass, DOMAIN) or {}
 
         existing = hass.services.async_services().get(DOMAIN, {})
         for existing_service in existing:

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -63,7 +63,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     async def reload_service_handler(service: ServiceCall) -> None:
         """Remove all rest_commands and load new ones from config."""
         conf = await async_integration_yaml_config(hass, DOMAIN)
-        
+
         # conf will be None if the configuration can't be parsed
         if conf is None:
             return

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -64,11 +64,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async def reload_service_handler(service: ServiceCall) -> None:
         """Remove all rest_commands and load new ones from config."""
-        conf = None
-        with contextlib.suppress(HomeAssistantError):
-            conf = await async_integration_yaml_config(hass, DOMAIN)
-        if conf is None or DOMAIN not in conf:
-            return
+        conf = await async_integration_yaml_config(hass, DOMAIN)
 
         existing = hass.services.async_services().get(DOMAIN, {})
         for existing_service in existing:

--- a/tests/components/rest_command/test_init.py
+++ b/tests/components/rest_command/test_init.py
@@ -57,6 +57,18 @@ class TestRestCommandSetup:
         assert self.hass.services.has_service(rc.DOMAIN, "test_get")
         assert not self.hass.services.has_service(rc.DOMAIN, "new_test")
 
+        # Old config retained if rest_command is not in new config
+        with patch(
+            "homeassistant.config.load_yaml_config_file",
+            autospec=True,
+            return_value={},
+        ):
+            self.hass.services.call(rc.DOMAIN, SERVICE_RELOAD, blocking=True)
+
+        assert self.hass.services.has_service(rc.DOMAIN, "test_get")
+        assert not self.hass.services.has_service(rc.DOMAIN, "new_test")
+
+        # Successful reload
         new_config = {
             rc.DOMAIN: {
                 "new_test": {"url": "https://example.org", "method": "get"},

--- a/tests/components/rest_command/test_init.py
+++ b/tests/components/rest_command/test_init.py
@@ -57,18 +57,6 @@ class TestRestCommandSetup:
         assert self.hass.services.has_service(rc.DOMAIN, "test_get")
         assert not self.hass.services.has_service(rc.DOMAIN, "new_test")
 
-        # Old config retained if rest_command is not in new config
-        with patch(
-            "homeassistant.config.load_yaml_config_file",
-            autospec=True,
-            return_value={},
-        ):
-            self.hass.services.call(rc.DOMAIN, SERVICE_RELOAD, blocking=True)
-
-        assert self.hass.services.has_service(rc.DOMAIN, "test_get")
-        assert not self.hass.services.has_service(rc.DOMAIN, "new_test")
-
-        # Successful reload
         new_config = {
             rc.DOMAIN: {
                 "new_test": {"url": "https://example.org", "method": "get"},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the option to reload the `rest_command` integration.

A usefull addition [that has been missing](https://community.home-assistant.io/t/is-it-possible-to-reload-rest-command-without-restarting-ha/567981), especially when the `rest_command`s have been made more usefull by adding response values as per PR #97208 or #97593 and the addition of actions for trigger based template sensors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
