### PR TITLE
Fix mqtt light rgbww update without state topic

### DIFF
--- a/homeassistant/components/mqtt/light/schema_basic.py
+++ b/homeassistant/components/mqtt/light/schema_basic.py
@@ -533,11 +533,25 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
         @log_messages(self.hass, self.entity_id)
         def rgbww_received(msg: ReceiveMessage) -> None:
             """Handle new MQTT messages for RGBWW."""
+
+            def _converter(
+                r: int, g: int, b: int, cw: int, ww: int
+            ) -> tuple[int, int, int]:
+                min_kelvin = color_util.color_temperature_mired_to_kelvin(
+                    self.min_mireds
+                )
+                max_kelvin = color_util.color_temperature_mired_to_kelvin(
+                    self.min_mireds
+                )
+                return color_util.color_rgbww_to_rgb(
+                    r, g, b, cw, ww, min_kelvin, max_kelvin
+                )
+
             rgbww = _rgbx_received(
                 msg,
                 CONF_RGBWW_VALUE_TEMPLATE,
                 ColorMode.RGBWW,
-                color_util.color_rgbww_to_rgb,
+                _converter,
             )
             if rgbww is None:
                 return

--- a/homeassistant/components/mqtt/light/schema_basic.py
+++ b/homeassistant/components/mqtt/light/schema_basic.py
@@ -463,6 +463,7 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
 
         add_topic(CONF_BRIGHTNESS_STATE_TOPIC, brightness_received)
 
