### PR TITLE
Remove async-timeout as core dependency

### DIFF
--- a/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
+++ b/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
@@ -8,7 +8,6 @@ import dataclasses
 import logging
 from typing import Any, Protocol
 
-import async_timeout
 import voluptuous as vol
 import yarl
 
@@ -74,7 +73,7 @@ class WaitingAddonManager(AddonManager):
 
     async def async_wait_until_addon_state(self, *states: AddonState) -> None:
         """Poll an addon's info until it is in a specific state."""
-        async with async_timeout.timeout(ADDON_INFO_POLL_TIMEOUT):
+        async with asyncio.timeout(ADDON_INFO_POLL_TIMEOUT):
             while True:
                 try:
                     info = await self.async_get_addon_info()

--- a/homeassistant/components/rainbird/coordinator.py
+++ b/homeassistant/components/rainbird/coordinator.py
@@ -9,7 +9,6 @@ from functools import cached_property
 import logging
 from typing import TypeVar
 
-import async_timeout
 from pyrainbird.async_client import (
     AsyncRainbirdController,
     RainbirdApiException,
@@ -140,7 +139,7 @@ class RainbirdScheduleUpdateCoordinator(DataUpdateCoordinator[Schedule]):
     async def _async_update_data(self) -> Schedule:
         """Fetch data from Rain Bird device."""
         try:
-            async with async_timeout.timeout(TIMEOUT_SECONDS):
+            async with asyncio.timeout(TIMEOUT_SECONDS):
                 return await self._controller.get_schedule()
         except RainbirdApiException as err:
             raise UpdateFailed(f"Error communicating with Device: {err}") from err

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -2,7 +2,6 @@ aiodiscover==1.5.1
 aiohttp==3.8.5
 aiohttp_cors==0.7.0
 astral==2.2
-async-timeout==4.0.3
 async-upnp-client==0.36.0
 atomicwrites-homeassistant==1.4.1
 attrs==23.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ requires-python = ">=3.11.0"
 dependencies    = [
     "aiohttp==3.8.5",
     "astral==2.2",
-    "async-timeout==4.0.3",
     "attrs==23.1.0",
     "atomicwrites-homeassistant==1.4.1",
     "awesomeversion==23.8.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 # Home Assistant Core
 aiohttp==3.8.5
 astral==2.2
-async-timeout==4.0.3
 attrs==23.1.0
 atomicwrites-homeassistant==1.4.1
 awesomeversion==23.8.0


### PR DESCRIPTION
## Proposed change
`async-timeout` can be fully replaced by `asyncio.timeout` (Python 3.11+).
This PR updates the last instances where `async_timeout` is used and subsequently removes it as a core dependency.

Note however, that many dependencies still use it, so it will continue to be installed in our CI environment.
This might be an area where a custom pylint check might make sense to prevent it from accidentally showing up again.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
