### PR TITLE
Add support for caching entity properties

### DIFF
--- a/homeassistant/components/template/image.py
+++ b/homeassistant/components/template/image.py
@@ -94,9 +94,9 @@ class StateImageEntity(TemplateEntity, ImageEntity):
     @property
     def entity_picture(self) -> str | None:
         """Return entity picture."""
-        # mypy doesn't know about fget: https://github.com/python/mypy/issues/6185
         if self._entity_picture_template:
-            return TemplateEntity.entity_picture.fget(self)  # type: ignore[attr-defined]
+            return TemplateEntity.entity_picture.__get__(self)
+        # mypy doesn't know about fget: https://github.com/python/mypy/issues/6185
         return ImageEntity.entity_picture.fget(self)  # type: ignore[attr-defined]
 
     @callback

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -44,7 +44,7 @@ from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
     PLATFORM_SCHEMA_BASE,
 )
-from homeassistant.helpers.entity import Entity, EntityDescription
+from homeassistant.helpers.entity import ABCCachedProperties, Entity, EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.entity_platform import EntityPlatform
 import homeassistant.helpers.issue_registry as ir
@@ -254,10 +254,10 @@ class WeatherEntityDescription(EntityDescription, frozen_or_thawed=True):
     """A class that describes weather entities."""
 
 
-class PostInitMeta(abc.ABCMeta):
+class PostInitMeta(ABCCachedProperties):
     """Meta class which calls __post_init__ after __new__ and __init__."""
 
-    def __call__(cls, *args: Any, **kwargs: Any) -> Any:
+    def __call__(cls, *args: Any, **kwargs: Any) -> Any:  # noqa: N805  ruff bug, ruff does not understand this is a metaclass
         """Create an instance."""
         instance: PostInit = super().__call__(*args, **kwargs)
         instance.__post_init__(*args, **kwargs)

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -360,8 +360,8 @@ class CachedProperties(type):
             If the class being created has an _attr class attribute, move it, and its
             annotations, to the __attr attribute.
             """
-            attr_name = f"_attr_{name}"
-            private_attr_name = f"__attr_{name}"
+            attr_name = f"_attr_{property_name}"
+            private_attr_name = f"__attr_{property_name}"
             # Check if an _attr_ class attribute exits and move it to __attr_. We check
             # __dict__ here because we don't care about _attr_ class attributes in parents.
             if attr_name in cls.__dict__:
@@ -387,7 +387,7 @@ class CachedProperties(type):
             for property_name in cached_properties:
                 if property_name in seen_props:
                     continue
-                attr_name = f"_attr_{name}"
+                attr_name = f"_attr_{property_name}"
                 # Check if an _attr_ class attribute exits. We check __dict__ here because
                 # we don't care about _attr_ class attributes in parents.
                 if (attr_name) not in cls.__dict__:

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -313,12 +313,16 @@ class CachedProperties(type):
                 Does two things:
                 - Delete the __attr_ attribute
                 - Invalidate the cache of the cached property
+
+                Raises AttributeError if the __attr_ attribute does not exist
                 """
-                for attr in (name, private_attr_name):
-                    try:  # noqa: SIM105  suppress is much slower
-                        delattr(o, attr)
-                    except AttributeError:
-                        pass
+                # Invalidate the cache of the cached property
+                try:  # noqa: SIM105  suppress is much slower
+                    delattr(o, name)
+                except AttributeError:
+                    pass
+                # Delete the __attr_ attribute
+                delattr(o, private_attr_name)
 
             return _deleter
 

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -341,7 +341,12 @@ class CachedProperties(type):
                 if (attr_name) not in cls.__dict__:
                     continue
                 if hasattr(cls, attr_name):
