### PR TITLE
Add device info to Hydrawise

### DIFF
--- a/homeassistant/components/hydrawise/__init__.py
+++ b/homeassistant/components/hydrawise/__init__.py
@@ -1,7 +1,7 @@
 """Support for Hydrawise cloud."""
 
 
-from pydrawise.legacy import LegacyHydrawise
+from pydrawise import legacy
 from requests.exceptions import ConnectTimeout, HTTPError
 import voluptuous as vol
 
@@ -54,7 +54,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     """Set up Hydrawise from a config entry."""
     access_token = config_entry.data[CONF_API_KEY]
     try:
-        hydrawise = await hass.async_add_executor_job(LegacyHydrawise, access_token)
+        hydrawise = await hass.async_add_executor_job(
+            legacy.LegacyHydrawise, access_token
+        )
     except (ConnectTimeout, HTTPError) as ex:
         LOGGER.error("Unable to connect to Hydrawise cloud service: %s", str(ex))
         raise ConfigEntryNotReady(

--- a/homeassistant/components/hydrawise/binary_sensor.py
+++ b/homeassistant/components/hydrawise/binary_sensor.py
@@ -77,6 +77,7 @@ async def async_setup_entry(
             data=hydrawise.current_controller,
             coordinator=coordinator,
             description=BINARY_SENSOR_STATUS,
+            device_id_key="controller_id",
         )
     ]
 

--- a/homeassistant/components/hydrawise/const.py
+++ b/homeassistant/components/hydrawise/const.py
@@ -11,6 +11,8 @@ CONF_WATERING_TIME = "watering_minutes"
 DOMAIN = "hydrawise"
 DEFAULT_WATERING_TIME = 15
 
+MANUFACTURER = "Hydrawise"
+
 SCAN_INTERVAL = timedelta(seconds=120)
 
 SIGNAL_UPDATE_HYDRAWISE = "hydrawise_update"

--- a/homeassistant/components/hydrawise/entity.py
+++ b/homeassistant/components/hydrawise/entity.py
@@ -15,7 +15,6 @@ class HydrawiseEntity(CoordinatorEntity[HydrawiseDataUpdateCoordinator]):
     """Entity class for Hydrawise devices."""
 
     _attr_attribution = "Data provided by hydrawise.com"
-    _attr_has_entity_name = True
 
     def __init__(
         self,

--- a/homeassistant/components/hydrawise/entity.py
+++ b/homeassistant/components/hydrawise/entity.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 
 from typing import Any
 
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .const import DOMAIN, MANUFACTURER
 from .coordinator import HydrawiseDataUpdateCoordinator
 
 
@@ -13,6 +15,7 @@ class HydrawiseEntity(CoordinatorEntity[HydrawiseDataUpdateCoordinator]):
     """Entity class for Hydrawise devices."""
 
     _attr_attribution = "Data provided by hydrawise.com"
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -20,14 +23,16 @@ class HydrawiseEntity(CoordinatorEntity[HydrawiseDataUpdateCoordinator]):
         data: dict[str, Any],
         coordinator: HydrawiseDataUpdateCoordinator,
         description: EntityDescription,
+        device_id_key: str = "relay_id",
     ) -> None:
         """Initialize the Hydrawise entity."""
         super().__init__(coordinator=coordinator)
         self.data = data
         self.entity_description = description
