### PR TITLE
Add secret_token support to telegram_bot component

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -113,10 +113,6 @@ SERVICE_ANSWER_CALLBACK_QUERY = "answer_callback_query"
 SERVICE_DELETE_MESSAGE = "delete_message"
 SERVICE_LEAVE_CHAT = "leave_chat"
 
-STORE_VERSION = 1
-STORE_SECRET_TOKEN = "secret_token"
-SECRET_TOKEN_LENGTH = 32
-
 EVENT_TELEGRAM_CALLBACK = "telegram_callback"
 EVENT_TELEGRAM_COMMAND = "telegram_command"
 EVENT_TELEGRAM_TEXT = "telegram_text"

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -94,7 +94,6 @@ CONF_ALLOWED_CHAT_IDS = "allowed_chat_ids"
 CONF_PROXY_URL = "proxy_url"
 CONF_PROXY_PARAMS = "proxy_params"
 CONF_TRUSTED_NETWORKS = "trusted_networks"
-CONF_SECRET_TOKEN = "secret_token"
 
 DOMAIN = "telegram_bot"
 
@@ -114,6 +113,10 @@ SERVICE_ANSWER_CALLBACK_QUERY = "answer_callback_query"
 SERVICE_DELETE_MESSAGE = "delete_message"
 SERVICE_LEAVE_CHAT = "leave_chat"
 
+STORE_VERSION = 1
+STORE_SECRET_TOKEN = "secret_token"
+SECRET_TOKEN_LENGTH = 32
+
 EVENT_TELEGRAM_CALLBACK = "telegram_callback"
 EVENT_TELEGRAM_COMMAND = "telegram_command"
 EVENT_TELEGRAM_TEXT = "telegram_text"
@@ -123,7 +126,6 @@ PARSER_HTML = "html"
 PARSER_MD = "markdown"
 
 DEFAULT_TRUSTED_NETWORKS = [ip_network("149.154.160.0/20"), ip_network("91.108.4.0/22")]
-DEFAULT_SECRET_TOKEN = "insecure_default_secret_token"
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -147,7 +149,6 @@ CONFIG_SCHEMA = vol.Schema(
                         vol.Optional(
                             CONF_TRUSTED_NETWORKS, default=DEFAULT_TRUSTED_NETWORKS
                         ): vol.All(cv.ensure_list, [ip_network]),
-                        vol.Optional(CONF_SECRET_TOKEN, default=DEFAULT_SECRET_TOKEN): cv.string,
                     }
                 )
             ],

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -94,6 +94,7 @@ CONF_ALLOWED_CHAT_IDS = "allowed_chat_ids"
 CONF_PROXY_URL = "proxy_url"
 CONF_PROXY_PARAMS = "proxy_params"
 CONF_TRUSTED_NETWORKS = "trusted_networks"
+CONF_SECRET_TOKEN = "secret_token"
 
 DOMAIN = "telegram_bot"
 
@@ -122,6 +123,7 @@ PARSER_HTML = "html"
 PARSER_MD = "markdown"
 
 DEFAULT_TRUSTED_NETWORKS = [ip_network("149.154.160.0/20"), ip_network("91.108.4.0/22")]
+DEFAULT_SECRET_TOKEN = "insecure_default_secret_token"
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -145,6 +147,7 @@ CONFIG_SCHEMA = vol.Schema(
                         vol.Optional(
                             CONF_TRUSTED_NETWORKS, default=DEFAULT_TRUSTED_NETWORKS
                         ): vol.All(cv.ensure_list, [ip_network]),
+                        vol.Optional(CONF_SECRET_TOKEN, default=DEFAULT_SECRET_TOKEN): cv.string,
                     }
                 )
             ],

--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -142,7 +142,7 @@ class PushBotView(HomeAssistantView):
             _LOGGER.warning("Access denied from %s", real_ip)
             return self.json_message("Access denied", HTTPStatus.UNAUTHORIZED)
         # If a secret token is expected, verify the header
-        if self.secret_token:
+        if self.secret_token and bool(self.secret_token):
             secret_token_header = request.headers.get("X-Telegram-Bot-Api-Secret-Token")
             if secret_token_header is None or self.secret_token != secret_token_header:
                 _LOGGER.warning("Invalid secret token from %s", real_ip)

--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -23,16 +23,12 @@ REMOVE_WEBHOOK_URL = ""
 SECRET_TOKEN_LENGTH = 32
 
 
-def generate_secret_token(length):
-    alphabet = string.ascii_letters + string.digits + "-_"
-    return "".join(secrets.choice(alphabet) for _ in range(length))
-
-
 async def async_setup_platform(hass, bot, config):
     """Set up the Telegram webhooks platform."""
 
     # Generate an ephemeral secret token
-    secret_token = generate_secret_token(SECRET_TOKEN_LENGTH)
+    alphabet = string.ascii_letters + string.digits + "-_"
+    secret_token = "".join(secrets.choice(alphabet) for _ in range(SECRET_TOKEN_LENGTH))
 
     pushbot = PushBot(hass, bot, config, secret_token)
 

--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -145,7 +145,6 @@ class PushBotView(HomeAssistantView):
         if not any(real_ip in net for net in self.trusted_networks):
             _LOGGER.warning("Access denied from %s", real_ip)
             return self.json_message("Access denied", HTTPStatus.UNAUTHORIZED)
-        # If a secret token is expected, verify the header
         secret_token_header = request.headers.get("X-Telegram-Bot-Api-Secret-Token")
         if secret_token_header is None or self.secret_token != secret_token_header:
             _LOGGER.warning("Invalid secret token from %s", real_ip)

--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -14,11 +14,7 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers.network import get_url
 
-from . import (
-    CONF_TRUSTED_NETWORKS,
-    CONF_URL,
-    BaseTelegramBotEntity,
-)
+from . import CONF_TRUSTED_NETWORKS, CONF_URL, BaseTelegramBotEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,9 +28,7 @@ async def async_setup_platform(hass, bot, config):
 
     # Generate a ephemeral secret token
     alphabet = string.ascii_letters + string.digits + "-_"
-    secret_token = "".join(
-        secrets.choice(alphabet) for _ in range(SECRET_TOKEN_LENGTH)
-    )
+    secret_token = "".join(secrets.choice(alphabet) for _ in range(SECRET_TOKEN_LENGTH))
 
     pushbot = PushBot(hass, bot, config, secret_token)
 

--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -141,9 +141,12 @@ class PushBotView(HomeAssistantView):
         if not any(real_ip in net for net in self.trusted_networks):
             _LOGGER.warning("Access denied from %s", real_ip)
             return self.json_message("Access denied", HTTPStatus.UNAUTHORIZED)
-        if self.secret_token != request.headers["X-Telegram-Bot-Api-Secret-Token"]:
-            _LOGGER.warning("Invalid secret token from %s", real_ip)
-            return self.json_message("Access denied", HTTPStatus.UNAUTHORIZED)
+        # If a secret token is expected, verify the header
+        if self.secret_token:
+            secret_token_header = request.headers.get("X-Telegram-Bot-Api-Secret-Token")
+            if secret_token_header is None or self.secret_token != secret_token_header:
+                _LOGGER.warning("Invalid secret token from %s", real_ip)
+                return self.json_message("Access denied", HTTPStatus.UNAUTHORIZED)
 
         try:
             update_data = await request.json()

--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -146,11 +146,10 @@ class PushBotView(HomeAssistantView):
             _LOGGER.warning("Access denied from %s", real_ip)
             return self.json_message("Access denied", HTTPStatus.UNAUTHORIZED)
         # If a secret token is expected, verify the header
