### PR TITLE
Rework UniFi websocket

### DIFF
--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -52,7 +52,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     if len(hass.data[UNIFI_DOMAIN]) == 1:
         async_setup_services(hass)
 
-    api.start_websocket()
+    controller.start_websocket()
 
     config_entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, controller.shutdown)

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -406,6 +406,16 @@ class UniFiController:
         if self.ws_task is not None:
             self.ws_task.cancel()
 
+            _, pending = await asyncio.wait([self.ws_task], timeout=10)
+
+            if pending:
+                LOGGER.warning(
+                    "Unloading %s (%s) config entry. Task %s did not complete in time",
+                    self.config_entry.title,
+                    self.config_entry.domain,
+                    self.ws_task,
+                )
+
         unload_ok = await self.hass.config_entries.async_unload_platforms(
             self.config_entry, PLATFORMS
         )

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -355,9 +355,7 @@ class UniFiController:
 
         async def _websocket_runner() -> None:
             """Start websocket."""
-            LOGGER.warning("YES YES")
             await self.api.start_websocket()
-            LOGGER.warning("FAIL LALALALALALALA")
             self.available = False
             async_dispatcher_send(self.hass, self.signal_reachable)
             self.hass.loop.call_later(RETRY_TIMER, self.reconnect, True)

--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_push",
   "loggers": ["aiounifi"],
   "quality_scale": "platinum",
