### PR TITLE
Add a select entity for homekit temperature display units

### DIFF
--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -101,6 +101,7 @@ CHARACTERISTIC_PLATFORMS = {
     CharacteristicsTypes.MUTE: "switch",
     CharacteristicsTypes.FILTER_LIFE_LEVEL: "sensor",
     CharacteristicsTypes.VENDOR_AIRVERSA_SLEEP_MODE: "switch",
+    CharacteristicsTypes.TEMPERATURE_UNITS: "select",
 }
 
 STARTUP_EXCEPTIONS = (

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -14,6 +14,6 @@
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
   "iot_class": "local_push",
   "loggers": ["aiohomekit", "commentjson"],
-  "requirements": ["aiohomekit==3.0.3"],
+  "requirements": ["aiohomekit==3.0.4"],
   "zeroconf": ["_hap._tcp.local.", "_hap._udp.local."]
 }

--- a/homeassistant/components/homekit_controller/select.py
+++ b/homeassistant/components/homekit_controller/select.py
@@ -32,13 +32,15 @@ class HomeKitSelectEntityDescription(
 ):
     """A generic description of a select entity backed by a single characteristic."""
 
+    name: str | None = None
+
 
 SELECT_ENTITIES: dict[str, HomeKitSelectEntityDescription] = {
     CharacteristicsTypes.TEMPERATURE_UNITS: HomeKitSelectEntityDescription(
         key="temperature_display_units",
         translation_key="temperature_display_units",
         name="Temperature Display Units",
-        icon="mdi:water",
+        icon="mdi:thermometer",
         entity_category=EntityCategory.CONFIG,
         choices={
             "celsius": TemperatureDisplayUnits.CELSIUS,
@@ -88,11 +90,11 @@ class HomeKitSelect(BaseHomeKitSelect):
         return [self._char.type]
 
     @property
-    def name(self) -> str:
+    def name(self) -> str | None:
         """Return the name of the device if any."""
         if name := self.accessory.name:
             return f"{name} {self.entity_description.name}"
-        return f"{self.entity_description.name}"
+        return self.entity_description.name
 
     @property
     def current_option(self) -> str | None:

--- a/homeassistant/components/homekit_controller/select.py
+++ b/homeassistant/components/homekit_controller/select.py
@@ -1,17 +1,51 @@
 """Support for Homekit select entities."""
 from __future__ import annotations
 
-from aiohomekit.model.characteristics import Characteristic, CharacteristicsTypes
+from dataclasses import dataclass
+from enum import IntEnum
 
-from homeassistant.components.select import SelectEntity
+from aiohomekit.model.characteristics import Characteristic, CharacteristicsTypes
+from aiohomekit.model.characteristics.const import TemperatureDisplayUnits
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType
 
 from . import KNOWN_DEVICES
 from .connection import HKDevice
 from .entity import CharacteristicEntity
+
+
+@dataclass
+class HomeKitSelectEntityDescriptionRequired:
+    """Required fields for HomeKitSelectEntityDescription."""
+
+    choices: dict[str, IntEnum]
+
+
+@dataclass
+class HomeKitSelectEntityDescription(
+    SelectEntityDescription, HomeKitSelectEntityDescriptionRequired
+):
+    """A generic description of a select entity backed by a single characteristic."""
+
+
+SELECT_ENTITIES: dict[str, HomeKitSelectEntityDescription] = {
+    CharacteristicsTypes.TEMPERATURE_UNITS: HomeKitSelectEntityDescription(
+        key="temperature_display_units",
+        translation_key="temperature_display_units",
+        name="Temperature Display Units",
+        icon="mdi:water",
+        entity_category=EntityCategory.CONFIG,
+        choices={
+            "celsius": TemperatureDisplayUnits.CELSIUS,
+            "fahrenheit": TemperatureDisplayUnits.FAHRENHEIT,
+        },
+    ),
+}
 
 _ECOBEE_MODE_TO_TEXT = {
     0: "home",
@@ -21,7 +55,58 @@ _ECOBEE_MODE_TO_TEXT = {
 _ECOBEE_MODE_TO_NUMBERS = {v: k for (k, v) in _ECOBEE_MODE_TO_TEXT.items()}
 
 
-class EcobeeModeSelect(CharacteristicEntity, SelectEntity):
+class BaseHomeKitSelect(CharacteristicEntity, SelectEntity):
+    """Base entity for select entities backed by a single characteristics."""
+
+
+class HomeKitSelect(BaseHomeKitSelect):
+    """Representation of a select control on a homekit accessory."""
+
+    entity_description: HomeKitSelectEntityDescription
+
+    def __init__(
+        self,
+        conn: HKDevice,
+        info: ConfigType,
+        char: Characteristic,
+        description: HomeKitSelectEntityDescription,
+    ) -> None:
+        """Initialise a HomeKit select control."""
+        self.entity_description = description
+
+        self._choice_to_enum = self.entity_description.choices
+        self._enum_to_choice = {
+            v: k for (k, v) in self.entity_description.choices.items()
+        }
+
+        self._attr_options = list(self.entity_description.choices.keys())
+
+        super().__init__(conn, info, char)
+
+    def get_characteristic_types(self) -> list[str]:
+        """Define the homekit characteristics the entity cares about."""
+        return [self._char.type]
+
+    @property
+    def name(self) -> str:
+        """Return the name of the device if any."""
+        if name := self.accessory.name:
+            return f"{name} {self.entity_description.name}"
+        return f"{self.entity_description.name}"
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current selected option."""
+        return self._enum_to_choice.get(self._char.value)
+
+    async def async_select_option(self, option: str) -> None:
+        """Set the current option."""
+        await self.async_put_characteristics(
+            {self._char.type: self._choice_to_enum[option]}
+        )
+
+
+class EcobeeModeSelect(BaseHomeKitSelect):
     """Represents a ecobee mode select entity."""
 
     _attr_options = ["home", "sleep", "away"]
@@ -64,14 +149,23 @@ async def async_setup_entry(
 
     @callback
     def async_add_characteristic(char: Characteristic) -> bool:
-        if char.type == CharacteristicsTypes.VENDOR_ECOBEE_CURRENT_MODE:
-            info = {"aid": char.service.accessory.aid, "iid": char.service.iid}
-            entity = EcobeeModeSelect(conn, info, char)
+        entities: list[BaseHomeKitSelect] = []
+        info = {"aid": char.service.accessory.aid, "iid": char.service.iid}
+
+        if description := SELECT_ENTITIES.get(char.type):
+            entities.append(HomeKitSelect(conn, info, char, description))
+        elif char.type == CharacteristicsTypes.VENDOR_ECOBEE_CURRENT_MODE:
+            entities.append(EcobeeModeSelect(conn, info, char))
+
+        if not entities:
+            return False
+
+        for entity in entities:
             conn.async_migrate_unique_id(
                 entity.old_unique_id, entity.unique_id, Platform.SELECT
             )
-            async_add_entities([entity])
-            return True
-        return False
+
+        async_add_entities(entities)
+        return True
 
     conn.add_char_factory(async_add_characteristic)

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -102,6 +102,12 @@
           "home": "[%key:common::state::home%]",
           "sleep": "Sleep"
         }
+      },
+      "temperature_display_units": {
+        "state": {
+          "celsius": "Celsius",
+          "fahrenheit": "Fahrenheit"
+        }
       }
     },
     "sensor": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -250,7 +250,7 @@ aioguardian==2022.07.0
 aioharmony==0.2.10
 
 # homeassistant.components.homekit_controller
-aiohomekit==3.0.3
+aiohomekit==3.0.4
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -228,7 +228,7 @@ aioguardian==2022.07.0
 aioharmony==0.2.10
 
 # homeassistant.components.homekit_controller
-aiohomekit==3.0.3
+aiohomekit==3.0.4
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/tests/components/homekit_controller/test_select.py
+++ b/tests/components/homekit_controller/test_select.py
@@ -1,6 +1,7 @@
 """Basic checks for HomeKit select entities."""
 from aiohomekit.model import Accessory
 from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.characteristics.const import TemperatureDisplayUnits
 from aiohomekit.model.services import ServicesTypes
 
 from homeassistant.core import HomeAssistant
@@ -18,6 +19,16 @@ def create_service_with_ecobee_mode(accessory: Accessory):
     current_mode.perms.append("ev")
 
     service.add_char(CharacteristicsTypes.VENDOR_ECOBEE_SET_HOLD_SCHEDULE)
+
+    return service
+
+
+def create_service_with_temperature_units(accessory: Accessory):
+    """Define a thermostat with ecobee mode characteristics."""
+    service = accessory.add_service(ServicesTypes.TEMPERATURE_SENSOR, add_required=True)
+
+    units = service.add_char(CharacteristicsTypes.TEMPERATURE_UNITS)
+    units.value = 0
 
     return service
 
@@ -124,4 +135,77 @@ async def test_write_current_mode(hass: HomeAssistant, utcnow) -> None:
     current_mode.async_assert_service_values(
         ServicesTypes.THERMOSTAT,
         {CharacteristicsTypes.VENDOR_ECOBEE_SET_HOLD_SCHEDULE: 2},
+    )
+
+
+async def test_read_select(hass: HomeAssistant, utcnow) -> None:
+    """Test the generic select can read the current value."""
+    helper = await setup_test_component(hass, create_service_with_temperature_units)
+
+    # Helper will be for the primary entity, which is the service. Make a helper for the sensor.
+    select_entity = Helper(
+        hass,
+        "select.testdevice_temperature_display_units",
+        helper.pairing,
+        helper.accessory,
+        helper.config_entry,
+    )
+
+    state = await select_entity.async_update(
+        ServicesTypes.TEMPERATURE_SENSOR,
+        {
+            CharacteristicsTypes.TEMPERATURE_UNITS: 0,
+        },
+    )
+    assert state.state == "celsius"
+
+    state = await select_entity.async_update(
+        ServicesTypes.TEMPERATURE_SENSOR,
+        {
+            CharacteristicsTypes.TEMPERATURE_UNITS: 1,
+        },
+    )
+    assert state.state == "fahrenheit"
+
+
+async def test_write_select(hass: HomeAssistant, utcnow) -> None:
+    """Test can set a value."""
+    helper = await setup_test_component(hass, create_service_with_temperature_units)
+    helper.accessory.services.first(service_type=ServicesTypes.THERMOSTAT)
+
+    # Helper will be for the primary entity, which is the service. Make a helper for the sensor.
+    current_mode = Helper(
+        hass,
+        "select.testdevice_temperature_display_units",
+        helper.pairing,
+        helper.accessory,
+        helper.config_entry,
+    )
+
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {
+            "entity_id": "select.testdevice_temperature_display_units",
+            "option": "fahrenheit",
+        },
+        blocking=True,
+    )
+    current_mode.async_assert_service_values(
+        ServicesTypes.TEMPERATURE_SENSOR,
+        {CharacteristicsTypes.TEMPERATURE_UNITS: TemperatureDisplayUnits.FAHRENHEIT},
+    )
+
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {
+            "entity_id": "select.testdevice_temperature_display_units",
+            "option": "celsius",
+        },
+        blocking=True,
+    )
+    current_mode.async_assert_service_values(
+        ServicesTypes.TEMPERATURE_SENSOR,
+        {CharacteristicsTypes.TEMPERATURE_UNITS: TemperatureDisplayUnits.CELSIUS},
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Some HomeKit temperature sensors (like Eve Degree) have a display that can show temperature in celsius or fahrenheit. There is a enum characteristic to select which to display. This PR maps that characteristic to a HomeKit select entity.

This can't currently use translations because the base class implements `name()`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
