### PR TITLE
Add scripts and data-templating to alerts

### DIFF
--- a/homeassistant/components/alert/const.py
+++ b/homeassistant/components/alert/const.py
@@ -14,6 +14,8 @@ CONF_ALERT_MESSAGE = "message"
 CONF_DONE_MESSAGE = "done_message"
 CONF_TITLE = "title"
 CONF_DATA = "data"
+CONF_VARIABLES = "variables"
+CONF_SCRIPT = "script"
 
 DEFAULT_CAN_ACK = True
 DEFAULT_SKIP_FIRST = False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Alerts are a great tool for easy repeating notifications of things that need to be done. Occasionally, cases come up where users need more functionality than is currently given. In my case, I wanted to be able to have a templated subtitle:
```
alert_script:
  garage_doors_open:
    name: Garage Doors Open Alert
    done_message: All garage doors have been closed
    entity_id: binary_sensor.garage_doors_open
    state: "on"
    repeat: 10
    can_acknowledge: true
    skip_first: true
    message: >
      {% set entities = states.cover
        | selectattr('state','match', 'open')
        | list | map(attribute='name') | map('replace', " Sensor", "") | join(", ") %}
        Please check {{ entities }}.
    notifiers:
      - default
    data:
      subtitle: >-
        {% if states('sensor.garage_doors_open_count') | int(0) > 0 %}
        {{ states('sensor.garage_doors_open_count') }} garage doors have been left open!
        {% endif %}
```
Other's have wanted to be able to call scripts from `alert`, so they can do things like TTS calls ([ex1](https://community.home-assistant.io/t/solved-alert-notifier-to-invoke-a-script/258463), [ex2](https://community.home-assistant.io/t/possible-to-define-a-named-notify-that-calls-a-script/205926)). Calling a script gives effectively infinite possibilities for the notification message, or other actions, and was my initial implementation to solve this problem. As far as I am aware, `alert` integrations are the only place that specifically requires a `notify` object. Introducing a `notify` that calls a script would be another solution (aka, a `template_notify`), but it seemed cleaner to me to add the ability for an `alert` to call a script directly.

After getting script calling working, I realized I should just add templating support to the `data` (or `data_template`, which I copied the logic from the `rest` integration). Both are included in this PR. I can split if needed, or eliminate one half if desired.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
