### PR TITLE
Add tests for fitbit integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -389,7 +389,6 @@ omit =
     homeassistant/components/firmata/pin.py
     homeassistant/components/firmata/sensor.py
     homeassistant/components/firmata/switch.py
-    homeassistant/components/fitbit/*
     homeassistant/components/fivem/__init__.py
     homeassistant/components/fivem/binary_sensor.py
     homeassistant/components/fivem/coordinator.py

--- a/homeassistant/components/fitbit/const.py
+++ b/homeassistant/components/fitbit/const.py
@@ -12,6 +12,8 @@ from homeassistant.const import (
     UnitOfVolume,
 )
 
+DOMAIN: Final = "fitbit"
+
 ATTR_ACCESS_TOKEN: Final = "access_token"
 ATTR_REFRESH_TOKEN: Final = "refresh_token"
 ATTR_LAST_SAVED_AT: Final = "last_saved_at"

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -629,6 +629,9 @@ feedparser==6.0.10
 # homeassistant.components.file
 file-read-backwards==2.0.0
 
+# homeassistant.components.fitbit
+fitbit==0.3.1
+
 # homeassistant.components.fivem
 fivem-api==0.1.2
 

--- a/tests/components/fitbit/__init__.py
+++ b/tests/components/fitbit/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for fitbit component."""

--- a/tests/components/fitbit/conftest.py
+++ b/tests/components/fitbit/conftest.py
@@ -1,0 +1,167 @@
+"""Test fixtures for fitbit."""
+
+from collections.abc import Awaitable, Callable, Generator
+import datetime
+from http import HTTPStatus
+import time
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from requests_mock.mocker import Mocker
+
+from homeassistant.components.fitbit.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+CLIENT_ID = "1234"
+CLIENT_SECRET = "5678"
+PROFILE_USER_ID = "fitbit-api-user-id-1"
+FAKE_TOKEN = "some-token"
+FAKE_REFRESH_TOKEN = "some-refresh-token"
+
+PROFILE_API_URL = "https://api.fitbit.com/1/user/-/profile.json"
+DEVICES_API_URL = "https://api.fitbit.com/1/user/-/devices.json"
+TIMESERIES_API_URL_FORMAT = (
+    "https://api.fitbit.com/1/user/-/{resource}/date/today/7d.json"
+)
+
+
+@pytest.fixture(name="token_expiration_time")
+def mcok_token_expiration_time() -> float:
+    """Fixture for expiration time of the config entry auth token."""
+    return time.time() + 86400
+
+
+@pytest.fixture(name="fitbit_config_yaml")
+def mock_fitbit_config_yaml(token_expiration_time: float) -> dict[str, Any]:
+    """Fixture for the yaml fitbit.conf file contents."""
+    return {
+        "access_token": FAKE_TOKEN,
+        "refresh_token": FAKE_REFRESH_TOKEN,
+        "last_saved_at": token_expiration_time,
+    }
+
+
+@pytest.fixture(name="fitbit_config_setup", autouse=True)
+def mock_fitbit_config_setup(
+    fitbit_config_yaml: dict[str, Any],
+) -> Generator[None, None, None]:
+    """Fixture to mock out fitbit.conf file data loading and persistence."""
+
+    with patch(
+        "homeassistant.components.fitbit.sensor.os.path.isfile", return_value=True
+    ), patch(
+        "homeassistant.components.fitbit.sensor.load_json_object",
+        return_value=fitbit_config_yaml,
+    ), patch(
+        "homeassistant.components.fitbit.sensor.save_json",
+    ):
+        yield
+
+
+@pytest.fixture(name="monitored_resources")
+def mock_monitored_resources() -> list[str] | None:
+    """Fixture for the fitbit yaml config monitored_resources field."""
+    return None
+
+
+@pytest.fixture(name="sensor_platform_config")
+def mock_sensor_platform_config(
+    monitored_resources: list[str] | None,
+) -> dict[str, Any]:
+    """Fixture for the fitbit sensor platform configuration data in configuration.yaml."""
+    config = {}
+    if monitored_resources is not None:
+        config["monitored_resources"] = monitored_resources
+    return config
+
+
+@pytest.fixture(name="sensor_platform_setup")
+async def mock_sensor_platform_setup(
+    hass: HomeAssistant,
+    sensor_platform_config: dict[str, Any],
+) -> Callable[[], Awaitable[bool]]:
+    """Fixture to set up the integration."""
+
+    async def run() -> bool:
+        result = await async_setup_component(
+            hass,
+            "sensor",
+            {
+                "sensor": [
+                    {
+                        "platform": DOMAIN,
+                        **sensor_platform_config,
+                    }
+                ]
+            },
+        )
+        await hass.async_block_till_done()
+        return result
+
+    return run
+
+
+@pytest.fixture(name="profile_id")
+async def mock_profile_id() -> str:
+    """Fixture for the profile id returned from the API response."""
+    return PROFILE_USER_ID
+
+
+@pytest.fixture(name="profile", autouse=True)
+async def mock_profile(requests_mock: Mocker, profile_id: str) -> None:
+    """Fixture to setup fake requests made to Fitbit API during config flow."""
+    requests_mock.register_uri(
+        "GET",
+        PROFILE_API_URL,
+        status_code=HTTPStatus.OK,
+        json={
+            "user": {
+                "encodedId": profile_id,
+                "fullName": "My name",
+                "locale": "en_US",
+            },
+        },
+    )
+
+
+@pytest.fixture(name="devices_response")
+async def mock_device_response() -> list[dict[str, Any]]:
+    """Return the list of devices."""
+    return []
+
+
+@pytest.fixture(autouse=True)
+async def mock_devices(requests_mock: Mocker, devices_response: dict[str, Any]) -> None:
+    """Fixture to setup fake device responses."""
+    requests_mock.register_uri(
+        "GET",
+        DEVICES_API_URL,
+        status_code=HTTPStatus.OK,
+        json=devices_response,
+    )
+
+
+def timeseries_response(resource: str, value: str) -> dict[str, Any]:
+    """Create a timeseries response value."""
+    return {
+        resource: [{"dateTime": datetime.datetime.today().isoformat(), "value": value}]
+    }
+
+
+@pytest.fixture(name="register_timeseries")
+async def mock_register_timeseries(
+    requests_mock: Mocker,
+) -> Callable[[str, dict[str, Any]], None]:
+    """Fixture to setup fake timeseries API responses."""
+
+    def register(resource: str, response: dict[str, Any]) -> None:
+        requests_mock.register_uri(
+            "GET",
+            TIMESERIES_API_URL_FORMAT.format(resource=resource),
+            status_code=HTTPStatus.OK,
+            json=response,
+        )
+
+    return register

--- a/tests/components/fitbit/test_sensor.py
+++ b/tests/components/fitbit/test_sensor.py
@@ -1,0 +1,92 @@
+"""Tests for the fitbit sensor platform."""
+
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+
+from .conftest import timeseries_response
+
+DEVICE_RESPONSE_CHARGE_2 = {
+    "battery": "Medium",
+    "batteryLevel": 60,
+    "deviceVersion": "Charge 2",
+    "id": "816713257",
+    "lastSyncTime": "2019-11-07T12:00:58.000",
+    "mac": "16ADD56D54GD",
+    "type": "TRACKER",
+}
+DEVICE_RESPONSE_ARIA_AIR = {
+    "battery": "High",
+    "batteryLevel": 95,
+    "deviceVersion": "Aria Air",
+    "id": "016713257",
+    "lastSyncTime": "2019-11-07T12:00:58.000",
+    "mac": "06ADD56D54GD",
+    "type": "SCALE",
+}
+
+
+@pytest.mark.parametrize(
+    "monitored_resources",
+    [["activities/steps"]],
+)
+async def test_step_sensor(
+    hass: HomeAssistant,
+    sensor_platform_setup: Callable[[], Awaitable[bool]],
+    register_timeseries: Callable[[str, dict[str, Any]], None],
+) -> None:
+    """Test battery level sensor."""
+
+    register_timeseries(
+        "activities/steps", timeseries_response("activities-steps", "5600")
+    )
+    await sensor_platform_setup()
+
+    state = hass.states.get("sensor.steps")
+    assert state
+    assert state.state == "5600"
+    assert state.attributes == {
+        "attribution": "Data provided by Fitbit.com",
+        "friendly_name": "Steps",
+        "icon": "mdi:walk",
+        "unit_of_measurement": "steps",
+    }
+
+
+@pytest.mark.parametrize(
+    ("devices_response", "monitored_resources"),
+    [([DEVICE_RESPONSE_CHARGE_2, DEVICE_RESPONSE_ARIA_AIR], ["devices/battery"])],
+)
+async def test_device_battery_level(
+    hass: HomeAssistant,
+    sensor_platform_setup: Callable[[], Awaitable[bool]],
+) -> None:
+    """Test battery level sensor for devices."""
+
+    await sensor_platform_setup()
+
+    state = hass.states.get("sensor.charge_2_battery")
+    assert state
+    assert state.state == "Medium"
+    assert state.attributes == {
+        "attribution": "Data provided by Fitbit.com",
+        "friendly_name": "Charge 2 Battery",
+        "icon": "mdi:battery-50",
+        "model": "Charge 2",
+        "type": "tracker",
+    }
+
+    state = hass.states.get("sensor.aria_air_battery")
+    assert state
+    assert state.state == "High"
+    assert state.attributes == {
+        "attribution": "Data provided by Fitbit.com",
+        "friendly_name": "Aria Air Battery",
+        "icon": "mdi:battery",
+        "model": "Aria Air",
+        "type": "scale",
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add tests for fitbit integration, which I plan to overhaul, modernize, and move to UI based configuration.

The fitbit integration currently has a custom configurator based oauth flow and platform configuration that uses `configuration.yaml` for platform config and `fitbit.conf` for oauth token storage. This adds initial test harness and coverage as a first step before further code cleanups.

This is pulled out of a larger overhaul to modernize the fitbit integration and make it configurable from the UI and following current design standards, similar to previous approach on Google calendar :
- [X] Add test harness #100765
- [X] #100766
- [X] Increase test coverage #100776
- [X] Simplify response parsing and entity descriptions #100782
- [X] Refactor unit system #100825
- [X] Ascynio client library #100933
- [X] Config flow and UI based configuration, application credentials, import of existing credentials #100897
- [x] Reauth support in config flow #101178

These will be pulled out of the end-to-end [proof of concept commit](https://github.com/home-assistant/core/compare/dev...allenporter:home-assistant-core:fitbit-config-flow?expand=1) into separate PRs for easier review.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