-  "requirements": ["aiounifi==62"],
+  "requirements": ["aiounifi==63"],
   "ssdp": [
     {
       "manufacturer": "Ubiquiti Networks",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -363,7 +363,7 @@ aiosyncthing==0.5.1
 aiotractive==0.5.6
 
 # homeassistant.components.unifi
-aiounifi==62
+aiounifi==63
 
 # homeassistant.components.vlc_telnet
 aiovlc==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -338,7 +338,7 @@ aiosyncthing==0.5.1
 aiotractive==0.5.6
 
 # homeassistant.components.unifi
-aiounifi==62
+aiounifi==63
 
 # homeassistant.components.vlc_telnet
 aiovlc==0.1.0

--- a/tests/components/unifi/conftest.py
+++ b/tests/components/unifi/conftest.py
@@ -8,12 +8,14 @@ from unittest.mock import patch
 from aiounifi.models.message import MessageKey
 import pytest
 
+from homeassistant.components.unifi.const import DOMAIN as UNIFI_DOMAIN
 from homeassistant.components.unifi.controller import RETRY_TIMER
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 import homeassistant.util.dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.components.unifi.test_controller import DEFAULT_CONFIG_ENTRY_ID
 
 
 class WebsocketStateManager(asyncio.Event):
@@ -54,16 +56,16 @@ def websocket_mock(hass):
 
 
 @pytest.fixture(autouse=True)
-def mock_unifi_websocket():
+def mock_unifi_websocket(hass):
     """No real websocket allowed."""
 
     def make_websocket_call(
-        controller,
         *,
         message: MessageKey | None = None,
         data: list[dict] | dict | None = None,
     ):
         """Generate a websocket call."""
+        controller = hass.data[UNIFI_DOMAIN][DEFAULT_CONFIG_ENTRY_ID]
         if data and not message:
             controller.api.messages.handler(data)
         elif data and message:

--- a/tests/components/unifi/conftest.py
+++ b/tests/components/unifi/conftest.py
@@ -62,7 +62,7 @@ class WebsocketStateManager(asyncio.Event):
 
 @pytest.fixture(autouse=True)
 def websocket_mock(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker):
-    """Mock aiounifi websocket."""
+    """Mock 'await self.api.start_websocket' in 'UniFiController.start_websocket'."""
     websocket_state_manager = WebsocketStateManager(hass, aioclient_mock)
     with patch("aiounifi.Controller.start_websocket") as ws_mock:
         ws_mock.side_effect = websocket_state_manager.wait

--- a/tests/components/unifi/conftest.py
+++ b/tests/components/unifi/conftest.py
@@ -44,19 +44,13 @@ class WebsocketStateManager(asyncio.Event):
         await self.hass.async_block_till_done()
 
 
-@pytest.fixture(autouse=True, name="websocket_state")
-def websocket_context_manager(hass: HomeAssistant) -> WebsocketStateManager:
-    """Async event representing websocket context manager."""
-    return WebsocketStateManager(hass)
-
-
 @pytest.fixture(autouse=True)
-def websocket_mock(websocket_state):
+def websocket_mock(hass):
     """Mock aiounifi websocket."""
+    websocket_state_manager = WebsocketStateManager(hass)
     with patch("aiounifi.Controller.start_websocket") as ws_mock:
-        # with patch("aiounifi.controller.Connectivity.websocket") as ws_mock:
-        ws_mock.side_effect = websocket_state.wait
-        yield ws_mock
+        ws_mock.side_effect = websocket_state_manager.wait
+        yield websocket_state_manager
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/unifi/test_button.py
+++ b/tests/components/unifi/test_button.py
@@ -17,7 +17,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 async def test_restart_device_button(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, websocket_state
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, websocket_mock
 ) -> None:
     """Test restarting device button."""
     config_entry = await setup_unifi_integration(
@@ -80,9 +80,9 @@ async def test_restart_device_button(
     )
 
     # Controller disconnects
-    await websocket_state.disconnect()
+    await websocket_mock.disconnect()
     assert hass.states.get("button.switch_restart").state == STATE_UNAVAILABLE
 
     # Controller reconnects
-    await websocket_state.reconnect()
+    await websocket_mock.reconnect()
     assert hass.states.get("button.switch_restart").state != STATE_UNAVAILABLE

--- a/tests/components/unifi/test_button.py
+++ b/tests/components/unifi/test_button.py
@@ -2,12 +2,7 @@
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, ButtonDeviceClass
 from homeassistant.components.unifi.const import DOMAIN as UNIFI_DOMAIN
-from homeassistant.const import (
-    ATTR_DEVICE_CLASS,
-    CONTENT_TYPE_JSON,
-    STATE_UNAVAILABLE,
-    EntityCategory,
-)
+from homeassistant.const import ATTR_DEVICE_CLASS, STATE_UNAVAILABLE, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -72,12 +67,6 @@ async def test_restart_device_button(
     }
 
     # Availability signalling
-    aioclient_mock.get(f"https://{controller.host}:1234", status=302)  # Check UniFi OS
-    aioclient_mock.post(
-        f"https://{controller.host}:1234/api/login",
-        json={"data": "login successful", "meta": {"rc": "ok"}},
-        headers={"content-type": CONTENT_TYPE_JSON},
-    )
 
     # Controller disconnects
     await websocket_mock.disconnect()

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -375,10 +375,7 @@ async def test_connection_state_signalling(
         "last_seen": dt_util.as_timestamp(dt_util.utcnow()),
         "mac": "00:00:00:00:00:01",
     }
-    config_entry = await setup_unifi_integration(
-        hass, aioclient_mock, clients_response=[client]
-    )
-    hass.data[UNIFI_DOMAIN][config_entry.entry_id]
+    await setup_unifi_integration(hass, aioclient_mock, clients_response=[client])
 
     # Controller is connected
     assert hass.states.get("device_tracker.client").state == "home"

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -6,7 +6,6 @@ from http import HTTPStatus
 from unittest.mock import Mock, patch
 
 import aiounifi
-from aiounifi.websocket import WebsocketState
 import pytest
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
@@ -28,7 +27,7 @@ from homeassistant.components.unifi.const import (
     PLATFORMS,
     UNIFI_WIRELESS_CLIENTS,
 )
-from homeassistant.components.unifi.controller import RETRY_TIMER, get_unifi_controller
+from homeassistant.components.unifi.controller import get_unifi_controller
 from homeassistant.components.unifi.errors import AuthenticationRequired, CannotConnect
 from homeassistant.const import (
     CONF_HOST,
@@ -44,7 +43,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 DEFAULT_CONFIG_ENTRY_ID = "1"
@@ -365,8 +364,9 @@ async def test_reset_fails(
 async def test_connection_state_signalling(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    mock_unifi_websocket,
     mock_device_registry,
+    websocket_state: asyncio.Event,
+    websocket_mock,
 ) -> None:
     """Verify connection statesignalling and connection state are working."""
     client = {
@@ -376,26 +376,25 @@ async def test_connection_state_signalling(
         "last_seen": dt_util.as_timestamp(dt_util.utcnow()),
         "mac": "00:00:00:00:00:01",
     }
-    await setup_unifi_integration(hass, aioclient_mock, clients_response=[client])
+    config_entry = await setup_unifi_integration(
+        hass, aioclient_mock, clients_response=[client]
+    )
+    hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
     # Controller is connected
     assert hass.states.get("device_tracker.client").state == "home"
 
-    mock_unifi_websocket(state=WebsocketState.DISCONNECTED)
-    await hass.async_block_till_done()
-
+    await websocket_state.disconnect()
     # Controller is disconnected
     assert hass.states.get("device_tracker.client").state == "unavailable"
 
-    mock_unifi_websocket(state=WebsocketState.RUNNING)
-    await hass.async_block_till_done()
-
+    await websocket_state.reconnect()
     # Controller is once again connected
     assert hass.states.get("device_tracker.client").state == "home"
 
 
 async def test_reconnect_mechanism(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_unifi_websocket
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, websocket_state
 ) -> None:
     """Verify reconnect prints only on first reconnection try."""
     await setup_unifi_integration(hass, aioclient_mock)
@@ -403,21 +402,13 @@ async def test_reconnect_mechanism(
     aioclient_mock.clear_requests()
     aioclient_mock.get(f"https://{DEFAULT_HOST}:1234/", status=HTTPStatus.BAD_GATEWAY)
 
-    mock_unifi_websocket(state=WebsocketState.DISCONNECTED)
-    await hass.async_block_till_done()
-
+    await websocket_state.disconnect()
     assert aioclient_mock.call_count == 0
 
-    new_time = dt_util.utcnow() + timedelta(seconds=RETRY_TIMER)
-    async_fire_time_changed(hass, new_time)
-    await hass.async_block_till_done()
-
+    await websocket_state.reconnect(fail=True)
     assert aioclient_mock.call_count == 1
 
-    new_time = dt_util.utcnow() + timedelta(seconds=RETRY_TIMER)
-    async_fire_time_changed(hass, new_time)
-    await hass.async_block_till_done()
-
+    await websocket_state.reconnect(fail=True)
     assert aioclient_mock.call_count == 2
 
 
@@ -431,10 +422,7 @@ async def test_reconnect_mechanism(
     ],
 )
 async def test_reconnect_mechanism_exceptions(
-    hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
-    mock_unifi_websocket,
-    exception,
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, websocket_state, exception
 ) -> None:
     """Verify async_reconnect calls expected methods."""
     await setup_unifi_integration(hass, aioclient_mock)
@@ -442,11 +430,9 @@ async def test_reconnect_mechanism_exceptions(
     with patch("aiounifi.Controller.login", side_effect=exception), patch(
         "homeassistant.components.unifi.controller.UniFiController.reconnect"
     ) as mock_reconnect:
-        mock_unifi_websocket(state=WebsocketState.DISCONNECTED)
-        await hass.async_block_till_done()
+        await websocket_state.disconnect()
 
-        new_time = dt_util.utcnow() + timedelta(seconds=RETRY_TIMER)
-        async_fire_time_changed(hass, new_time)
+        await websocket_state.reconnect()
         mock_reconnect.assert_called_once()
 
 

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -411,7 +411,7 @@ async def test_remove_clients(
 async def test_controller_state_change(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    websocket_state,
+    websocket_mock,
     mock_device_registry,
 ) -> None:
     """Verify entities state reflect on controller becoming unavailable."""
@@ -461,12 +461,12 @@ async def test_controller_state_change(
     )
 
     # Controller disconnects
-    await websocket_state.disconnect()
+    await websocket_mock.disconnect()
     assert hass.states.get("device_tracker.client").state == STATE_UNAVAILABLE
     assert hass.states.get("device_tracker.device").state == STATE_UNAVAILABLE
 
     # Controller reconnects
-    await websocket_state.reconnect()
+    await websocket_mock.reconnect()
     assert hass.states.get("device_tracker.client").state == STATE_NOT_HOME
     assert hass.states.get("device_tracker.device").state == STATE_HOME
 

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -441,14 +441,12 @@ async def test_controller_state_change(
     assert hass.states.get("device_tracker.client").state == STATE_NOT_HOME
     assert hass.states.get("device_tracker.device").state == STATE_HOME
 
-    # Availability signalling
-
-    # Controller disconnects
+    # Controller unavailable
     await websocket_mock.disconnect()
     assert hass.states.get("device_tracker.client").state == STATE_UNAVAILABLE
     assert hass.states.get("device_tracker.device").state == STATE_UNAVAILABLE
 
-    # Controller reconnects
+    # Controller available
     await websocket_mock.reconnect()
     assert hass.states.get("device_tracker.client").state == STATE_NOT_HOME
     assert hass.states.get("device_tracker.device").state == STATE_HOME

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -16,12 +16,7 @@ from homeassistant.components.unifi.const import (
     CONF_TRACK_WIRED_CLIENTS,
     DOMAIN as UNIFI_DOMAIN,
 )
-from homeassistant.const import (
-    CONTENT_TYPE_JSON,
-    STATE_HOME,
-    STATE_NOT_HOME,
-    STATE_UNAVAILABLE,
-)
+from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 import homeassistant.util.dt as dt_util
@@ -435,25 +430,18 @@ async def test_controller_state_change(
         "version": "4.0.42.10433",
     }
 
-    config_entry = await setup_unifi_integration(
+    await setup_unifi_integration(
         hass,
         aioclient_mock,
         clients_response=[client],
         devices_response=[device],
     )
-    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
     assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 2
     assert hass.states.get("device_tracker.client").state == STATE_NOT_HOME
     assert hass.states.get("device_tracker.device").state == STATE_HOME
 
     # Availability signalling
-    aioclient_mock.get(f"https://{controller.host}:1234", status=302)  # Check UniFi OS
-    aioclient_mock.post(
-        f"https://{controller.host}:1234/api/login",
-        json={"data": "login successful", "meta": {"rc": "ok"}},
-        headers={"content-type": CONTENT_TYPE_JSON},
-    )
 
     # Controller disconnects
     await websocket_mock.disconnect()

--- a/tests/components/unifi/test_image.py
+++ b/tests/components/unifi/test_image.py
@@ -65,7 +65,7 @@ async def test_wlan_qr_code(
     hass_client: ClientSessionGenerator,
     snapshot: SnapshotAssertion,
     mock_unifi_websocket,
-    websocket_state,
+    websocket_mock,
 ) -> None:
     """Test the update_clients function when no clients are found."""
     config_entry = await setup_unifi_integration(
@@ -132,11 +132,11 @@ async def test_wlan_qr_code(
     )
 
     # Controller disconnects
-    await websocket_state.disconnect()
+    await websocket_mock.disconnect()
     assert hass.states.get("image.ssid_1_qr_code").state == STATE_UNAVAILABLE
 
     # Controller reconnects
-    await websocket_state.reconnect()
+    await websocket_mock.reconnect()
     assert hass.states.get("image.ssid_1_qr_code").state != STATE_UNAVAILABLE
 
     # WLAN gets disabled

--- a/tests/components/unifi/test_image.py
+++ b/tests/components/unifi/test_image.py
@@ -8,9 +8,8 @@ from aiounifi.models.message import MessageKey
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.image import DOMAIN as IMAGE_DOMAIN
-from homeassistant.components.unifi.const import DOMAIN as UNIFI_DOMAIN
 from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
-from homeassistant.const import CONTENT_TYPE_JSON, STATE_UNAVAILABLE, EntityCategory
+from homeassistant.const import STATE_UNAVAILABLE, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryDisabler
@@ -68,9 +67,7 @@ async def test_wlan_qr_code(
     websocket_mock,
 ) -> None:
     """Test the update_clients function when no clients are found."""
-    config_entry = await setup_unifi_integration(
-        hass, aioclient_mock, wlans_response=[WLAN]
-    )
+    await setup_unifi_integration(hass, aioclient_mock, wlans_response=[WLAN])
     assert len(hass.states.async_entity_ids(IMAGE_DOMAIN)) == 0
 
     ent_reg = er.async_get(hass)
@@ -88,8 +85,6 @@ async def test_wlan_qr_code(
         dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
     )
     await hass.async_block_till_done()
-
-    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
     # Validate state object
     image_state_1 = hass.states.get("image.ssid_1_qr_code")
@@ -124,12 +119,6 @@ async def test_wlan_qr_code(
     assert body == snapshot
 
     # Availability signalling
-    aioclient_mock.get(f"https://{controller.host}:1234", status=302)  # Check UniFi OS
-    aioclient_mock.post(
-        f"https://{controller.host}:1234/api/login",
-        json={"data": "login successful", "meta": {"rc": "ok"}},
-        headers={"content-type": CONTENT_TYPE_JSON},
-    )
 
     # Controller disconnects
     await websocket_mock.disconnect()

--- a/tests/components/unifi/test_image.py
+++ b/tests/components/unifi/test_image.py
@@ -103,7 +103,7 @@ async def test_wlan_qr_code(
     assert body == snapshot
 
     # Update state object - same password - no change to state
-    mock_unifi_websocket(controller, message=MessageKey.WLAN_CONF_UPDATED, data=WLAN)
+    mock_unifi_websocket(message=MessageKey.WLAN_CONF_UPDATED, data=WLAN)
     await hass.async_block_till_done()
     image_state_2 = hass.states.get("image.ssid_1_qr_code")
     assert image_state_1.state == image_state_2.state
@@ -111,7 +111,7 @@ async def test_wlan_qr_code(
     # Update state object - changed password - new state
     data = deepcopy(WLAN)
     data["x_passphrase"] = "new password"
-    mock_unifi_websocket(controller, message=MessageKey.WLAN_CONF_UPDATED, data=data)
+    mock_unifi_websocket(message=MessageKey.WLAN_CONF_UPDATED, data=data)
     await hass.async_block_till_done()
     image_state_3 = hass.states.get("image.ssid_1_qr_code")
     assert image_state_1.state != image_state_3.state
@@ -142,12 +142,12 @@ async def test_wlan_qr_code(
     # WLAN gets disabled
     wlan_1 = deepcopy(WLAN)
     wlan_1["enabled"] = False
-    mock_unifi_websocket(controller, message=MessageKey.WLAN_CONF_UPDATED, data=wlan_1)
+    mock_unifi_websocket(message=MessageKey.WLAN_CONF_UPDATED, data=wlan_1)
     await hass.async_block_till_done()
     assert hass.states.get("image.ssid_1_qr_code").state == STATE_UNAVAILABLE
 
     # WLAN gets re-enabled
     wlan_1["enabled"] = True
-    mock_unifi_websocket(controller, message=MessageKey.WLAN_CONF_UPDATED, data=wlan_1)
+    mock_unifi_websocket(message=MessageKey.WLAN_CONF_UPDATED, data=wlan_1)
     await hass.async_block_till_done()
     assert hass.states.get("image.ssid_1_qr_code").state != STATE_UNAVAILABLE

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -575,7 +575,7 @@ async def test_poe_port_switches(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     mock_unifi_websocket,
-    websocket_state,
+    websocket_mock,
 ) -> None:
     """Test the update_items function with some clients."""
     config_entry = await setup_unifi_integration(
@@ -629,13 +629,13 @@ async def test_poe_port_switches(
     )
 
     # Controller disconnects
-    await websocket_state.disconnect()
+    await websocket_mock.disconnect()
     assert (
         hass.states.get("sensor.mock_name_port_1_poe_power").state == STATE_UNAVAILABLE
     )
 
     # Controller reconnects
-    await websocket_state.reconnect()
+    await websocket_mock.reconnect()
     assert (
         hass.states.get("sensor.mock_name_port_1_poe_power").state != STATE_UNAVAILABLE
     )
@@ -659,7 +659,7 @@ async def test_wlan_client_sensors(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     mock_unifi_websocket,
-    websocket_state,
+    websocket_mock,
 ) -> None:
     """Verify that WLAN client sensors are working as expected."""
     wireless_client_1 = {
@@ -752,11 +752,11 @@ async def test_wlan_client_sensors(
     )
 
     # Controller disconnects
-    await websocket_state.disconnect()
+    await websocket_mock.disconnect()
     assert hass.states.get("sensor.ssid_1").state == STATE_UNAVAILABLE
 
     # Controller reconnects
-    await websocket_state.reconnect()
+    await websocket_mock.reconnect()
     assert hass.states.get("sensor.ssid_1").state == "0"
 
     # WLAN gets disabled

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -1328,6 +1328,7 @@ async def test_poe_port_switches(
     config_entry = await setup_unifi_integration(
         hass, aioclient_mock, devices_response=[DEVICE_1]
     )
+    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
 
@@ -1350,8 +1351,6 @@ async def test_poe_port_switches(
         dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
     )
     await hass.async_block_till_done()
-
-    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
     # Validate state object
     switch_1 = hass.states.get("switch.mock_name_port_1_poe")

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -1011,7 +1011,7 @@ async def test_dpi_switches(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     mock_unifi_websocket,
-    websocket_state,
+    websocket_mock,
 ) -> None:
     """Test the update_items function with some clients."""
     config_entry = await setup_unifi_integration(
@@ -1043,11 +1043,11 @@ async def test_dpi_switches(
     )
 
     # Controller disconnects
-    await websocket_state.disconnect()
+    await websocket_mock.disconnect()
     assert hass.states.get("switch.block_media_streaming").state == STATE_UNAVAILABLE
 
     # Controller reconnects
-    await websocket_state.reconnect()
+    await websocket_mock.reconnect()
     assert hass.states.get("switch.block_media_streaming").state == STATE_OFF
 
     # Remove app
@@ -1146,7 +1146,7 @@ async def test_outlet_switches(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     mock_unifi_websocket,
-    websocket_state,
+    websocket_mock,
     entity_id: str,
     test_data: any,
     outlet_index: int,
@@ -1217,11 +1217,11 @@ async def test_outlet_switches(
     )
 
     # Controller disconnects
-    await websocket_state.disconnect()
+    await websocket_mock.disconnect()
     assert hass.states.get(f"switch.{entity_id}").state == STATE_UNAVAILABLE
 
     # Controller reconnects
-    await websocket_state.reconnect()
+    await websocket_mock.reconnect()
     assert hass.states.get(f"switch.{entity_id}").state == STATE_OFF
 
     # Device gets disabled
@@ -1347,7 +1347,7 @@ async def test_poe_port_switches(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     mock_unifi_websocket,
-    websocket_state,
+    websocket_mock,
 ) -> None:
     """Test the update_items function with some clients."""
     config_entry = await setup_unifi_integration(
@@ -1442,11 +1442,11 @@ async def test_poe_port_switches(
     )
 
     # Controller disconnects
-    await websocket_state.disconnect()
+    await websocket_mock.disconnect()
     assert hass.states.get("switch.mock_name_port_1_poe").state == STATE_UNAVAILABLE
 
     # Controller reconnects
-    await websocket_state.reconnect()
+    await websocket_mock.reconnect()
     assert hass.states.get("switch.mock_name_port_1_poe").state == STATE_OFF
 
     # Device gets disabled
@@ -1466,7 +1466,7 @@ async def test_wlan_switches(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     mock_unifi_websocket,
-    websocket_state,
+    websocket_mock,
 ) -> None:
     """Test control of UniFi WLAN availability."""
     config_entry = await setup_unifi_integration(
@@ -1529,11 +1529,11 @@ async def test_wlan_switches(
     )
 
     # Controller disconnects
-    await websocket_state.disconnect()
+    await websocket_mock.disconnect()
     assert hass.states.get("switch.ssid_1").state == STATE_UNAVAILABLE
 
     # Controller reconnects
-    await websocket_state.reconnect()
+    await websocket_mock.reconnect()
     assert hass.states.get("switch.ssid_1").state == STATE_OFF
 
 
@@ -1541,7 +1541,7 @@ async def test_port_forwarding_switches(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     mock_unifi_websocket,
-    websocket_state,
+    websocket_mock,
 ) -> None:
     """Test control of UniFi port forwarding."""
     _data = {
@@ -1618,11 +1618,11 @@ async def test_port_forwarding_switches(
     )
 
     # Controller disconnects
-    await websocket_state.disconnect()
+    await websocket_mock.disconnect()
     assert hass.states.get("switch.unifi_network_plex").state == STATE_UNAVAILABLE
 
     # Controller reconnects
-    await websocket_state.reconnect()
+    await websocket_mock.reconnect()
     assert hass.states.get("switch.unifi_network_plex").state == STATE_OFF
 
     # Remove entity on deleted message

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -22,7 +22,6 @@ from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
-    CONTENT_TYPE_JSON,
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
@@ -1007,13 +1006,12 @@ async def test_dpi_switches(
     websocket_mock,
 ) -> None:
     """Test the update_items function with some clients."""
-    config_entry = await setup_unifi_integration(
+    await setup_unifi_integration(
         hass,
         aioclient_mock,
         dpigroup_response=DPI_GROUPS,
         dpiapp_response=DPI_APPS,
     )
-    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 1
 
@@ -1028,12 +1026,6 @@ async def test_dpi_switches(
     assert hass.states.get("switch.block_media_streaming").state == STATE_OFF
 
     # Availability signalling
-    aioclient_mock.get(f"https://{controller.host}:1234", status=302)  # Check UniFi OS
-    aioclient_mock.post(
-        f"https://{controller.host}:1234/api/login",
-        json={"data": "login successful", "meta": {"rc": "ok"}},
-        headers={"content-type": CONTENT_TYPE_JSON},
-    )
 
     # Controller disconnects
     await websocket_mock.disconnect()
@@ -1199,12 +1191,6 @@ async def test_outlet_switches(
     }
 
     # Availability signalling
-    aioclient_mock.get(f"https://{controller.host}:1234", status=302)  # Check UniFi OS
-    aioclient_mock.post(
-        f"https://{controller.host}:1234/api/login",
-        json={"data": "login successful", "meta": {"rc": "ok"}},
-        headers={"content-type": CONTENT_TYPE_JSON},
-    )
 
     # Controller disconnects
     await websocket_mock.disconnect()
@@ -1423,12 +1409,6 @@ async def test_poe_port_switches(
     }
 
     # Availability signalling
-    aioclient_mock.get(f"https://{controller.host}:1234", status=302)  # Check UniFi OS
-    aioclient_mock.post(
-        f"https://{controller.host}:1234/api/login",
-        json={"data": "login successful", "meta": {"rc": "ok"}},
-        headers={"content-type": CONTENT_TYPE_JSON},
-    )
 
     # Controller disconnects
     await websocket_mock.disconnect()
@@ -1510,12 +1490,6 @@ async def test_wlan_switches(
     assert aioclient_mock.mock_calls[1][2] == {"enabled": True}
 
     # Availability signalling
-    aioclient_mock.get(f"https://{controller.host}:1234", status=302)  # Check UniFi OS
-    aioclient_mock.post(
-        f"https://{controller.host}:1234/api/login",
-        json={"data": "login successful", "meta": {"rc": "ok"}},
-        headers={"content-type": CONTENT_TYPE_JSON},
-    )
 
     # Controller disconnects
     await websocket_mock.disconnect()
@@ -1599,12 +1573,6 @@ async def test_port_forwarding_switches(
     assert aioclient_mock.mock_calls[1][2] == _data
 
     # Availability signalling
-    aioclient_mock.get(f"https://{controller.host}:1234", status=302)  # Check UniFi OS
-    aioclient_mock.post(
-        f"https://{controller.host}:1234/api/login",
-        json={"data": "login successful", "meta": {"rc": "ok"}},
-        headers={"content-type": CONTENT_TYPE_JSON},
-    )
 
     # Controller disconnects
     await websocket_mock.disconnect()

--- a/tests/components/unifi/test_update.py
+++ b/tests/components/unifi/test_update.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from aiounifi.models.message import MessageKey
 from yarl import URL
 
-from homeassistant.components.unifi.const import CONF_SITE_ID, DOMAIN as UNIFI_DOMAIN
+from homeassistant.components.unifi.const import CONF_SITE_ID
 from homeassistant.components.update import (
     ATTR_IN_PROGRESS,
     ATTR_INSTALLED_VERSION,
@@ -19,7 +19,6 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
     CONF_HOST,
-    CONTENT_TYPE_JSON,
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
@@ -188,23 +187,12 @@ async def test_controller_state_change(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, websocket_mock
 ) -> None:
     """Verify entities state reflect on controller becoming unavailable."""
-    config_entry = await setup_unifi_integration(
-        hass,
-        aioclient_mock,
-        devices_response=[DEVICE_1],
-    )
-    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
+    await setup_unifi_integration(hass, aioclient_mock, devices_response=[DEVICE_1])
 
     assert len(hass.states.async_entity_ids(UPDATE_DOMAIN)) == 1
     assert hass.states.get("update.device_1").state == STATE_ON
 
     # Availability signalling
-    aioclient_mock.get(f"https://{controller.host}:1234", status=302)  # Check UniFi OS
-    aioclient_mock.post(
-        f"https://{controller.host}:1234/api/login",
-        json={"data": "login successful", "meta": {"rc": "ok"}},
-        headers={"content-type": CONTENT_TYPE_JSON},
-    )
 
     # Controller disconnects
     await websocket_mock.disconnect()

--- a/tests/components/unifi/test_update.py
+++ b/tests/components/unifi/test_update.py
@@ -192,12 +192,10 @@ async def test_controller_state_change(
     assert len(hass.states.async_entity_ids(UPDATE_DOMAIN)) == 1
     assert hass.states.get("update.device_1").state == STATE_ON
 
-    # Availability signalling
-
-    # Controller disconnects
+    # Controller unavailable
     await websocket_mock.disconnect()
     assert hass.states.get("update.device_1").state == STATE_UNAVAILABLE
 
-    # Controller reconnects
+    # Controller available
     await websocket_mock.reconnect()
     assert hass.states.get("update.device_1").state == STATE_ON

--- a/tests/components/unifi/test_update.py
+++ b/tests/components/unifi/test_update.py
@@ -74,12 +74,11 @@ async def test_device_updates(
 ) -> None:
     """Test the update_items function with some devices."""
     device_1 = deepcopy(DEVICE_1)
-    config_entry = await setup_unifi_integration(
+    await setup_unifi_integration(
         hass,
         aioclient_mock,
         devices_response=[device_1, DEVICE_2],
     )
-    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
     assert len(hass.states.async_entity_ids(UPDATE_DOMAIN)) == 2
 
@@ -108,7 +107,7 @@ async def test_device_updates(
     # Simulate start of update
 
     device_1["state"] = 4
-    mock_unifi_websocket(controller, message=MessageKey.DEVICE, data=device_1)
+    mock_unifi_websocket(message=MessageKey.DEVICE, data=device_1)
     await hass.async_block_till_done()
 
     device_1_state = hass.states.get("update.device_1")
@@ -123,7 +122,7 @@ async def test_device_updates(
     device_1["version"] = "4.3.17.11279"
     device_1["upgradable"] = False
     del device_1["upgrade_to_firmware"]
-    mock_unifi_websocket(controller, message=MessageKey.DEVICE, data=device_1)
+    mock_unifi_websocket(message=MessageKey.DEVICE, data=device_1)
     await hass.async_block_till_done()
 
     device_1_state = hass.states.get("update.device_1")

--- a/tests/components/unifi/test_update.py
+++ b/tests/components/unifi/test_update.py
@@ -186,7 +186,7 @@ async def test_install(
 
 
 async def test_controller_state_change(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, websocket_state
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, websocket_mock
 ) -> None:
     """Verify entities state reflect on controller becoming unavailable."""
     config_entry = await setup_unifi_integration(
@@ -208,9 +208,9 @@ async def test_controller_state_change(
     )
 
     # Controller disconnects
-    await websocket_state.disconnect()
+    await websocket_mock.disconnect()
     assert hass.states.get("update.device_1").state == STATE_UNAVAILABLE
 
     # Controller reconnects
-    await websocket_state.reconnect()
+    await websocket_mock.reconnect()
     assert hass.states.get("update.device_1").state == STATE_ON


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removed most websocket logic except for setting up context manager from aiounifi. (https://github.com/Kane610/aiounifi/pull/475)
https://github.com/Kane610/aiounifi/compare/v62...v63

Connection logic is now handled in integration.

Some test related changes would benefit a broader rework of tests...

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
