### PR TITLE
Add support for receivers to HomeKit

### DIFF
--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -183,7 +183,9 @@ def get_accessory(  # noqa: C901
         device_class = state.attributes.get(ATTR_DEVICE_CLASS)
         feature_list = config.get(CONF_FEATURE_LIST, [])
 
-        if device_class == MediaPlayerDeviceClass.TV:
+        if device_class == MediaPlayerDeviceClass.RECEIVER:
+            a_type = "ReceiverMediaPlayer"
+        elif device_class == MediaPlayerDeviceClass.TV:
             a_type = "TelevisionMediaPlayer"
         elif validate_media_player_features(state, feature_list):
             a_type = "MediaPlayer"
@@ -274,7 +276,7 @@ class HomeAccessory(Accessory):  # type: ignore[misc]
         aid: int,
         config: dict,
         *args: Any,
-        category: str = CATEGORY_OTHER,
+        category: int = CATEGORY_OTHER,
         device_id: str | None = None,
         **kwargs: Any,
     ) -> None:

--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -115,6 +115,9 @@ TYPE_SPRINKLER = "sprinkler"
 TYPE_SWITCH = "switch"
 TYPE_VALVE = "valve"
 
+# #### Categories ####
+CATEGORY_RECEIVER = 34
+
 # #### Services ####
 SERV_ACCESSORY_INFO = "AccessoryInformation"
 SERV_AIR_QUALITY_SENSOR = "AirQualitySensor"

--- a/homeassistant/components/homekit/strings.json
+++ b/homeassistant/components/homekit/strings.json
@@ -11,7 +11,7 @@
           "include_exclude_mode": "Inclusion Mode",
           "domains": "[%key:component::homekit::config::step::user::data::include_domains%]"
         },
-        "description": "HomeKit can be configured expose a bridge or a single accessory. In accessory mode, only a single entity can be used. Accessory mode is required for media players with the TV device class to function properly. Entities in the \u201cDomains to include\u201d will be included to HomeKit. You will be able to select which entities to include or exclude from this list on the next screen.",
+        "description": "HomeKit can be configured expose a bridge or a single accessory. In accessory mode, only a single entity can be used. Accessory mode is required for media players with the TV or RECEIVER device class to function properly. Entities in the \u201cDomains to include\u201d will be included to HomeKit. You will be able to select which entities to include or exclude from this list on the next screen.",
         "title": "Select mode and domains."
       },
       "accessory": {
@@ -57,7 +57,7 @@
         "data": {
           "include_domains": "Domains to include"
         },
-        "description": "Choose the domains to be included. All supported entities in the domain will be included except for categorized entities. A separate HomeKit instance in accessory mode will be created for each tv media player, activity based remote, lock, and camera.",
+        "description": "Choose the domains to be included. All supported entities in the domain will be included except for categorized entities. A separate HomeKit instance in accessory mode will be created for each tv/receiver media player, activity based remote, lock, and camera.",
         "title": "Select domains to be included"
       },
       "pairing": {

--- a/homeassistant/components/homekit/type_remotes.py
+++ b/homeassistant/components/homekit/type_remotes.py
@@ -1,6 +1,7 @@
 """Class to hold remote accessories."""
 from abc import ABC, abstractmethod
 import logging
+from typing import Any
 
 from pyhap.const import CATEGORY_TELEVISION
 
@@ -80,19 +81,21 @@ class RemoteInputSelectAccessory(HomeAccessory, ABC):
 
     def __init__(
         self,
-        required_feature,
-        source_key,
-        source_list_key,
-        *args,
-        **kwargs,
-    ):
+        required_feature: int,
+        source_key: str,
+        source_list_key: str,
+        *args: Any,
+        category: int = CATEGORY_TELEVISION,
+        **kwargs: Any,
+    ) -> None:
         """Initialize a InputSelect accessory object."""
-        super().__init__(*args, category=CATEGORY_TELEVISION, **kwargs)
+        super().__init__(*args, category=category, **kwargs)
         state = self.hass.states.get(self.entity_id)
+        assert state
         features = state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
 
-        self._mapped_sources_list = []
-        self._mapped_sources = {}
+        self._mapped_sources_list: list[str] = []
+        self._mapped_sources: dict[str, str] = {}
         self.source_key = source_key
         self.source_list_key = source_list_key
         self.sources = []

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -614,7 +614,8 @@ def state_needs_accessory_mode(state: State) -> bool:
 
     return (
         state.domain == MEDIA_PLAYER_DOMAIN
-        and state.attributes.get(ATTR_DEVICE_CLASS) == MediaPlayerDeviceClass.TV
+        and state.attributes.get(ATTR_DEVICE_CLASS)
+        in (MediaPlayerDeviceClass.TV, MediaPlayerDeviceClass.RECEIVER)
         or state.domain == REMOTE_DOMAIN
         and state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         & RemoteEntityFeature.ACTIVITY

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -17,7 +17,10 @@ from homeassistant.components.homekit.const import (
     TYPE_SWITCH,
     TYPE_VALVE,
 )
-from homeassistant.components.media_player import MediaPlayerEntityFeature
+from homeassistant.components.media_player import (
+    MediaPlayerDeviceClass,
+    MediaPlayerEntityFeature,
+)
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.vacuum import VacuumEntityFeature
 from homeassistant.const import (
@@ -202,7 +205,14 @@ def test_type_covers(type_name, entity_id, state, attrs) -> None:
             "TelevisionMediaPlayer",
             "media_player.tv",
             "on",
-            {ATTR_DEVICE_CLASS: "tv"},
+            {ATTR_DEVICE_CLASS: MediaPlayerDeviceClass.TV},
+            {},
+        ),
+        (
+            "ReceiverMediaPlayer",
+            "media_player.receiver",
+            "on",
+            {ATTR_DEVICE_CLASS: MediaPlayerDeviceClass.RECEIVER},
             {},
         ),
     ],


### PR DESCRIPTION
## Breaking change

The HomeKit integration now supports media player receivers.  HomeKit expects Receivers to be paired in accessory mode. Existing receivers that were paired in bridge mode should be re-added in [accessory mode](https://www.home-assistant.io/integrations/homekit/#accessory-mode).




## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for MediaPlayerDeviceClass.RECEIVER to HomeKit

Receivers will likely continue to work in bridge mode until they are re-added in accessory mode, but they will likely show the wrong icon in the mean time.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28988

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
