### PR TITLE
Add device class to denonavr

### DIFF
--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -219,6 +219,7 @@ class DenonDevice(MediaPlayerEntity):
 
     _attr_has_entity_name = True
     _attr_name = None
+    _attr_device_class = MediaPlayerDeviceClass.RECEIVER
 
     def __init__(
         self,
@@ -239,7 +240,6 @@ class DenonDevice(MediaPlayerEntity):
             name=receiver.name,
         )
         self._attr_sound_mode_list = receiver.sound_mode_list
-        self._attr_device_class = MediaPlayerDeviceClass.TV
         
         self._receiver = receiver
         self._update_audyssey = update_audyssey

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -19,6 +19,7 @@ from denonavr.exceptions import (
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
+    MediaPlayerDeviceClass,
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
     MediaPlayerState,
@@ -238,7 +239,8 @@ class DenonDevice(MediaPlayerEntity):
             name=receiver.name,
         )
         self._attr_sound_mode_list = receiver.sound_mode_list
-
+        self._attr_device_class = MediaPlayerDeviceClass.TV
+        
         self._receiver = receiver
         self._update_audyssey = update_audyssey
 

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -240,7 +240,6 @@ class DenonDevice(MediaPlayerEntity):
             name=receiver.name,
         )
         self._attr_sound_mode_list = receiver.sound_mode_list
-        
         self._receiver = receiver
         self._update_audyssey = update_audyssey
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
adding device_class TV to denonavr component
fixes partially https://github.com/home-assistant/core/issues/94917


## Type of change

- [ ] Dependency upgrade
- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information


- This PR fixes or closes issue: 
- This PR is related to issue: #94917 
- Link to documentation pull request: 

## Checklist

- [ x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.



