### PR TITLE
Add `event` platform for Shelly gen1 devices

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -58,6 +58,7 @@ BLOCK_PLATFORMS: Final = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.COVER,
+    Platform.EVENT,
     Platform.LIGHT,
     Platform.SENSOR,
     Platform.SWITCH,

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -170,6 +170,7 @@ class ShellyBlockCoordinator(ShellyCoordinatorBase[BlockDevice]):
         self._last_input_events_count: dict = {}
         self._last_target_temp: float | None = None
         self._push_update_failures: int = 0
+        self._input_event_listeners: list[Callable[[dict[str, Any]], None]] = []
 
         entry.async_on_unload(
             self.async_add_listener(self._async_device_updates_handler)
@@ -177,6 +178,19 @@ class ShellyBlockCoordinator(ShellyCoordinatorBase[BlockDevice]):
         entry.async_on_unload(
             hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self._handle_ha_stop)
         )
+
+    @callback
+    def async_subscribe_input_events(
+        self, input_event_callback: Callable[[dict[str, Any]], None]
+    ) -> CALLBACK_TYPE:
+        """Subscribe to input events."""
+
+        def _unsubscribe() -> None:
+            self._input_event_listeners.remove(input_event_callback)
+
+        self._input_event_listeners.append(input_event_callback)
+
+        return _unsubscribe
 
     @callback
     def _async_device_updates_handler(self) -> None:
@@ -242,6 +256,10 @@ class ShellyBlockCoordinator(ShellyCoordinatorBase[BlockDevice]):
                 continue
 
             if event_type in INPUTS_EVENTS_DICT:
+                for event_callback in self._input_event_listeners:
+                    event_callback(
+                        {"id": channel, "event": INPUTS_EVENTS_DICT[event_type]}
+                    )
                 self.hass.bus.async_fire(
                     EVENT_SHELLY_CLICK,
                     {

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -258,7 +258,7 @@ class ShellyBlockCoordinator(ShellyCoordinatorBase[BlockDevice]):
             if event_type in INPUTS_EVENTS_DICT:
                 for event_callback in self._input_event_listeners:
                     event_callback(
-                        {"id": channel, "event": INPUTS_EVENTS_DICT[event_type]}
+                        {"channel": channel, "event": INPUTS_EVENTS_DICT[event_type]}
                     )
                 self.hass.bus.async_fire(
                     EVENT_SHELLY_CLICK,

--- a/homeassistant/components/shelly/event.py
+++ b/homeassistant/components/shelly/event.py
@@ -56,6 +56,7 @@ RPC_EVENT: Final = ShellyRpcEventDescription(
 )
 BLOCK_EVENT: Final = ShellyBlockEventDescription(
     key="input",
+    translation_key="input",
     device_class=EventDeviceClass.BUTTON,
     event_types=list(BLOCK_INPUTS_EVENTS_TYPES),
     removal_condition=lambda settings, block: not is_block_momentary_input(
@@ -173,7 +174,7 @@ class ShellyBlockEvent(CoordinatorEntity[ShellyBlockCoordinator], EventEntity):
         self._attr_device_info = DeviceInfo(
             connections={(CONNECTION_NETWORK_MAC, coordinator.mac)}
         )
-        self._attr_unique_id = f"{coordinator.mac}-input-{input_id}"
+        self._attr_unique_id = f"{coordinator.mac}-{description.key}-{input_id}"
         self._attr_name = f"{coordinator.device.name} Input {input_id}"
         self.entity_description = description
 

--- a/homeassistant/components/shelly/event.py
+++ b/homeassistant/components/shelly/event.py
@@ -109,15 +109,15 @@ async def async_setup_entry(
             if not is_block_momentary_input(coordinator.device.settings, block, True):
                 continue
 
-            input_id = int(block.channel or 0) + 1
+            channel = int(block.channel or 0) + 1
 
             if BLOCK_EVENT.removal_condition and BLOCK_EVENT.removal_condition(
                 coordinator.device.settings, block
             ):
-                unique_id = f"{coordinator.mac}-{input_id}"
+                unique_id = f"{coordinator.mac}-{channel}"
                 async_remove_shelly_entity(hass, EVENT_DOMAIN, unique_id)
             else:
-                entities.append(ShellyBlockEvent(coordinator, input_id, BLOCK_EVENT))
+                entities.append(ShellyBlockEvent(coordinator, channel, BLOCK_EVENT))
 
     async_add_entities(entities)
 
@@ -168,17 +168,17 @@ class ShellyBlockEvent(CoordinatorEntity[ShellyBlockCoordinator], EventEntity):
     def __init__(
         self,
         coordinator: ShellyBlockCoordinator,
-        input_id: int,
+        channel: int,
         description: ShellyBlockEventDescription,
     ) -> None:
         """Initialize Shelly entity."""
         super().__init__(coordinator)
-        self.input_id = input_id
+        self.channel = channel
         self._attr_device_info = DeviceInfo(
             connections={(CONNECTION_NETWORK_MAC, coordinator.mac)}
         )
-        self._attr_unique_id = f"{coordinator.mac}-{description.key}-{input_id}"
-        self._attr_name = f"{coordinator.device.name} Input {input_id}"
+        self._attr_unique_id = f"{coordinator.mac}-{description.key}-{channel}"
+        self._attr_name = f"{coordinator.device.name} Input {channel}"
         if coordinator.device.model == "SHIX3-1":
             self._attr_event_types = list(SHIX3_1_INPUTS_EVENTS_TYPES)
         else:
@@ -195,6 +195,6 @@ class ShellyBlockEvent(CoordinatorEntity[ShellyBlockCoordinator], EventEntity):
     @callback
     def _async_handle_event(self, event: dict[str, Any]) -> None:
         """Handle the demo button event."""
-        if event["id"] == self.input_id:
+        if event["channel"] == self.channel:
             self._trigger_event(event["event"])
             self.async_write_ha_state()

--- a/homeassistant/components/shelly/event.py
+++ b/homeassistant/components/shelly/event.py
@@ -176,7 +176,7 @@ class ShellyBlockEvent(CoordinatorEntity[ShellyBlockCoordinator], EventEntity):
         )
         self._attr_unique_id = f"{coordinator.mac}-{description.key}-{channel}"
         self._attr_name = f"{coordinator.device.name} Input {channel}"
-        if coordinator.device.model == "SHIX3-1":
+        if coordinator.model == "SHIX3-1":
             self._attr_event_types = list(SHIX3_1_INPUTS_EVENTS_TYPES)
         else:
             self._attr_event_types = list(BASIC_INPUTS_EVENTS_TYPES)

--- a/homeassistant/components/shelly/event.py
+++ b/homeassistant/components/shelly/event.py
@@ -111,7 +111,7 @@ async def async_setup_entry(
                 coordinator.device.settings, block
             ):
                 channel = int(block.channel or 0) + 1
-                unique_id = f"{coordinator.mac}-{block.type}-{channel}"
+                unique_id = f"{coordinator.mac}-{block.description}-{channel}"
                 async_remove_shelly_entity(hass, EVENT_DOMAIN, unique_id)
             else:
                 entities.append(ShellyBlockEvent(coordinator, block, BLOCK_EVENT))

--- a/homeassistant/components/shelly/event.py
+++ b/homeassistant/components/shelly/event.py
@@ -19,7 +19,11 @@ from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, Device
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import BLOCK_INPUTS_EVENTS_TYPES, RPC_INPUTS_EVENTS_TYPES
+from .const import (
+    BASIC_INPUTS_EVENTS_TYPES,
+    RPC_INPUTS_EVENTS_TYPES,
+    SHIX3_1_INPUTS_EVENTS_TYPES,
+)
 from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator, get_entry_data
 from .utils import (
     async_remove_shelly_entity,
@@ -58,7 +62,6 @@ BLOCK_EVENT: Final = ShellyBlockEventDescription(
     key="input",
     translation_key="input",
     device_class=EventDeviceClass.BUTTON,
-    event_types=list(BLOCK_INPUTS_EVENTS_TYPES),
     removal_condition=lambda settings, block: not is_block_momentary_input(
         settings, block, True
     ),
@@ -176,6 +179,10 @@ class ShellyBlockEvent(CoordinatorEntity[ShellyBlockCoordinator], EventEntity):
         )
         self._attr_unique_id = f"{coordinator.mac}-{description.key}-{input_id}"
         self._attr_name = f"{coordinator.device.name} Input {input_id}"
+        if coordinator.device.model == "SHIX3-1":
+            self._attr_event_types = list(SHIX3_1_INPUTS_EVENTS_TYPES)
+        else:
+            self._attr_event_types = list(BASIC_INPUTS_EVENTS_TYPES)
         self.entity_description = description
 
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/shelly/event.py
+++ b/homeassistant/components/shelly/event.py
@@ -106,15 +106,12 @@ async def async_setup_entry(
             ):
                 continue
 
-            if not is_block_momentary_input(coordinator.device.settings, block, True):
-                continue
-
             channel = int(block.channel or 0) + 1
 
             if BLOCK_EVENT.removal_condition and BLOCK_EVENT.removal_condition(
                 coordinator.device.settings, block
             ):
-                unique_id = f"{coordinator.mac}-{channel}"
+                unique_id = f"{coordinator.mac}-{BLOCK_EVENT.key}-{channel}"
                 async_remove_shelly_entity(hass, EVENT_DOMAIN, unique_id)
             else:
                 entities.append(ShellyBlockEvent(coordinator, channel, BLOCK_EVENT))

--- a/homeassistant/components/shelly/event.py
+++ b/homeassistant/components/shelly/event.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Final
+from typing import TYPE_CHECKING, Any, Final
+
+from aioshelly.block_device import Block
 
 from homeassistant.components.event import (
     DOMAIN as EVENT_DOMAIN,
@@ -17,31 +19,47 @@ from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, Device
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import RPC_INPUTS_EVENTS_TYPES
-from .coordinator import ShellyRpcCoordinator, get_entry_data
+from .const import BLOCK_INPUTS_EVENTS_TYPES, RPC_INPUTS_EVENTS_TYPES
+from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator, get_entry_data
 from .utils import (
     async_remove_shelly_entity,
     get_device_entry_gen,
     get_rpc_input_name,
     get_rpc_key_instances,
+    is_block_momentary_input,
     is_rpc_momentary_input,
 )
 
 
 @dataclass
-class ShellyEventDescription(EventEntityDescription):
+class ShellyRpcEventDescription(EventEntityDescription):
     """Class to describe Shelly event."""
 
     removal_condition: Callable[[dict, dict, str], bool] | None = None
 
 
-RPC_EVENT: Final = ShellyEventDescription(
+@dataclass
+class ShellyBlockEventDescription(EventEntityDescription):
+    """Class to describe Shelly event."""
+
+    removal_condition: Callable[[dict, Block], bool] | None = None
+
+
+RPC_EVENT: Final = ShellyRpcEventDescription(
     key="input",
     translation_key="input",
     device_class=EventDeviceClass.BUTTON,
     event_types=list(RPC_INPUTS_EVENTS_TYPES),
     removal_condition=lambda config, status, key: not is_rpc_momentary_input(
         config, status, key
+    ),
+)
+BLOCK_EVENT: Final = ShellyBlockEventDescription(
+    key="input",
+    device_class=EventDeviceClass.BUTTON,
+    event_types=list(BLOCK_INPUTS_EVENTS_TYPES),
+    removal_condition=lambda settings, block: not is_block_momentary_input(
+        settings, block, True
     ),
 )
 
@@ -52,11 +70,15 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up sensors for device."""
+    entities: list[ShellyBlockEvent | ShellyRpcEvent] = []
+
+    coordinator: ShellyRpcCoordinator | ShellyBlockCoordinator | None = None
+
     if get_device_entry_gen(config_entry) == 2:
         coordinator = get_entry_data(hass)[config_entry.entry_id].rpc
-        assert coordinator
+        if TYPE_CHECKING:
+            assert coordinator
 
-        entities = []
         key_instances = get_rpc_key_instances(coordinator.device.status, RPC_EVENT.key)
 
         for key in key_instances:
@@ -67,21 +89,46 @@ async def async_setup_entry(
                 async_remove_shelly_entity(hass, EVENT_DOMAIN, unique_id)
             else:
                 entities.append(ShellyRpcEvent(coordinator, key, RPC_EVENT))
+    else:
+        coordinator = get_entry_data(hass)[config_entry.entry_id].block
+        if TYPE_CHECKING:
+            assert coordinator
+            assert coordinator.device.blocks
 
-        async_add_entities(entities)
+        for block in coordinator.device.blocks:
+            if (
+                "inputEvent" not in block.sensor_ids
+                or "inputEventCnt" not in block.sensor_ids
+            ):
+                continue
+
+            if not is_block_momentary_input(coordinator.device.settings, block, True):
+                continue
+
+            input_id = int(block.channel or 0) + 1
+
+            if BLOCK_EVENT.removal_condition and BLOCK_EVENT.removal_condition(
+                coordinator.device.settings, block
+            ):
+                unique_id = f"{coordinator.mac}-{input_id}"
+                async_remove_shelly_entity(hass, EVENT_DOMAIN, unique_id)
+            else:
+                entities.append(ShellyBlockEvent(coordinator, input_id, BLOCK_EVENT))
+
+    async_add_entities(entities)
 
 
 class ShellyRpcEvent(CoordinatorEntity[ShellyRpcCoordinator], EventEntity):
     """Represent RPC event entity."""
 
     _attr_should_poll = False
-    entity_description: ShellyEventDescription
+    entity_description: ShellyRpcEventDescription
 
     def __init__(
         self,
         coordinator: ShellyRpcCoordinator,
         key: str,
-        description: ShellyEventDescription,
+        description: ShellyRpcEventDescription,
     ) -> None:
         """Initialize Shelly entity."""
         super().__init__(coordinator)
@@ -104,5 +151,42 @@ class ShellyRpcEvent(CoordinatorEntity[ShellyRpcCoordinator], EventEntity):
     def _async_handle_event(self, event: dict[str, Any]) -> None:
         """Handle the demo button event."""
         if event["id"] == self.input_index:
+            self._trigger_event(event["event"])
+            self.async_write_ha_state()
+
+
+class ShellyBlockEvent(CoordinatorEntity[ShellyBlockCoordinator], EventEntity):
+    """Represent Block event entity."""
+
+    _attr_should_poll = False
+    entity_description: ShellyBlockEventDescription
+
+    def __init__(
+        self,
+        coordinator: ShellyBlockCoordinator,
+        input_id: int,
+        description: ShellyBlockEventDescription,
+    ) -> None:
+        """Initialize Shelly entity."""
+        super().__init__(coordinator)
+        self.input_id = input_id
+        self._attr_device_info = DeviceInfo(
+            connections={(CONNECTION_NETWORK_MAC, coordinator.mac)}
+        )
+        self._attr_unique_id = f"{coordinator.mac}-input-{input_id}"
+        self._attr_name = f"{coordinator.device.name} Input {input_id}"
+        self.entity_description = description
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to hass."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.coordinator.async_subscribe_input_events(self._async_handle_event)
+        )
+
+    @callback
+    def _async_handle_event(self, event: dict[str, Any]) -> None:
+        """Handle the demo button event."""
+        if event["id"] == self.input_id:
             self._trigger_event(event["event"])
             self.async_write_ha_state()

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -106,9 +106,15 @@
               "btn_down": "Button down",
               "btn_up": "Button up",
               "double_push": "Double push",
+              "double": "Double push",
               "long_push": "Long push",
+              "long_single": "Long push and then short push",
+              "long": "Long push",
+              "single_long": "Short push and then long push",
               "single_push": "Single push",
-              "triple_push": "Triple push"
+              "single": "Single push",
+              "triple_push": "Triple push",
+              "triple": "Triple push"
             }
           }
         }

--- a/tests/components/shelly/test_event.py
+++ b/tests/components/shelly/test_event.py
@@ -75,7 +75,7 @@ async def test_rpc_event_removal(
 async def test_block_event(hass: HomeAssistant, monkeypatch, mock_block_device) -> None:
     """Test block device event."""
     await init_integration(hass, 1)
-    entity_id = "event.test_name_input_1"
+    entity_id = "event.test_name_channel_1"
     registry = async_get(hass)
 
     state = hass.states.get(entity_id)
@@ -87,7 +87,7 @@ async def test_block_event(hass: HomeAssistant, monkeypatch, mock_block_device) 
 
     entry = registry.async_get(entity_id)
     assert entry
-    assert entry.unique_id == "123456789ABC-input-1"
+    assert entry.unique_id == "123456789ABC-relay_0-1"
 
     monkeypatch.setattr(
         mock_block_device.blocks[DEVICE_BLOCK_ID],
@@ -105,7 +105,7 @@ async def test_block_event(hass: HomeAssistant, monkeypatch, mock_block_device) 
 async def test_block_event_shix3_1(hass: HomeAssistant, mock_block_device) -> None:
     """Test block device event for SHIX3-1."""
     await init_integration(hass, 1, model="SHIX3-1")
-    entity_id = "event.test_name_input_1"
+    entity_id = "event.test_name_channel_1"
 
     state = hass.states.get(entity_id)
     assert state

--- a/tests/components/shelly/test_event.py
+++ b/tests/components/shelly/test_event.py
@@ -15,6 +15,8 @@ from homeassistant.helpers.entity_registry import async_get
 
 from . import init_integration, inject_rpc_device_event, register_entity
 
+DEVICE_BLOCK_ID = 4
+
 
 async def test_rpc_button(hass: HomeAssistant, mock_rpc_device, monkeypatch) -> None:
     """Test RPC device event."""
@@ -68,3 +70,45 @@ async def test_rpc_event_removal(
     await init_integration(hass, 2)
 
     assert registry.async_get(entity_id) is None
+
+
+async def test_block_event(hass: HomeAssistant, monkeypatch, mock_block_device) -> None:
+    """Test block device event."""
+    await init_integration(hass, 1)
+    entity_id = "event.test_name_input_1"
+    registry = async_get(hass)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(ATTR_EVENT_TYPES) == unordered(["single", "long"])
+    assert state.attributes.get(ATTR_EVENT_TYPE) is None
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == EventDeviceClass.BUTTON
+
+    entry = registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-input-1"
+
+    monkeypatch.setattr(
+        mock_block_device.blocks[DEVICE_BLOCK_ID],
+        "sensor_ids",
+        {"inputEvent": "L", "inputEventCnt": 0},
+    )
+    monkeypatch.setattr(mock_block_device.blocks[DEVICE_BLOCK_ID], "inputEvent", "L")
+    mock_block_device.mock_update()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.attributes.get(ATTR_EVENT_TYPE) == "long"
+
+
+async def test_block_event_shix3_1(hass: HomeAssistant, mock_block_device) -> None:
+    """Test block device event for SHIX3-1."""
+    await init_integration(hass, 1, model="SHIX3-1")
+    entity_id = "event.test_name_input_1"
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes.get(ATTR_EVENT_TYPES) == unordered(
+        ["double", "long", "long_single", "single", "single_long", "triple"]
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds `event` platform for Shelly gen1 devices.

Tested with Shelly 1L and 2.5.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28979

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