-        if self.secret_token and bool(self.secret_token):
-            secret_token_header = request.headers.get("X-Telegram-Bot-Api-Secret-Token")
-            if secret_token_header is None or self.secret_token != secret_token_header:
-                _LOGGER.warning("Invalid secret token from %s", real_ip)
-                return self.json_message("Access denied", HTTPStatus.UNAUTHORIZED)
+        secret_token_header = request.headers.get("X-Telegram-Bot-Api-Secret-Token")
+        if secret_token_header is None or self.secret_token != secret_token_header:
+            _LOGGER.warning("Invalid secret token from %s", real_ip)
+            return self.json_message("Access denied", HTTPStatus.FORBIDDEN)
 
         try:
             update_data = await request.json()

--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -148,7 +148,7 @@ class PushBotView(HomeAssistantView):
         secret_token_header = request.headers.get("X-Telegram-Bot-Api-Secret-Token")
         if secret_token_header is None or self.secret_token != secret_token_header:
             _LOGGER.warning("Invalid secret token from %s", real_ip)
-            return self.json_message("Access denied", HTTPStatus.FORBIDDEN)
+            return self.json_message("Access denied", HTTPStatus.UNAUTHORIZED)
 
         try:
             update_data = await request.json()

--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -23,12 +23,16 @@ REMOVE_WEBHOOK_URL = ""
 SECRET_TOKEN_LENGTH = 32
 
 
+def generate_secret_token(length):
+    alphabet = string.ascii_letters + string.digits + "-_"
+    return "".join(secrets.choice(alphabet) for _ in range(length))
+
+
 async def async_setup_platform(hass, bot, config):
     """Set up the Telegram webhooks platform."""
 
     # Generate an ephemeral secret token
-    alphabet = string.ascii_letters + string.digits + "-_"
-    secret_token = "".join(secrets.choice(alphabet) for _ in range(SECRET_TOKEN_LENGTH))
+    secret_token = generate_secret_token(SECRET_TOKEN_LENGTH)
 
     pushbot = PushBot(hass, bot, config, secret_token)
 

--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -26,7 +26,7 @@ SECRET_TOKEN_LENGTH = 32
 async def async_setup_platform(hass, bot, config):
     """Set up the Telegram webhooks platform."""
 
-    # Generate a ephemeral secret token
+    # Generate an ephemeral secret token
     alphabet = string.ascii_letters + string.digits + "-_"
     secret_token = "".join(secrets.choice(alphabet) for _ in range(SECRET_TOKEN_LENGTH))
 

--- a/tests/components/telegram_bot/conftest.py
+++ b/tests/components/telegram_bot/conftest.py
@@ -1,5 +1,5 @@
 """Tests for the telegram_bot integration."""
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import pytest
 
@@ -63,6 +63,18 @@ def mock_register_webhook():
         return_value=True,
     ):
         yield
+
+
+@pytest.fixture
+def mock_generate_secret_token():
+    """Mock secret token generated for webhook"""
+    mock_secret_token = "DEADBEEF12345678DEADBEEF87654321"
+    with patch(
+        "homeassistant.components.telegram_bot.webhooks.generate_secret_token",
+        return_value=mock_secret_token,
+    ):
+        yield mock_secret_token
+
 
 
 @pytest.fixture
@@ -156,7 +168,7 @@ def update_callback_query():
 
 
 @pytest.fixture
-async def webhook_platform(hass, config_webhooks, mock_register_webhook):
+async def webhook_platform(hass, config_webhooks, mock_register_webhook, mock_generate_secret_token):
     """Fixture for setting up the webhooks platform using appropriate config and mocks."""
     await async_setup_component(
         hass,

--- a/tests/components/telegram_bot/conftest.py
+++ b/tests/components/telegram_bot/conftest.py
@@ -67,18 +67,18 @@ def mock_register_webhook():
 
 @pytest.fixture
 def mock_generate_secret_token():
-    """Mock secret token generated for webhook"""
+    """Mock secret token generated for webhook."""
     mock_secret_token = "DEADBEEF12345678DEADBEEF87654321"
     with patch(
-        "homeassistant.components.telegram_bot.webhooks.generate_secret_token",
-        return_value=mock_secret_token,
+        "homeassistant.components.telegram_bot.webhooks.secrets.choice",
+        side_effect=mock_secret_token,
     ):
         yield mock_secret_token
 
 
 @pytest.fixture
 def incorrect_secret_token():
-    """Mock incorrect secret token"""
+    """Mock incorrect secret token."""
     return "AAAABBBBCCCCDDDDEEEEFFFF00009999"
 
 

--- a/tests/components/telegram_bot/conftest.py
+++ b/tests/components/telegram_bot/conftest.py
@@ -1,5 +1,5 @@
 """Tests for the telegram_bot integration."""
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 
@@ -75,6 +75,11 @@ def mock_generate_secret_token():
     ):
         yield mock_secret_token
 
