### PR TITLE
Add config flow to color extractor

### DIFF
--- a/homeassistant/components/color_extractor/__init__.py
+++ b/homeassistant/components/color_extractor/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.components.light import (
     DOMAIN as LIGHT_DOMAIN,
     LIGHT_TURN_ON_SCHEMA,
 )
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import SERVICE_TURN_ON as LIGHT_SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import aiohttp_client
@@ -58,8 +59,20 @@ def _get_color(file_handler) -> tuple:
     return color
 
 
-async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
-    """Set up services for color_extractor integration."""
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Color extractor component."""
+
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data={}
+        )
+    )
+
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Load a config entry."""
 
     async def async_handle_service(service_call: ServiceCall) -> None:
         """Decide which color_extractor method to call based on service."""

--- a/homeassistant/components/color_extractor/config_flow.py
+++ b/homeassistant/components/color_extractor/config_flow.py
@@ -1,0 +1,64 @@
+"""Config flow to configure the Color extractor integration."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.config_entries import ConfigFlow
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN
+from homeassistant.data_entry_flow import FlowResult, FlowResultType
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
+
+from .const import DEFAULT_NAME, DOMAIN
+
+
+class ColorExtractorConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Config flow for Color extractor."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle a flow initialized by the user."""
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        if user_input is not None:
+            return self.async_create_entry(title=DEFAULT_NAME, data={})
+
+        return self.async_show_form(step_id="user")
+
+    async def async_step_import(self, user_input: dict[str, Any]) -> FlowResult:
+        """Handle import from configuration.yaml."""
+        result = await self.async_step_user(user_input)
+        if result["type"] == FlowResultType.CREATE_ENTRY:
+            async_create_issue(
+                self.hass,
+                HOMEASSISTANT_DOMAIN,
+                f"deprecated_yaml_{DOMAIN}",
+                breaks_in_ha_version="2024.4.0",
+                is_fixable=False,
+                issue_domain=DOMAIN,
+                severity=IssueSeverity.WARNING,
+                translation_key="deprecated_yaml",
+                translation_placeholders={
+                    "domain": DOMAIN,
+                    "integration_title": "Color extractor",
+                },
+            )
+        else:
+            async_create_issue(
+                self.hass,
+                DOMAIN,
+                "deprecated_yaml",
+                breaks_in_ha_version="2024.4.0",
+                is_fixable=False,
+                issue_domain=DOMAIN,
+                severity=IssueSeverity.WARNING,
+                translation_key="deprecated_yaml",
+                translation_placeholders={
+                    "domain": DOMAIN,
+                    "integration_title": "Color extractor",
+                },
+            )
+        return result

--- a/homeassistant/components/color_extractor/const.py
+++ b/homeassistant/components/color_extractor/const.py
@@ -3,5 +3,6 @@ ATTR_PATH = "color_extract_path"
 ATTR_URL = "color_extract_url"
 
 DOMAIN = "color_extractor"
+DEFAULT_NAME = "Color extractor"
 
 SERVICE_TURN_ON = "turn_on"

--- a/homeassistant/components/color_extractor/manifest.json
+++ b/homeassistant/components/color_extractor/manifest.json
@@ -2,7 +2,7 @@
   "domain": "color_extractor",
   "name": "ColorExtractor",
   "codeowners": ["@GenericStudent"],
-  "config_flow": false,
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/color_extractor",
   "requirements": ["colorthief==0.2.1"]
 }

