### PR TITLE
Avoid redundant calls to async_ha_write_state mqtt update platform

### DIFF
--- a/homeassistant/components/mqtt/update.py
+++ b/homeassistant/components/mqtt/update.py
@@ -33,9 +33,14 @@ from .const import (
     PAYLOAD_EMPTY_JSON,
 )
 from .debug_info import log_messages
-from .mixins import MQTT_ENTITY_COMMON_SCHEMA, MqttEntity, async_setup_entry_helper
+from .mixins import (
+    MQTT_ENTITY_COMMON_SCHEMA,
+    MqttEntity,
+    async_setup_entry_helper,
+    write_state_on_attr_change,
+)
 from .models import MessageCallbackType, MqttValueTemplate, ReceiveMessage
-from .util import get_mqtt_data, valid_publish_topic, valid_subscribe_topic
+from .util import valid_publish_topic, valid_subscribe_topic
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -171,6 +176,17 @@ class MqttUpdate(MqttEntity, UpdateEntity, RestoreEntity):
 
         @callback
         @log_messages(self.hass, self.entity_id)
+        @write_state_on_attr_change(
+            self,
+            {
+                "_attr_installed_version",
+                "_attr_latest_version",
+                "_attr_title",
+                "_attr_release_summary",
+                "_attr_release_url",
+                "_entity_picture",
+            },
+        )
         def handle_state_message_received(msg: ReceiveMessage) -> None:
             """Handle receiving state message via MQTT."""
             payload = self._templates[CONF_VALUE_TEMPLATE](msg.payload)
@@ -219,39 +235,33 @@ class MqttUpdate(MqttEntity, UpdateEntity, RestoreEntity):
 
             if "installed_version" in json_payload:
                 self._attr_installed_version = json_payload["installed_version"]
-                get_mqtt_data(self.hass).state_write_requests.write_state_request(self)
 
             if "latest_version" in json_payload:
                 self._attr_latest_version = json_payload["latest_version"]
-                get_mqtt_data(self.hass).state_write_requests.write_state_request(self)
 
             if "title" in json_payload:
                 self._attr_title = json_payload["title"]
-                get_mqtt_data(self.hass).state_write_requests.write_state_request(self)
 
             if "release_summary" in json_payload:
                 self._attr_release_summary = json_payload["release_summary"]
-                get_mqtt_data(self.hass).state_write_requests.write_state_request(self)
 
             if "release_url" in json_payload:
                 self._attr_release_url = json_payload["release_url"]
-                get_mqtt_data(self.hass).state_write_requests.write_state_request(self)
 
             if "entity_picture" in json_payload:
                 self._entity_picture = json_payload["entity_picture"]
-                get_mqtt_data(self.hass).state_write_requests.write_state_request(self)
 
         add_subscription(topics, CONF_STATE_TOPIC, handle_state_message_received)
 
         @callback
         @log_messages(self.hass, self.entity_id)
+        @write_state_on_attr_change(self, {"_attr_latest_version"})
         def handle_latest_version_received(msg: ReceiveMessage) -> None:
             """Handle receiving latest version via MQTT."""
             latest_version = self._templates[CONF_LATEST_VERSION_TEMPLATE](msg.payload)
 
             if isinstance(latest_version, str) and latest_version != "":
                 self._attr_latest_version = latest_version
-                get_mqtt_data(self.hass).state_write_requests.write_state_request(self)
 
         add_subscription(
             topics, CONF_LATEST_VERSION_TOPIC, handle_latest_version_received
@@ -278,8 +288,6 @@ class MqttUpdate(MqttEntity, UpdateEntity, RestoreEntity):
             self._config[CONF_RETAIN],
             self._config[CONF_ENCODING],
         )
-
-        get_mqtt_data(self.hass).state_write_requests.write_state_request(self)
 
     @property
     def supported_features(self) -> UpdateEntityFeature:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow up on #100438, Avoid redundant calls to async_write_ha_state in MQTT update platform.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
