### PR TITLE
Update for pyTwitchAPI version 4.0.0

### DIFF
--- a/homeassistant/components/twitch/const.py
+++ b/homeassistant/components/twitch/const.py
@@ -7,4 +7,4 @@ LOGGER = logging.getLogger(__package__)
 
 CONF_CHANNELS = "channels"
 
-OAUTH_SCOPES = [AuthScope.USER_READ_SUBSCRIPTIONS]
+OAUTH_SCOPES = [AuthScope.USER_READ_SUBSCRIPTIONS, AuthScope.USER_READ_FOLLOWS]

--- a/homeassistant/components/twitch/manifest.json
+++ b/homeassistant/components/twitch/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/twitch",
   "iot_class": "cloud_polling",
   "loggers": ["twitch"],
-  "requirements": ["twitchAPI==3.10.0"]
+  "requirements": ["twitchAPI==4.0.0"]
 }

--- a/homeassistant/components/twitch/sensor.py
+++ b/homeassistant/components/twitch/sensor.py
@@ -109,7 +109,7 @@ class TwitchSensor(SensorEntity):
 
     async def async_update(self) -> None:
         """Update device state."""
-        followers = (await self._client.get_users_follows(to_id=self._channel.id)).total
+        followers = (await self._client.get_channel_followers(self._channel.id)).total
         self._attr_extra_state_attributes = {
             ATTR_FOLLOWING: followers,
             ATTR_VIEWS: self._channel.view_count,
@@ -149,11 +149,11 @@ class TwitchSensor(SensorEntity):
         except TwitchAPIException as exc:
             LOGGER.error("Error response on check_user_subscription: %s", exc)
 
-        follows = (
-            await self._client.get_users_follows(
-                from_id=user.id, to_id=self._channel.id
-            )
-        ).data
+        user_follows = await self._client.get_followed_channels(
+            broadcaster_id=self._channel.id, user_id=user.id
+        )
+
+        follows = user_follows.data
         self._attr_extra_state_attributes[ATTR_FOLLOW] = len(follows) > 0
         if len(follows):
             self._attr_extra_state_attributes[ATTR_FOLLOW_SINCE] = follows[

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2608,7 +2608,7 @@ twentemilieu==1.0.0
 twilio==6.32.0
 
 # homeassistant.components.twitch
-twitchAPI==3.10.0
+twitchAPI==4.0.0
 
 # homeassistant.components.ukraine_alarm
 uasiren==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1926,7 +1926,7 @@ twentemilieu==1.0.0
 twilio==6.32.0
 
 # homeassistant.components.twitch
-twitchAPI==3.10.0
+twitchAPI==4.0.0
 
 # homeassistant.components.ukraine_alarm
 uasiren==0.0.1


### PR DESCRIPTION
Bump pyTwitchAPI to 4.0.0
Replaced obsoleted API methods with new ones.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Due to the switch to new API calls, existing OAuth keys will not work. New ones needs to be created  
with the `user:read:follows`and `user:read:subscriptions` scopes. See the documnetation for more details.

PR for doc changes: https://github.com/home-assistant/home-assistant.io/pull/29007

## Proposed change
Twitch has made 2 of the calls in this integration obsolete, and the maintainer of pyTwitchAPI directed me to using two new ones instead, and also made a 4.0.0 release to solve a final issue.

## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
The existing API:s was oboleted 3rd of August 2023.

PyTwitchAPI v4.0.0.0 realease notes: https://github.com/Teekeks/pyTwitchAPI/releases/tag/v4.0.0
Changes made to the existing integration: https://github.com/home-assistant/core/compare/dev...jonnybergdahl:home_assistant_core:dev

- This PR fixes or closes issue: #99768
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29007

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr