### PR TITLE
Preserve private ble device broadcast interval when MAC address rotates

### DIFF
--- a/homeassistant/components/private_ble_device/coordinator.py
+++ b/homeassistant/components/private_ble_device/coordinator.py
@@ -102,6 +102,18 @@ class PrivateDevicesCoordinator:
 
     def _async_irk_resolved_to_mac(self, irk: bytes, mac: str) -> None:
         if previous_mac := self._irk_to_mac.get(irk):
+            previous_interval = bluetooth.async_get_learned_advertising_interval(
+                self.hass, previous_mac
+            )
+            if not previous_interval:
+                previous_interval = bluetooth.async_get_fallback_availability_interval(
+                    self.hass, previous_mac
+                )
+            if previous_interval:
+                bluetooth.async_set_fallback_availability_interval(
+                    self.hass, mac, previous_interval
+                )
+
             self._mac_to_irk.pop(previous_mac, None)
 
         self._mac_to_irk[mac] = irk

--- a/homeassistant/components/private_ble_device/coordinator.py
+++ b/homeassistant/components/private_ble_device/coordinator.py
@@ -104,11 +104,9 @@ class PrivateDevicesCoordinator:
         if previous_mac := self._irk_to_mac.get(irk):
             previous_interval = bluetooth.async_get_learned_advertising_interval(
                 self.hass, previous_mac
+            ) or bluetooth.async_get_fallback_availability_interval(
+                self.hass, previous_mac
             )
