### PR TITLE
Fix missspelled package names

### DIFF
--- a/homeassistant/components/aquostv/manifest.json
+++ b/homeassistant/components/aquostv/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/aquostv",
   "iot_class": "local_polling",
   "loggers": ["sharp_aquos_rc"],
-  "requirements": ["sharp-aquos-rc==0.3.2"]
+  "requirements": ["sharp_aquos_rc==0.3.2"]
 }

--- a/homeassistant/components/asterisk_mbox/manifest.json
+++ b/homeassistant/components/asterisk_mbox/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/asterisk_mbox",
   "iot_class": "local_push",
   "loggers": ["asterisk_mbox"],
-  "requirements": ["asterisk-mbox==0.5.0"]
+  "requirements": ["asterisk_mbox==0.5.0"]
 }

--- a/homeassistant/components/duotecno/manifest.json
+++ b/homeassistant/components/duotecno/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/duotecno",
   "iot_class": "local_push",
-  "requirements": ["pyduotecno==2023.8.4"]
+  "requirements": ["pyDuotecno==2023.8.4"]
 }

--- a/homeassistant/components/emulated_hue/manifest.json
+++ b/homeassistant/components/emulated_hue/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/emulated_hue",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["aiohttp-cors==0.7.0"]
+  "requirements": ["aiohttp_cors==0.7.0"]
 }

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -15,7 +15,7 @@
   "iot_class": "local_push",
   "loggers": ["aioesphomeapi", "noiseprotocol"],
   "requirements": [
-    "async_interrupt==1.1.1",
+    "async-interrupt==1.1.1",
     "aioesphomeapi==16.0.5",
     "bluetooth-data-tools==1.11.0",
     "esphome-dashboard-api==1.2.3"

--- a/homeassistant/components/foobot/manifest.json
+++ b/homeassistant/components/foobot/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/foobot",
   "iot_class": "cloud_polling",
   "loggers": ["foobot_async"],
-  "requirements": ["foobot-async==1.0.0"]
+  "requirements": ["foobot_async==1.0.0"]
 }

--- a/homeassistant/components/gardena_bluetooth/manifest.json
+++ b/homeassistant/components/gardena_bluetooth/manifest.json
@@ -13,5 +13,5 @@
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/gardena_bluetooth",
   "iot_class": "local_polling",
-  "requirements": ["gardena_bluetooth==1.4.0"]
+  "requirements": ["gardena-bluetooth==1.4.0"]
 }

--- a/homeassistant/components/greeneye_monitor/manifest.json
+++ b/homeassistant/components/greeneye_monitor/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/greeneye_monitor",
   "iot_class": "local_push",
   "loggers": ["greeneye"],
-  "requirements": ["greeneye-monitor==3.0.3"]
+  "requirements": ["greeneye_monitor==3.0.3"]
 }

--- a/homeassistant/components/http/manifest.json
+++ b/homeassistant/components/http/manifest.json
@@ -6,5 +6,5 @@
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["aiohttp-cors==0.7.0"]
+  "requirements": ["aiohttp_cors==0.7.0"]
 }

--- a/homeassistant/components/pushover/manifest.json
+++ b/homeassistant/components/pushover/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/pushover",
   "iot_class": "cloud_push",
   "loggers": ["pushover_complete"],
-  "requirements": ["pushover-complete==1.1.1"]
+  "requirements": ["pushover_complete==1.1.1"]
 }

--- a/homeassistant/components/tplink_omada/manifest.json
+++ b/homeassistant/components/tplink_omada/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/tplink_omada",
   "integration_type": "hub",
   "iot_class": "local_polling",