-                    setattr(cls, "__attr_" + property_name, getattr(cls, attr_name))
+                    private_attr_name = "__attr_" + property_name
+                    attr = getattr(cls, attr_name)
+                    setattr(cls, private_attr_name, attr)
+                    if isinstance(attr, dataclasses.Field):
+                        annotations: dict[str, str] = cls.__dict__["__annotations__"]
+                        annotations[private_attr_name] = annotations.pop(attr_name)
                 setattr(
                     cls,
                     attr_name,

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -339,7 +339,7 @@ class CachedProperties(type):
             moved_attrs.add(property_name)
 
         for parent in cls.__mro__[:0:-1]:
-            if not hasattr(parent, "_CachedProperties__cached_properties"):
+            if "_CachedProperties__cached_properties" not in parent.__dict__:
                 continue
             cached_properties = getattr(parent, "_CachedProperties__cached_properties")
             for property_name in cached_properties:

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -328,7 +328,7 @@ class CachedProperties(type):
                 annotations = cls.__annotations__
                 if attr_name in annotations:
                     annotations[private_attr_name] = annotations.pop(attr_name)
-            type.__setattr__(cls, attr_name, make_property(property_name))
+            setattr(cls, attr_name, make_property(property_name))
 
         cached_properties: set[str] = namespace["_CachedProperties__cached_properties"]
         moved_attrs: set[str] = set()

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -27,7 +27,6 @@ from typing import (
 
 import voluptuous as vol
 
-from homeassistant.backports.functools import cached_property
 from homeassistant.config import DATA_CUSTOMIZE
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
@@ -64,8 +63,11 @@ from .event import (
 from .typing import UNDEFINED, EventType, StateType, UndefinedType
 
 if TYPE_CHECKING:
-    from .entity_platform import EntityPlatform
+    from functools import cached_property
 
+    from .entity_platform import EntityPlatform
+else:
+    from homeassistant.backports.functools import cached_property
 
 _T = TypeVar("_T")
 

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -262,7 +262,19 @@ class CalculatedState:
 
 
 class CachedProperties(type):
-    """Metaclass which invalidates cached entity propertis on write to _attr_."""
+    """Metaclass which invalidates cached entity propertis on write to _attr_.
+
+    A class which has CachedProperties can optionally have a list of cached
+    properties, passed as cached_properties, which must be a set of strings.
+    - Each item in the cached_property set must be the name of a method decorated
+      with @cached_property
+    - For each item in the cached_property set, a property function with the
+      same name, prefixed with _attr_, will be created
+    - The property _attr_-property functions allow setting, getting and deleting
+      data, which will be stored in an attribute prefixed with __attr_
+    - The _attr_-property setter will invalidate the @cached_property by calling
+      delattr on it
+    """
 
     def __new__(
         mcs,  # noqa: N804  ruff bug, ruff does not understand this is a metaclass
@@ -272,7 +284,10 @@ class CachedProperties(type):
         cached_properties: set[str] | None = None,
         **kwargs: Any,
     ) -> Any:
-        """Pop cached_properties and store it in the namespace."""
+        """Start creating a new CachedProperties.
+
+        Pop cached_properties and store it in the namespace.
+        """
         namespace["_CachedProperties__cached_properties"] = cached_properties or set()
         return super().__new__(mcs, name, bases, namespace)
 
@@ -283,12 +298,22 @@ class CachedProperties(type):
         namespace: dict[Any, Any],
         **kwargs: Any,
     ) -> None:
-        """Wrap _attr_ for cached properties in property objects."""
+        """Finish creating a new CachedProperties.
+
+        Wrap _attr_ for cached properties in property objects.
+        """
 
         def deleter(name: str) -> Callable[[Any], None]:
+            """Create a deleter for an _attr_ property."""
             private_attribute_name = "__attr_" + name
 
             def _deleter(o: Any) -> None:
+                """Delete an _attr_ property.
+
+                Does two things:
+                - Delete the __attr_ attribute
+                - Invalidate the cache of the cached property
+                """
                 for attr in (name, private_attribute_name):
                     try:  # noqa: SIM105  suppress is much slower
                         delattr(o, attr)
@@ -298,17 +323,25 @@ class CachedProperties(type):
             return _deleter
 
         def getter(name: str) -> Callable[[Any], Any]:
+            """Create a getter for an _attr_ property."""
             private_attribute_name = "__attr_" + name
 
             def _getter(o: Any) -> Any:
+                """Get an _attr_ property from the backing __attr attribute."""
                 return getattr(o, private_attribute_name)
 
             return _getter
 
         def setter(name: str) -> Callable[[Any, Any], None]:
+            """Create a setter for an _attr_ property."""
             private_attribute_name = "__attr_" + name
 
             def _setter(o: Any, val: Any) -> None:
+                """Set an _attr_ property to the backing __attr attribute.
+
+                Also invalidates the corresponding cached_property by calling
+                delattr on it.
+                """
                 setattr(o, private_attribute_name, val)
                 try:  # noqa: SIM105  suppress is much slower
                     delattr(o, name)
@@ -318,38 +351,49 @@ class CachedProperties(type):
             return _setter
 
         def make_property(name: str) -> property:
+            """Help create a property object."""
             return property(fget=getter(name), fset=setter(name), fdel=deleter(name))
 
-        def move_attr(cls: CachedProperties, property_name: str) -> None:
+        def wrap_attr(cls: CachedProperties, property_name: str) -> None:
+            """Wrap a cached property's corresponding _attr in a property.
+
+            If the class being created has an _attr class attribute, move it, and its
+            annotations, to the __attr attribute.
+            """
             attr_name = "_attr_" + property_name
             private_attr_name = "__attr_" + property_name
+            # Check if an _attr_ class attribute exits and move it to __attr_. We check
+            # __dict__ here because we don't care about _attr_ class attributes in parents.
             if attr_name in cls.__dict__:
                 setattr(cls, private_attr_name, getattr(cls, attr_name))
                 annotations = cls.__annotations__
                 if attr_name in annotations:
                     annotations[private_attr_name] = annotations.pop(attr_name)
+            # Create the _attr_ property
             setattr(cls, attr_name, make_property(property_name))
 
         cached_properties: set[str] = namespace["_CachedProperties__cached_properties"]
-        moved_attrs: set[str] = set()
+        seen_props: set[str] = set()  # Keep track of properties which have been handled
         for property_name in cached_properties:
-            if property_name in moved_attrs:
-                continue
-            move_attr(cls, property_name)
-            moved_attrs.add(property_name)
+            wrap_attr(cls, property_name)
+            seen_props.add(property_name)
 
+        # Look for cached properties of parent classes where this class has
+        # corresponding _attr_ class attributes and re-wrap them.
         for parent in cls.__mro__[:0:-1]:
             if "_CachedProperties__cached_properties" not in parent.__dict__:
                 continue
             cached_properties = getattr(parent, "_CachedProperties__cached_properties")
             for property_name in cached_properties:
-                if property_name in moved_attrs:
+                if property_name in seen_props:
                     continue
                 attr_name = "_attr_" + property_name
+                # Check if an _attr_ class attribute exits. We check __dict__ here because
+                # we don't care about _attr_ class attributes in parents.
                 if (attr_name) not in cls.__dict__:
                     continue
-                move_attr(cls, property_name)
-                moved_attrs.add(property_name)
+                wrap_attr(cls, property_name)
+                seen_props.add(property_name)
 
 
 class ABCCachedProperties(CachedProperties, ABCMeta):

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -588,7 +588,11 @@ class Entity(
         # The check for self.platform guards against integrations not using an
         # EntityComponent and can be removed in HA Core 2024.1
         # mypy doesn't know about fget: https://github.com/python/mypy/issues/6185
-        if self.__class__.name.fget is Entity.name.fget and self.platform:  # type: ignore[attr-defined]
+        if (
+            type.__getattribute__(self.__class__, "name")
+            is type.__getattribute__(Entity, "name")
+            and self.platform
+        ):
             name = self._name_internal(
                 self._object_id_device_class_name,
                 self.platform.object_id_platform_translations,

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -262,7 +262,7 @@ class CalculatedState:
 
 
 class CachedProperties(type):
-    """Metaclass which invalidates cached entity propertis on write to _attr_.
+    """Metaclass which invalidates cached entity properties on write to _attr_.
 
     A class which has CachedProperties can optionally have a list of cached
     properties, passed as cached_properties, which must be a set of strings.
@@ -428,7 +428,6 @@ CACHED_PROPERTIES_WITH_ATTR_ = {
 class Entity(
     metaclass=ABCCachedProperties, cached_properties=CACHED_PROPERTIES_WITH_ATTR_
 ):
-    # class Entity(ABC):
     """An abstract class for Home Assistant entities."""
 
     # SAFE TO OVERWRITE

--- a/tests/components/zha/test_registries.py
+++ b/tests/components/zha/test_registries.py
@@ -585,18 +585,18 @@ def test_quirk_classes() -> None:
 def test_entity_names() -> None:
     """Make sure that all handlers expose entities with valid names."""
 
-    for _, entities in iter_all_rules():
-        for entity in entities:
-            if hasattr(entity, "_attr_name"):
+    for _, entity_classes in iter_all_rules():
+        for entity_class in entity_classes:
+            if hasattr(entity_class, "__attr_name"):
                 # The entity has a name
-                assert isinstance(entity._attr_name, str) and entity._attr_name
-            elif hasattr(entity, "_attr_translation_key"):
+                assert (name := entity_class.__attr_name) and isinstance(name, str)
+            elif hasattr(entity_class, "__attr_translation_key"):
                 assert (
-                    isinstance(entity._attr_translation_key, str)
-                    and entity._attr_translation_key
+                    isinstance(entity_class.__attr_translation_key, str)
+                    and entity_class.__attr_translation_key
                 )
-            elif hasattr(entity, "_attr_device_class"):
-                assert entity._attr_device_class
+            elif hasattr(entity_class, "__attr_device_class"):
+                assert entity_class.__attr_device_class
             else:
                 # The only exception (for now) is IASZone
-                assert entity is IASZone
+                assert entity_class is IASZone

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1916,3 +1916,36 @@ async def test_update_capabilities_too_often_cooldown(
     assert entry.supported_features == supported_features + 1
 
     assert capabilities_too_often_warning not in caplog.text
+
+
+@pytest.mark.parametrize(("property", "values"), [("attribution", ["abcd", "efgh"])])
+async def test_cached_entity_properties(
+    hass: HomeAssistant, property: str, values: Any
+) -> None:
+    """Test entity properties are cached."""
+    ent = entity.Entity()
+    setattr(ent, f"_attr_{property}", values[0])
+    assert getattr(ent, property) == values[0]
+
+    # Test update
+    setattr(ent, f"_attr_{property}", values[1])
+    assert getattr(ent, property) == values[1]
+
+
+async def test_cached_entity_property_class_attribute(hass: HomeAssistant) -> None:
+    """Test entity properties on class level work."""
+    property = "attribution"
+    values = ["abcd", "efgh"]
+
+    class EntityWithClassAttribute(entity.Entity):
+        _attr_attribution = values[0]
+
+    ent1 = EntityWithClassAttribute()
+    ent2 = EntityWithClassAttribute()
+    assert getattr(ent1, property) == values[0]
+    assert getattr(ent2, property) == values[0]
+
+    # Test update
+    setattr(ent1, f"_attr_{property}", values[1])
+    assert getattr(ent1, property) == values[1]
+    assert getattr(ent2, property) == values[0]

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1941,6 +1941,34 @@ async def test_cached_entity_properties(
     assert getattr(ent1, property) == values[1]
     assert getattr(ent2, property) == default_value
 
+    # Test delete
+    delattr(ent1, f"_attr_{property}")
+    assert getattr(ent1, property) == default_value
+    assert getattr(ent2, property) == default_value
+
+
+async def test_cached_entity_property_delete_attr(hass: HomeAssistant) -> None:
+    """Test deleting an _attr corresponding to a cached property."""
+    property = "has_entity_name"
+
+    ent = entity.Entity()
+    assert not hasattr(ent, f"_attr_{property}")
+    with pytest.raises(AttributeError):
+        delattr(ent, f"_attr_{property}")
+    assert getattr(ent, property) is False
+
+    with pytest.raises(AttributeError):
+        delattr(ent, f"_attr_{property}")
+    assert not hasattr(ent, f"_attr_{property}")
+    assert getattr(ent, property) is False
+
+    setattr(ent, f"_attr_{property}", True)
+    assert getattr(ent, property) is True
+
+    delattr(ent, f"_attr_{property}")
+    assert not hasattr(ent, f"_attr_{property}")
+    assert getattr(ent, property) is False
+
 
 async def test_cached_entity_property_class_attribute(hass: HomeAssistant) -> None:
     """Test entity properties on class level work in derived classes."""

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1918,18 +1918,27 @@ async def test_update_capabilities_too_often_cooldown(
     assert capabilities_too_often_warning not in caplog.text
 
 
-@pytest.mark.parametrize(("property", "values"), [("attribution", ["abcd", "efgh"])])
+@pytest.mark.parametrize(
+    ("property", "default_value", "values"), [("attribution", None, ["abcd", "efgh"])]
+)
 async def test_cached_entity_properties(
-    hass: HomeAssistant, property: str, values: Any
+    hass: HomeAssistant, property: str, default_value: Any, values: Any
 ) -> None:
     """Test entity properties are cached."""
-    ent = entity.Entity()
-    setattr(ent, f"_attr_{property}", values[0])
-    assert getattr(ent, property) == values[0]
+    ent1 = entity.Entity()
+    ent2 = entity.Entity()
+    assert getattr(ent1, property) == default_value
+    assert getattr(ent2, property) == default_value
+
+    # Test set
+    setattr(ent1, f"_attr_{property}", values[0])
+    assert getattr(ent1, property) == values[0]
+    assert getattr(ent2, property) == default_value
 
     # Test update
-    setattr(ent, f"_attr_{property}", values[1])
-    assert getattr(ent, property) == values[1]
+    setattr(ent1, f"_attr_{property}", values[1])
+    assert getattr(ent1, property) == values[1]
+    assert getattr(ent2, property) == default_value
 
 
 async def test_cached_entity_property_class_attribute(hass: HomeAssistant) -> None:
@@ -1938,6 +1947,7 @@ async def test_cached_entity_property_class_attribute(hass: HomeAssistant) -> No
     values = ["abcd", "efgh"]
 
     class EntityWithClassAttribute(entity.Entity):
+        pass
         _attr_attribution = values[0]
 
     ent1 = EntityWithClassAttribute()

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -13,6 +13,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 import voluptuous as vol
 
+from homeassistant.backports.functools import cached_property
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_DEVICE_CLASS,
@@ -1942,20 +1943,68 @@ async def test_cached_entity_properties(
 
 
 async def test_cached_entity_property_class_attribute(hass: HomeAssistant) -> None:
-    """Test entity properties on class level work."""
+    """Test entity properties on class level work in derived classes."""
     property = "attribution"
     values = ["abcd", "efgh"]
 
-    class EntityWithClassAttribute(entity.Entity):
-        pass
+    class EntityWithClassAttribute1(entity.Entity):
+        """A derived class which overrides an _attr_ from a parent."""
+
         _attr_attribution = values[0]
 
-    ent1 = EntityWithClassAttribute()
-    ent2 = EntityWithClassAttribute()
-    assert getattr(ent1, property) == values[0]
-    assert getattr(ent2, property) == values[0]
+    class EntityWithClassAttribute2(entity.Entity, cached_properties={property}):
+        """A derived class which overrides an _attr_ from a parent.
+
+        This class also redundantly marks the overridden _attr_ as cached.
+        """
+
+        _attr_attribution = values[0]
+
+    class EntityWithClassAttribute3(entity.Entity, cached_properties={property}):
+        """A derived class which overrides an _attr_ from a parent.
+
+        This class overrides the attribute property.
+        """
+
+        def __init__(self):
+            self._attr_attribution = values[0]
+
+        @cached_property
+        def attribution(self) -> str | None:
+            """Return the attribution."""
+            return self._attr_attribution
+
+    class EntityWithClassAttribute4(entity.Entity, cached_properties={property}):
+        """A derived class which overrides an _attr_ from a parent.
+
+        This class overrides the attribute property and the _attr_.
+        """
+
+        _attr_attribution = values[0]
+
+        @cached_property
+        def attribution(self) -> str | None:
+            """Return the attribution."""
+            return self._attr_attribution
+
+    classes = (
+        EntityWithClassAttribute1,
+        EntityWithClassAttribute2,
+        EntityWithClassAttribute3,
+        EntityWithClassAttribute4,
+    )
+
+    entities: list[tuple[entity.Entity, entity.Entity]] = []
+    for cls in classes:
+        entities.append((cls(), cls()))
+
+    for ent in entities:
+        assert getattr(ent[0], property) == values[0]
+        assert getattr(ent[1], property) == values[0]
 
     # Test update
-    setattr(ent1, f"_attr_{property}", values[1])
-    assert getattr(ent1, property) == values[1]
-    assert getattr(ent2, property) == values[0]
+    for ent in entities:
+        setattr(ent[0], f"_attr_{property}", values[1])
+    for ent in entities:
+        assert getattr(ent[0], property) == values[1]
+        assert getattr(ent[1], property) == values[0]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for caching entity properties

The implementation in this PR is essentially the same as in https://github.com/home-assistant/core/pull/95315 but:
- Updates of `Entity._attr_*` are caught and cause the corresponding property's cache to be invalidated
- All properties which by default return the corresponding `Entity._attr_*` attribute are cached

With the simple test below, the time needed for calculating state is decreased by around 1/3 on my development machine, from ~3.3 µs / iteration to ~1.8 µs / iteration:
```py
from homeassistant.helpers.entity import Entity

ent = Entity()
return timeit.timeit(ent._async_calculate_state)
```

If this PR is accepted, base classes for entity domains should be modified in the same way in follow-up PRs

Needs:
- https://github.com/home-assistant/core/pull/106175

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
