### PR TITLE
Fix Shelly Gen2 event get input name method

### DIFF
--- a/homeassistant/components/shelly/event.py
+++ b/homeassistant/components/shelly/event.py
@@ -22,7 +22,7 @@ from .coordinator import ShellyRpcCoordinator, get_entry_data
 from .utils import (
     async_remove_shelly_entity,
     get_device_entry_gen,
-    get_rpc_input_name,
+    get_rpc_entity_name,
     get_rpc_key_instances,
     is_rpc_momentary_input,
 )
@@ -90,7 +90,7 @@ class ShellyRpcEvent(CoordinatorEntity[ShellyRpcCoordinator], EventEntity):
             connections={(CONNECTION_NETWORK_MAC, coordinator.mac)}
         )
         self._attr_unique_id = f"{coordinator.mac}-{key}"
-        self._attr_name = get_rpc_input_name(coordinator.device, key)
+        self._attr_name = get_rpc_entity_name(coordinator.device, key)
         self.entity_description = description
 
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -285,22 +285,10 @@ def get_model_name(info: dict[str, Any]) -> str:
     return cast(str, MODEL_NAMES.get(info["type"], info["type"]))
 
 
-def get_rpc_input_name(device: RpcDevice, key: str) -> str:
-    """Get input name based from the device configuration."""
-    input_config = device.config[key]
-
-    if input_name := input_config.get("name"):
-        return f"{device.name} {input_name}"
-
-    return f"{device.name} {key.replace(':', ' ').capitalize()}"
-
-
 def get_rpc_channel_name(device: RpcDevice, key: str) -> str:
     """Get name based on device and channel name."""
     key = key.replace("emdata", "em")
     key = key.replace("em1data", "em1")
-    if device.config.get("switch:0"):
-        key = key.replace("input", "switch")
     device_name = device.name
     entity_name: str | None = None
     if key in device.config:

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -144,7 +144,7 @@ MOCK_BLOCKS = [
 ]
 
 MOCK_CONFIG = {
-    "input:0": {"id": 0, "type": "button"},
+    "input:0": {"id": 0, "name": "Test name input 0", "type": "button"},
     "light:0": {"name": "test light_0"},
     "switch:0": {"name": "test switch_0"},
     "cover:0": {"name": "test cover_0"},

--- a/tests/components/shelly/test_logbook.py
+++ b/tests/components/shelly/test_logbook.py
@@ -108,7 +108,7 @@ async def test_humanify_shelly_click_event_rpc_device(
     assert event1["domain"] == DOMAIN
     assert (
         event1["message"]
-        == "'single_push' click event for test switch_0 Input was fired"
+        == "'single_push' click event for Test name input 0 Input was fired"
     )
 
     assert event2["name"] == "Shelly"

--- a/tests/components/shelly/test_utils.py
+++ b/tests/components/shelly/test_utils.py
@@ -8,7 +8,6 @@ from homeassistant.components.shelly.utils import (
     get_device_uptime,
     get_number_of_channels,
     get_rpc_channel_name,
-    get_rpc_input_name,
     get_rpc_input_triggers,
     is_block_momentary_input,
 )
@@ -207,20 +206,8 @@ async def test_get_block_input_triggers(mock_block_device, monkeypatch) -> None:
 
 async def test_get_rpc_channel_name(mock_rpc_device) -> None:
     """Test get RPC channel name."""
-    assert get_rpc_channel_name(mock_rpc_device, "input:0") == "test switch_0"
-    assert get_rpc_channel_name(mock_rpc_device, "input:3") == "Test name switch_3"
-
-
-async def test_get_rpc_input_name(mock_rpc_device, monkeypatch) -> None:
-    """Test get RPC input name."""
-    assert get_rpc_input_name(mock_rpc_device, "input:0") == "Test name Input 0"
-
-    monkeypatch.setitem(
-        mock_rpc_device.config,
-        "input:0",
-        {"id": 0, "type": "button", "name": "Input name"},
-    )
-    assert get_rpc_input_name(mock_rpc_device, "input:0") == "Test name Input name"
+    assert get_rpc_channel_name(mock_rpc_device, "input:0") == "Test name input 0"
+    assert get_rpc_channel_name(mock_rpc_device, "input:3") == "Test name input_3"
 
 
 async def test_get_rpc_input_triggers(mock_rpc_device, monkeypatch) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When testing https://github.com/home-assistant/core/pull/99659, I used an older commit (https://github.com/home-assistant/core/pull/99659/commits/654cfd75ce84cffd954ea9940458682bcdc179e1) and didn't notice a new method was introduced instead of reusing the existing one. The existing method had a patch for the early device firmware which is not needed anymore since we enforce a minimum version in [aioshelly](https://github.com/home-assistant-libs/aioshelly/blob/870d89a83957dd5ae519f0e27b823607d98c959e/aioshelly/common.py#L121) and we can use the same method for generating the input name.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