+
+@pytest.fixture
+def incorrect_secret_token():
+    """Mock incorrect secret token"""
+    return "AAAABBBBCCCCDDDDEEEEFFFF00009999"
 
 
 @pytest.fixture
@@ -168,7 +173,9 @@ def update_callback_query():
 
 
 @pytest.fixture
-async def webhook_platform(hass, config_webhooks, mock_register_webhook, mock_generate_secret_token):
+async def webhook_platform(
+    hass, config_webhooks, mock_register_webhook, mock_generate_secret_token
+):
     """Fixture for setting up the webhooks platform using appropriate config and mocks."""
     await async_setup_component(
         hass,

--- a/tests/components/telegram_bot/test_telegram_bot.py
+++ b/tests/components/telegram_bot/test_telegram_bot.py
@@ -160,9 +160,9 @@ async def test_webhook_endpoint_without_secret_token_is_denied(
     hass_client: ClientSessionGenerator,
     update_message_text,
 ) -> None:
-    """Request without a secret token header should be denied"""
+    """Request without a secret token header should be denied."""
     client = await hass_client()
-    events = async_capture_events(hass, "telegram_text")
+    async_capture_events(hass, "telegram_text")
 
     response = await client.post(
         TELEGRAM_WEBHOOK_URL,
@@ -178,9 +178,9 @@ async def test_webhook_endpoint_invalid_secret_token_is_denied(
     update_message_text,
     incorrect_secret_token,
 ) -> None:
-    """Request with an invalid secret token header should be denied"""
+    """Request with an invalid secret token header should be denied."""
     client = await hass_client()
-    events = async_capture_events(hass, "telegram_text")
+    async_capture_events(hass, "telegram_text")
 
     response = await client.post(
         TELEGRAM_WEBHOOK_URL,

--- a/tests/components/telegram_bot/test_telegram_bot.py
+++ b/tests/components/telegram_bot/test_telegram_bot.py
@@ -168,7 +168,7 @@ async def test_webhook_endpoint_without_secret_token_is_denied(
         TELEGRAM_WEBHOOK_URL,
         json=update_message_text,
     )
-    assert response.status == 403
+    assert response.status == 401
 
 
 async def test_webhook_endpoint_invalid_secret_token_is_denied(
@@ -187,4 +187,4 @@ async def test_webhook_endpoint_invalid_secret_token_is_denied(
         json=update_message_text,
         headers={"X-Telegram-Bot-Api-Secret-Token": incorrect_secret_token},
     )
-    assert response.status == 403
+    assert response.status == 401

--- a/tests/components/telegram_bot/test_telegram_bot.py
+++ b/tests/components/telegram_bot/test_telegram_bot.py
@@ -35,12 +35,17 @@ async def test_webhook_endpoint_generates_telegram_text_event(
     webhook_platform,
     hass_client: ClientSessionGenerator,
     update_message_text,
+    mock_generate_secret_token,
 ) -> None:
     """POST to the configured webhook endpoint and assert fired `telegram_text` event."""
     client = await hass_client()
     events = async_capture_events(hass, "telegram_text")
 
-    response = await client.post(TELEGRAM_WEBHOOK_URL, json=update_message_text)
+    response = await client.post(
+        TELEGRAM_WEBHOOK_URL,
+        json=update_message_text,
+        headers={"X-Telegram-Bot-Api-Secret-Token": mock_generate_secret_token},
+    )
     assert response.status == 200
     assert (await response.read()).decode("utf-8") == ""
 
@@ -56,12 +61,17 @@ async def test_webhook_endpoint_generates_telegram_command_event(
     webhook_platform,
     hass_client: ClientSessionGenerator,
     update_message_command,
+    mock_generate_secret_token,
 ) -> None:
     """POST to the configured webhook endpoint and assert fired `telegram_command` event."""
     client = await hass_client()
     events = async_capture_events(hass, "telegram_command")
 
-    response = await client.post(TELEGRAM_WEBHOOK_URL, json=update_message_command)
+    response = await client.post(
+        TELEGRAM_WEBHOOK_URL,
+        json=update_message_command,
+        headers={"X-Telegram-Bot-Api-Secret-Token": mock_generate_secret_token},
+    )
     assert response.status == 200
     assert (await response.read()).decode("utf-8") == ""
 
@@ -77,12 +87,17 @@ async def test_webhook_endpoint_generates_telegram_callback_event(
     webhook_platform,
     hass_client: ClientSessionGenerator,
     update_callback_query,
+    mock_generate_secret_token,
 ) -> None:
     """POST to the configured webhook endpoint and assert fired `telegram_callback` event."""
     client = await hass_client()
     events = async_capture_events(hass, "telegram_callback")
 
-    response = await client.post(TELEGRAM_WEBHOOK_URL, json=update_callback_query)
+    response = await client.post(
+        TELEGRAM_WEBHOOK_URL,
+        json=update_callback_query,
+        headers={"X-Telegram-Bot-Api-Secret-Token": mock_generate_secret_token},
+    )
     assert response.status == 200
     assert (await response.read()).decode("utf-8") == ""
 
@@ -119,13 +134,16 @@ async def test_webhook_endpoint_unauthorized_update_doesnt_generate_telegram_tex
     webhook_platform,
     hass_client: ClientSessionGenerator,
     unauthorized_update_message_text,
+    mock_generate_secret_token,
 ) -> None:
     """Update with unauthorized user/chat should not trigger event."""
     client = await hass_client()
     events = async_capture_events(hass, "telegram_text")
 
     response = await client.post(
-        TELEGRAM_WEBHOOK_URL, json=unauthorized_update_message_text
+        TELEGRAM_WEBHOOK_URL,
+        json=unauthorized_update_message_text,
+        headers={"X-Telegram-Bot-Api-Secret-Token": mock_generate_secret_token},
     )
     assert response.status == 200
     assert (await response.read()).decode("utf-8") == ""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is an updated PR over #100787. There will be no changes to the YAML configuration. In fact, the creation of Telegram Bot webhook secret token does not need user's entry or any other interactions. The secret token is generated automatically if not exists, and will be stored in [Store](https://dev-docs.home-assistant.io/en/dev/api/helpers.html?highlight=async_setup_platform#module-homeassistant.helpers.storage).

Below is the original proposal in the previous PR.

> Supports `secret_token` in Telegram [setWebHook](https://core.telegram.org/bots/api#setwebhook) API. This is to prevent an adversary from sending crafted messages to the Telegram webhook, as an additional layer of protection to the [trusted networks](https://www.home-assistant.io/integrations/telegram_webhooks#trusted_networks).
>
> It should be noted that this component's dependency, [python-telegram-bot](https://github.com/python-telegram-bot/python-telegram-bot), adds explicit support for `secret_token` as of the latest version [v20.5](https://docs.python-telegram-bot.org/en/v20.5/telegram.bot.html#telegram.Bot.set_webhook) (currently [v13.1](https://docs.python-telegram-bot.org/en/v13.1/telegram.bot.html#telegram.Bot.set_webhook) is used). However, this new version introduces many breaking changes to not only this component `telegram_bot`, but also `telegram`, which it is not considered given the simplicity of this feature being added.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
