### PR TITLE
Remove duplicate mobile_app client fixture

### DIFF
--- a/tests/components/mobile_app/conftest.py
+++ b/tests/components/mobile_app/conftest.py
@@ -10,18 +10,16 @@ from .const import REGISTER, REGISTER_CLEARTEXT
 
 
 @pytest.fixture
-async def create_registrations(hass, authed_api_client):
+async def create_registrations(hass, webhook_client):
     """Return two new registrations."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
-    enc_reg = await authed_api_client.post(
-        "/api/mobile_app/registrations", json=REGISTER
-    )
+    enc_reg = await webhook_client.post("/api/mobile_app/registrations", json=REGISTER)
 
     assert enc_reg.status == HTTPStatus.CREATED
     enc_reg_json = await enc_reg.json()
 
-    clear_reg = await authed_api_client.post(
+    clear_reg = await webhook_client.post(
         "/api/mobile_app/registrations", json=REGISTER_CLEARTEXT
     )
 
@@ -34,11 +32,11 @@ async def create_registrations(hass, authed_api_client):
 
 
 @pytest.fixture
-async def push_registration(hass, authed_api_client):
+async def push_registration(hass, webhook_client):
     """Return registration with push notifications enabled."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
-    enc_reg = await authed_api_client.post(
+    enc_reg = await webhook_client.post(
         "/api/mobile_app/registrations",
         json={
             **REGISTER,
@@ -54,17 +52,7 @@ async def push_registration(hass, authed_api_client):
 
 
 @pytest.fixture
-async def webhook_client(hass, authed_api_client, aiohttp_client):
-    """mobile_app mock client."""
-    # We pass in the authed_api_client server instance because
-    # it is used inside create_registrations and just passing in
-    # the app instance would cause the server to start twice,
-    # which caused deprecation warnings to be printed.
-    return await aiohttp_client(authed_api_client.server)
-
-
-@pytest.fixture
-async def authed_api_client(hass, hass_client):
+async def webhook_client(hass, hass_client):
     """Provide an authenticated client for mobile_app to use."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     await hass.async_block_till_done()

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -196,9 +196,9 @@ async def test_webhook_handle_fire_event(
     assert events[0].data["hello"] == "yo world"
 
 
-async def test_webhook_update_registration(webhook_client, authed_api_client) -> None:
+async def test_webhook_update_registration(webhook_client) -> None:
     """Test that a we can update an existing registration via webhook."""
-    register_resp = await authed_api_client.post(
+    register_resp = await webhook_client.post(
         "/api/mobile_app/registrations", json=REGISTER_CLEARTEXT
     )
 


### PR DESCRIPTION
## Proposed change
The `authed_api_client` and `webhook_client` fixtures do basically the same. They can be merged into one to not create two different TestClient instances.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
