### PR TITLE
Add 'last_reset' for 'total' state_class template sensor

### DIFF
--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 from datetime import date, datetime
 from typing import Any
 
+import logging
 import voluptuous as vol
 
 from homeassistant.components.sensor import (
+    ATTR_LAST_RESET,
     CONF_STATE_CLASS,
     DEVICE_CLASSES_SCHEMA,
     DOMAIN as SENSOR_DOMAIN,
@@ -15,6 +17,7 @@ from homeassistant.components.sensor import (
     RestoreSensor,
     SensorDeviceClass,
     SensorEntity,
+    SensorStateClass,
 )
 from homeassistant.components.sensor.helpers import async_parse_date_datetime
 from homeassistant.config_entries import ConfigEntry
@@ -41,6 +44,7 @@ from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.trigger_template_entity import TEMPLATE_SENSOR_BASE_SCHEMA
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.util import dt as dt_util
 
 from . import TriggerUpdateCoordinator
 from .const import (
@@ -63,14 +67,26 @@ LEGACY_FIELDS = {
 }
 
 
-SENSOR_SCHEMA = (
+def validate_last_reset(val):
+    """Run extra validation checks."""
+    if ATTR_LAST_RESET in val and val.get(CONF_STATE_CLASS) != SensorStateClass.TOTAL:
+        raise vol.Invalid(
+            "last_reset is only valid for template sensors with state_class 'total'"
+        )
+
+    return val
+
+
+SENSOR_SCHEMA = vol.All(
     vol.Schema(
         {
             vol.Required(CONF_STATE): cv.template,
+            vol.Optional(ATTR_LAST_RESET): cv.template,
         }
     )
     .extend(TEMPLATE_SENSOR_BASE_SCHEMA.schema)
-    .extend(TEMPLATE_ENTITY_COMMON_SCHEMA.schema)
+    .extend(TEMPLATE_ENTITY_COMMON_SCHEMA.schema),
+    validate_last_reset,
 )
 
 
@@ -137,6 +153,8 @@ PLATFORM_SCHEMA = vol.All(
     ),
     extra_validation_checks,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @callback
@@ -283,6 +301,13 @@ class TriggerSensorEntity(TriggerEntity, RestoreSensor):
     ) -> None:
         """Initialize."""
         super().__init__(hass, coordinator, config)
+
+        if (last_reset_template := config.get(ATTR_LAST_RESET)) is not None:
+            if last_reset_template.is_static:
+                self._static_rendered[ATTR_LAST_RESET] = last_reset_template.template
+            else:
+                self._to_render_simple.append(ATTR_LAST_RESET)
+
         self._attr_state_class = config.get(CONF_STATE_CLASS)
         self._attr_native_unit_of_measurement = config.get(CONF_UNIT_OF_MEASUREMENT)
 
@@ -309,6 +334,20 @@ class TriggerSensorEntity(TriggerEntity, RestoreSensor):
     def _process_data(self) -> None:
         """Process new data."""
         super()._process_data()
+
+        # Update last_reset
+        if ATTR_LAST_RESET in self._rendered:
+            parsed_timestamp = dt_util.parse_datetime(
+                self._rendered.get(ATTR_LAST_RESET)
+            )
+            if parsed_timestamp is None:
+                _LOGGER.warning(
+                    "%s rendered invalid timestamp for last_reset attribute: %s",
+                    self.entity_id,
+                    self._rendered.get(ATTR_LAST_RESET),
+                )
+            else:
+                self._attr_last_reset = parsed_timestamp
 
         if (
             state := self._rendered.get(CONF_STATE)

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -283,10 +283,6 @@ class SensorTemplate(TemplateEntity, SensorEntity):
 
     @callback
     def _update_last_reset(self, result):
-        if isinstance(result, TemplateError):
-            self._attr_available = True
-            return
-
         self._attr_last_reset = result
 
     @callback

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -8,6 +8,7 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.bootstrap import async_from_config_dict
 from homeassistant.components import sensor, template
+from homeassistant.components.template.sensor import TriggerSensorEntity
 from homeassistant.const import (
     ATTR_ENTITY_PICTURE,
     ATTR_ICON,
@@ -1569,6 +1570,23 @@ async def test_entity_last_reset_setup(
         total_trigger_state.attributes.get("last_reset")
         == datetime(2023, 1, 1).isoformat()
     )
+
+
+async def test_entity_last_reset_static_value(hass: HomeAssistant) -> None:
+    """Test static last_reset marked as static_rendered."""
+
+    tse = TriggerSensorEntity(
+        hass,
+        None,
+        {
+            "name": Template("Static last_reset entity", hass),
+            "state": Template("{{ states('sensor.test_state') | int(0) }}", hass),
+            "state_class": "total",
+            "last_reset": Template("2023-01-01T00:00:00", hass),
+        },
+    )
+
+    assert "last_reset" in tse._static_rendered
 
 
 async def test_entity_last_reset_parsing(

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -1600,9 +1600,7 @@ async def test_entity_last_reset_parsing(
         "homeassistant.components.template.sensor._LOGGER.warning"
     ) as mocked_warning, patch(
         "homeassistant.components.template.template_entity._LOGGER.error"
-    ) as mocked_error, patch(
-        "homeassistant.util.dt.now", return_value=now
-    ):
+    ) as mocked_error, patch("homeassistant.util.dt.now", return_value=now):
         assert await async_setup_component(
             hass,
             "template",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Users are able to configure the `state_class` to be `total` for template sensors, but currently do not have the option to add a `last_reset` to this configuration. For e.g. sensors that _do_ have a periodic reset, but may not be monotonically increasing this is a missing feature when properly trying to track statistics.

This PR aims to fix that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:  **TO-DO**
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29082

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