-  "requirements": ["tplink_omada_client==1.3.2"]
+  "requirements": ["tplink-omada-client==1.3.2"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,6 +1,6 @@
 aiodiscover==1.5.1
-aiohttp-cors==0.7.0
 aiohttp==3.8.5
+aiohttp_cors==0.7.0
 astral==2.2
 async-timeout==4.0.3
 async-upnp-client==0.35.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -254,7 +254,7 @@ aiohomekit==3.0.3
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http
-aiohttp-cors==0.7.0
+aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
 aiohue==4.6.2
@@ -448,7 +448,10 @@ arris-tg2492lg==1.2.1
 asmog==0.0.6
 
 # homeassistant.components.asterisk_mbox
-asterisk-mbox==0.5.0
+asterisk_mbox==0.5.0
+
+# homeassistant.components.esphome
+async-interrupt==1.1.1
 
 # homeassistant.components.dlna_dmr
 # homeassistant.components.dlna_dms
@@ -457,9 +460,6 @@ asterisk-mbox==0.5.0
 # homeassistant.components.upnp
 # homeassistant.components.yeelight
 async-upnp-client==0.35.1
-
-# homeassistant.components.esphome
-async_interrupt==1.1.1
 
 # homeassistant.components.keyboard_remote
 asyncinotify==4.0.2
@@ -818,7 +818,7 @@ flux-led==1.0.4
 fnv-hash-fast==0.4.1
 
 # homeassistant.components.foobot
-foobot-async==1.0.0
+foobot_async==1.0.0
 
 # homeassistant.components.forecast_solar
 forecast-solar==3.0.0
@@ -840,7 +840,7 @@ fritzconnection[qr]==1.13.2
 gTTS==2.2.4
 
 # homeassistant.components.gardena_bluetooth
-gardena_bluetooth==1.4.0
+gardena-bluetooth==1.4.0
 
 # homeassistant.components.google_assistant_sdk
 gassist-text==0.0.10
@@ -922,7 +922,7 @@ gps3==0.33.3
 greeclimate==1.4.1
 
 # homeassistant.components.greeneye_monitor
-greeneye-monitor==3.0.3
+greeneye_monitor==3.0.3
 
 # homeassistant.components.greenwave
 greenwavereality==0.5.1
@@ -1488,7 +1488,7 @@ pure-python-adb[async]==0.3.0.dev0
 pushbullet.py==0.11.0
 
 # homeassistant.components.pushover
-pushover-complete==1.1.1
+pushover_complete==1.1.1
 
 # homeassistant.components.pvoutput
 pvo==1.0.0
@@ -1534,6 +1534,9 @@ pyCEC==0.5.2
 
 # homeassistant.components.control4
 pyControl4==1.1.0
+
+# homeassistant.components.duotecno
+pyDuotecno==2023.8.4
 
 # homeassistant.components.eight_sleep
 pyEight==0.3.2
@@ -1661,9 +1664,6 @@ pydrawise==2023.8.0
 
 # homeassistant.components.android_ip_webcam
 pydroid-ipcam==2.0.0
-
-# homeassistant.components.duotecno
-pyduotecno==2023.8.4
 
 # homeassistant.components.ebox
 pyebox==1.1.4
@@ -2398,7 +2398,7 @@ sfrbox-api==0.0.6
 sharkiq==1.0.2
 
 # homeassistant.components.aquostv
-sharp-aquos-rc==0.3.2
+sharp_aquos_rc==0.3.2
 
 # homeassistant.components.shodan
 shodan==1.28.0
@@ -2587,7 +2587,7 @@ total-connect-client==2023.2
 tp-connected==0.0.4
 
 # homeassistant.components.tplink_omada
-tplink_omada_client==1.3.2
+tplink-omada-client==1.3.2
 
 # homeassistant.components.transmission
 transmission-rpc==4.1.5

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -29,7 +29,7 @@ pytest-unordered==0.5.2
 pytest-picked==0.4.6
 pytest-xdist==3.3.1
 pytest==7.3.1
-requests_mock==1.11.0
+requests-mock==1.11.0
 respx==0.20.2
 syrupy==4.5.0
 tqdm==4.66.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -232,7 +232,7 @@ aiohomekit==3.0.3
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http
-aiohttp-cors==0.7.0
+aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
 aiohue==4.6.2
@@ -404,6 +404,9 @@ aranet4==2.1.3
 # homeassistant.components.arcam_fmj
 arcam-fmj==1.4.0
 
+# homeassistant.components.esphome
+async-interrupt==1.1.1
+
 # homeassistant.components.dlna_dmr
 # homeassistant.components.dlna_dms
 # homeassistant.components.samsungtv
@@ -411,9 +414,6 @@ arcam-fmj==1.4.0
 # homeassistant.components.upnp
 # homeassistant.components.yeelight
 async-upnp-client==0.35.1
-
-# homeassistant.components.esphome
-async_interrupt==1.1.1
 
 # homeassistant.components.sleepiq
 asyncsleepiq==1.3.7
@@ -646,7 +646,7 @@ flux-led==1.0.4
 fnv-hash-fast==0.4.1
 
 # homeassistant.components.foobot
-foobot-async==1.0.0
+foobot_async==1.0.0
 
 # homeassistant.components.forecast_solar
 forecast-solar==3.0.0
@@ -662,7 +662,7 @@ fritzconnection[qr]==1.13.2
 gTTS==2.2.4
 
 # homeassistant.components.gardena_bluetooth
-gardena_bluetooth==1.4.0
+gardena-bluetooth==1.4.0
 
 # homeassistant.components.google_assistant_sdk
 gassist-text==0.0.10
@@ -726,7 +726,7 @@ govee-ble==0.23.0
 greeclimate==1.4.1
 
 # homeassistant.components.greeneye_monitor
-greeneye-monitor==3.0.3
+greeneye_monitor==3.0.3
 
 # homeassistant.components.pure_energie
 gridnet==4.2.0
@@ -1127,7 +1127,7 @@ pure-python-adb[async]==0.3.0.dev0
 pushbullet.py==0.11.0
 
 # homeassistant.components.pushover
-pushover-complete==1.1.1
+pushover_complete==1.1.1
 
 # homeassistant.components.pvoutput
 pvo==1.0.0
@@ -1161,6 +1161,9 @@ pyCEC==0.5.2
 
 # homeassistant.components.control4
 pyControl4==1.1.0
+
+# homeassistant.components.duotecno
+pyDuotecno==2023.8.4
 
 # homeassistant.components.eight_sleep
 pyEight==0.3.2
@@ -1237,9 +1240,6 @@ pydiscovergy==2.0.3
 
 # homeassistant.components.android_ip_webcam
 pydroid-ipcam==2.0.0
-
-# homeassistant.components.duotecno
-pyduotecno==2023.8.4
 
 # homeassistant.components.econet
 pyeconet==0.1.20
@@ -1896,7 +1896,7 @@ toonapi==0.2.1
 total-connect-client==2023.2
 
 # homeassistant.components.tplink_omada
-tplink_omada_client==1.3.2
+tplink-omada-client==1.3.2
 
 # homeassistant.components.transmission
 transmission-rpc==4.1.5


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Runned `pypi-package-name` (from #100646) on the project and fixed the following packages:
```
vscode ➜ /workspaces/core (pip-name-checker) $ python -m script.pypi_name_validator --mode all
The following requirements should be renamed to match Pypi's name:
* "aiohttp-cors" to "aiohttp_cors"
* "asterisk-mbox" to "asterisk_mbox"
* "async_interrupt" to "async-interrupt"
* "foobot-async" to "foobot_async"
* "gardena_bluetooth" to "gardena-bluetooth"
* "greeneye-monitor" to "greeneye_monitor"
* "pushover-complete" to "pushover_complete"
* "pyduotecno" to "pyDuotecno"
* "requests_mock" to "requests-mock"
* "sharp-aquos-rc" to "sharp_aquos_rc"
* "tplink_omada_client" to "tplink-omada-client"
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