+        @callback
         def _rgbx_received(
             msg: ReceiveMessage,
             template: str,
@@ -534,11 +535,12 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
         def rgbww_received(msg: ReceiveMessage) -> None:
             """Handle new MQTT messages for RGBWW."""
 
+            @callback
             def _converter(
                 r: int, g: int, b: int, cw: int, ww: int
             ) -> tuple[int, int, int]:
                 min_kelvin = color_util.color_temperature_mired_to_kelvin(
-                    self.min_mireds
+                    self.max_mireds
                 )
                 max_kelvin = color_util.color_temperature_mired_to_kelvin(
                     self.min_mireds

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -198,6 +198,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, State
 
 from .test_common import (
+    help_custom_config,
     help_test_availability_when_connection_lost,
     help_test_availability_without_topic,
     help_test_custom_availability_payload,
@@ -439,6 +440,176 @@ async def test_controlling_state_via_topic(
     assert light_state.attributes.get("xy_color") == (0.675, 0.322)
     assert light_state.attributes.get(light.ATTR_COLOR_MODE) == "xy"
     assert light_state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
+
+
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        help_custom_config(
+            light.DOMAIN,
+            DEFAULT_CONFIG,
+            (
+                {
+                    "state_topic": "test-topic",
+                    "optimistic": True,
+                    "brightness_command_topic": "test_light_rgb/brightness/set",
+                    "color_mode_state_topic": "color-mode-state-topic",
+                    "rgb_command_topic": "test_light_rgb/rgb/set",
+                    "rgb_state_topic": "rgb-state-topic",
+                    "rgbw_command_topic": "test_light_rgb/rgbw/set",
+                    "rgbw_state_topic": "rgbw-state-topic",
+                    "rgbww_command_topic": "test_light_rgb/rgbww/set",
+                    "rgbww_state_topic": "rgbww-state-topic",
+                },
+            ),
+        )
+    ],
+)
+async def test_received_rgbx_values_set_state_optimistic(
+    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+) -> None:
+    """Test the state is set correctly when an rgbx update is received."""
+    await mqtt_mock_entry()
+    state = hass.states.get("light.test")
+    assert state and state.state is not None
+    async_fire_mqtt_message(hass, "test-topic", "ON")
+    ## Test rgb processing
+    async_fire_mqtt_message(hass, "rgb-state-topic", "255,255,255")
+    await hass.async_block_till_done()
+    state = hass.states.get("light.test")
+    assert state.attributes["brightness"] == 255
+    assert state.attributes["color_mode"] == "rgb"
+    assert state.attributes["rgb_color"] == (255, 255, 255)
+
+    # Only update color mode
+    async_fire_mqtt_message(hass, "color-mode-state-topic", "rgbww")
+    await hass.async_block_till_done()
+    state = hass.states.get("light.test")
+    assert state.attributes["brightness"] == 255
+    assert state.attributes["color_mode"] == "rgbww"
+
+    # Resending same rgb value should restore color mode
+    async_fire_mqtt_message(hass, "rgb-state-topic", "255,255,255")
+    await hass.async_block_till_done()
+    state = hass.states.get("light.test")
+    assert state.attributes["brightness"] == 255
+    assert state.attributes["color_mode"] == "rgb"
+    assert state.attributes["rgb_color"] == (255, 255, 255)
+
+    # Only update brightness
+    await common.async_turn_on(hass, "light.test", brightness=128)
+    state = hass.states.get("light.test")
+    assert state.attributes["brightness"] == 128
+    assert state.attributes["color_mode"] == "rgb"
+    assert state.attributes["rgb_color"] == (255, 255, 255)
+
+    # Resending same rgb value should restore brightness
+    async_fire_mqtt_message(hass, "rgb-state-topic", "255,255,255")
+    await hass.async_block_till_done()
+    state = hass.states.get("light.test")
+    assert state.attributes["brightness"] == 255
+    assert state.attributes["color_mode"] == "rgb"
+    assert state.attributes["rgb_color"] == (255, 255, 255)
+
+    # Only change rgb value
+    async_fire_mqtt_message(hass, "rgb-state-topic", "255,255,0")
+    await hass.async_block_till_done()
+    state = hass.states.get("light.test")
+    assert state.attributes["brightness"] == 255
+    assert state.attributes["color_mode"] == "rgb"
+    assert state.attributes["rgb_color"] == (255, 255, 0)
+
+    ## Test rgbw processing
+    async_fire_mqtt_message(hass, "rgbw-state-topic", "255,255,255,255")
+    await hass.async_block_till_done()
+    state = hass.states.get("light.test")
+    assert state.attributes["brightness"] == 255
+    assert state.attributes["color_mode"] == "rgbw"
+    assert state.attributes["rgbw_color"] == (255, 255, 255, 255)
+
+    # Only update color mode
+    async_fire_mqtt_message(hass, "color-mode-state-topic", "rgb")
+    await hass.async_block_till_done()
+    state = hass.states.get("light.test")
+    assert state.attributes["brightness"] == 255
+    assert state.attributes["color_mode"] == "rgb"
+
+    # Resending same rgbw value should restore color mode
+    async_fire_mqtt_message(hass, "rgbw-state-topic", "255,255,255,255")
+    await hass.async_block_till_done()
+    state = hass.states.get("light.test")
+    assert state.attributes["brightness"] == 255
+    assert state.attributes["color_mode"] == "rgbw"
+    assert state.attributes["rgbw_color"] == (255, 255, 255, 255)
+
+    # Only update brightness
+    await common.async_turn_on(hass, "light.test", brightness=128)
+    state = hass.states.get("light.test")
+    assert state.attributes["brightness"] == 128
+    assert state.attributes["color_mode"] == "rgbw"
+    assert state.attributes["rgbw_color"] == (255, 255, 255, 255)
+
+    # Resending same rgbw value should restore brightness
+    async_fire_mqtt_message(hass, "rgbw-state-topic", "255,255,255,255")
+    await hass.async_block_till_done()
+    state = hass.states.get("light.test")
+    assert state.attributes["brightness"] == 255
+    assert state.attributes["color_mode"] == "rgbw"
+    assert state.attributes["rgbw_color"] == (255, 255, 255, 255)
+
+    # Only change rgbw value
+    async_fire_mqtt_message(hass, "rgbw-state-topic", "255,255,128,255")
+    await hass.async_block_till_done()
+    state = hass.states.get("light.test")
+    assert state.attributes["brightness"] == 255
+    assert state.attributes["color_mode"] == "rgbw"
+    assert state.attributes["rgbw_color"] == (255, 255, 128, 255)
+
+    ## Test rgbww processing
+    async_fire_mqtt_message(hass, "rgbww-state-topic", "255,255,255,32,255")
+    await hass.async_block_till_done()
+    state = hass.states.get("light.test")
+    assert state.attributes["brightness"] == 255
+    assert state.attributes["color_mode"] == "rgbww"
+    assert state.attributes["rgbww_color"] == (255, 255, 255, 32, 255)
+
+    # Only update color mode
+    async_fire_mqtt_message(hass, "color-mode-state-topic", "rgb")
+    await hass.async_block_till_done()
+    state = hass.states.get("light.test")
+    assert state.attributes["brightness"] == 255
+    assert state.attributes["color_mode"] == "rgb"
+
+    # Resending same rgbw value should restore color mode
+    async_fire_mqtt_message(hass, "rgbww-state-topic", "255,255,255,32,255")
+    await hass.async_block_till_done()
+    state = hass.states.get("light.test")
+    assert state.attributes["brightness"] == 255
+    assert state.attributes["color_mode"] == "rgbww"
+    assert state.attributes["rgbww_color"] == (255, 255, 255, 32, 255)
+
+    # Only update brightness
+    await common.async_turn_on(hass, "light.test", brightness=128)
+    state = hass.states.get("light.test")
+    assert state.attributes["brightness"] == 128
+    assert state.attributes["color_mode"] == "rgbww"
+    assert state.attributes["rgbww_color"] == (255, 255, 255, 32, 255)
+
+    # Resending same rgbww value should restore brightness
+    async_fire_mqtt_message(hass, "rgbww-state-topic", "255,255,255,32,255")
+    await hass.async_block_till_done()
+    state = hass.states.get("light.test")
+    assert state.attributes["brightness"] == 255
+    assert state.attributes["color_mode"] == "rgbww"
+    assert state.attributes["rgbww_color"] == (255, 255, 255, 32, 255)
+
+    # Only change rgbww value
+    async_fire_mqtt_message(hass, "rgbww-state-topic", "255,255,128,32,255")
+    await hass.async_block_till_done()
+    state = hass.states.get("light.test")
+    assert state.attributes["brightness"] == 255
+    assert state.attributes["color_mode"] == "rgbww"
+    assert state.attributes["rgbww_color"] == (255, 255, 128, 32, 255)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix mqtt light rgbww update without state topic.
When an rgbww update is received `color_util.color_rgbww_to_rgb` is called in `_rgbx_received`  and without the brightness state topic passing the color value missing 2 positional attributes `min_kelvin` and `max_kelvin`.
This PR fixes this condition and add a test updating `_attr_color_mode`  `_attr_brighness` and `_attr_rgb_color`, `_attr_rgbw_color` and `_attr_rgbww_color` when a rgbx color update message is received.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
