### PR TITLE
Move faa_delays coordinator to its own file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -357,6 +357,7 @@ omit =
     homeassistant/components/ezviz/update.py
     homeassistant/components/faa_delays/__init__.py
     homeassistant/components/faa_delays/binary_sensor.py
+    homeassistant/components/faa_delays/coordinator.py
     homeassistant/components/familyhub/camera.py
     homeassistant/components/fastdotcom/*
     homeassistant/components/ffmpeg/camera.py

--- a/homeassistant/components/faa_delays/__init__.py
+++ b/homeassistant/components/faa_delays/__init__.py
@@ -1,20 +1,10 @@
 """The FAA Delays integration."""
-import asyncio
-from datetime import timedelta
-import logging
-
-from aiohttp import ClientConnectionError
-from faadelays import Airport
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ID, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import aiohttp_client
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
+from .coordinator import FAADataUpdateCoordinator
 
 PLATFORMS = [Platform.BINARY_SENSOR]
 
@@ -40,24 +30,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok
-
-
-class FAADataUpdateCoordinator(DataUpdateCoordinator):
-    """Class to manage fetching FAA API data from a single endpoint."""
-
-    def __init__(self, hass, code):
-        """Initialize the coordinator."""
-        super().__init__(
-            hass, _LOGGER, name=DOMAIN, update_interval=timedelta(minutes=1)
-        )
-        self.session = aiohttp_client.async_get_clientsession(hass)
-        self.data = Airport(code, self.session)
-        self.code = code
-
-    async def _async_update_data(self):
-        try:
-            async with asyncio.timeout(10):
-                await self.data.update()
-        except ClientConnectionError as err:
-            raise UpdateFailed(err) from err
-        return self.data

--- a/homeassistant/components/faa_delays/coordinator.py
+++ b/homeassistant/components/faa_delays/coordinator.py
@@ -1,0 +1,35 @@
+"""DataUpdateCoordinator for faa_delays integration."""
+import asyncio
+from datetime import timedelta
+import logging
+
+from aiohttp import ClientConnectionError
+from faadelays import Airport
+
+from homeassistant.helpers import aiohttp_client
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class FAADataUpdateCoordinator(DataUpdateCoordinator):
+    """Class to manage fetching FAA API data from a single endpoint."""
+
+    def __init__(self, hass, code):
+        """Initialize the coordinator."""
+        super().__init__(
+            hass, _LOGGER, name=DOMAIN, update_interval=timedelta(minutes=1)
+        )
+        self.session = aiohttp_client.async_get_clientsession(hass)
+        self.data = Airport(code, self.session)
+        self.code = code
+
+    async def _async_update_data(self):
+        try:
+            async with asyncio.timeout(10):
+                await self.data.update()
+        except ClientConnectionError as err:
+            raise UpdateFailed(err) from err
+        return self.data


### PR DESCRIPTION
## Proposed changeMove the coordinator to its own file, to comply with the recommended way introduced in home-assistant/developers.home-assistant#1895. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