-        self._attr_name = f"{self.data['name']} {description.name}"
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return the state attributes."""
-        return {"identifier": self.data.get("relay")}
+        self._device_id = str(data.get(device_id_key))
+        self._attr_unique_id = f"{self._device_id}_{self.entity_description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._device_id)},
+            name=self.data["name"],
+            manufacturer=MANUFACTURER,
+        )

--- a/homeassistant/components/hydrawise/entity.py
+++ b/homeassistant/components/hydrawise/entity.py
@@ -30,9 +30,9 @@ class HydrawiseEntity(CoordinatorEntity[HydrawiseDataUpdateCoordinator]):
         self.data = data
         self.entity_description = description
         self._device_id = str(data.get(device_id_key))
-        self._attr_unique_id = f"{self._device_id}_{self.entity_description.key}"
+        self._attr_unique_id = f"{self._device_id}_{description.key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._device_id)},
-            name=self.data["name"],
+            name=data["name"],
             manufacturer=MANUFACTURER,
         )

--- a/tests/components/hydrawise/conftest.py
+++ b/tests/components/hydrawise/conftest.py
@@ -1,9 +1,16 @@
 """Common fixtures for the Hydrawise tests."""
 
 from collections.abc import Generator
-from unittest.mock import AsyncMock, patch
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+
+from homeassistant.components.hydrawise.const import DOMAIN
+from homeassistant.const import CONF_API_KEY
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture
@@ -13,3 +20,85 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
         "homeassistant.components.hydrawise.async_setup_entry", return_value=True
     ) as mock_setup_entry:
         yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_pydrawise(
+    mock_controller: dict[str, Any],
+    mock_zones: list[dict[str, Any]],
+) -> Generator[Mock, None, None]:
+    """Mock LegacyHydrawise."""
+    with patch("pydrawise.legacy.LegacyHydrawise", autospec=True) as mock_pydrawise:
+        mock_pydrawise.return_value.controller_info = {"controllers": [mock_controller]}
+        mock_pydrawise.return_value.current_controller = mock_controller
+        mock_pydrawise.return_value.controller_status = {"relays": mock_zones}
+        mock_pydrawise.return_value.relays = mock_zones
+        yield mock_pydrawise.return_value
+
+
+@pytest.fixture
+def mock_controller() -> dict[str, Any]:
+    """Mock Hydrawise controller."""
+    return {
+        "name": "Home Controller",
+        "last_contact": 1693292420,
+        "serial_number": "0310b36090",
+        "controller_id": 52496,
+        "status": "Unknown",
+    }
+
+
+@pytest.fixture
+def mock_zones() -> list[dict[str, Any]]:
+    """Mock Hydrawise zones."""
+    return [
+        {
+            "name": "Zone One",
+            "period": 259200,
+            "relay": 1,
+            "relay_id": 5965394,
+            "run": 1800,
+            "stop": 1,
+            "time": 330597,
+            "timestr": "Sat",
+            "type": 1,
+        },
+        {
+            "name": "Zone Two",
+            "period": 259200,
+            "relay": 2,
+            "relay_id": 5965395,
+            "run": 1788,
+            "stop": 1,
+            "time": 1,
+            "timestr": "Now",
+            "type": 106,
+        },
+    ]
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Mock ConfigEntry."""
+    return MockConfigEntry(
+        title="Hydrawise",
+        domain=DOMAIN,
+        data={
+            CONF_API_KEY: "abc123",
+        },
+        unique_id="hydrawise-customerid",
+    )
+
+
+@pytest.fixture
+async def mock_added_config_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_pydrawise: Mock,
+) -> MockConfigEntry:
+    """Mock ConfigEntry that's been added to HA."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert DOMAIN in hass.config_entries.async_domains()
+    return mock_config_entry

--- a/tests/components/hydrawise/test_device.py
+++ b/tests/components/hydrawise/test_device.py
@@ -1,0 +1,36 @@
+"""Tests for Hydrawise devices."""
+
+from unittest.mock import Mock
+
+from homeassistant.components.hydrawise.const import DOMAIN
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+
+def test_zones_in_device_registry(
+    hass: HomeAssistant, mock_added_config_entry: ConfigEntry, mock_pydrawise: Mock
+) -> None:
+    """Test that devices are added to the device registry."""
+    device_registry = dr.async_get(hass)
+
+    device1 = device_registry.async_get_device(identifiers={(DOMAIN, "5965394")})
+    assert device1 is not None
+    assert device1.name == "Zone One"
+    assert device1.manufacturer == "Hydrawise"
+
+    device2 = device_registry.async_get_device(identifiers={(DOMAIN, "5965395")})
+    assert device2 is not None
+    assert device2.name == "Zone Two"
+    assert device2.manufacturer == "Hydrawise"
+
+
+def test_controller_in_device_registry(
+    hass: HomeAssistant, mock_added_config_entry: ConfigEntry, mock_pydrawise: Mock
+) -> None:
+    """Test that devices are added to the device registry."""
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device(identifiers={(DOMAIN, "52496")})
+    assert device is not None
+    assert device.name == "Home Controller"
+    assert device.manufacturer == "Hydrawise"


### PR DESCRIPTION
## Proposed change
Add device info to the Hydrawise integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