--- a/homeassistant/components/color_extractor/strings.json
+++ b/homeassistant/components/color_extractor/strings.json
@@ -1,4 +1,20 @@
 {
+  "config": {
+    "step": {
+      "user": {
+        "description": "[%key:common::config_flow::description::confirm_setup%]"
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+    }
+  },
+  "issues": {
+    "deprecated_yaml": {
+      "title": "The {integration_title} YAML configuration is being removed",
+      "description": "Configuring {integration_title} using YAML is being removed.\n\nYour configuration is already imported.\n\nRemove the `{domain}` configuration from your configuration.yaml file and restart Home Assistant to fix this issue."
+    }
+  },
   "services": {
     "turn_on": {
       "name": "[%key:common::action::turn_on%]",

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -82,6 +82,7 @@ FLOWS = {
         "cloudflare",
         "co2signal",
         "coinbase",
+        "color_extractor",
         "comelit",
         "control4",
         "coolmaster",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -876,7 +876,7 @@
     "color_extractor": {
       "name": "ColorExtractor",
       "integration_type": "hub",
-      "config_flow": false
+      "config_flow": true
     },
     "comed": {
       "name": "Commonwealth Edison (ComEd)",

--- a/tests/components/color_extractor/test_config_flow.py
+++ b/tests/components/color_extractor/test_config_flow.py
@@ -68,19 +68,3 @@ async def test_import_flow(
     assert result.get("title") == "Color extractor"
     assert result.get("data") == {}
     assert result.get("options") == {}
-
-
-# async def test_import_flow_already_exists(
-#     hass: HomeAssistant,
-# ) -> None:
-#     """Test the import configuration flow."""
-#     result = await hass.config_entries.flow.async_init(
-#         DOMAIN,
-#         context={"source": SOURCE_IMPORT},
-#         data={},
-#     )
-#
-#     assert result.get("type") == FlowResultType.CREATE_ENTRY
-#     assert result.get("title") == "Color extractor"
-#     assert result.get("data") == {}
-#     assert result.get("options") == {}

--- a/tests/components/color_extractor/test_config_flow.py
+++ b/tests/components/color_extractor/test_config_flow.py
@@ -1,0 +1,86 @@
+"""Tests for the Color extractor config flow."""
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.color_extractor.const import DOMAIN
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+
+async def test_full_user_flow(hass: HomeAssistant) -> None:
+    """Test the full user configuration flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "user"
+
+    with patch(
+        "homeassistant.components.color_extractor.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={},
+        )
+
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    assert result.get("title") == "Color extractor"
+    assert result.get("data") == {}
+    assert result.get("options") == {}
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+@pytest.mark.parametrize("source", [SOURCE_USER, SOURCE_IMPORT])
+async def test_single_instance_allowed(
+    hass: HomeAssistant,
+    source: str,
+) -> None:
+    """Test we abort if already setup."""
+    mock_config_entry = MockConfigEntry(domain=DOMAIN)
+
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": source}, data={}
+    )
+
+    assert result.get("type") == FlowResultType.ABORT
+    assert result.get("reason") == "single_instance_allowed"
+
+
+async def test_import_flow(
+    hass: HomeAssistant,
+) -> None:
+    """Test the import configuration flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data={},
+    )
+
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    assert result.get("title") == "Color extractor"
+    assert result.get("data") == {}
+    assert result.get("options") == {}
+
+
+# async def test_import_flow_already_exists(
+#     hass: HomeAssistant,
+# ) -> None:
+#     """Test the import configuration flow."""
+#     result = await hass.config_entries.flow.async_init(
+#         DOMAIN,
+#         context={"source": SOURCE_IMPORT},
+#         data={},
+#     )
+#
+#     assert result.get("type") == FlowResultType.CREATE_ENTRY
+#     assert result.get("title") == "Color extractor"
+#     assert result.get("data") == {}
+#     assert result.get("options") == {}

--- a/tests/components/color_extractor/test_service.py
+++ b/tests/components/color_extractor/test_service.py
@@ -63,7 +63,7 @@ def _close_enough(actual_rgb, testing_rgb):
 
 
 @pytest.fixture(autouse=True)
-async def setup_light(hass):
+async def setup_light(hass: HomeAssistant):
     """Configure our light component to work against for testing."""
     assert await async_setup_component(
         hass, LIGHT_DOMAIN, {LIGHT_DOMAIN: {"platform": "demo"}}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The YAML configuration for color extractor is deprecated and will be removed in 2024.4. Please remove it from your configuration.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add config flow to color extractor

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29018

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
