### PR TITLE
Update zeroconf discovery to use IPAddress objects to avoid conversions

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -100,13 +100,23 @@ CONFIG_SCHEMA = vol.Schema(
 class ZeroconfServiceInfo(BaseServiceInfo):
     """Prepared info from mDNS entries."""
 
-    host: str
-    addresses: list[str]
+    ip_address: IPv4Address | IPv6Address
+    ip_addresses: list[IPv4Address | IPv6Address]
     port: int | None
     hostname: str
     type: str
     name: str
     properties: dict[str, Any]
+
+    @property
+    def host(self) -> str:
+        """Return the host."""
+        return _stringify_ip_address(self.ip_address)
+
+    @property
+    def addresses(self) -> list[str]:
+        """Return the addresses."""
+        return [_stringify_ip_address(ip_address) for ip_address in self.ip_addresses]
 
 
 @bind_hass
@@ -536,10 +546,8 @@ def async_get_homekit_discovery(
     return None
 
 
-@lru_cache(maxsize=256)  # matches to the cache in zeroconf itself
-def _stringify_ip_address(ip_addr: IPv4Address | IPv6Address) -> str:
-    """Stringify an IP address."""
-    return str(ip_addr)
+# matches to the cache in zeroconf itself
+_stringify_ip_address = lru_cache(maxsize=256)(str)
 
 
 def info_from_service(service: AsyncServiceInfo) -> ZeroconfServiceInfo | None:
@@ -547,14 +555,18 @@ def info_from_service(service: AsyncServiceInfo) -> ZeroconfServiceInfo | None:
     # See https://ietf.org/rfc/rfc6763.html#section-6.4 and
     # https://ietf.org/rfc/rfc6763.html#section-6.5 for expected encodings
     # for property keys and values
-    if not (ip_addresses := service.ip_addresses_by_version(IPVersion.All)):
+    if not (maybe_ip_addresses := service.ip_addresses_by_version(IPVersion.All)):
         return None
-    host: str | None = None
+    if TYPE_CHECKING:
+        ip_addresses = cast(list[IPv4Address | IPv6Address], maybe_ip_addresses)
+    else:
+        ip_addresses = maybe_ip_addresses
+    ip_address: IPv4Address | IPv6Address | None = None
     for ip_addr in ip_addresses:
         if not ip_addr.is_link_local and not ip_addr.is_unspecified:
-            host = _stringify_ip_address(ip_addr)
+            ip_address = ip_addr
             break
-    if not host:
+    if not ip_address:
         return None
 
     # Service properties are always bytes if they are set from the network.
@@ -571,8 +583,8 @@ def info_from_service(service: AsyncServiceInfo) -> ZeroconfServiceInfo | None:
 
     assert service.server is not None, "server cannot be none if there are addresses"
     return ZeroconfServiceInfo(
-        host=host,
-        addresses=[_stringify_ip_address(ip_addr) for ip_addr in ip_addresses],
+        ip_address=ip_address,
+        ip_addresses=ip_addresses,
         port=service.port,
         hostname=service.server,
         type=service.type,

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -98,7 +98,14 @@ CONFIG_SCHEMA = vol.Schema(
 
 @dataclass(slots=True)
 class ZeroconfServiceInfo(BaseServiceInfo):
-    """Prepared info from mDNS entries."""
+    """Prepared info from mDNS entries.
+
+    The ip_address is the most recently updated address
+    that is not a link local or unspecified address.
+
+    The ip_addresses are all addresses in order of most
+    recently updated to least recently updated.
+    """
 
     ip_address: IPv4Address | IPv6Address
     ip_addresses: list[IPv4Address | IPv6Address]

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -105,6 +105,16 @@ class ZeroconfServiceInfo(BaseServiceInfo):
 
     The ip_addresses are all addresses in order of most
     recently updated to least recently updated.
+
+    The host is the string representation of the ip_address.
+
+    The addresses are the string representations of the
+    ip_addresses.
+
+    It is recommended to use the ip_address to determine
+    the address to connect to as it will be the most
+    recently updated address that is not a link local
+    or unspecified address.
     """
 
     ip_address: IPv4Address | IPv6Address

--- a/tests/components/androidtv_remote/test_config_flow.py
+++ b/tests/components/androidtv_remote/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Android TV Remote config flow."""
+from ipaddress import ip_address
 from unittest.mock import AsyncMock, MagicMock
 
 from androidtvremote2 import CannotConnect, ConnectionClosed, InvalidAuth
@@ -431,8 +432,8 @@ async def test_zeroconf_flow_success(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host=host,
-            addresses=[host],
+            ip_address=ip_address(host),
+            ip_addresses=[ip_address(host)],
             port=6466,
             hostname=host,
             type="mock_type",
@@ -509,8 +510,8 @@ async def test_zeroconf_flow_cannot_connect(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host=host,
-            addresses=[host],
+            ip_address=ip_address(host),
+            ip_addresses=[ip_address(host)],
             port=6466,
             hostname=host,
             type="mock_type",
@@ -560,8 +561,8 @@ async def test_zeroconf_flow_pairing_invalid_auth(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host=host,
-            addresses=[host],
+            ip_address=ip_address(host),
+            ip_addresses=[ip_address(host)],
             port=6466,
             hostname=host,
             type="mock_type",
@@ -643,8 +644,8 @@ async def test_zeroconf_flow_already_configured_host_changed_reloads_entry(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host=host,
-            addresses=[host],
+            ip_address=ip_address(host),
+            ip_addresses=[ip_address(host)],
             port=6466,
             hostname=host,
             type="mock_type",
@@ -696,8 +697,8 @@ async def test_zeroconf_flow_already_configured_host_not_changed_no_reload_entry
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host=host,
-            addresses=[host],
+            ip_address=ip_address(host),
+            ip_addresses=[ip_address(host)],
             port=6466,
             hostname=host,
             type="mock_type",
@@ -729,8 +730,8 @@ async def test_zeroconf_flow_abort_if_mac_is_missing(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host=host,
-            addresses=[host],
+            ip_address=ip_address(host),
+            ip_addresses=[ip_address(host)],
             port=6466,
             hostname=host,
             type="mock_type",

--- a/tests/components/apple_tv/test_config_flow.py
+++ b/tests/components/apple_tv/test_config_flow.py
@@ -1,5 +1,5 @@
 """Test config flow."""
-from ipaddress import IPv4Address
+from ipaddress import IPv4Address, ip_address
 from unittest.mock import ANY, patch
 
 from pyatv import exceptions
@@ -21,8 +21,8 @@ from .common import airplay_service, create_conf, mrp_service, raop_service
 from tests.common import MockConfigEntry
 
 DMAP_SERVICE = zeroconf.ZeroconfServiceInfo(
-    host="127.0.0.1",
-    addresses=["127.0.0.1"],
+    ip_address=ip_address("127.0.0.1"),
+    ip_addresses=[ip_address("127.0.0.1")],
     hostname="mock_hostname",
     port=None,
     type="_touch-able._tcp.local.",
@@ -32,8 +32,8 @@ DMAP_SERVICE = zeroconf.ZeroconfServiceInfo(
 
 
 RAOP_SERVICE = zeroconf.ZeroconfServiceInfo(
-    host="127.0.0.1",
-    addresses=["127.0.0.1"],
+    ip_address=ip_address("127.0.0.1"),
+    ip_addresses=[ip_address("127.0.0.1")],
     hostname="mock_hostname",
     port=None,
     type="_raop._tcp.local.",
@@ -558,8 +558,8 @@ async def test_zeroconf_unsupported_service_aborts(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="127.0.0.1",
-            addresses=["127.0.0.1"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
@@ -579,8 +579,8 @@ async def test_zeroconf_add_mrp_device(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="127.0.0.2",
-            addresses=["127.0.0.2"],
+            ip_address=ip_address("127.0.0.2"),
+            ip_addresses=[ip_address("127.0.0.2")],
             hostname="mock_hostname",
             port=None,
             name="Kitchen",
@@ -594,8 +594,8 @@ async def test_zeroconf_add_mrp_device(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="127.0.0.1",
-            addresses=["127.0.0.1"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             port=None,
             name="Kitchen",
@@ -836,8 +836,8 @@ async def test_zeroconf_abort_if_other_in_progress(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="127.0.0.1",
-            addresses=["127.0.0.1"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             port=None,
             type="_airplay._tcp.local.",
@@ -859,8 +859,8 @@ async def test_zeroconf_abort_if_other_in_progress(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="127.0.0.1",
-            addresses=["127.0.0.1"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             port=None,
             type="_mediaremotetv._tcp.local.",
@@ -885,8 +885,8 @@ async def test_zeroconf_missing_device_during_protocol_resolve(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="127.0.0.1",
-            addresses=["127.0.0.1"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             port=None,
             type="_airplay._tcp.local.",
@@ -907,8 +907,8 @@ async def test_zeroconf_missing_device_during_protocol_resolve(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="127.0.0.1",
-            addresses=["127.0.0.1"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             port=None,
             type="_mediaremotetv._tcp.local.",
@@ -943,8 +943,8 @@ async def test_zeroconf_additional_protocol_resolve_failure(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="127.0.0.1",
-            addresses=["127.0.0.1"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             port=None,
             type="_airplay._tcp.local.",
@@ -965,8 +965,8 @@ async def test_zeroconf_additional_protocol_resolve_failure(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="127.0.0.1",
-            addresses=["127.0.0.1"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             port=None,
             type="_mediaremotetv._tcp.local.",
@@ -1003,8 +1003,8 @@ async def test_zeroconf_pair_additionally_found_protocols(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="127.0.0.1",
-            addresses=["127.0.0.1"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             port=None,
             type="_airplay._tcp.local.",
@@ -1046,8 +1046,8 @@ async def test_zeroconf_pair_additionally_found_protocols(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="127.0.0.1",
-            addresses=["127.0.0.1"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             port=None,
             type="_mediaremotetv._tcp.local.",
@@ -1158,8 +1158,8 @@ async def test_zeroconf_rejects_ipv6(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="fd00::b27c:63bb:cc85:4ea0",
-            addresses=["fd00::b27c:63bb:cc85:4ea0"],
+            ip_address=ip_address("fd00::b27c:63bb:cc85:4ea0"),
+            ip_addresses=[ip_address("fd00::b27c:63bb:cc85:4ea0")],
             hostname="mock_hostname",
             port=None,
             type="_touch-able._tcp.local.",

--- a/tests/components/awair/const.py
+++ b/tests/components/awair/const.py
@@ -1,5 +1,7 @@
 """Constants used in Awair tests."""
 
+from ipaddress import ip_address
+
 from homeassistant.components import zeroconf
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST
 
@@ -9,8 +11,8 @@ LOCAL_CONFIG = {CONF_HOST: "192.0.2.5"}
 CLOUD_UNIQUE_ID = "foo@bar.com"
 LOCAL_UNIQUE_ID = "00:B0:D0:63:C2:26"
 ZEROCONF_DISCOVERY = zeroconf.ZeroconfServiceInfo(
-    host="192.0.2.5",
-    addresses=["192.0.2.5"],
+    ip_address=ip_address("192.0.2.5"),
+    ip_addresses=[ip_address("192.0.2.5")],
     hostname="mock_hostname",
     name="awair12345",
     port=None,

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test Axis config flow."""
+from ipaddress import ip_address
 from unittest.mock import patch
 
 import pytest
@@ -294,8 +295,8 @@ async def test_reauth_flow_update_configuration(
         (
             SOURCE_ZEROCONF,
             zeroconf.ZeroconfServiceInfo(
-                host=DEFAULT_HOST,
-                addresses=[DEFAULT_HOST],
+                ip_address=ip_address(DEFAULT_HOST),
+                ip_addresses=[ip_address(DEFAULT_HOST)],
                 port=80,
                 hostname=f"axis-{MAC.lower()}.local.",
                 type="_axis-video._tcp.local.",
@@ -377,8 +378,8 @@ async def test_discovery_flow(
         (
             SOURCE_ZEROCONF,
             zeroconf.ZeroconfServiceInfo(
-                host=DEFAULT_HOST,
-                addresses=[DEFAULT_HOST],
+                ip_address=ip_address(DEFAULT_HOST),
+                ip_addresses=[ip_address(DEFAULT_HOST)],
                 hostname="mock_hostname",
                 name=f"AXIS M1065-LW - {MAC}._axis-video._tcp.local.",
                 port=80,
@@ -431,8 +432,8 @@ async def test_discovered_device_already_configured(
         (
             SOURCE_ZEROCONF,
             zeroconf.ZeroconfServiceInfo(
-                host="2.3.4.5",
-                addresses=["2.3.4.5"],
+                ip_address=ip_address("2.3.4.5"),
+                ip_addresses=[ip_address("2.3.4.5")],
                 hostname="mock_hostname",
                 name=f"AXIS M1065-LW - {MAC}._axis-video._tcp.local.",
                 port=8080,
@@ -505,8 +506,8 @@ async def test_discovery_flow_updated_configuration(
         (
             SOURCE_ZEROCONF,
             zeroconf.ZeroconfServiceInfo(
-                host="",
-                addresses=[""],
+                ip_address=None,
+                ip_addresses=[],
                 hostname="mock_hostname",
                 name="",
                 port=0,
@@ -554,8 +555,8 @@ async def test_discovery_flow_ignore_non_axis_device(
         (
             SOURCE_ZEROCONF,
             zeroconf.ZeroconfServiceInfo(
-                host="169.254.3.4",
-                addresses=["169.254.3.4"],
+                ip_address=ip_address("169.254.3.4"),
+                ip_addresses=[ip_address("169.254.3.4")],
                 hostname="mock_hostname",
                 name=f"AXIS M1065-LW - {MAC}._axis-video._tcp.local.",
                 port=80,

--- a/tests/components/axis/test_device.py
+++ b/tests/components/axis/test_device.py
@@ -1,4 +1,5 @@
 """Test Axis device."""
+from ipaddress import ip_address
 from unittest import mock
 from unittest.mock import Mock, patch
 
@@ -117,8 +118,8 @@ async def test_update_address(
         await hass.config_entries.flow.async_init(
             AXIS_DOMAIN,
             data=zeroconf.ZeroconfServiceInfo(
-                host="2.3.4.5",
-                addresses=["2.3.4.5"],
+                ip_address=ip_address("2.3.4.5"),
+                ip_addresses=[ip_address("2.3.4.5")],
                 hostname="mock_hostname",
                 name="name",
                 port=80,

--- a/tests/components/baf/test_config_flow.py
+++ b/tests/components/baf/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the baf config flow."""
 import asyncio
+from ipaddress import ip_address
 from unittest.mock import patch
 
 from homeassistant import config_entries
@@ -87,8 +88,8 @@ async def test_zeroconf_discovery(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="127.0.0.1",
-            addresses=["127.0.0.1"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             name="testfan",
             port=None,
@@ -125,8 +126,8 @@ async def test_zeroconf_updates_existing_ip(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="127.0.0.1",
-            addresses=["127.0.0.1"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             name="testfan",
             port=None,
@@ -145,8 +146,8 @@ async def test_zeroconf_rejects_ipv6(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="fd00::b27c:63bb:cc85:4ea0",
-            addresses=["fd00::b27c:63bb:cc85:4ea0"],
+            ip_address=ip_address("fd00::b27c:63bb:cc85:4ea0"),
+            ip_addresses=[ip_address("fd00::b27c:63bb:cc85:4ea0")],
             hostname="mock_hostname",
             name="testfan",
             port=None,
@@ -164,8 +165,8 @@ async def test_user_flow_is_not_blocked_by_discovery(hass: HomeAssistant) -> Non
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="127.0.0.1",
-            addresses=["127.0.0.1"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             name="testfan",
             port=None,

--- a/tests/components/blebox/test_config_flow.py
+++ b/tests/components/blebox/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test Home Assistant config flow for BleBox devices."""
+from ipaddress import ip_address
 from unittest.mock import DEFAULT, AsyncMock, PropertyMock, patch
 
 import blebox_uniapi
@@ -211,8 +212,8 @@ async def test_flow_with_zeroconf(hass: HomeAssistant) -> None:
         config_flow.DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="172.100.123.4",
-            addresses=["172.100.123.4"],
+            ip_address=ip_address("172.100.123.4"),
+            ip_addresses=[ip_address("172.100.123.4")],
             port=80,
             hostname="bbx-bbtest123456.local.",
             type="_bbxsrv._tcp.local.",
@@ -251,8 +252,8 @@ async def test_flow_with_zeroconf_when_already_configured(hass: HomeAssistant) -
             config_flow.DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="172.100.123.4",
-                addresses=["172.100.123.4"],
+                ip_address=ip_address("172.100.123.4"),
+                ip_addresses=[ip_address("172.100.123.4")],
                 port=80,
                 hostname="bbx-bbtest123456.local.",
                 type="_bbxsrv._tcp.local.",
@@ -275,8 +276,8 @@ async def test_flow_with_zeroconf_when_device_unsupported(hass: HomeAssistant) -
             config_flow.DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="172.100.123.4",
-                addresses=["172.100.123.4"],
+                ip_address=ip_address("172.100.123.4"),
+                ip_addresses=[ip_address("172.100.123.4")],
                 port=80,
                 hostname="bbx-bbtest123456.local.",
                 type="_bbxsrv._tcp.local.",
@@ -301,8 +302,8 @@ async def test_flow_with_zeroconf_when_device_response_unsupported(
             config_flow.DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="172.100.123.4",
-                addresses=["172.100.123.4"],
+                ip_address=ip_address("172.100.123.4"),
+                ip_addresses=[ip_address("172.100.123.4")],
                 port=80,
                 hostname="bbx-bbtest123456.local.",
                 type="_bbxsrv._tcp.local.",

--- a/tests/components/bond/test_config_flow.py
+++ b/tests/components/bond/test_config_flow.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from http import HTTPStatus
+from ipaddress import ip_address
 from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
@@ -203,8 +204,8 @@ async def test_zeroconf_form(hass: HomeAssistant) -> None:
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="test-host",
-                addresses=["test-host"],
+                ip_address=ip_address("127.0.0.1"),
+                ip_addresses=[ip_address("127.0.0.1")],
                 hostname="mock_hostname",
                 name="ZXXX12345.some-other-tail-info",
                 port=None,
@@ -227,7 +228,7 @@ async def test_zeroconf_form(hass: HomeAssistant) -> None:
     assert result2["type"] == "create_entry"
     assert result2["title"] == "bond-name"
     assert result2["data"] == {
-        CONF_HOST: "test-host",
+        CONF_HOST: "127.0.0.1",
         CONF_ACCESS_TOKEN: "test-token",
     }
     assert len(mock_setup_entry.mock_calls) == 1
@@ -241,8 +242,8 @@ async def test_zeroconf_form_token_unavailable(hass: HomeAssistant) -> None:
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="test-host",
-                addresses=["test-host"],
+                ip_address=ip_address("127.0.0.1"),
+                ip_addresses=[ip_address("127.0.0.1")],
                 hostname="mock_hostname",
                 name="ZXXX12345.some-other-tail-info",
                 port=None,
@@ -264,7 +265,7 @@ async def test_zeroconf_form_token_unavailable(hass: HomeAssistant) -> None:
     assert result2["type"] == "create_entry"
     assert result2["title"] == "bond-name"
     assert result2["data"] == {
-        CONF_HOST: "test-host",
+        CONF_HOST: "127.0.0.1",
         CONF_ACCESS_TOKEN: "test-token",
     }
     assert len(mock_setup_entry.mock_calls) == 1
@@ -278,8 +279,8 @@ async def test_zeroconf_form_token_times_out(hass: HomeAssistant) -> None:
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="test-host",
-                addresses=["test-host"],
+                ip_address=ip_address("127.0.0.1"),
+                ip_addresses=[ip_address("127.0.0.1")],
                 hostname="mock_hostname",
                 name="ZXXX12345.some-other-tail-info",
                 port=None,
@@ -301,7 +302,7 @@ async def test_zeroconf_form_token_times_out(hass: HomeAssistant) -> None:
     assert result2["type"] == "create_entry"
     assert result2["title"] == "bond-name"
     assert result2["data"] == {
-        CONF_HOST: "test-host",
+        CONF_HOST: "127.0.0.1",
         CONF_ACCESS_TOKEN: "test-token",
     }
     assert len(mock_setup_entry.mock_calls) == 1
@@ -319,8 +320,8 @@ async def test_zeroconf_form_with_token_available(hass: HomeAssistant) -> None:
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="test-host",
-                addresses=["test-host"],
+                ip_address=ip_address("127.0.0.1"),
+                ip_addresses=[ip_address("127.0.0.1")],
                 hostname="mock_hostname",
                 name="ZXXX12345.some-other-tail-info",
                 port=None,
@@ -342,7 +343,7 @@ async def test_zeroconf_form_with_token_available(hass: HomeAssistant) -> None:
     assert result2["type"] == "create_entry"
     assert result2["title"] == "discovered-name"
     assert result2["data"] == {
-        CONF_HOST: "test-host",
+        CONF_HOST: "127.0.0.1",
         CONF_ACCESS_TOKEN: "discovered-token",
     }
     assert len(mock_setup_entry.mock_calls) == 1
@@ -360,8 +361,8 @@ async def test_zeroconf_form_with_token_available_name_unavailable(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="test-host",
-                addresses=["test-host"],
+                ip_address=ip_address("127.0.0.1"),
+                ip_addresses=[ip_address("127.0.0.1")],
                 hostname="mock_hostname",
                 name="ZXXX12345.some-other-tail-info",
                 port=None,
@@ -383,7 +384,7 @@ async def test_zeroconf_form_with_token_available_name_unavailable(
     assert result2["type"] == "create_entry"
     assert result2["title"] == "ZXXX12345"
     assert result2["data"] == {
-        CONF_HOST: "test-host",
+        CONF_HOST: "127.0.0.1",
         CONF_ACCESS_TOKEN: "discovered-token",
     }
     assert len(mock_setup_entry.mock_calls) == 1
@@ -404,8 +405,8 @@ async def test_zeroconf_already_configured(hass: HomeAssistant) -> None:
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="updated-host",
-                addresses=["updated-host"],
+                ip_address=ip_address("127.0.0.2"),
+                ip_addresses=[ip_address("127.0.0.2")],
                 hostname="mock_hostname",
                 name="already-registered-bond-id.some-other-tail-info",
                 port=None,
@@ -417,7 +418,7 @@ async def test_zeroconf_already_configured(hass: HomeAssistant) -> None:
 
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
-    assert entry.data["host"] == "updated-host"
+    assert entry.data["host"] == "127.0.0.2"
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -442,8 +443,8 @@ async def test_zeroconf_in_setup_retry_state(hass: HomeAssistant) -> None:
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="updated-host",
-                addresses=["updated-host"],
+                ip_address=ip_address("127.0.0.2"),
+                ip_addresses=[ip_address("127.0.0.2")],
                 hostname="mock_hostname",
                 name="already-registered-bond-id.some-other-tail-info",
                 port=None,
@@ -455,7 +456,7 @@ async def test_zeroconf_in_setup_retry_state(hass: HomeAssistant) -> None:
 
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
-    assert entry.data["host"] == "updated-host"
+    assert entry.data["host"] == "127.0.0.2"
     assert len(mock_setup_entry.mock_calls) == 1
     assert entry.state is ConfigEntryState.LOADED
 
@@ -488,8 +489,8 @@ async def test_zeroconf_already_configured_refresh_token(hass: HomeAssistant) ->
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="updated-host",
-                addresses=["updated-host"],
+                ip_address=ip_address("127.0.0.2"),
+                ip_addresses=[ip_address("127.0.0.2")],
                 hostname="mock_hostname",
                 name="already-registered-bond-id.some-other-tail-info",
                 port=None,
@@ -501,7 +502,7 @@ async def test_zeroconf_already_configured_refresh_token(hass: HomeAssistant) ->
 
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
-    assert entry.data["host"] == "updated-host"
+    assert entry.data["host"] == "127.0.0.2"
     assert entry.data[CONF_ACCESS_TOKEN] == "discovered-token"
     # entry2 should not get changed
     assert entry2.data[CONF_ACCESS_TOKEN] == "correct-token"
@@ -515,7 +516,7 @@ async def test_zeroconf_already_configured_no_reload_same_host(
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="already-registered-bond-id",
-        data={CONF_HOST: "stored-host", CONF_ACCESS_TOKEN: "correct-token"},
+        data={CONF_HOST: "127.0.0.3", CONF_ACCESS_TOKEN: "correct-token"},
     )
     entry.add_to_hass(hass)
 
@@ -526,8 +527,8 @@ async def test_zeroconf_already_configured_no_reload_same_host(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="stored-host",
-                addresses=["stored-host"],
+                ip_address=ip_address("127.0.0.3"),
+                ip_addresses=[ip_address("127.0.0.3")],
                 hostname="mock_hostname",
                 name="already-registered-bond-id.some-other-tail-info",
                 port=None,
@@ -548,8 +549,8 @@ async def test_zeroconf_form_unexpected_error(hass: HomeAssistant) -> None:
         hass,
         source=config_entries.SOURCE_ZEROCONF,
         initial_input=zeroconf.ZeroconfServiceInfo(
-            host="test-host",
-            addresses=["test-host"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             name="ZXXX12345.some-other-tail-info",
             port=None,

--- a/tests/components/bosch_shc/test_config_flow.py
+++ b/tests/components/bosch_shc/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Bosch SHC config flow."""
+from ipaddress import ip_address
 from unittest.mock import PropertyMock, mock_open, patch
 
 from boschshcpy.exceptions import (
@@ -22,8 +23,8 @@ MOCK_SETTINGS = {
     "device": {"mac": "test-mac", "hostname": "test-host"},
 }
 DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
-    host="1.1.1.1",
-    addresses=["1.1.1.1"],
+    ip_address=ip_address("1.1.1.1"),
+    ip_addresses=[ip_address("1.1.1.1")],
     hostname="shc012345.local.",
     name="Bosch SHC [test-mac]._http._tcp.local.",
     port=0,
@@ -548,8 +549,8 @@ async def test_zeroconf_not_bosch_shc(hass: HomeAssistant, mock_zeroconf: None) 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.1.1.1",
-            addresses=["1.1.1.1"],
+            ip_address=ip_address("1.1.1.1"),
+            ip_addresses=[ip_address("1.1.1.1")],
             hostname="mock_hostname",
             name="notboschshc",
             port=None,

--- a/tests/components/brother/test_config_flow.py
+++ b/tests/components/brother/test_config_flow.py
@@ -1,4 +1,5 @@
 """Define tests for the Brother Printer config flow."""
+from ipaddress import ip_address
 import json
 from unittest.mock import patch
 
@@ -155,8 +156,8 @@ async def test_zeroconf_snmp_error(hass: HomeAssistant) -> None:
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="127.0.0.1",
-                addresses=["mock_host"],
+                ip_address=ip_address("127.0.0.1"),
+                ip_addresses=[ip_address("127.0.0.1")],
                 hostname="example.local.",
                 name="Brother Printer",
                 port=None,
@@ -178,8 +179,8 @@ async def test_zeroconf_unsupported_model(hass: HomeAssistant) -> None:
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="127.0.0.1",
-                addresses=["mock_host"],
+                ip_address=ip_address("127.0.0.1"),
+                ip_addresses=[ip_address("127.0.0.1")],
                 hostname="example.local.",
                 name="Brother Printer",
                 port=None,
@@ -210,8 +211,8 @@ async def test_zeroconf_device_exists_abort(hass: HomeAssistant) -> None:
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="127.0.0.1",
-                addresses=["mock_host"],
+                ip_address=ip_address("127.0.0.1"),
+                ip_addresses=[ip_address("127.0.0.1")],
                 hostname="example.local.",
                 name="Brother Printer",
                 port=None,
@@ -238,8 +239,8 @@ async def test_zeroconf_no_probe_existing_device(hass: HomeAssistant) -> None:
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="127.0.0.1",
-                addresses=["mock_host"],
+                ip_address=ip_address("127.0.0.1"),
+                ip_addresses=[ip_address("127.0.0.1")],
                 hostname="example.local.",
                 name="Brother Printer",
                 port=None,
@@ -264,8 +265,8 @@ async def test_zeroconf_confirm_create_entry(hass: HomeAssistant) -> None:
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="127.0.0.1",
-                addresses=["mock_host"],
+                ip_address=ip_address("127.0.0.1"),
+                ip_addresses=[ip_address("127.0.0.1")],
                 hostname="example.local.",
                 name="Brother Printer",
                 port=None,

--- a/tests/components/daikin/test_config_flow.py
+++ b/tests/components/daikin/test_config_flow.py
@@ -1,5 +1,6 @@
 """Tests for the Daikin config flow."""
 import asyncio
+from ipaddress import ip_address
 from unittest.mock import PropertyMock, patch
 
 from aiohttp import ClientError, web_exceptions
@@ -119,8 +120,8 @@ async def test_api_password_abort(hass: HomeAssistant) -> None:
         (
             SOURCE_ZEROCONF,
             zeroconf.ZeroconfServiceInfo(
-                host=HOST,
-                addresses=[HOST],
+                ip_address=ip_address(HOST),
+                ip_addresses=[ip_address(HOST)],
                 hostname="mock_hostname",
                 name="mock_name",
                 port=None,

--- a/tests/components/devolo_home_control/const.py
+++ b/tests/components/devolo_home_control/const.py
@@ -1,10 +1,12 @@
 """Constants used for mocking data."""
 
+from ipaddress import ip_address
+
 from homeassistant.components import zeroconf
 
 DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
-    host="192.168.0.1",
-    addresses=["192.168.0.1"],
+    ip_address=ip_address("192.168.0.1"),
+    ip_addresses=[ip_address("192.168.0.1")],
     port=14791,
     hostname="test.local.",
     type="_dvl-deviceapi._tcp.local.",
@@ -21,8 +23,8 @@ DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
 )
 
 DISCOVERY_INFO_WRONG_DEVOLO_DEVICE = zeroconf.ZeroconfServiceInfo(
-    host="mock_host",
-    addresses=["mock_host"],
+    ip_address=ip_address("192.168.0.1"),
+    ip_addresses=[ip_address("192.168.0.1")],
     hostname="mock_hostname",
     name="mock_name",
     port=None,
@@ -31,8 +33,8 @@ DISCOVERY_INFO_WRONG_DEVOLO_DEVICE = zeroconf.ZeroconfServiceInfo(
 )
 
 DISCOVERY_INFO_WRONG_DEVICE = zeroconf.ZeroconfServiceInfo(
-    host="mock_host",
-    addresses=["mock_host"],
+    ip_address=ip_address("192.168.0.1"),
+    ip_addresses=[ip_address("192.168.0.1")],
     hostname="mock_hostname",
     name="mock_name",
     port=None,

--- a/tests/components/devolo_home_network/const.py
+++ b/tests/components/devolo_home_network/const.py
@@ -1,5 +1,7 @@
 """Constants used for mocking data."""
 
+from ipaddress import ip_address
+
 from devolo_plc_api.device_api import (
     UPDATE_AVAILABLE,
     WIFI_BAND_2G,
@@ -30,8 +32,8 @@ CONNECTED_STATIONS = [
 NO_CONNECTED_STATIONS = []
 
 DISCOVERY_INFO = ZeroconfServiceInfo(
-    host=IP,
-    addresses=[IP],
+    ip_address=ip_address(IP),
+    ip_addresses=[ip_address(IP)],
     port=14791,
     hostname="test.local.",
     type="_dvl-deviceapi._tcp.local.",
@@ -51,8 +53,8 @@ DISCOVERY_INFO = ZeroconfServiceInfo(
 )
 
 DISCOVERY_INFO_CHANGED = ZeroconfServiceInfo(
-    host=IP_ALT,
-    addresses=[IP_ALT],
+    ip_address=ip_address(IP_ALT),
+    ip_addresses=[ip_address(IP_ALT)],
     port=14791,
     hostname="test.local.",
     type="_dvl-deviceapi._tcp.local.",
@@ -72,8 +74,8 @@ DISCOVERY_INFO_CHANGED = ZeroconfServiceInfo(
 )
 
 DISCOVERY_INFO_WRONG_DEVICE = ZeroconfServiceInfo(
-    host="mock_host",
-    addresses=["mock_host"],
+    ip_address=ip_address("127.0.0.2"),
+    ip_addresses=[ip_address("127.0.0.2")],
     hostname="mock_hostname",
     name="mock_name",
     port=None,

--- a/tests/components/doorbird/test_config_flow.py
+++ b/tests/components/doorbird/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the DoorBird config flow."""
+from ipaddress import ip_address
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -84,8 +85,8 @@ async def test_form_zeroconf_wrong_oui(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.8",
-            addresses=["192.168.1.8"],
+            ip_address=ip_address("192.168.1.8"),
+            ip_addresses=[ip_address("192.168.1.8")],
             hostname="mock_hostname",
             name="Doorstation - abc123._axis-video._tcp.local.",
             port=None,
@@ -104,8 +105,8 @@ async def test_form_zeroconf_link_local_ignored(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="169.254.103.61",
-            addresses=["169.254.103.61"],
+            ip_address=ip_address("169.254.103.61"),
+            ip_addresses=[ip_address("169.254.103.61")],
             hostname="mock_hostname",
             name="Doorstation - abc123._axis-video._tcp.local.",
             port=None,
@@ -131,8 +132,8 @@ async def test_form_zeroconf_ipv4_address(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="4.4.4.4",
-            addresses=["4.4.4.4"],
+            ip_address=ip_address("4.4.4.4"),
+            ip_addresses=[ip_address("4.4.4.4")],
             hostname="mock_hostname",
             name="Doorstation - abc123._axis-video._tcp.local.",
             port=None,
@@ -152,8 +153,8 @@ async def test_form_zeroconf_non_ipv4_ignored(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="fd00::b27c:63bb:cc85:4ea0",
-            addresses=["fd00::b27c:63bb:cc85:4ea0"],
+            ip_address=ip_address("fd00::b27c:63bb:cc85:4ea0"),
+            ip_addresses=[ip_address("fd00::b27c:63bb:cc85:4ea0")],
             hostname="mock_hostname",
             name="Doorstation - abc123._axis-video._tcp.local.",
             port=None,
@@ -179,8 +180,8 @@ async def test_form_zeroconf_correct_oui(hass: HomeAssistant) -> None:
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="192.168.1.5",
-                addresses=["192.168.1.5"],
+                ip_address=ip_address("192.168.1.5"),
+                ip_addresses=[ip_address("192.168.1.5")],
                 hostname="mock_hostname",
                 name="Doorstation - abc123._axis-video._tcp.local.",
                 port=None,
@@ -244,8 +245,8 @@ async def test_form_zeroconf_correct_oui_wrong_device(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="192.168.1.5",
-                addresses=["192.168.1.5"],
+                ip_address=ip_address("192.168.1.5"),
+                ip_addresses=[ip_address("192.168.1.5")],
                 hostname="mock_hostname",
                 name="Doorstation - abc123._axis-video._tcp.local.",
                 port=None,

--- a/tests/components/elgato/test_config_flow.py
+++ b/tests/components/elgato/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the Elgato Key Light config flow."""
+from ipaddress import ip_address
 from unittest.mock import AsyncMock, MagicMock
 
 from elgato import ElgatoConnectionError
@@ -52,8 +53,8 @@ async def test_full_zeroconf_flow_implementation(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="127.0.0.1",
-            addresses=["127.0.0.1"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="example.local.",
             name="mock_name",
             port=9123,
@@ -110,8 +111,8 @@ async def test_zeroconf_connection_error(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="127.0.0.1",
-            addresses=["127.0.0.1"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             name="mock_name",
             port=9123,
@@ -150,8 +151,8 @@ async def test_zeroconf_device_exists_abort(
         DOMAIN,
         context={CONF_SOURCE: SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="127.0.0.1",
-            addresses=["127.0.0.1"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             name="mock_name",
             port=9123,
@@ -171,8 +172,8 @@ async def test_zeroconf_device_exists_abort(
         DOMAIN,
         context={CONF_SOURCE: SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="127.0.0.2",
-            addresses=["127.0.0.2"],
+            ip_address=ip_address("127.0.0.2"),
+            ip_addresses=[ip_address("127.0.0.2")],
             hostname="mock_hostname",
             name="mock_name",
             port=9123,
@@ -200,8 +201,8 @@ async def test_zeroconf_during_onboarding(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="127.0.0.1",
-            addresses=["127.0.0.1"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="example.local.",
             name="mock_name",
             port=9123,

--- a/tests/components/enphase_envoy/test_config_flow.py
+++ b/tests/components/enphase_envoy/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Enphase Envoy config flow."""
+from ipaddress import ip_address
 from unittest.mock import AsyncMock
 
 from pyenphase import EnvoyAuthenticationError, EnvoyError
@@ -175,8 +176,8 @@ async def test_zeroconf_pre_token_firmware(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.1.1.1",
-            addresses=["1.1.1.1"],
+            ip_address=ip_address("1.1.1.1"),
+            ip_addresses=[ip_address("1.1.1.1")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
@@ -216,8 +217,8 @@ async def test_zeroconf_token_firmware(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.1.1.1",
-            addresses=["1.1.1.1"],
+            ip_address=ip_address("1.1.1.1"),
+            ip_addresses=[ip_address("1.1.1.1")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
@@ -278,8 +279,8 @@ async def test_zeroconf_serial_already_exists(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="4.4.4.4",
-            addresses=["4.4.4.4"],
+            ip_address=ip_address("4.4.4.4"),
+            ip_addresses=[ip_address("4.4.4.4")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
@@ -301,8 +302,8 @@ async def test_zeroconf_serial_already_exists_ignores_ipv6(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="fd00::b27c:63bb:cc85:4ea0",
-            addresses=["fd00::b27c:63bb:cc85:4ea0"],
+            ip_address=ip_address("fd00::b27c:63bb:cc85:4ea0"),
+            ip_addresses=[ip_address("fd00::b27c:63bb:cc85:4ea0")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
@@ -325,8 +326,8 @@ async def test_zeroconf_host_already_exists(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.1.1.1",
-            addresses=["1.1.1.1"],
+            ip_address=ip_address("1.1.1.1"),
+            ip_addresses=[ip_address("1.1.1.1")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test config flow."""
 import asyncio
+from ipaddress import ip_address
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -121,8 +122,8 @@ async def test_user_sets_unique_id(
 ) -> None:
     """Test that the user flow sets the unique id."""
     service_info = zeroconf.ZeroconfServiceInfo(
-        host="192.168.43.183",
-        addresses=["192.168.43.183"],
+        ip_address=ip_address("192.168.43.183"),
+        ip_addresses=[ip_address("192.168.43.183")],
         hostname="test8266.local.",
         name="mock_name",
         port=6053,
@@ -198,8 +199,8 @@ async def test_user_causes_zeroconf_to_abort(
 ) -> None:
     """Test that the user flow sets the unique id and aborts the zeroconf flow."""
     service_info = zeroconf.ZeroconfServiceInfo(
-        host="192.168.43.183",
-        addresses=["192.168.43.183"],
+        ip_address=ip_address("192.168.43.183"),
+        ip_addresses=[ip_address("192.168.43.183")],
         hostname="test8266.local.",
         name="mock_name",
         port=6053,
@@ -558,8 +559,8 @@ async def test_discovery_initiation(
 ) -> None:
     """Test discovery importing works."""
     service_info = zeroconf.ZeroconfServiceInfo(
-        host="192.168.43.183",
-        addresses=["192.168.43.183"],
+        ip_address=ip_address("192.168.43.183"),
+        ip_addresses=[ip_address("192.168.43.183")],
         hostname="test.local.",
         name="mock_name",
         port=6053,
@@ -590,8 +591,8 @@ async def test_discovery_no_mac(
 ) -> None:
     """Test discovery aborted if old ESPHome without mac in zeroconf."""
     service_info = zeroconf.ZeroconfServiceInfo(
-        host="192.168.43.183",
-        addresses=["192.168.43.183"],
+        ip_address=ip_address("192.168.43.183"),
+        ip_addresses=[ip_address("192.168.43.183")],
         hostname="test8266.local.",
         name="mock_name",
         port=6053,
@@ -618,8 +619,8 @@ async def test_discovery_already_configured(
     entry.add_to_hass(hass)
 
     service_info = zeroconf.ZeroconfServiceInfo(
-        host="192.168.43.183",
-        addresses=["192.168.43.183"],
+        ip_address=ip_address("192.168.43.183"),
+        ip_addresses=[ip_address("192.168.43.183")],
         hostname="test8266.local.",
         name="mock_name",
         port=6053,
@@ -639,8 +640,8 @@ async def test_discovery_duplicate_data(
 ) -> None:
     """Test discovery aborts if same mDNS packet arrives."""
     service_info = zeroconf.ZeroconfServiceInfo(
-        host="192.168.43.183",
-        addresses=["192.168.43.183"],
+        ip_address=ip_address("192.168.43.183"),
+        ip_addresses=[ip_address("192.168.43.183")],
         hostname="test.local.",
         name="mock_name",
         port=6053,
@@ -674,8 +675,8 @@ async def test_discovery_updates_unique_id(
     entry.add_to_hass(hass)
 
     service_info = zeroconf.ZeroconfServiceInfo(
-        host="192.168.43.183",
-        addresses=["192.168.43.183"],
+        ip_address=ip_address("192.168.43.183"),
+        ip_addresses=[ip_address("192.168.43.183")],
         hostname="test8266.local.",
         name="mock_name",
         port=6053,
@@ -1173,8 +1174,8 @@ async def test_zeroconf_encryption_key_via_dashboard(
 ) -> None:
     """Test encryption key retrieved from dashboard."""
     service_info = zeroconf.ZeroconfServiceInfo(
-        host="192.168.43.183",
-        addresses=["192.168.43.183"],
+        ip_address=ip_address("192.168.43.183"),
+        ip_addresses=[ip_address("192.168.43.183")],
         hostname="test8266.local.",
         name="mock_name",
         port=6053,
@@ -1239,8 +1240,8 @@ async def test_zeroconf_encryption_key_via_dashboard_with_api_encryption_prop(
 ) -> None:
     """Test encryption key retrieved from dashboard with api_encryption property set."""
     service_info = zeroconf.ZeroconfServiceInfo(
-        host="192.168.43.183",
-        addresses=["192.168.43.183"],
+        ip_address=ip_address("192.168.43.183"),
+        ip_addresses=[ip_address("192.168.43.183")],
         hostname="test8266.local.",
         name="mock_name",
         port=6053,
@@ -1305,8 +1306,8 @@ async def test_zeroconf_no_encryption_key_via_dashboard(
 ) -> None:
     """Test encryption key not retrieved from dashboard."""
     service_info = zeroconf.ZeroconfServiceInfo(
-        host="192.168.43.183",
-        addresses=["192.168.43.183"],
+        ip_address=ip_address("192.168.43.183"),
+        ip_addresses=[ip_address("192.168.43.183")],
         hostname="test8266.local.",
         name="mock_name",
         port=6053,

--- a/tests/components/forked_daapd/test_config_flow.py
+++ b/tests/components/forked_daapd/test_config_flow.py
@@ -1,4 +1,5 @@
 """The config flow tests for the forked_daapd media player platform."""
+from ipaddress import ip_address
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -103,8 +104,8 @@ async def test_zeroconf_updates_title(hass: HomeAssistant, config_entry) -> None
     config_entry.add_to_hass(hass)
     assert len(hass.config_entries.async_entries(DOMAIN)) == 2
     discovery_info = zeroconf.ZeroconfServiceInfo(
-        host="192.168.1.1",
-        addresses=["192.168.1.1"],
+        ip_address=ip_address("192.168.1.1"),
+        ip_addresses=[ip_address("192.168.1.1")],
         hostname="mock_hostname",
         name="mock_name",
         port=23,
@@ -138,8 +139,8 @@ async def test_config_flow_zeroconf_invalid(hass: HomeAssistant) -> None:
     """Test that an invalid zeroconf entry doesn't work."""
     # test with no discovery properties
     discovery_info = zeroconf.ZeroconfServiceInfo(
-        host="127.0.0.1",
-        addresses=["127.0.0.1"],
+        ip_address=ip_address("127.0.0.1"),
+        ip_addresses=[ip_address("127.0.0.1")],
         hostname="mock_hostname",
         name="mock_name",
         port=23,
@@ -153,8 +154,8 @@ async def test_config_flow_zeroconf_invalid(hass: HomeAssistant) -> None:
     assert result["reason"] == "not_forked_daapd"
     # test with forked-daapd version < 27
     discovery_info = zeroconf.ZeroconfServiceInfo(
-        host="127.0.0.1",
-        addresses=["127.0.0.1"],
+        ip_address=ip_address("127.0.0.1"),
+        ip_addresses=[ip_address("127.0.0.1")],
         hostname="mock_hostname",
         name="mock_name",
         port=23,
@@ -168,8 +169,8 @@ async def test_config_flow_zeroconf_invalid(hass: HomeAssistant) -> None:
     assert result["reason"] == "not_forked_daapd"
     # test with verbose mtd-version from Firefly
     discovery_info = zeroconf.ZeroconfServiceInfo(
-        host="127.0.0.1",
-        addresses=["127.0.0.1"],
+        ip_address=ip_address("127.0.0.1"),
+        ip_addresses=[ip_address("127.0.0.1")],
         hostname="mock_hostname",
         name="mock_name",
         port=23,
@@ -183,8 +184,8 @@ async def test_config_flow_zeroconf_invalid(hass: HomeAssistant) -> None:
     assert result["reason"] == "not_forked_daapd"
     # test with svn mtd-version from Firefly
     discovery_info = zeroconf.ZeroconfServiceInfo(
-        host="127.0.0.1",
-        addresses=["127.0.0.1"],
+        ip_address=ip_address("127.0.0.1"),
+        ip_addresses=[ip_address("127.0.0.1")],
         hostname="mock_hostname",
         name="mock_name",
         port=23,
@@ -201,8 +202,8 @@ async def test_config_flow_zeroconf_invalid(hass: HomeAssistant) -> None:
 async def test_config_flow_zeroconf_valid(hass: HomeAssistant) -> None:
     """Test that a valid zeroconf entry works."""
     discovery_info = zeroconf.ZeroconfServiceInfo(
-        host="192.168.1.1",
-        addresses=["192.168.1.1"],
+        ip_address=ip_address("192.168.1.1"),
+        ip_addresses=[ip_address("192.168.1.1")],
         hostname="mock_hostname",
         name="mock_name",
         port=23,

--- a/tests/components/freebox/test_config_flow.py
+++ b/tests/components/freebox/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the Freebox config flow."""
+from ipaddress import ip_address
 from unittest.mock import Mock, patch
 
 from freebox_api.exceptions import (
@@ -19,8 +20,8 @@ from .const import MOCK_HOST, MOCK_PORT
 from tests.common import MockConfigEntry
 
 MOCK_ZEROCONF_DATA = zeroconf.ZeroconfServiceInfo(
-    host="192.168.0.254",
-    addresses=["192.168.0.254"],
+    ip_address=ip_address("192.168.0.254"),
+    ip_addresses=[ip_address("192.168.0.254")],
     port=80,
     hostname="Freebox-Server.local.",
     type="_fbx-api._tcp.local.",

--- a/tests/components/gogogate2/test_config_flow.py
+++ b/tests/components/gogogate2/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the GogoGate2 component."""
+from ipaddress import ip_address
 from unittest.mock import MagicMock, patch
 
 from ismartgate import GogoGate2Api, ISmartGateApi
@@ -104,8 +105,8 @@ async def test_form_homekit_unique_id_already_setup(hass: HomeAssistant) -> None
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.2.3.4",
-            addresses=["1.2.3.4"],
+            ip_address=ip_address("1.2.3.4"),
+            ip_addresses=[ip_address("1.2.3.4")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
@@ -132,8 +133,8 @@ async def test_form_homekit_unique_id_already_setup(hass: HomeAssistant) -> None
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.2.3.4",
-            addresses=["1.2.3.4"],
+            ip_address=ip_address("1.2.3.4"),
+            ip_addresses=[ip_address("1.2.3.4")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
@@ -157,8 +158,8 @@ async def test_form_homekit_ip_address_already_setup(hass: HomeAssistant) -> Non
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.2.3.4",
-            addresses=["1.2.3.4"],
+            ip_address=ip_address("1.2.3.4"),
+            ip_addresses=[ip_address("1.2.3.4")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
@@ -176,8 +177,8 @@ async def test_form_homekit_ip_address(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.2.3.4",
-            addresses=["1.2.3.4"],
+            ip_address=ip_address("1.2.3.4"),
+            ip_addresses=[ip_address("1.2.3.4")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
@@ -259,8 +260,8 @@ async def test_discovered_by_homekit_and_dhcp(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.2.3.4",
-            addresses=["1.2.3.4"],
+            ip_address=ip_address("1.2.3.4"),
+            ip_addresses=[ip_address("1.2.3.4")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,

--- a/tests/components/guardian/test_config_flow.py
+++ b/tests/components/guardian/test_config_flow.py
@@ -1,4 +1,5 @@
 """Define tests for the Elexa Guardian config flow."""
+from ipaddress import ip_address
 from unittest.mock import patch
 
 from aioguardian.errors import GuardianError
@@ -79,8 +80,8 @@ async def test_step_user(hass: HomeAssistant, config, setup_guardian) -> None:
 async def test_step_zeroconf(hass: HomeAssistant, setup_guardian) -> None:
     """Test the zeroconf step."""
     zeroconf_data = zeroconf.ZeroconfServiceInfo(
-        host="192.168.1.100",
-        addresses=["192.168.1.100"],
+        ip_address=ip_address("192.168.1.100"),
+        ip_addresses=[ip_address("192.168.1.100")],
         port=7777,
         hostname="GVC1-ABCD.local.",
         type="_api._udp.local.",
@@ -109,8 +110,8 @@ async def test_step_zeroconf(hass: HomeAssistant, setup_guardian) -> None:
 async def test_step_zeroconf_already_in_progress(hass: HomeAssistant) -> None:
     """Test the zeroconf step aborting because it's already in progress."""
     zeroconf_data = zeroconf.ZeroconfServiceInfo(
-        host="192.168.1.100",
-        addresses=["192.168.1.100"],
+        ip_address=ip_address("192.168.1.100"),
+        ip_addresses=[ip_address("192.168.1.100")],
         port=7777,
         hostname="GVC1-ABCD.local.",
         type="_api._udp.local.",

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -1,5 +1,6 @@
 """Tests for homekit_controller config flow."""
 import asyncio
+from ipaddress import ip_address
 import unittest.mock
 from unittest.mock import AsyncMock, patch
 
@@ -174,10 +175,10 @@ def get_device_discovery_info(
 ) -> zeroconf.ZeroconfServiceInfo:
     """Turn a aiohomekit format zeroconf entry into a homeassistant one."""
     result = zeroconf.ZeroconfServiceInfo(
-        host="127.0.0.1",
+        ip_address=ip_address("127.0.0.1"),
+        ip_addresses=[ip_address("127.0.0.1")],
         hostname=device.description.name,
         name=device.description.name + "._hap._tcp.local.",
-        addresses=["127.0.0.1"],
         port=8080,
         properties={
             "md": device.description.model,

--- a/tests/components/homewizard/test_config_flow.py
+++ b/tests/components/homewizard/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the homewizard config flow."""
+from ipaddress import ip_address
 from unittest.mock import MagicMock, patch
 
 from homewizard_energy.errors import DisabledError, RequestError, UnsupportedError
@@ -58,8 +59,8 @@ async def test_discovery_flow_works(
     """Test discovery setup flow works."""
 
     service_info = zeroconf.ZeroconfServiceInfo(
-        host="192.168.43.183",
-        addresses=["192.168.43.183"],
+        ip_address=ip_address("192.168.43.183"),
+        ip_addresses=[ip_address("192.168.43.183")],
         port=80,
         hostname="p1meter-ddeeff.local.",
         type="",
@@ -131,8 +132,8 @@ async def test_discovery_flow_during_onboarding(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="192.168.43.183",
-                addresses=["192.168.43.183"],
+                ip_address=ip_address("192.168.43.183"),
+                ip_addresses=[ip_address("192.168.43.183")],
                 port=80,
                 hostname="p1meter-ddeeff.local.",
                 type="mock_type",
@@ -177,8 +178,8 @@ async def test_discovery_flow_during_onboarding_disabled_api(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="192.168.43.183",
-                addresses=["192.168.43.183"],
+                ip_address=ip_address("192.168.43.183"),
+                ip_addresses=[ip_address("192.168.43.183")],
                 port=80,
                 hostname="p1meter-ddeeff.local.",
                 type="mock_type",
@@ -229,8 +230,8 @@ async def test_discovery_disabled_api(
     """Test discovery detecting disabled api."""
 
     service_info = zeroconf.ZeroconfServiceInfo(
-        host="192.168.43.183",
-        addresses=["192.168.43.183"],
+        ip_address=ip_address("192.168.43.183"),
+        ip_addresses=[ip_address("192.168.43.183")],
         port=80,
         hostname="p1meter-ddeeff.local.",
         type="",
@@ -279,8 +280,8 @@ async def test_discovery_missing_data_in_service_info(
     """Test discovery detecting missing discovery info."""
 
     service_info = zeroconf.ZeroconfServiceInfo(
-        host="192.168.43.183",
-        addresses=["192.168.43.183"],
+        ip_address=ip_address("192.168.43.183"),
+        ip_addresses=[ip_address("192.168.43.183")],
         port=80,
         hostname="p1meter-ddeeff.local.",
         type="",
@@ -310,8 +311,8 @@ async def test_discovery_invalid_api(
     """Test discovery detecting invalid_api."""
 
     service_info = zeroconf.ZeroconfServiceInfo(
-        host="192.168.43.183",
-        addresses=["192.168.43.183"],
+        ip_address=ip_address("192.168.43.183"),
+        ip_addresses=[ip_address("192.168.43.183")],
         port=80,
         hostname="p1meter-ddeeff.local.",
         type="",

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -1,5 +1,6 @@
 """Tests for Philips Hue config flow."""
 import asyncio
+from ipaddress import ip_address
 from unittest.mock import Mock, patch
 
 from aiohue.discovery import URL_NUPNP
@@ -416,8 +417,8 @@ async def test_bridge_homekit(
         const.DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="0.0.0.0",
-            addresses=["0.0.0.0"],
+            ip_address=ip_address("0.0.0.0"),
+            ip_addresses=[ip_address("0.0.0.0")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
@@ -466,8 +467,8 @@ async def test_bridge_homekit_already_configured(
         const.DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="0.0.0.0",
-            addresses=["0.0.0.0"],
+            ip_address=ip_address("0.0.0.0"),
+            ip_addresses=[ip_address("0.0.0.0")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
@@ -568,8 +569,8 @@ async def test_bridge_zeroconf(
         const.DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.217",
-            addresses=["192.168.1.217"],
+            ip_address=ip_address("192.168.1.217"),
+            ip_addresses=[ip_address("192.168.1.217")],
             port=443,
             hostname="Philips-hue.local",
             type="_hue._tcp.local.",
@@ -604,8 +605,8 @@ async def test_bridge_zeroconf_already_exists(
         const.DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.217",
-            addresses=["192.168.1.217"],
+            ip_address=ip_address("192.168.1.217"),
+            ip_addresses=[ip_address("192.168.1.217")],
             port=443,
             hostname="Philips-hue.local",
             type="_hue._tcp.local.",
@@ -629,8 +630,8 @@ async def test_bridge_zeroconf_ipv6(hass: HomeAssistant) -> None:
         const.DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="fd00::eeb5:faff:fe84:b17d",
-            addresses=["fd00::eeb5:faff:fe84:b17d"],
+            ip_address=ip_address("fd00::eeb5:faff:fe84:b17d"),
+            ip_addresses=[ip_address("fd00::eeb5:faff:fe84:b17d")],
             port=443,
             hostname="Philips-hue.local",
             type="_hue._tcp.local.",
@@ -677,8 +678,8 @@ async def test_bridge_connection_failed(
             const.DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="blah",
-                addresses=["1.2.3.4"],
+                ip_address=ip_address("1.2.3.4"),
+                ip_addresses=[ip_address("1.2.3.4")],
                 port=443,
                 hostname="Philips-hue.local",
                 type="_hue._tcp.local.",
@@ -698,8 +699,8 @@ async def test_bridge_connection_failed(
             const.DOMAIN,
             context={"source": config_entries.SOURCE_HOMEKIT},
             data=zeroconf.ZeroconfServiceInfo(
-                host="0.0.0.0",
-                addresses=["0.0.0.0"],
+                ip_address=ip_address("0.0.0.0"),
+                ip_addresses=[ip_address("0.0.0.0")],
                 hostname="mock_hostname",
                 name="mock_name",
                 port=None,

--- a/tests/components/hunterdouglas_powerview/test_config_flow.py
+++ b/tests/components/hunterdouglas_powerview/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the Logitech Harmony Hub config flow."""
 import asyncio
+from ipaddress import ip_address
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -12,9 +13,10 @@ from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_fixture
 
+ZEROCONF_HOST = "1.2.3.4"
 HOMEKIT_DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
-    host="1.2.3.4",
-    addresses=["1.2.3.4"],
+    ip_address=ip_address(ZEROCONF_HOST),
+    ip_addresses=[ip_address(ZEROCONF_HOST)],
     hostname="mock_hostname",
     name="Hunter Douglas Powerview Hub._hap._tcp.local.",
     port=None,
@@ -23,8 +25,8 @@ HOMEKIT_DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
 )
 
 ZEROCONF_DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
-    host="1.2.3.4",
-    addresses=["1.2.3.4"],
+    ip_address=ip_address(ZEROCONF_HOST),
+    ip_addresses=[ip_address(ZEROCONF_HOST)],
     hostname="mock_hostname",
     name="Hunter Douglas Powerview Hub._powerview._tcp.local.",
     port=None,

--- a/tests/components/ipp/__init__.py
+++ b/tests/components/ipp/__init__.py
@@ -1,5 +1,7 @@
 """Tests for the IPP integration."""
 
+from ipaddress import ip_address
+
 from homeassistant.components import zeroconf
 from homeassistant.components.ipp.const import CONF_BASE_PATH
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SSL, CONF_VERIFY_SSL
@@ -31,8 +33,8 @@ MOCK_USER_INPUT = {
 MOCK_ZEROCONF_IPP_SERVICE_INFO = zeroconf.ZeroconfServiceInfo(
     type=IPP_ZEROCONF_SERVICE_TYPE,
     name=f"{ZEROCONF_NAME}.{IPP_ZEROCONF_SERVICE_TYPE}",
-    host=ZEROCONF_HOST,
-    addresses=[ZEROCONF_HOST],
+    ip_address=ip_address(ZEROCONF_HOST),
+    ip_addresses=[ip_address(ZEROCONF_HOST)],
     hostname=ZEROCONF_HOSTNAME,
     port=ZEROCONF_PORT,
     properties={"rp": ZEROCONF_RP},
@@ -41,8 +43,8 @@ MOCK_ZEROCONF_IPP_SERVICE_INFO = zeroconf.ZeroconfServiceInfo(
 MOCK_ZEROCONF_IPPS_SERVICE_INFO = zeroconf.ZeroconfServiceInfo(
     type=IPPS_ZEROCONF_SERVICE_TYPE,
     name=f"{ZEROCONF_NAME}.{IPPS_ZEROCONF_SERVICE_TYPE}",
-    host=ZEROCONF_HOST,
-    addresses=[ZEROCONF_HOST],
+    ip_address=ip_address(ZEROCONF_HOST),
+    ip_addresses=[ip_address(ZEROCONF_HOST)],
     hostname=ZEROCONF_HOSTNAME,
     port=ZEROCONF_PORT,
     properties={"rp": ZEROCONF_RP},

--- a/tests/components/ipp/test_config_flow.py
+++ b/tests/components/ipp/test_config_flow.py
@@ -1,5 +1,6 @@
 """Tests for the IPP config flow."""
 import dataclasses
+from ipaddress import ip_address
 import json
 from unittest.mock import MagicMock, patch
 
@@ -326,7 +327,9 @@ async def test_zeroconf_with_uuid_device_exists_abort_new_host(
     """Test we abort zeroconf flow if printer already configured."""
     mock_config_entry.add_to_hass(hass)
 
-    discovery_info = dataclasses.replace(MOCK_ZEROCONF_IPP_SERVICE_INFO, host="1.2.3.9")
+    discovery_info = dataclasses.replace(
+        MOCK_ZEROCONF_IPP_SERVICE_INFO, ip_address=ip_address("1.2.3.9")
+    )
     discovery_info.properties = {
         **MOCK_ZEROCONF_IPP_SERVICE_INFO.properties,
         "UUID": "cfe92100-67c4-11d4-a45f-f8d027761251",

--- a/tests/components/kodi/util.py
+++ b/tests/components/kodi/util.py
@@ -1,4 +1,6 @@
 """Test the Kodi config flow."""
+from ipaddress import ip_address
+
 from homeassistant.components import zeroconf
 from homeassistant.components.kodi.const import DEFAULT_SSL
 
@@ -8,7 +10,6 @@ TEST_HOST = {
     "ssl": DEFAULT_SSL,
 }
 
-
 TEST_CREDENTIALS = {"username": "username", "password": "password"}
 
 
@@ -16,8 +17,8 @@ TEST_WS_PORT = {"ws_port": 9090}
 
 UUID = "11111111-1111-1111-1111-111111111111"
 TEST_DISCOVERY = zeroconf.ZeroconfServiceInfo(
-    host="1.1.1.1",
-    addresses=["1.1.1.1"],
+    ip_address=ip_address("1.1.1.1"),
+    ip_addresses=[ip_address("1.1.1.1")],
     port=8080,
     hostname="hostname.local.",
     type="_xbmc-jsonrpc-h._tcp.local.",

--- a/tests/components/kodi/util.py
+++ b/tests/components/kodi/util.py
@@ -28,8 +28,8 @@ TEST_DISCOVERY = zeroconf.ZeroconfServiceInfo(
 
 
 TEST_DISCOVERY_WO_UUID = zeroconf.ZeroconfServiceInfo(
-    host="1.1.1.1",
-    addresses=["1.1.1.1"],
+    ip_address=ip_address("1.1.1.1"),
+    ip_addresses=[ip_address("1.1.1.1")],
     port=8080,
     hostname="hostname.local.",
     type="_xbmc-jsonrpc-h._tcp.local.",

--- a/tests/components/lifx/test_config_flow.py
+++ b/tests/components/lifx/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the lifx integration config flow."""
+from ipaddress import ip_address
 import socket
 from unittest.mock import patch
 
@@ -388,8 +389,8 @@ async def test_discovered_by_discovery_and_dhcp(hass: HomeAssistant) -> None:
         (
             config_entries.SOURCE_HOMEKIT,
             zeroconf.ZeroconfServiceInfo(
-                host=IP_ADDRESS,
-                addresses=[IP_ADDRESS],
+                ip_address=ip_address(IP_ADDRESS),
+                ip_addresses=[ip_address(IP_ADDRESS)],
                 hostname=LABEL,
                 name=LABEL,
                 port=None,
@@ -443,8 +444,8 @@ async def test_discovered_by_dhcp_or_discovery(
         (
             config_entries.SOURCE_HOMEKIT,
             zeroconf.ZeroconfServiceInfo(
-                host=IP_ADDRESS,
-                addresses=[IP_ADDRESS],
+                ip_address=ip_address(IP_ADDRESS),
+                ip_addresses=[ip_address(IP_ADDRESS)],
                 hostname=LABEL,
                 name=LABEL,
                 port=None,
@@ -484,8 +485,8 @@ async def test_discovered_by_dhcp_or_discovery_failed_to_get_device(
         (
             config_entries.SOURCE_HOMEKIT,
             zeroconf.ZeroconfServiceInfo(
-                host=IP_ADDRESS,
-                addresses=[IP_ADDRESS],
+                ip_address=ip_address(IP_ADDRESS),
+                ip_addresses=[ip_address(IP_ADDRESS)],
                 hostname=LABEL,
                 name=LABEL,
                 port=None,

--- a/tests/components/lookin/__init__.py
+++ b/tests/components/lookin/__init__.py
@@ -1,6 +1,7 @@
 """Tests for the lookin integration."""
 from __future__ import annotations
 
+from ipaddress import ip_address
 from unittest.mock import MagicMock, patch
 
 from aiolookin import Climate, Device, Remote
@@ -18,8 +19,8 @@ DEFAULT_ENTRY_TITLE = DEVICE_NAME
 ZC_NAME = f"LOOKin_{DEVICE_ID}"
 ZC_TYPE = "_lookin._tcp."
 ZEROCONF_DATA = ZeroconfServiceInfo(
-    host=IP_ADDRESS,
-    addresses=[IP_ADDRESS],
+    ip_address=ip_address(IP_ADDRESS),
+    ip_addresses=[ip_address(IP_ADDRESS)],
     hostname=f"{ZC_NAME.lower()}.local.",
     port=80,
     type=ZC_TYPE,

--- a/tests/components/lookin/test_config_flow.py
+++ b/tests/components/lookin/test_config_flow.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import dataclasses
+from ipaddress import ip_address
 from unittest.mock import patch
 
 from aiolookin import NoUsableService
@@ -135,7 +136,7 @@ async def test_discovered_zeroconf(hass: HomeAssistant) -> None:
 
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     zc_data_new_ip = dataclasses.replace(ZEROCONF_DATA)
-    zc_data_new_ip.host = "127.0.0.2"
+    zc_data_new_ip.ip_address = ip_address("127.0.0.2")
 
     with _patch_get_info(), patch(
         f"{MODULE}.async_setup_entry", return_value=True

--- a/tests/components/loqed/test_config_flow.py
+++ b/tests/components/loqed/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Loqed config flow."""
+from ipaddress import ip_address
 import json
 from unittest.mock import Mock, patch
 
@@ -16,8 +17,8 @@ from tests.common import load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 zeroconf_data = zeroconf.ZeroconfServiceInfo(
-    host="192.168.12.34",
-    addresses=["127.0.0.1"],
+    ip_address=ip_address("192.168.12.34"),
+    ip_addresses=[ip_address("192.168.12.34")],
     hostname="LOQED-ffeeddccbbaa.local",
     name="mock_name",
     port=9123,

--- a/tests/components/lutron_caseta/test_config_flow.py
+++ b/tests/components/lutron_caseta/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the Lutron Caseta config flow."""
 import asyncio
+from ipaddress import ip_address
 from pathlib import Path
 import ssl
 from unittest.mock import AsyncMock, patch
@@ -404,8 +405,8 @@ async def test_zeroconf_host_already_configured(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.1.1.1",
-            addresses=["1.1.1.1"],
+            ip_address=ip_address("1.1.1.1"),
+            ip_addresses=[ip_address("1.1.1.1")],
             hostname="LuTrOn-abc.local.",
             name="mock_name",
             port=None,
@@ -432,8 +433,8 @@ async def test_zeroconf_lutron_id_already_configured(hass: HomeAssistant) -> Non
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.1.1.1",
-            addresses=["1.1.1.1"],
+            ip_address=ip_address("1.1.1.1"),
+            ip_addresses=[ip_address("1.1.1.1")],
             hostname="LuTrOn-abc.local.",
             name="mock_name",
             port=None,
@@ -455,8 +456,8 @@ async def test_zeroconf_not_lutron_device(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.1.1.1",
-            addresses=["1.1.1.1"],
+            ip_address=ip_address("1.1.1.1"),
+            ip_addresses=[ip_address("1.1.1.1")],
             hostname="notlutron-abc.local.",
             name="mock_name",
             port=None,
@@ -483,8 +484,8 @@ async def test_zeroconf(hass: HomeAssistant, source, tmp_path: Path) -> None:
         DOMAIN,
         context={"source": source},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.1.1.1",
-            addresses=["1.1.1.1"],
+            ip_address=ip_address("1.1.1.1"),
+            ip_addresses=[ip_address("1.1.1.1")],
             hostname="LuTrOn-abc.local.",
             name="mock_name",
             port=None,

--- a/tests/components/modern_forms/test_config_flow.py
+++ b/tests/components/modern_forms/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the Modern Forms config flow."""
+from ipaddress import ip_address
 from unittest.mock import MagicMock, patch
 
 import aiohttp
@@ -65,8 +66,8 @@ async def test_full_zeroconf_flow_implementation(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.123",
-            addresses=["192.168.1.123"],
+            ip_address=ip_address("192.168.1.123"),
+            ip_addresses=[ip_address("192.168.1.123")],
             hostname="example.local.",
             name="mock_name",
             port=None,
@@ -134,8 +135,8 @@ async def test_zeroconf_connection_error(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.123",
-            addresses=["192.168.1.123"],
+            ip_address=ip_address("192.168.1.123"),
+            ip_addresses=[ip_address("192.168.1.123")],
             hostname="example.local.",
             name="mock_name",
             port=None,
@@ -166,8 +167,8 @@ async def test_zeroconf_confirm_connection_error(
             CONF_NAME: "test",
         },
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.123",
-            addresses=["192.168.1.123"],
+            ip_address=ip_address("192.168.1.123"),
+            ip_addresses=[ip_address("192.168.1.123")],
             hostname="example.com.",
             name="mock_name",
             port=None,
@@ -236,8 +237,8 @@ async def test_zeroconf_with_mac_device_exists_abort(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.123",
-            addresses=["192.168.1.123"],
+            ip_address=ip_address("192.168.1.123"),
+            ip_addresses=[ip_address("192.168.1.123")],
             hostname="example.local.",
             name="mock_name",
             port=None,

--- a/tests/components/nam/test_config_flow.py
+++ b/tests/components/nam/test_config_flow.py
@@ -1,5 +1,6 @@
 """Define tests for the Nettigo Air Monitor config flow."""
 import asyncio
+from ipaddress import ip_address
 from unittest.mock import patch
 
 from nettigo_air_monitor import ApiError, AuthFailedError, CannotGetMacError
@@ -14,8 +15,8 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry
 
 DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
-    host="10.10.2.3",
-    addresses=["10.10.2.3"],
+    ip_address=ip_address("10.10.2.3"),
+    ip_addresses=[ip_address("10.10.2.3")],
     hostname="mock_hostname",
     name="mock_name",
     port=None,

--- a/tests/components/nanoleaf/test_config_flow.py
+++ b/tests/components/nanoleaf/test_config_flow.py
@@ -1,6 +1,7 @@
 """Test the Nanoleaf config flow."""
 from __future__ import annotations
 
+from ipaddress import ip_address
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aionanoleaf import InvalidToken, Unauthorized, Unavailable
@@ -237,8 +238,8 @@ async def test_discovery_link_unavailable(
             DOMAIN,
             context={"source": source},
             data=zeroconf.ZeroconfServiceInfo(
-                host=TEST_HOST,
-                addresses=[TEST_HOST],
+                ip_address=ip_address(TEST_HOST),
+                ip_addresses=[ip_address(TEST_HOST)],
                 hostname="mock_hostname",
                 name=f"{TEST_NAME}.{type_in_discovery_info}",
                 port=None,
@@ -372,8 +373,8 @@ async def test_import_discovery_integration(
             DOMAIN,
             context={"source": source},
             data=zeroconf.ZeroconfServiceInfo(
-                host=TEST_HOST,
-                addresses=[TEST_HOST],
+                ip_address=ip_address(TEST_HOST),
+                ip_addresses=[ip_address(TEST_HOST)],
                 hostname="mock_hostname",
                 name=f"{TEST_NAME}.{type_in_discovery}",
                 port=None,

--- a/tests/components/netatmo/test_config_flow.py
+++ b/tests/components/netatmo/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Netatmo config flow."""
+from ipaddress import ip_address
 from unittest.mock import patch
 
 from pyatmo.const import ALL_SCOPES
@@ -44,8 +45,8 @@ async def test_abort_if_existing_entry(hass: HomeAssistant) -> None:
         "netatmo",
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="0.0.0.0",
-            addresses=["0.0.0.0"],
+            ip_address=ip_address("192.168.1.5"),
+            ip_addresses=[ip_address("192.168.1.5")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,

--- a/tests/components/nut/test_config_flow.py
+++ b/tests/components/nut/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Network UPS Tools (NUT) config flow."""
+from ipaddress import ip_address
 from unittest.mock import patch
 
 from pynut2.nut2 import PyNUTError
@@ -36,8 +37,8 @@ async def test_form_zeroconf(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.5",
-            addresses=["192.168.1.5"],
+            ip_address=ip_address("192.168.1.5"),
+            ip_addresses=[ip_address("192.168.1.5")],
             hostname="mock_hostname",
             name="mock_name",
             port=1234,

--- a/tests/components/octoprint/test_config_flow.py
+++ b/tests/components/octoprint/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the OctoPrint config flow."""
+from ipaddress import ip_address
 from unittest.mock import patch
 
 from pyoctoprintapi import ApiError, DiscoverySettings
@@ -174,8 +175,8 @@ async def test_show_zerconf_form(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.123",
-            addresses=["192.168.1.123"],
+            ip_address=ip_address("192.168.1.123"),
+            ip_addresses=[ip_address("192.168.1.123")],
             hostname="example.local.",
             name="mock_name",
             port=80,
@@ -496,8 +497,8 @@ async def test_duplicate_zerconf_ignored(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.123",
-            addresses=["192.168.1.123"],
+            ip_address=ip_address("192.168.1.123"),
+            ip_addresses=[ip_address("192.168.1.123")],
             hostname="example.local.",
             name="mock_name",
             port=80,

--- a/tests/components/overkiz/test_config_flow.py
+++ b/tests/components/overkiz/test_config_flow.py
@@ -1,6 +1,7 @@
 """Tests for Overkiz (by Somfy) config flow."""
 from __future__ import annotations
 
+from ipaddress import ip_address
 from unittest.mock import AsyncMock, Mock, patch
 
 from aiohttp import ClientError
@@ -37,8 +38,8 @@ MOCK_GATEWAY_RESPONSE = [Mock(id=TEST_GATEWAY_ID)]
 MOCK_GATEWAY2_RESPONSE = [Mock(id=TEST_GATEWAY_ID2)]
 
 FAKE_ZERO_CONF_INFO = ZeroconfServiceInfo(
-    host="192.168.0.51",
-    addresses=["192.168.0.51"],
+    ip_address=ip_address("192.168.0.51"),
+    ip_addresses=[ip_address("192.168.0.51")],
     port=443,
     hostname=f"gateway-{TEST_GATEWAY_ID}.local.",
     type="_kizbox._tcp.local.",

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Plugwise config flow."""
+from ipaddress import ip_address
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from plugwise.exceptions import (
@@ -36,8 +37,8 @@ TEST_USERNAME = "smile"
 TEST_USERNAME2 = "stretch"
 
 TEST_DISCOVERY = ZeroconfServiceInfo(
-    host=TEST_HOST,
-    addresses=[TEST_HOST],
+    ip_address=ip_address(TEST_HOST),
+    ip_addresses=[ip_address(TEST_HOST)],
     # The added `-2` is to simulate mDNS collision
     hostname=f"{TEST_HOSTNAME}-2.local.",
     name="mock_name",
@@ -51,8 +52,8 @@ TEST_DISCOVERY = ZeroconfServiceInfo(
 )
 
 TEST_DISCOVERY2 = ZeroconfServiceInfo(
-    host=TEST_HOST,
-    addresses=[TEST_HOST],
+    ip_address=ip_address(TEST_HOST),
+    ip_addresses=[ip_address(TEST_HOST)],
     hostname=f"{TEST_HOSTNAME2}.local.",
     name="mock_name",
     port=DEFAULT_PORT,
@@ -65,8 +66,8 @@ TEST_DISCOVERY2 = ZeroconfServiceInfo(
 )
 
 TEST_DISCOVERY_ANNA = ZeroconfServiceInfo(
-    host=TEST_HOST,
-    addresses=[TEST_HOST],
+    ip_address=ip_address(TEST_HOST),
+    ip_addresses=[ip_address(TEST_HOST)],
     hostname=f"{TEST_HOSTNAME}.local.",
     name="mock_name",
     port=DEFAULT_PORT,
@@ -79,8 +80,8 @@ TEST_DISCOVERY_ANNA = ZeroconfServiceInfo(
 )
 
 TEST_DISCOVERY_ADAM = ZeroconfServiceInfo(
-    host=TEST_HOST,
-    addresses=[TEST_HOST],
+    ip_address=ip_address(TEST_HOST),
+    ip_addresses=[ip_address(TEST_HOST)],
     hostname=f"{TEST_HOSTNAME2}.local.",
     name="mock_name",
     port=DEFAULT_PORT,

--- a/tests/components/pure_energie/test_config_flow.py
+++ b/tests/components/pure_energie/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Pure Energie config flow."""
+from ipaddress import ip_address
 from unittest.mock import MagicMock
 
 from gridnet import GridNetConnectionError
@@ -47,8 +48,8 @@ async def test_full_zeroconf_flow_implementationn(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.123",
-            addresses=["192.168.1.123"],
+            ip_address=ip_address("192.168.1.123"),
+            ip_addresses=[ip_address("192.168.1.123")],
             hostname="example.local.",
             name="mock_name",
             port=None,
@@ -103,8 +104,8 @@ async def test_zeroconf_connection_error(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.123",
-            addresses=["192.168.1.123"],
+            ip_address=ip_address("192.168.1.123"),
+            ip_addresses=[ip_address("192.168.1.123")],
             hostname="example.local.",
             name="mock_name",
             port=None,

--- a/tests/components/rachio/test_config_flow.py
+++ b/tests/components/rachio/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Rachio config flow."""
+from ipaddress import ip_address
 from unittest.mock import MagicMock, patch
 
 from homeassistant import config_entries
@@ -114,8 +115,8 @@ async def test_form_homekit(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="mock_host",
-            addresses=["mock_host"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
@@ -139,8 +140,8 @@ async def test_form_homekit(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="mock_host",
-            addresses=["mock_host"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
@@ -165,8 +166,8 @@ async def test_form_homekit_ignored(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="mock_host",
-            addresses=["mock_host"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,

--- a/tests/components/rainmachine/test_config_flow.py
+++ b/tests/components/rainmachine/test_config_flow.py
@@ -1,4 +1,5 @@
 """Define tests for the OpenUV config flow."""
+from ipaddress import ip_address
 from unittest.mock import patch
 
 import pytest
@@ -157,8 +158,8 @@ async def test_step_homekit_zeroconf_ip_already_exists(
             DOMAIN,
             context={"source": source},
             data=zeroconf.ZeroconfServiceInfo(
-                host="192.168.1.100",
-                addresses=["192.168.1.100"],
+                ip_address=ip_address("192.168.1.100"),
+                ip_addresses=[ip_address("192.168.1.100")],
                 hostname="mock_hostname",
                 name="mock_name",
                 port=None,
@@ -185,8 +186,8 @@ async def test_step_homekit_zeroconf_ip_change(
             DOMAIN,
             context={"source": source},
             data=zeroconf.ZeroconfServiceInfo(
-                host="192.168.1.2",
-                addresses=["192.168.1.2"],
+                ip_address=ip_address("192.168.1.2"),
+                ip_addresses=[ip_address("192.168.1.2")],
                 hostname="mock_hostname",
                 name="mock_name",
                 port=None,
@@ -214,8 +215,8 @@ async def test_step_homekit_zeroconf_new_controller_when_some_exist(
             DOMAIN,
             context={"source": source},
             data=zeroconf.ZeroconfServiceInfo(
-                host="192.168.1.100",
-                addresses=["192.168.1.100"],
+                ip_address=ip_address("192.168.1.100"),
+                ip_addresses=[ip_address("192.168.1.100")],
                 hostname="mock_hostname",
                 name="mock_name",
                 port=None,
@@ -264,8 +265,8 @@ async def test_discovery_by_homekit_and_zeroconf_same_time(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="192.168.1.100",
-                addresses=["192.168.1.100"],
+                ip_address=ip_address("192.168.1.100"),
+                ip_addresses=[ip_address("192.168.1.100")],
                 hostname="mock_hostname",
                 name="mock_name",
                 port=None,
@@ -284,8 +285,8 @@ async def test_discovery_by_homekit_and_zeroconf_same_time(
             DOMAIN,
             context={"source": config_entries.SOURCE_HOMEKIT},
             data=zeroconf.ZeroconfServiceInfo(
-                host="192.168.1.100",
-                addresses=["192.168.1.100"],
+                ip_address=ip_address("192.168.1.100"),
+                ip_addresses=[ip_address("192.168.1.100")],
                 hostname="mock_hostname",
                 name="mock_name",
                 port=None,

--- a/tests/components/roku/__init__.py
+++ b/tests/components/roku/__init__.py
@@ -1,4 +1,6 @@
 """Tests for the Roku component."""
+from ipaddress import ip_address
+
 from homeassistant.components import ssdp, zeroconf
 from homeassistant.components.ssdp import ATTR_UPNP_FRIENDLY_NAME, ATTR_UPNP_SERIAL
 
@@ -23,8 +25,8 @@ MOCK_SSDP_DISCOVERY_INFO = ssdp.SsdpServiceInfo(
 HOMEKIT_HOST = "192.168.1.161"
 
 MOCK_HOMEKIT_DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
-    host=HOMEKIT_HOST,
-    addresses=[HOMEKIT_HOST],
+    ip_address=ip_address(HOMEKIT_HOST),
+    ip_addresses=[ip_address(HOMEKIT_HOST)],
     hostname="mock_hostname",
     name="onn._hap._tcp.local.",
     port=None,

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the iRobot Roomba config flow."""
+from ipaddress import ip_address
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
@@ -36,25 +37,25 @@ DISCOVERY_DEVICES = [
     (
         config_entries.SOURCE_ZEROCONF,
         zeroconf.ZeroconfServiceInfo(
-            host=MOCK_IP,
+            ip_address=ip_address(MOCK_IP),
+            ip_addresses=[ip_address(MOCK_IP)],
             hostname="irobot-blid.local.",
             name="irobot-blid._amzn-alexa._tcp.local.",
             type="_amzn-alexa._tcp.local.",
             port=443,
             properties={},
-            addresses=[MOCK_IP],
         ),
     ),
     (
         config_entries.SOURCE_ZEROCONF,
         zeroconf.ZeroconfServiceInfo(
-            host=MOCK_IP,
+            ip_address=ip_address(MOCK_IP),
+            ip_addresses=[ip_address(MOCK_IP)],
             hostname="roomba-blid.local.",
             name="roomba-blid._amzn-alexa._tcp.local.",
             type="_amzn-alexa._tcp.local.",
             port=443,
             properties={},
-            addresses=[MOCK_IP],
         ),
     ),
 ]

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for Samsung TV config flow."""
+from ipaddress import ip_address
 from unittest.mock import ANY, AsyncMock, Mock, call, patch
 
 import pytest
@@ -130,8 +131,8 @@ MOCK_DHCP_DATA = dhcp.DhcpServiceInfo(
 )
 EXISTING_IP = "192.168.40.221"
 MOCK_ZEROCONF_DATA = zeroconf.ZeroconfServiceInfo(
-    host="fake_host",
-    addresses=["fake_host"],
+    ip_address=ip_address("127.0.0.1"),
+    ip_addresses=[ip_address("127.0.0.1")],
     hostname="mock_hostname",
     name="mock_name",
     port=1234,
@@ -975,7 +976,7 @@ async def test_zeroconf(hass: HomeAssistant) -> None:
     )
     assert result["type"] == "create_entry"
     assert result["title"] == "Living Room (82GXARRS)"
-    assert result["data"][CONF_HOST] == "fake_host"
+    assert result["data"][CONF_HOST] == "127.0.0.1"
     assert result["data"][CONF_NAME] == "Living Room"
     assert result["data"][CONF_MAC] == "aa:bb:ww:ii:ff:ii"
     assert result["data"][CONF_MANUFACTURER] == "Samsung"
@@ -1273,7 +1274,9 @@ async def test_update_missing_mac_unique_id_added_from_zeroconf(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
     """Test missing mac and unique id added."""
-    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY, unique_id=None)
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={**MOCK_OLD_ENTRY, "host": "127.0.0.1"}, unique_id=None
+    )
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
@@ -1539,7 +1542,7 @@ async def test_update_missing_mac_added_unique_id_preserved_from_zeroconf(
     """Test missing mac and unique id added."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data=MOCK_OLD_ENTRY,
+        data={**MOCK_OLD_ENTRY, "host": "127.0.0.1"},
         unique_id="0d1cef00-00dc-1000-9c80-4844f7b172de",
     )
     entry.add_to_hass(hass)

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from ipaddress import ip_address
 from unittest.mock import AsyncMock, patch
 
 from aioshelly.exceptions import (
@@ -29,8 +30,8 @@ from tests.common import MockConfigEntry
 from tests.typing import WebSocketGenerator
 
 DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
-    host="1.1.1.1",
-    addresses=["1.1.1.1"],
+    ip_address=ip_address("1.1.1.1"),
+    ip_addresses=[ip_address("1.1.1.1")],
     hostname="mock_hostname",
     name="shelly1pm-12345",
     port=None,
@@ -38,8 +39,8 @@ DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
     type="mock_type",
 )
 DISCOVERY_INFO_WITH_MAC = zeroconf.ZeroconfServiceInfo(
-    host="1.1.1.1",
-    addresses=["1.1.1.1"],
+    ip_address=ip_address("1.1.1.1"),
+    ip_addresses=[ip_address("1.1.1.1")],
     hostname="mock_hostname",
     name="shelly1pm-AABBCCDDEEFF",
     port=None,
@@ -651,7 +652,9 @@ async def test_zeroconf_with_wifi_ap_ip(hass: HomeAssistant) -> None:
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
-            data=replace(DISCOVERY_INFO, host=config_flow.INTERNAL_WIFI_AP_IP),
+            data=replace(
+                DISCOVERY_INFO, ip_address=ip_address(config_flow.INTERNAL_WIFI_AP_IP)
+            ),
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
         assert result["type"] == data_entry_flow.FlowResultType.ABORT

--- a/tests/components/smappee/test_config_flow.py
+++ b/tests/components/smappee/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the Smappee component config flow module."""
 from http import HTTPStatus
+from ipaddress import ip_address
 from unittest.mock import patch
 
 from homeassistant import data_entry_flow, setup
@@ -59,8 +60,8 @@ async def test_show_zeroconf_connection_error_form(hass: HomeAssistant) -> None:
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="1.2.3.4",
-                addresses=["1.2.3.4"],
+                ip_address=ip_address("1.2.3.4"),
+                ip_addresses=[ip_address("1.2.3.4")],
                 port=22,
                 hostname="Smappee1006000212.local.",
                 type="_ssh._tcp.local.",
@@ -91,8 +92,8 @@ async def test_show_zeroconf_connection_error_form_next_generation(
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="1.2.3.4",
-                addresses=["1.2.3.4"],
+                ip_address=ip_address("1.2.3.4"),
+                ip_addresses=[ip_address("1.2.3.4")],
                 port=22,
                 hostname="Smappee5001000212.local.",
                 type="_ssh._tcp.local.",
@@ -174,8 +175,8 @@ async def test_zeroconf_wrong_mdns(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.2.3.4",
-            addresses=["1.2.3.4"],
+            ip_address=ip_address("1.2.3.4"),
+            ip_addresses=[ip_address("1.2.3.4")],
             port=22,
             hostname="example.local.",
             type="_ssh._tcp.local.",
@@ -285,8 +286,8 @@ async def test_zeroconf_device_exists_abort(hass: HomeAssistant) -> None:
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="1.2.3.4",
-                addresses=["1.2.3.4"],
+                ip_address=ip_address("1.2.3.4"),
+                ip_addresses=[ip_address("1.2.3.4")],
                 port=22,
                 hostname="Smappee1006000212.local.",
                 type="_ssh._tcp.local.",
@@ -335,8 +336,8 @@ async def test_zeroconf_abort_if_cloud_device_exists(hass: HomeAssistant) -> Non
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.2.3.4",
-            addresses=["1.2.3.4"],
+            ip_address=ip_address("1.2.3.4"),
+            ip_addresses=[ip_address("1.2.3.4")],
             port=22,
             hostname="Smappee1006000212.local.",
             type="_ssh._tcp.local.",
@@ -357,8 +358,8 @@ async def test_zeroconf_confirm_abort_if_cloud_device_exists(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.2.3.4",
-            addresses=["1.2.3.4"],
+            ip_address=ip_address("1.2.3.4"),
+            ip_addresses=[ip_address("1.2.3.4")],
             port=22,
             hostname="Smappee1006000212.local.",
             type="_ssh._tcp.local.",
@@ -480,8 +481,8 @@ async def test_full_zeroconf_flow(hass: HomeAssistant) -> None:
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="1.2.3.4",
-                addresses=["1.2.3.4"],
+                ip_address=ip_address("1.2.3.4"),
+                ip_addresses=[ip_address("1.2.3.4")],
                 port=22,
                 hostname="Smappee1006000212.local.",
                 type="_ssh._tcp.local.",
@@ -559,8 +560,8 @@ async def test_full_zeroconf_flow_next_generation(hass: HomeAssistant) -> None:
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="1.2.3.4",
-                addresses=["1.2.3.4"],
+                ip_address=ip_address("1.2.3.4"),
+                ip_addresses=[ip_address("1.2.3.4")],
                 port=22,
                 hostname="Smappee5001000212.local.",
                 type="_ssh._tcp.local.",

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -1,5 +1,6 @@
 """Configuration for Sonos tests."""
 from copy import copy
+from ipaddress import ip_address
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -69,8 +70,8 @@ class SonosMockEvent:
 def zeroconf_payload():
     """Return a default zeroconf payload."""
     return zeroconf.ZeroconfServiceInfo(
-        host="192.168.4.2",
-        addresses=["192.168.4.2"],
+        ip_address=ip_address("192.168.4.2"),
+        ip_addresses=[ip_address("192.168.4.2")],
         hostname="Sonos-aaa",
         name="Sonos-aaa@Living Room._sonos._tcp.local.",
         port=None,

--- a/tests/components/sonos/test_config_flow.py
+++ b/tests/components/sonos/test_config_flow.py
@@ -1,6 +1,7 @@
 """Test the sonos config flow."""
 from __future__ import annotations
 
+from ipaddress import ip_address
 from unittest.mock import MagicMock, patch
 
 from homeassistant import config_entries
@@ -162,8 +163,8 @@ async def test_zeroconf_sonos_v1(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.107",
-            addresses=["192.168.1.107"],
+            ip_address=ip_address("192.168.1.107"),
+            ip_addresses=[ip_address("192.168.1.107")],
             port=1443,
             hostname="sonos5CAAFDE47AC8.local.",
             type="_sonos._tcp.local.",

--- a/tests/components/soundtouch/test_config_flow.py
+++ b/tests/components/soundtouch/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test config flow."""
+from ipaddress import ip_address
 from unittest.mock import patch
 
 from requests import RequestException
@@ -75,8 +76,8 @@ async def test_zeroconf_flow_create_entry(
         DOMAIN,
         context={CONF_SOURCE: SOURCE_ZEROCONF},
         data=ZeroconfServiceInfo(
-            host=DEVICE_1_IP,
-            addresses=[DEVICE_1_IP],
+            ip_address=ip_address(DEVICE_1_IP),
+            ip_addresses=[ip_address(DEVICE_1_IP)],
             port=8090,
             hostname="Bose-SM2-060000000001.local.",
             type="_soundtouch._tcp.local.",

--- a/tests/components/spotify/test_config_flow.py
+++ b/tests/components/spotify/test_config_flow.py
@@ -1,5 +1,6 @@
 """Tests for the Spotify config flow."""
 from http import HTTPStatus
+from ipaddress import ip_address
 from unittest.mock import patch
 
 import pytest
@@ -22,8 +23,8 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import ClientSessionGenerator
 
 BLANK_ZEROCONF_INFO = zeroconf.ZeroconfServiceInfo(
-    host="1.2.3.4",
-    addresses=["1.2.3.4"],
+    ip_address=ip_address("1.2.3.4"),
+    ip_addresses=[ip_address("1.2.3.4")],
     hostname="mock_hostname",
     name="mock_name",
     port=None,

--- a/tests/components/synology_dsm/test_config_flow.py
+++ b/tests/components/synology_dsm/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the Synology DSM config flow."""
+from ipaddress import ip_address
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -666,8 +667,8 @@ async def test_discovered_via_zeroconf(hass: HomeAssistant, service: MagicMock) 
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.5",
-            addresses=["192.168.1.5"],
+            ip_address=ip_address("192.168.1.5"),
+            ip_addresses=[ip_address("192.168.1.5")],
             port=5000,
             hostname="mydsm.local.",
             type="_http._tcp.local.",
@@ -714,8 +715,8 @@ async def test_discovered_via_zeroconf_missing_mac(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.5",
-            addresses=["192.168.1.5"],
+            ip_address=ip_address("192.168.1.5"),
+            ip_addresses=[ip_address("192.168.1.5")],
             port=5000,
             hostname="mydsm.local.",
             type="_http._tcp.local.",

--- a/tests/components/system_bridge/test_config_flow.py
+++ b/tests/components/system_bridge/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the System Bridge config flow."""
 import asyncio
+from ipaddress import ip_address
 from unittest.mock import patch
 
 from systembridgeconnector.const import MODEL_SYSTEM, TYPE_DATA_UPDATE
@@ -37,8 +38,8 @@ FIXTURE_ZEROCONF_INPUT = {
 }
 
 FIXTURE_ZEROCONF = zeroconf.ZeroconfServiceInfo(
-    host="test-bridge",
-    addresses=["1.1.1.1"],
+    ip_address=ip_address("1.1.1.1"),
+    ip_addresses=[ip_address("1.1.1.1")],
     port=9170,
     hostname="test-bridge.local.",
     type="_system-bridge._tcp.local.",
@@ -55,8 +56,8 @@ FIXTURE_ZEROCONF = zeroconf.ZeroconfServiceInfo(
 )
 
 FIXTURE_ZEROCONF_BAD = zeroconf.ZeroconfServiceInfo(
-    host="1.1.1.1",
-    addresses=["1.1.1.1"],
+    ip_address=ip_address("1.1.1.1"),
+    ip_addresses=[ip_address("1.1.1.1")],
     port=9170,
     hostname="test-bridge.local.",
     type="_system-bridge._tcp.local.",

--- a/tests/components/tado/test_config_flow.py
+++ b/tests/components/tado/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the Tado config flow."""
 from http import HTTPStatus
+from ipaddress import ip_address
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -222,8 +223,8 @@ async def test_form_homekit(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="mock_host",
-            addresses=["mock_host"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
@@ -249,8 +250,8 @@ async def test_form_homekit(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="mock_host",
-            addresses=["mock_host"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,

--- a/tests/components/thread/test_config_flow.py
+++ b/tests/components/thread/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Thread config flow."""
+from ipaddress import ip_address
 from unittest.mock import patch
 
 from homeassistant.components import thread, zeroconf
@@ -6,10 +7,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 TEST_ZEROCONF_RECORD = zeroconf.ZeroconfServiceInfo(
-    host="127.0.0.1",
+    ip_address=ip_address("127.0.0.1"),
+    ip_addresses=[ip_address("127.0.0.1")],
     hostname="HomeAssistant OpenThreadBorderRouter #0BBF",
     name="HomeAssistant OpenThreadBorderRouter #0BBF._meshcop._udp.local.",
-    addresses=["127.0.0.1"],
     port=8080,
     properties={
         "rv": "1",

--- a/tests/components/tradfri/test_config_flow.py
+++ b/tests/components/tradfri/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Tradfri config flow."""
+from ipaddress import ip_address
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -113,8 +114,8 @@ async def test_discovery_connection(
         "tradfri",
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="123.123.123.123",
-            addresses=["123.123.123.123"],
+            ip_address=ip_address("123.123.123.123"),
+            ip_addresses=[ip_address("123.123.123.123")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
@@ -148,8 +149,8 @@ async def test_discovery_duplicate_aborted(hass: HomeAssistant) -> None:
         "tradfri",
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="new-host",
-            addresses=["new-host"],
+            ip_address=ip_address("123.123.123.124"),
+            ip_addresses=[ip_address("123.123.123.124")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
@@ -161,7 +162,7 @@ async def test_discovery_duplicate_aborted(hass: HomeAssistant) -> None:
     assert flow["type"] == data_entry_flow.FlowResultType.ABORT
     assert flow["reason"] == "already_configured"
 
-    assert entry.data["host"] == "new-host"
+    assert entry.data["host"] == "123.123.123.124"
 
 
 async def test_duplicate_discovery(
@@ -172,8 +173,8 @@ async def test_duplicate_discovery(
         "tradfri",
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="123.123.123.123",
-            addresses=["123.123.123.123"],
+            ip_address=ip_address("123.123.123.123"),
+            ip_addresses=[ip_address("123.123.123.123")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
@@ -188,8 +189,8 @@ async def test_duplicate_discovery(
         "tradfri",
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="123.123.123.123",
-            addresses=["123.123.123.123"],
+            ip_address=ip_address("123.123.123.123"),
+            ip_addresses=[ip_address("123.123.123.123")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
@@ -205,7 +206,7 @@ async def test_discovery_updates_unique_id(hass: HomeAssistant) -> None:
     """Test a duplicate discovery host aborts and updates existing entry."""
     entry = MockConfigEntry(
         domain="tradfri",
-        data={"host": "some-host"},
+        data={"host": "123.123.123.123"},
     )
     entry.add_to_hass(hass)
 
@@ -213,8 +214,8 @@ async def test_discovery_updates_unique_id(hass: HomeAssistant) -> None:
         "tradfri",
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="some-host",
-            addresses=["some-host"],
+            ip_address=ip_address("123.123.123.123"),
+            ip_addresses=[ip_address("123.123.123.123")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,

--- a/tests/components/vizio/const.py
+++ b/tests/components/vizio/const.py
@@ -1,4 +1,6 @@
 """Constants for the Vizio integration tests."""
+from ipaddress import ip_address
+
 from homeassistant.components import zeroconf
 from homeassistant.components.media_player import (
     DOMAIN as MP_DOMAIN,
@@ -197,8 +199,8 @@ ZEROCONF_HOST = HOST.split(":")[0]
 ZEROCONF_PORT = HOST.split(":")[1]
 
 MOCK_ZEROCONF_SERVICE_INFO = zeroconf.ZeroconfServiceInfo(
-    host=ZEROCONF_HOST,
-    addresses=[ZEROCONF_HOST],
+    ip_address=ip_address(ZEROCONF_HOST),
+    ip_addresses=[ip_address(ZEROCONF_HOST)],
     hostname="mock_hostname",
     name=ZEROCONF_NAME,
     port=ZEROCONF_PORT,

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -801,8 +801,9 @@ async def test_zeroconf_flow_with_port_in_host(
     entry.add_to_hass(hass)
 
     # Try rediscovering same device, this time with port already in host
+    # This test needs to be refactored as the port is never in the host
+    # field of the zeroconf service info
     discovery_info = dataclasses.replace(MOCK_ZEROCONF_SERVICE_INFO)
-    discovery_info.host = f"{discovery_info.host}:{discovery_info.port}"
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )

--- a/tests/components/volumio/test_config_flow.py
+++ b/tests/components/volumio/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Volumio config flow."""
+from ipaddress import ip_address
 from unittest.mock import patch
 
 from homeassistant import config_entries
@@ -19,8 +20,8 @@ TEST_CONNECTION = {
 
 
 TEST_DISCOVERY = zeroconf.ZeroconfServiceInfo(
-    host="1.1.1.1",
-    addresses=["1.1.1.1"],
+    ip_address=ip_address("1.1.1.1"),
+    ip_addresses=[ip_address("1.1.1.1")],
     hostname="mock_hostname",
     name="mock_name",
     port=3000,

--- a/tests/components/wled/test_config_flow.py
+++ b/tests/components/wled/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the WLED config flow."""
+from ipaddress import ip_address
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -44,8 +45,8 @@ async def test_full_zeroconf_flow_implementation(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.123",
-            addresses=["192.168.1.123"],
+            ip_address=ip_address("192.168.1.123"),
+            ip_addresses=[ip_address("192.168.1.123")],
             hostname="example.local.",
             name="mock_name",
             port=None,
@@ -88,8 +89,8 @@ async def test_zeroconf_during_onboarding(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.123",
-            addresses=["192.168.1.123"],
+            ip_address=ip_address("192.168.1.123"),
+            ip_addresses=[ip_address("192.168.1.123")],
             hostname="example.local.",
             name="mock_name",
             port=None,
@@ -133,8 +134,8 @@ async def test_zeroconf_connection_error(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.123",
-            addresses=["192.168.1.123"],
+            ip_address=ip_address("192.168.1.123"),
+            ip_addresses=[ip_address("192.168.1.123")],
             hostname="example.local.",
             name="mock_name",
             port=None,
@@ -193,8 +194,8 @@ async def test_zeroconf_without_mac_device_exists_abort(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.123",
-            addresses=["192.168.1.123"],
+            ip_address=ip_address("192.168.1.123"),
+            ip_addresses=[ip_address("192.168.1.123")],
             hostname="example.local.",
             name="mock_name",
             port=None,
@@ -218,8 +219,8 @@ async def test_zeroconf_with_mac_device_exists_abort(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.123",
-            addresses=["192.168.1.123"],
+            ip_address=ip_address("192.168.1.123"),
+            ip_addresses=[ip_address("192.168.1.123")],
             hostname="example.local.",
             name="mock_name",
             port=None,
@@ -243,8 +244,8 @@ async def test_zeroconf_with_cct_channel_abort(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.123",
-            addresses=["192.168.1.123"],
+            ip_address=ip_address("192.168.1.123"),
+            ip_addresses=[ip_address("192.168.1.123")],
             hostname="example.local.",
             name="mock_name",
             port=None,

--- a/tests/components/xiaomi_aqara/test_config_flow.py
+++ b/tests/components/xiaomi_aqara/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Xiaomi Aqara config flow."""
+from ipaddress import ip_address
 from socket import gaierror
 from unittest.mock import Mock, patch
 
@@ -403,8 +404,8 @@ async def test_zeroconf_success(hass: HomeAssistant) -> None:
         const.DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host=TEST_HOST,
-            addresses=[TEST_HOST],
+            ip_address=ip_address(TEST_HOST),
+            ip_addresses=[ip_address(TEST_HOST)],
             hostname="mock_hostname",
             name=TEST_ZEROCONF_NAME,
             port=None,
@@ -450,8 +451,8 @@ async def test_zeroconf_missing_data(hass: HomeAssistant) -> None:
         const.DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host=TEST_HOST,
-            addresses=[TEST_HOST],
+            ip_address=ip_address(TEST_HOST),
+            ip_addresses=[ip_address(TEST_HOST)],
             hostname="mock_hostname",
             name=TEST_ZEROCONF_NAME,
             port=None,
@@ -470,8 +471,8 @@ async def test_zeroconf_unknown_device(hass: HomeAssistant) -> None:
         const.DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host=TEST_HOST,
-            addresses=[TEST_HOST],
+            ip_address=ip_address(TEST_HOST),
+            ip_addresses=[ip_address(TEST_HOST)],
             hostname="mock_hostname",
             name="not-a-xiaomi-aqara-gateway",
             port=None,

--- a/tests/components/xiaomi_miio/test_config_flow.py
+++ b/tests/components/xiaomi_miio/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Xiaomi Miio config flow."""
+from ipaddress import ip_address
 from unittest.mock import Mock, patch
 
 from construct.core import ChecksumError
@@ -426,8 +427,8 @@ async def test_zeroconf_gateway_success(hass: HomeAssistant) -> None:
         const.DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host=TEST_HOST,
-            addresses=[TEST_HOST],
+            ip_address=ip_address(TEST_HOST),
+            ip_addresses=[ip_address(TEST_HOST)],
             hostname="mock_hostname",
             name=TEST_ZEROCONF_NAME,
             port=None,
@@ -469,8 +470,8 @@ async def test_zeroconf_unknown_device(hass: HomeAssistant) -> None:
         const.DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host=TEST_HOST,
-            addresses=[TEST_HOST],
+            ip_address=ip_address(TEST_HOST),
+            ip_addresses=[ip_address(TEST_HOST)],
             hostname="mock_hostname",
             name="not-a-xiaomi-miio-device",
             port=None,
@@ -489,8 +490,8 @@ async def test_zeroconf_no_data(hass: HomeAssistant) -> None:
         const.DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host=None,
-            addresses=[],
+            ip_address=None,
+            ip_addresses=[],
             hostname="mock_hostname",
             name=None,
             port=None,
@@ -509,8 +510,8 @@ async def test_zeroconf_missing_data(hass: HomeAssistant) -> None:
         const.DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host=TEST_HOST,
-            addresses=[TEST_HOST],
+            ip_address=ip_address(TEST_HOST),
+            ip_addresses=[ip_address(TEST_HOST)],
             hostname="mock_hostname",
             name=TEST_ZEROCONF_NAME,
             port=None,
@@ -791,8 +792,8 @@ async def zeroconf_device_success(hass, zeroconf_name_to_test, model_to_test):
         const.DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host=TEST_HOST,
-            addresses=[TEST_HOST],
+            ip_address=ip_address(TEST_HOST),
+            ip_addresses=[ip_address(TEST_HOST)],
             hostname="mock_hostname",
             name=zeroconf_name_to_test,
             port=None,

--- a/tests/components/yeelight/__init__.py
+++ b/tests/components/yeelight/__init__.py
@@ -1,5 +1,6 @@
 """Tests for the Yeelight integration."""
 from datetime import timedelta
+from ipaddress import ip_address
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from async_upnp_client.search import SsdpSearchListener
@@ -42,8 +43,8 @@ CAPABILITIES = {
 ID_DECIMAL = f"{int(ID, 16):08d}"
 
 ZEROCONF_DATA = zeroconf.ZeroconfServiceInfo(
-    host=IP_ADDRESS,
-    addresses=[IP_ADDRESS],
+    ip_address=ip_address(IP_ADDRESS),
+    ip_addresses=[ip_address(IP_ADDRESS)],
     port=54321,
     hostname=f"yeelink-light-strip1_miio{ID_DECIMAL}.local.",
     type="_miio._udp.local.",

--- a/tests/components/yeelight/test_config_flow.py
+++ b/tests/components/yeelight/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Yeelight config flow."""
+from ipaddress import ip_address
 from unittest.mock import patch
 
 import pytest
@@ -465,8 +466,8 @@ async def test_discovered_by_homekit_and_dhcp(hass: HomeAssistant) -> None:
             DOMAIN,
             context={"source": config_entries.SOURCE_HOMEKIT},
             data=zeroconf.ZeroconfServiceInfo(
-                host=IP_ADDRESS,
-                addresses=[IP_ADDRESS],
+                ip_address=ip_address(IP_ADDRESS),
+                ip_addresses=[ip_address(IP_ADDRESS)],
                 hostname="mock_hostname",
                 name="mock_name",
                 port=None,
@@ -535,8 +536,8 @@ async def test_discovered_by_homekit_and_dhcp(hass: HomeAssistant) -> None:
         (
             config_entries.SOURCE_HOMEKIT,
             zeroconf.ZeroconfServiceInfo(
-                host=IP_ADDRESS,
-                addresses=[IP_ADDRESS],
+                ip_address=ip_address(IP_ADDRESS),
+                ip_addresses=[ip_address(IP_ADDRESS)],
                 hostname="mock_hostname",
                 name="mock_name",
                 port=None,
@@ -603,8 +604,8 @@ async def test_discovered_by_dhcp_or_homekit(hass: HomeAssistant, source, data) 
         (
             config_entries.SOURCE_HOMEKIT,
             zeroconf.ZeroconfServiceInfo(
-                host=IP_ADDRESS,
-                addresses=[IP_ADDRESS],
+                ip_address=ip_address(IP_ADDRESS),
+                ip_addresses=[ip_address(IP_ADDRESS)],
                 hostname="mock_hostname",
                 name="mock_name",
                 port=None,
@@ -827,8 +828,8 @@ async def test_discovery_adds_missing_ip_id_only(hass: HomeAssistant) -> None:
         (
             config_entries.SOURCE_HOMEKIT,
             zeroconf.ZeroconfServiceInfo(
-                host=IP_ADDRESS,
-                addresses=[IP_ADDRESS],
+                ip_address=ip_address(IP_ADDRESS),
+                ip_addresses=[ip_address(IP_ADDRESS)],
                 hostname="mock_hostname",
                 name="mock_name",
                 port=None,

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -859,6 +859,7 @@ async def test_info_from_service_with_link_local_address_first(
     service_info.addresses = ["169.254.12.3", "192.168.66.12"]
     info = zeroconf.info_from_service(service_info)
     assert info.host == "192.168.66.12"
+    assert info.addresses == ["169.254.12.3", "192.168.66.12"]
 
 
 async def test_info_from_service_with_unspecified_address_first(
@@ -870,6 +871,7 @@ async def test_info_from_service_with_unspecified_address_first(
     service_info.addresses = ["0.0.0.0", "192.168.66.12"]
     info = zeroconf.info_from_service(service_info)
     assert info.host == "192.168.66.12"
+    assert info.addresses == ["0.0.0.0", "192.168.66.12"]
 
 
 async def test_info_from_service_with_unspecified_address_only(
@@ -892,6 +894,7 @@ async def test_info_from_service_with_link_local_address_second(
     service_info.addresses = ["192.168.66.12", "169.254.12.3"]
     info = zeroconf.info_from_service(service_info)
     assert info.host == "192.168.66.12"
+    assert info.addresses == ["192.168.66.12", "169.254.12.3"]
 
 
 async def test_info_from_service_with_link_local_address_only(

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -1,6 +1,7 @@
 """Tests for ZHA config flow."""
 import copy
 from datetime import timedelta
+from ipaddress import ip_address
 import json
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, create_autospec, patch
 import uuid
@@ -142,8 +143,8 @@ def com_port(device="/dev/ttyUSB1234"):
 async def test_zeroconf_discovery_znp(hass: HomeAssistant) -> None:
     """Test zeroconf flow -- radio detected."""
     service_info = zeroconf.ZeroconfServiceInfo(
-        host="192.168.1.200",
-        addresses=["192.168.1.200"],
+        ip_address=ip_address("192.168.1.200"),
+        ip_addresses=[ip_address("192.168.1.200")],
         hostname="tube._tube_zb_gw._tcp.local.",
         name="tube",
         port=6053,
@@ -192,8 +193,8 @@ async def test_zeroconf_discovery_znp(hass: HomeAssistant) -> None:
 async def test_zigate_via_zeroconf(setup_entry_mock, hass: HomeAssistant) -> None:
     """Test zeroconf flow -- zigate radio detected."""
     service_info = zeroconf.ZeroconfServiceInfo(
-        host="192.168.1.200",
-        addresses=["192.168.1.200"],
+        ip_address=ip_address("192.168.1.200"),
+        ip_addresses=[ip_address("192.168.1.200")],
         hostname="_zigate-zigbee-gateway._tcp.local.",
         name="any",
         port=1234,
@@ -247,8 +248,8 @@ async def test_zigate_via_zeroconf(setup_entry_mock, hass: HomeAssistant) -> Non
 async def test_efr32_via_zeroconf(hass: HomeAssistant) -> None:
     """Test zeroconf flow -- efr32 radio detected."""
     service_info = zeroconf.ZeroconfServiceInfo(
-        host="192.168.1.200",
-        addresses=["192.168.1.200"],
+        ip_address=ip_address("192.168.1.200"),
+        ip_addresses=[ip_address("192.168.1.200")],
         hostname="efr32._esphomelib._tcp.local.",
         name="efr32",
         port=1234,
@@ -310,8 +311,8 @@ async def test_discovery_via_zeroconf_ip_change(hass: HomeAssistant) -> None:
     entry.add_to_hass(hass)
 
     service_info = zeroconf.ZeroconfServiceInfo(
-        host="192.168.1.22",
-        addresses=["192.168.1.22"],
+        ip_address=ip_address("192.168.1.22"),
+        ip_addresses=[ip_address("192.168.1.22")],
         hostname="tube_zb_gw_cc2652p2_poe.local.",
         name="mock_name",
         port=6053,
@@ -343,8 +344,8 @@ async def test_discovery_via_zeroconf_ip_change_ignored(hass: HomeAssistant) -> 
     entry.add_to_hass(hass)
 
     service_info = zeroconf.ZeroconfServiceInfo(
-        host="192.168.1.22",
-        addresses=["192.168.1.22"],
+        ip_address=ip_address("192.168.1.22"),
+        ip_addresses=[ip_address("192.168.1.22")],
         hostname="tube_zb_gw_cc2652p2_poe.local.",
         name="mock_name",
         port=6053,
@@ -365,8 +366,8 @@ async def test_discovery_via_zeroconf_ip_change_ignored(hass: HomeAssistant) -> 
 async def test_discovery_confirm_final_abort_if_entries(hass: HomeAssistant) -> None:
     """Test discovery aborts if ZHA was set up after the confirmation dialog is shown."""
     service_info = zeroconf.ZeroconfServiceInfo(
-        host="192.168.1.200",
-        addresses=["192.168.1.200"],
+        ip_address=ip_address("192.168.1.200"),
+        ip_addresses=[ip_address("192.168.1.200")],
         hostname="tube._tube_zb_gw._tcp.local.",
         name="tube",
         port=6053,
@@ -698,8 +699,8 @@ async def test_discovery_via_usb_zha_ignored_updates(hass: HomeAssistant) -> Non
 async def test_discovery_already_setup(hass: HomeAssistant) -> None:
     """Test zeroconf flow -- radio detected."""
     service_info = zeroconf.ZeroconfServiceInfo(
-        host="192.168.1.200",
-        addresses=["192.168.1.200"],
+        ip_address=ip_address("192.168.1.200"),
+        ip_addresses=[ip_address("192.168.1.200")],
         hostname="_tube_zb_gw._tcp.local.",
         name="mock_name",
         port=6053,

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -2698,7 +2698,7 @@ async def test_zeroconf(hass: HomeAssistant) -> None:
     assert result["type"] == "create_entry"
     assert result["title"] == TITLE
     assert result["data"] == {
-        "url": "ws://localhost:3000",
+        "url": "ws://127.0.0.1:3000",
         "usb_path": None,
         "s0_legacy_key": None,
         "s2_access_control_key": None,

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -2,6 +2,7 @@
 import asyncio
 from collections.abc import Generator
 from copy import copy
+from ipaddress import ip_address
 from unittest.mock import DEFAULT, MagicMock, call, patch
 
 import aiohttp
@@ -2672,8 +2673,8 @@ async def test_zeroconf(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=ZeroconfServiceInfo(
-            host="localhost",
-            addresses=["127.0.0.1"],
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             name="mock_name",
             port=3000,

--- a/tests/components/zwave_me/test_config_flow.py
+++ b/tests/components/zwave_me/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the zwave_me config flow."""
+from ipaddress import ip_address
 from unittest.mock import patch
 
 from homeassistant import config_entries
@@ -10,10 +11,10 @@ from homeassistant.data_entry_flow import FlowResult, FlowResultType
 from tests.common import MockConfigEntry
 
 MOCK_ZEROCONF_DATA = zeroconf.ZeroconfServiceInfo(
-    host="ws://192.168.1.14",
+    ip_address=ip_address("192.168.1.14"),
+    ip_addresses=[ip_address("192.168.1.14")],
     hostname="mock_hostname",
     name="mock_name",
-    addresses=["192.168.1.14"],
     port=1234,
     properties={
         "deviceid": "aa:bb:cc:dd:ee:ff",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Note: the actual functional code change here is much smaller compared to all the tests to be updated. 

Most of the time we never access the list of hosts/ip addresses so we should avoid building them until needed. Since #47683 we now get significantly more zeroconf events - order(s) of magnitude more than I had original expected.  

This change better aligns our implementation with `python-zeroconf` since we are moving away from returning ip addresses in the library as strings because we have so many dev support requests and implementation errors from the mis-use of the strings and inconsistency in formatting IPv6 addresses between operating systems. This change provides some better future proofing.

`host` was poorly named since they are really ip addresses which lead to mistakes in integrations using hostnames (we even have some tests that are plain wrong since they used hostnames or urls), and since `python-zeroconf` returns `IPAddress` objects its better to avoid many conversions.  For backwards compatibility `host` and `addresses` are still there, but only built on demand. 

We also do a lot of checks for IPv6Addresses which requires converting all the strings back to IPv4/IPv6 Address objects. We can avoid all the conversions by passing them instead. I did a few of them in https://github.com/home-assistant/core/pull/100568

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
