### PR TITLE
Explicit delays in Velux updates

### DIFF
--- a/homeassistant/components/velux/__init__.py
+++ b/homeassistant/components/velux/__init__.py
@@ -1,7 +1,7 @@
 """Support for VELUX KLF 200 devices."""
 import asyncio
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from pyvlx import OpeningDevice, PyVLX, PyVLXException
 import voluptuous as vol
@@ -71,9 +71,9 @@ class DelayVelux(PyVLX):
 class VeluxModule:
     """Abstraction for velux component."""
 
-    def __init__(self, hass: HomeAssistant, domain_config: dict[str, Any]):
+    def __init__(self, hass: HomeAssistant, domain_config: dict[str, Any]) -> None:
         """Initialize for velux component."""
-        self.pyvlx = None
+        self.pyvlx: Optional[DelayVelux] = None
         self._hass = hass
         self._domain_config = domain_config
 
@@ -86,6 +86,7 @@ class VeluxModule:
             await self.pyvlx.disconnect()
 
         async def async_reboot_gateway(service_call: ServiceCall) -> None:
+            assert self.pyvlx is not None
             await self.pyvlx.reboot_gateway()
 
         self._hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, on_hass_stop)

--- a/homeassistant/components/velux/__init__.py
+++ b/homeassistant/components/velux/__init__.py
@@ -1,7 +1,7 @@
 """Support for VELUX KLF 200 devices."""
-import logging
 import asyncio
-from typing import Any, Dict
+import logging
+from typing import Any
 
 from pyvlx import OpeningDevice, PyVLX, PyVLXException
 import voluptuous as vol
@@ -55,6 +55,7 @@ class DelayVelux(PyVLX):
     """PyVLX, but with delays to workaround KLF 200 issues."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize DelayVelux class."""
         super().__init__(*args, **kwargs)
         self.__send_lock = asyncio.Lock()
 
@@ -70,7 +71,7 @@ class DelayVelux(PyVLX):
 class VeluxModule:
     """Abstraction for velux component."""
 
-    def __init__(self, hass: HomeAssistant, domain_config: Dict[str, Any]):
+    def __init__(self, hass: HomeAssistant, domain_config: dict[str, Any]):
         """Initialize for velux component."""
         self.pyvlx = None
         self._hass = hass


### PR DESCRIPTION
## Proposed change

So, this is a hack, but it works. Other options that work but are less of a hack would be appreciated!

Original problem was reported as https://github.com/Julius2342/pyvlx/issues/331. The core problem is that Velux KLF 200 devices are kinda terrible bits of hardware, but nothing else talks Velux'es proprietary protocol (and reverse engineering it is apparently hard), so we're stuck with them. If you do too many things in short succession, they just refuse to do things, so this works around it by adding an explicit `time.sleep` which makes everything work. It's a little slower, but good enough.

I tried adding in `await asyncio.sleep(1)` instead, but this seems to not work, as in the same problem occurs. I'm assuming that by not blocking the thread new commands turn up, which then just breaks things. `PARALLEL_UPDATES` has been set to 1 in the entity files, so I'd assumed that should be enough to only do one at a time, but apparently not.

1s is an un-optimised value that WFM, but could maybe do with further poking. Similarly, a "wait only if the last command wasn't recent" could be added in, but haven't done yet as I wanted to get feedback here first.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes https://github.com/Julius2342/pyvlx/issues/331

## Checklist
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
