### PR TITLE
Move uptimerobot coordinator to its own file

### DIFF
--- a/homeassistant/components/uptimerobot/__init__.py
+++ b/homeassistant/components/uptimerobot/__init__.py
@@ -1,12 +1,7 @@
 """The UptimeRobot integration."""
 from __future__ import annotations
 
-from pyuptimerobot import (
-    UptimeRobot,
-    UptimeRobotAuthenticationException,
-    UptimeRobotException,
-    UptimeRobotMonitor,
-)
+from pyuptimerobot import UptimeRobot
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY
@@ -14,9 +9,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import API_ATTR_OK, COORDINATOR_UPDATE_INTERVAL, DOMAIN, LOGGER, PLATFORMS
+from .const import DOMAIN, PLATFORMS
+from .coordinator import UptimeRobotDataUpdateCoordinator
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -51,64 +46,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
-
-
-class UptimeRobotDataUpdateCoordinator(DataUpdateCoordinator[list[UptimeRobotMonitor]]):
-    """Data update coordinator for UptimeRobot."""
-
-    config_entry: ConfigEntry
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        config_entry_id: str,
-        dev_reg: dr.DeviceRegistry,
-        api: UptimeRobot,
-    ) -> None:
-        """Initialize coordinator."""
-        super().__init__(
-            hass,
-            LOGGER,
-            name=DOMAIN,
-            update_interval=COORDINATOR_UPDATE_INTERVAL,
-        )
-        self._config_entry_id = config_entry_id
-        self._device_registry = dev_reg
-        self.api = api
-
-    async def _async_update_data(self) -> list[UptimeRobotMonitor]:
-        """Update data."""
-        try:
-            response = await self.api.async_get_monitors()
-        except UptimeRobotAuthenticationException as exception:
-            raise ConfigEntryAuthFailed(exception) from exception
-        except UptimeRobotException as exception:
-            raise UpdateFailed(exception) from exception
-
-        if response.status != API_ATTR_OK:
-            raise UpdateFailed(response.error.message)
-
-        monitors: list[UptimeRobotMonitor] = response.data
-
-        current_monitors = {
-            list(device.identifiers)[0][1]
-            for device in dr.async_entries_for_config_entry(
-                self._device_registry, self._config_entry_id
-            )
-        }
-        new_monitors = {str(monitor.id) for monitor in monitors}
-        if stale_monitors := current_monitors - new_monitors:
-            for monitor_id in stale_monitors:
-                if device := self._device_registry.async_get_device(
-                    identifiers={(DOMAIN, monitor_id)}
-                ):
-                    self._device_registry.async_remove_device(device.id)
-
-        # If there are new monitors, we should reload the config entry so we can
-        # create new devices and entities.
-        if self.data and new_monitors - {str(monitor.id) for monitor in self.data}:
-            self.hass.async_create_task(
-                self.hass.config_entries.async_reload(self._config_entry_id)
-            )
-
-        return monitors

--- a/homeassistant/components/uptimerobot/binary_sensor.py
+++ b/homeassistant/components/uptimerobot/binary_sensor.py
@@ -10,8 +10,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import UptimeRobotDataUpdateCoordinator
 from .const import DOMAIN
+from .coordinator import UptimeRobotDataUpdateCoordinator
 from .entity import UptimeRobotEntity
 
 

--- a/homeassistant/components/uptimerobot/coordinator.py
+++ b/homeassistant/components/uptimerobot/coordinator.py
@@ -1,0 +1,78 @@
+"""DataUpdateCoordinator for the uptimerobot integration."""
+from __future__ import annotations
+
+from pyuptimerobot import (
+    UptimeRobot,
+    UptimeRobotAuthenticationException,
+    UptimeRobotException,
+    UptimeRobotMonitor,
+)
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import API_ATTR_OK, COORDINATOR_UPDATE_INTERVAL, DOMAIN, LOGGER
+
+
+class UptimeRobotDataUpdateCoordinator(DataUpdateCoordinator[list[UptimeRobotMonitor]]):
+    """Data update coordinator for UptimeRobot."""
+
+    config_entry: ConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry_id: str,
+        dev_reg: dr.DeviceRegistry,
+        api: UptimeRobot,
+    ) -> None:
+        """Initialize coordinator."""
+        super().__init__(
+            hass,
+            LOGGER,
+            name=DOMAIN,
+            update_interval=COORDINATOR_UPDATE_INTERVAL,
+        )
+        self._config_entry_id = config_entry_id
+        self._device_registry = dev_reg
+        self.api = api
+
+    async def _async_update_data(self) -> list[UptimeRobotMonitor]:
+        """Update data."""
+        try:
+            response = await self.api.async_get_monitors()
+        except UptimeRobotAuthenticationException as exception:
+            raise ConfigEntryAuthFailed(exception) from exception
+        except UptimeRobotException as exception:
+            raise UpdateFailed(exception) from exception
+
+        if response.status != API_ATTR_OK:
+            raise UpdateFailed(response.error.message)
+
+        monitors: list[UptimeRobotMonitor] = response.data
+
+        current_monitors = {
+            list(device.identifiers)[0][1]
+            for device in dr.async_entries_for_config_entry(
+                self._device_registry, self._config_entry_id
+            )
+        }
+        new_monitors = {str(monitor.id) for monitor in monitors}
+        if stale_monitors := current_monitors - new_monitors:
+            for monitor_id in stale_monitors:
+                if device := self._device_registry.async_get_device(
+                    identifiers={(DOMAIN, monitor_id)}
+                ):
+                    self._device_registry.async_remove_device(device.id)
+
+        # If there are new monitors, we should reload the config entry so we can
+        # create new devices and entities.
+        if self.data and new_monitors - {str(monitor.id) for monitor in self.data}:
+            self.hass.async_create_task(
+                self.hass.config_entries.async_reload(self._config_entry_id)
+            )
+
+        return monitors

--- a/homeassistant/components/uptimerobot/diagnostics.py
+++ b/homeassistant/components/uptimerobot/diagnostics.py
@@ -8,8 +8,8 @@ from pyuptimerobot import UptimeRobotException
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from . import UptimeRobotDataUpdateCoordinator
 from .const import DOMAIN
+from .coordinator import UptimeRobotDataUpdateCoordinator
 
 
 async def async_get_config_entry_diagnostics(

--- a/homeassistant/components/uptimerobot/sensor.py
+++ b/homeassistant/components/uptimerobot/sensor.py
@@ -13,8 +13,8 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import UptimeRobotDataUpdateCoordinator
 from .const import DOMAIN
+from .coordinator import UptimeRobotDataUpdateCoordinator
 from .entity import UptimeRobotEntity
 
 

--- a/homeassistant/components/uptimerobot/switch.py
+++ b/homeassistant/components/uptimerobot/switch.py
@@ -14,8 +14,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import UptimeRobotDataUpdateCoordinator
 from .const import API_ATTR_OK, DOMAIN, LOGGER
+from .coordinator import UptimeRobotDataUpdateCoordinator
 from .entity import UptimeRobotEntity
 
 


### PR DESCRIPTION
## Proposed change
SSIA. Will also remove the unnecessary passing of `config_entry_id` in a second PR, since the base class already gets the `config_entry`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