-            if not previous_interval:
-                previous_interval = bluetooth.async_get_fallback_availability_interval(
-                    self.hass, previous_mac
-                )
             if previous_interval:
                 bluetooth.async_set_fallback_availability_interval(
                     self.hass, mac, previous_interval

--- a/homeassistant/components/private_ble_device/sensor.py
+++ b/homeassistant/components/private_ble_device/sensor.py
@@ -82,6 +82,7 @@ SENSOR_DESCRIPTIONS = (
         icon="mdi:timer-sync-outline",
         native_unit_of_measurement=UnitOfTime.SECONDS,
         entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda hass, service_info: bluetooth.async_get_learned_advertising_interval(
             hass, service_info.address
         )

--- a/homeassistant/components/private_ble_device/sensor.py
+++ b/homeassistant/components/private_ble_device/sensor.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     EntityCategory,
     UnitOfLength,
+    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -29,7 +30,9 @@ from .entity import BasePrivateDeviceEntity
 class PrivateDeviceSensorEntityDescriptionRequired:
     """Required domain specific fields for sensor entity."""
 
-    value_fn: Callable[[bluetooth.BluetoothServiceInfoBleak], str | int | float | None]
+    value_fn: Callable[
+        [HomeAssistant, bluetooth.BluetoothServiceInfoBleak], str | int | float | None
+    ]
 
 
 @dataclass
@@ -46,7 +49,7 @@ SENSOR_DESCRIPTIONS = (
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda service_info: service_info.advertisement.rssi,
+        value_fn=lambda _, service_info: service_info.advertisement.rssi,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     PrivateDeviceSensorEntityDescription(
@@ -56,7 +59,7 @@ SENSOR_DESCRIPTIONS = (
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda service_info: service_info.advertisement.tx_power,
+        value_fn=lambda _, service_info: service_info.advertisement.tx_power,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     PrivateDeviceSensorEntityDescription(
@@ -64,13 +67,28 @@ SENSOR_DESCRIPTIONS = (
         translation_key="estimated_distance",
         icon="mdi:signal-distance-variant",
         native_unit_of_measurement=UnitOfLength.METERS,
-        value_fn=lambda service_info: service_info.advertisement
+        value_fn=lambda _, service_info: service_info.advertisement
         and service_info.advertisement.tx_power
         and calculate_distance_meters(
             service_info.advertisement.tx_power * 10, service_info.advertisement.rssi
         ),
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.DISTANCE,
+        suggested_display_precision=1,
+    ),
+    PrivateDeviceSensorEntityDescription(
+        key="estimated_broadcast_interval",
+        translation_key="estimated_broadcast_interval",
+        icon="mdi:timer-sync-outline",
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        entity_registry_enabled_default=False,
+        value_fn=lambda hass, service_info: bluetooth.async_get_learned_advertising_interval(
+            hass, service_info.address
+        )
+        or bluetooth.async_get_fallback_availability_interval(
+            hass, service_info.address
+        )
+        or bluetooth.FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
         suggested_display_precision=1,
     ),
 )
@@ -124,4 +142,4 @@ class PrivateBLEDeviceSensor(BasePrivateDeviceEntity, SensorEntity):
     def native_value(self) -> str | int | float | None:
         """Return the state of the sensor."""
         assert self._last_info
-        return self.entity_description.value_fn(self._last_info)
+        return self.entity_description.value_fn(self.hass, self._last_info)

--- a/homeassistant/components/private_ble_device/strings.json
+++ b/homeassistant/components/private_ble_device/strings.json
@@ -24,6 +24,9 @@
       },
       "estimated_distance": {
         "name": "Estimated distance"
+      },
+      "estimated_broadcast_interval": {
+        "name": "Estimated broadcast interval"
       }
     }
   }

--- a/tests/components/private_ble_device/test_device_tracker.py
+++ b/tests/components/private_ble_device/test_device_tracker.py
@@ -6,6 +6,9 @@ import time
 from homeassistant.components.bluetooth.advertisement_tracker import (
     ADVERTISING_TIMES_NEEDED,
 )
+from homeassistant.components.bluetooth.api import (
+    async_get_fallback_availability_interval,
+)
 from homeassistant.core import HomeAssistant
 
 from . import (
@@ -181,3 +184,23 @@ async def test_old_tracker_leave_home(
     state = hass.states.get("device_tracker.private_ble_device_000000")
     assert state
     assert state.state == "not_home"
+
+
+async def test_mac_rotation(
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+    entity_registry_enabled_by_default: None,
+) -> None:
+    """Test sensors get value when we receive a broadcast."""
+    await async_mock_config_entry(hass)
+
+    assert async_get_fallback_availability_interval(hass, MAC_RPA_VALID_1) is None
+    assert async_get_fallback_availability_interval(hass, MAC_RPA_VALID_2) is None
+
+    for i in range(ADVERTISING_TIMES_NEEDED):
+        await async_inject_broadcast(
+            hass, MAC_RPA_VALID_1, mfr_data=bytes(i), broadcast_time=i * 10
+        )
+
+    await async_inject_broadcast(hass, MAC_RPA_VALID_2)
+    assert async_get_fallback_availability_interval(hass, MAC_RPA_VALID_2) == 10

--- a/tests/components/private_ble_device/test_sensor.py
+++ b/tests/components/private_ble_device/test_sensor.py
@@ -1,6 +1,10 @@
 """Tests for sensors."""
 
 
+from homeassistant.components.bluetooth import async_set_fallback_availability_interval
+from homeassistant.components.bluetooth.advertisement_tracker import (
+    ADVERTISING_TIMES_NEEDED,
+)
 from homeassistant.core import HomeAssistant
 
 from . import MAC_RPA_VALID_1, async_inject_broadcast, async_mock_config_entry
@@ -45,3 +49,39 @@ async def test_sensors_come_home(
     state = hass.states.get("sensor.private_ble_device_000000_signal_strength")
     assert state
     assert state.state == "-63"
+
+
+async def test_estimated_broadcast_interval(
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+    entity_registry_enabled_by_default: None,
+) -> None:
+    """Test sensors get value when we receive a broadcast."""
+    await async_mock_config_entry(hass)
+    await async_inject_broadcast(hass, MAC_RPA_VALID_1)
+
+    state = hass.states.get(
+        "sensor.private_ble_device_000000_estimated_broadcast_interval"
+    )
+    assert state
+    assert state.state == "900"
+
+    async_set_fallback_availability_interval(hass, MAC_RPA_VALID_1, 90)
+    await async_inject_broadcast(hass, MAC_RPA_VALID_1.upper())
+
+    state = hass.states.get(
+        "sensor.private_ble_device_000000_estimated_broadcast_interval"
+    )
+    assert state
+    assert state.state == "90"
+
+    for i in range(ADVERTISING_TIMES_NEEDED):
+        await async_inject_broadcast(
+            hass, MAC_RPA_VALID_1, mfr_data=bytes(i), broadcast_time=i * 10
+        )
+
+    state = hass.states.get(
+        "sensor.private_ble_device_000000_estimated_broadcast_interval"
+    )
+    assert state
+    assert state.state == "10"


### PR DESCRIPTION
## Proposed change

This builds on https://github.com/home-assistant/core/pull/100774 and preserves the broadcast interval when a bluetooth MAC address rotates - before it would reset to 15 minutes every time the MAC address rotated, which would delay the home -> away transition.

This also adds a sensor (disabled by default) so we can see the interval.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
