### PR TITLE
Add support for Minecraft Server Bedrock Edition

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -747,6 +747,7 @@ omit =
     homeassistant/components/mill/climate.py
     homeassistant/components/mill/sensor.py
     homeassistant/components/minecraft_server/__init__.py
+    homeassistant/components/minecraft_server/api.py
     homeassistant/components/minecraft_server/binary_sensor.py
     homeassistant/components/minecraft_server/coordinator.py
     homeassistant/components/minecraft_server/entity.py

--- a/homeassistant/components/minecraft_server/__init__.py
+++ b/homeassistant/components/minecraft_server/__init__.py
@@ -32,7 +32,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Check and create API instance.
     try:
-        api = MinecraftServer(
+        api = await hass.async_add_executor_job(
+            MinecraftServer,
             entry.data.get(CONF_TYPE, MinecraftServerType.JAVA_EDITION),
             entry.data[CONF_ADDRESS],
         )

--- a/homeassistant/components/minecraft_server/__init__.py
+++ b/homeassistant/components/minecraft_server/__init__.py
@@ -39,7 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
     except MinecraftServerAddressError as error:
         raise ConfigEntryError(
-            f"Address in configuration entry is invalid (error: {error}), please remove this device and add it again"
+            f"Server address in configuration entry is invalid (error: {error})"
         ) from error
 
     # Create coordinator instance.

--- a/homeassistant/components/minecraft_server/__init__.py
+++ b/homeassistant/components/minecraft_server/__init__.py
@@ -12,8 +12,9 @@ from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.device_registry as dr
 import homeassistant.helpers.entity_registry as er
 
+from .api import MinecraftServerType
 from .const import DOMAIN, KEY_LATENCY, KEY_MOTD
-from .coordinator import MinecraftServerCoordinator, MinecraftServerType
+from .coordinator import MinecraftServerCoordinator
 
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 

--- a/homeassistant/components/minecraft_server/__init__.py
+++ b/homeassistant/components/minecraft_server/__init__.py
@@ -7,13 +7,13 @@ from typing import Any
 from mcstatus import JavaServer
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ADDRESS, CONF_HOST, CONF_PORT, Platform
+from homeassistant.const import CONF_ADDRESS, CONF_HOST, CONF_PORT, CONF_TYPE, Platform
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.device_registry as dr
 import homeassistant.helpers.entity_registry as er
 
 from .const import DOMAIN, KEY_LATENCY, KEY_MOTD
-from .coordinator import MinecraftServerCoordinator
+from .coordinator import MinecraftServerCoordinator, MinecraftServerType
 
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
@@ -120,6 +120,24 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         hass.config_entries.async_update_entry(config_entry, data=new_data)
 
         _LOGGER.debug("Migration to version 3 successful")
+
+    # 3 --> 4: Add server type.
+    if config_entry.version == 3:
+        _LOGGER.debug("Migrating from version 3")
+
+        # Existing server(s) with version 2 can only be of type Java Edition.
+        _LOGGER.debug(
+            "Migrating config entry, adding server type '%s'",
+            MinecraftServerType.JAVA_EDITION,
+        )
+
+        config_data = config_entry.data
+        new_data = config_data.copy()
+        new_data[CONF_TYPE] = MinecraftServerType.JAVA_EDITION
+        config_entry.version = 4
+        hass.config_entries.async_update_entry(config_entry, data=new_data)
+
+        _LOGGER.debug("Migration to version 4 successful")
 
     return True
 

--- a/homeassistant/components/minecraft_server/api.py
+++ b/homeassistant/components/minecraft_server/api.py
@@ -24,12 +24,12 @@ class MinecraftServerData:
     version: str
 
     # Data available only in 'Java Edition'
-    players_list: list[str] | None
+    players_list: list[str] | None = None
 
     # Data available only in 'Bedrock Edition'
-    edition: str | None
-    game_mode: str | None
-    map_name: str | None
+    edition: str | None = None
+    game_mode: str | None = None
+    map_name: str | None = None
 
 
 class MinecraftServerType(StrEnum):
@@ -114,9 +114,6 @@ class MinecraftServer:
             protocol_version=status_response.version.protocol,
             version=status_response.version.name,
             players_list=players_list,
-            edition=None,
-            game_mode=None,
-            map_name=None,
         )
 
     def _extract_bedrock_data(
@@ -130,7 +127,6 @@ class MinecraftServer:
             players_online=status_response.players.online,
             protocol_version=status_response.version.protocol,
             version=status_response.version.name,
-            players_list=None,
             edition=status_response.version.brand,
             game_mode=status_response.gamemode,
             map_name=status_response.map_name,

--- a/homeassistant/components/minecraft_server/api.py
+++ b/homeassistant/components/minecraft_server/api.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 import logging
 
+from dns.resolver import LifetimeTimeout
 from mcstatus import BedrockServer, JavaServer
 from mcstatus.status_response import BedrockStatusResponse, JavaStatusResponse
 
@@ -59,7 +60,7 @@ class MinecraftServer:
                 self._server = JavaServer.lookup(address)
             else:
                 self._server = BedrockServer.lookup(address)
-        except ValueError as error:
+        except (ValueError, LifetimeTimeout) as error:
             raise MinecraftServerAddressError(
                 f"{server_type} server address '{address}' is invalid (error: {error})"
             ) from error

--- a/homeassistant/components/minecraft_server/api.py
+++ b/homeassistant/components/minecraft_server/api.py
@@ -1,0 +1,130 @@
+"""API for the Minecraft Server integration."""
+
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from mcstatus import BedrockServer, JavaServer
+from mcstatus.status_response import BedrockStatusResponse, JavaStatusResponse
+
+
+@dataclass
+class MinecraftServerData:
+    """Representation of Minecraft Server data."""
+
+    # Common data
+    latency: float
+    motd: str
+    players_max: int
+    players_online: int
+    protocol_version: int
+    version: str
+
+    # Data available only in 'Java Edition'
+    players_list: list[str] | None
+
+    # Data available only in 'Bedrock Edition'
+    edition: str | None
+    game_mode: str | None
+    map_name: str | None
+
+
+class MinecraftServerType(StrEnum):
+    """Enumeration of Minecraft Server types."""
+
+    JAVA_EDITION = "Java Edition"
+    BEDROCK_EDITION = "Bedrock Edition"
+
+
+class MinecraftServerAddressError(Exception):
+    """Raised when the input address is invalid."""
+
+
+class MinecraftServerConnectionError(Exception):
+    """Raised when no data can be fechted from the server."""
+
+
+class MinecraftServer:
+    """Minecraft Server wrapper class for 3rd party library mcstatus."""
+
+    _server: BedrockServer | JavaServer
+
+    def __init__(self, server_type: MinecraftServerType, address: str) -> None:
+        """Initialize server instance."""
+        try:
+            if server_type == MinecraftServerType.JAVA_EDITION:
+                self._server = JavaServer.lookup(address)
+            else:
+                self._server = BedrockServer.lookup(address)
+        except ValueError as error:
+            raise MinecraftServerAddressError(
+                f"{server_type} server address '{address}' is invalid (error: {error})"
+            ) from error
+
+    async def async_is_online(self) -> bool:
+        """Check if the server is online, supporting both Java and Bedrock Edition servers."""
+        try:
+            await self.async_get_data()
+        except MinecraftServerConnectionError:
+            return False
+
+        return True
+
+    async def async_get_data(self) -> MinecraftServerData:
+        """Get updated data from the server, supporting both Java and Bedrock Edition servers."""
+        status_response: BedrockStatusResponse | JavaStatusResponse
+
+        try:
+            status_response = await self._server.async_status()
+        except OSError as error:
+            raise MinecraftServerConnectionError(
+                f"Fetching data from the server failed (error: {error})"
+            ) from error
+
+        if isinstance(status_response, JavaStatusResponse):
+            data = self._extract_java_data(status_response)
+        else:
+            data = self._extract_bedrock_data(status_response)
+
+        return data
+
+    def _extract_java_data(
+        self, status_response: JavaStatusResponse
+    ) -> MinecraftServerData:
+        """Extract Java Edition server data out of status response."""
+        players_list = []
+
+        if players := status_response.players.sample:
+            for player in players:
+                players_list.append(player.name)
+            players_list.sort()
+
+        return MinecraftServerData(
+            latency=status_response.latency,
+            motd=status_response.motd.to_plain(),
+            players_max=status_response.players.max,
+            players_online=status_response.players.online,
+            protocol_version=status_response.version.protocol,
+            version=status_response.version.name,
+            players_list=players_list,
+            edition=None,
+            game_mode=None,
+            map_name=None,
+        )
+
+    def _extract_bedrock_data(
+        self, status_response: BedrockStatusResponse
+    ) -> MinecraftServerData:
+        """Extract Bedrock Edition server data out of status response."""
+        return MinecraftServerData(
+            latency=status_response.latency,
+            motd=status_response.motd.to_plain(),
+            players_max=status_response.players.max,
+            players_online=status_response.players.online,
+            protocol_version=status_response.version.protocol,
+            version=status_response.version.name,
+            players_list=None,
+            edition=status_response.version.brand,
+            game_mode=status_response.gamemode,
+            map_name=status_response.map_name,
+        )

--- a/homeassistant/components/minecraft_server/api.py
+++ b/homeassistant/components/minecraft_server/api.py
@@ -3,9 +3,12 @@
 
 from dataclasses import dataclass
 from enum import StrEnum
+import logging
 
 from mcstatus import BedrockServer, JavaServer
 from mcstatus.status_response import BedrockStatusResponse, JavaStatusResponse
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
@@ -60,6 +63,10 @@ class MinecraftServer:
             raise MinecraftServerAddressError(
                 f"{server_type} server address '{address}' is invalid (error: {error})"
             ) from error
+
+        _LOGGER.debug(
+            "%s server instance created with address '%s'", server_type, address
+        )
 
     async def async_is_online(self) -> bool:
         """Check if the server is online, supporting both Java and Bedrock Edition servers."""

--- a/homeassistant/components/minecraft_server/api.py
+++ b/homeassistant/components/minecraft_server/api.py
@@ -35,8 +35,8 @@ class MinecraftServerData:
 class MinecraftServerType(StrEnum):
     """Enumeration of Minecraft Server types."""
 
-    JAVA_EDITION = "Java Edition"
     BEDROCK_EDITION = "Bedrock Edition"
+    JAVA_EDITION = "Java Edition"
 
 
 class MinecraftServerAddressError(Exception):

--- a/homeassistant/components/minecraft_server/binary_sensor.py
+++ b/homeassistant/components/minecraft_server/binary_sensor.py
@@ -45,7 +45,7 @@ async def async_setup_entry(
     # Add binary sensor entities.
     async_add_entities(
         [
-            MinecraftServerBinarySensorEntity(coordinator, description)
+            MinecraftServerBinarySensorEntity(coordinator, description, config_entry)
             for description in BINARY_SENSOR_DESCRIPTIONS
         ]
     )
@@ -60,11 +60,12 @@ class MinecraftServerBinarySensorEntity(MinecraftServerEntity, BinarySensorEntit
         self,
         coordinator: MinecraftServerCoordinator,
         description: MinecraftServerBinarySensorEntityDescription,
+        config_entry: ConfigEntry,
     ) -> None:
         """Initialize binary sensor base entity."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, config_entry)
         self.entity_description = description
-        self._attr_unique_id = f"{coordinator.unique_id}-{description.key}"
+        self._attr_unique_id = f"{config_entry.entry_id}-{description.key}"
         self._attr_is_on = False
 
     @property

--- a/homeassistant/components/minecraft_server/config_flow.py
+++ b/homeassistant/components/minecraft_server/config_flow.py
@@ -20,7 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Minecraft Server."""
 
-    VERSION = 4
+    VERSION = 3
 
     async def async_step_user(self, user_input=None) -> FlowResult:
         """Handle the initial step."""

--- a/homeassistant/components/minecraft_server/config_flow.py
+++ b/homeassistant/components/minecraft_server/config_flow.py
@@ -6,6 +6,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import CONF_ADDRESS, CONF_NAME, CONF_TYPE
+from homeassistant.core import async_get_hass
 from homeassistant.data_entry_flow import FlowResult
 
 from .const import DEFAULT_NAME, DOMAIN
@@ -94,10 +95,11 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def _async_is_bedrock_server_online(self, address: str) -> bool:
         """Check Bedrock Edition server connection."""
+        hass = async_get_hass()
 
         # Parse and check server address.
         try:
-            server = BedrockServer.lookup(address)
+            server = await hass.async_add_executor_job(BedrockServer.lookup, address)
         except ValueError as error:
             _LOGGER.debug(
                 (

--- a/homeassistant/components/minecraft_server/config_flow.py
+++ b/homeassistant/components/minecraft_server/config_flow.py
@@ -36,11 +36,13 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
             # Some Bedrock Edition servers mimic a Java Edition server, therefore check for a Bedrock Edition server first.
             for server_type in MinecraftServerType:
                 try:
-                    server = MinecraftServer(server_type, address)
+                    api = await self.hass.async_add_executor_job(
+                        MinecraftServer, server_type, address
+                    )
                 except MinecraftServerAddressError:
                     pass
                 else:
-                    if await server.async_is_online():
+                    if await api.async_is_online():
                         config_data[CONF_TYPE] = server_type
                         return self.async_create_entry(title=address, data=config_data)
 

--- a/homeassistant/components/minecraft_server/coordinator.py
+++ b/homeassistant/components/minecraft_server/coordinator.py
@@ -4,18 +4,10 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ADDRESS, CONF_NAME, CONF_TYPE
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .api import (
-    MinecraftServer,
-    MinecraftServerAddressError,
-    MinecraftServerConnectionError,
-    MinecraftServerData,
-)
+from .api import MinecraftServer, MinecraftServerConnectionError, MinecraftServerData
 
 SCAN_INTERVAL = timedelta(seconds=60)
 
@@ -25,30 +17,15 @@ _LOGGER = logging.getLogger(__name__)
 class MinecraftServerCoordinator(DataUpdateCoordinator[MinecraftServerData]):
     """Minecraft Server data update coordinator."""
 
-    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+    def __init__(self, hass: HomeAssistant, name: str, api: MinecraftServer) -> None:
         """Initialize coordinator instance."""
-        config_data = config_entry.data
-        self.unique_id = config_entry.entry_id
-        self.server_type = config_data[CONF_TYPE]
+        self._api = api
 
         super().__init__(
             hass=hass,
-            name=config_data[CONF_NAME],
+            name=name,
             logger=_LOGGER,
             update_interval=SCAN_INTERVAL,
-        )
-
-        try:
-            self._api = MinecraftServer(self.server_type, config_data[CONF_ADDRESS])
-        except MinecraftServerAddressError as error:
-            raise HomeAssistantError(
-                f"Address in configuration entry is invalid (error: {error}), please remove this device and add it again"
-            ) from error
-
-        _LOGGER.debug(
-            "%s server instance created with address '%s'",
-            self.server_type,
-            config_data[CONF_ADDRESS],
         )
 
     async def _async_update_data(self) -> MinecraftServerData:

--- a/homeassistant/components/minecraft_server/coordinator.py
+++ b/homeassistant/components/minecraft_server/coordinator.py
@@ -1,13 +1,8 @@
 """The Minecraft Server integration."""
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import timedelta
-from enum import StrEnum
 import logging
-
-from mcstatus.server import BedrockServer, JavaServer
-from mcstatus.status_response import BedrockStatusResponse, JavaStatusResponse
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ADDRESS, CONF_NAME, CONF_TYPE
@@ -15,37 +10,16 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+from .api import (
+    MinecraftServer,
+    MinecraftServerAddressError,
+    MinecraftServerConnectionError,
+    MinecraftServerData,
+)
+
 SCAN_INTERVAL = timedelta(seconds=60)
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class MinecraftServerType(StrEnum):
-    """Enumeration of Minecraft Server types."""
-
-    JAVA_EDITION = "Java Edition"
-    BEDROCK_EDITION = "Bedrock Edition"
-
-
-@dataclass
-class MinecraftServerData:
-    """Representation of Minecraft Server data."""
-
-    # Common data
-    latency: float
-    motd: str
-    players_max: int
-    players_online: int
-    protocol_version: int
-    version: str
-
-    # Data available only in 'Java Edition'
-    players_list: list[str] | None
-
-    # Data available only in 'Bedrock Edition'
-    edition: str | None
-    game_mode: str | None
-    map_name: str | None
 
 
 class MinecraftServerCoordinator(DataUpdateCoordinator[MinecraftServerData]):
@@ -64,70 +38,22 @@ class MinecraftServerCoordinator(DataUpdateCoordinator[MinecraftServerData]):
             update_interval=SCAN_INTERVAL,
         )
 
-        self._server: BedrockServer | JavaServer
         try:
-            if self.server_type == MinecraftServerType.JAVA_EDITION:
-                self._server = JavaServer.lookup(config_data[CONF_ADDRESS])
-            else:
-                self._server = BedrockServer.lookup(config_data[CONF_ADDRESS])
-        except ValueError as error:
+            self._api = MinecraftServer(self.server_type, config_data[CONF_ADDRESS])
+        except MinecraftServerAddressError as error:
             raise HomeAssistantError(
-                f"Address in configuration entry cannot be parsed (error: {error}), please remove this device and add it again"
+                f"Address in configuration entry is invalid (error: {error}), please remove this device and add it again"
             ) from error
 
+        _LOGGER.debug(
+            "%s server instance created with address '%s'",
+            self.server_type,
+            config_data[CONF_ADDRESS],
+        )
+
     async def _async_update_data(self) -> MinecraftServerData:
-        """Get server data from 3rd party library and update properties."""
-        status_response: BedrockStatusResponse | JavaStatusResponse
-
+        """Get updated data from the server."""
         try:
-            status_response = await self._server.async_status()
-        except OSError as error:
+            return await self._api.async_get_data()
+        except MinecraftServerConnectionError as error:
             raise UpdateFailed(error) from error
-
-        if isinstance(status_response, JavaStatusResponse):
-            data = self._extract_java_data(status_response)
-        else:
-            data = self._extract_bedrock_data(status_response)
-
-        return data
-
-    def _extract_java_data(
-        self, status_response: JavaStatusResponse
-    ) -> MinecraftServerData:
-        """Extract Java Edition server data out of status response."""
-        players_list = []
-
-        if players := status_response.players.sample:
-            for player in players:
-                players_list.append(player.name)
-            players_list.sort()
-
-        return MinecraftServerData(
-            latency=status_response.latency,
-            motd=status_response.motd.to_plain(),
-            players_max=status_response.players.max,
-            players_online=status_response.players.online,
-            protocol_version=status_response.version.protocol,
-            version=status_response.version.name,
-            players_list=players_list,
-            edition=None,
-            game_mode=None,
-            map_name=None,
-        )
-
-    def _extract_bedrock_data(
-        self, status_response: BedrockStatusResponse
-    ) -> MinecraftServerData:
-        """Extract Bedrock Edition server data out of status response."""
-        return MinecraftServerData(
-            latency=status_response.latency,
-            motd=status_response.motd.to_plain(),
-            players_max=status_response.players.max,
-            players_online=status_response.players.online,
-            protocol_version=status_response.version.protocol,
-            version=status_response.version.name,
-            players_list=None,
-            edition=status_response.version.brand,
-            game_mode=status_response.gamemode,
-            map_name=status_response.map_name,
-        )

--- a/homeassistant/components/minecraft_server/coordinator.py
+++ b/homeassistant/components/minecraft_server/coordinator.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import timedelta
+from enum import StrEnum
 import logging
 
-from mcstatus.server import JavaServer
+from mcstatus.server import BedrockServer, JavaServer
+from mcstatus.status_response import BedrockStatusResponse, JavaStatusResponse
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ADDRESS, CONF_NAME
+from homeassistant.const import CONF_ADDRESS, CONF_NAME, CONF_TYPE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -18,17 +20,32 @@ SCAN_INTERVAL = timedelta(seconds=60)
 _LOGGER = logging.getLogger(__name__)
 
 
+class MinecraftServerType(StrEnum):
+    """Enumeration of Minecraft Server types."""
+
+    JAVA_EDITION = "Java Edition"
+    BEDROCK_EDITION = "Bedrock Edition"
+
+
 @dataclass
 class MinecraftServerData:
     """Representation of Minecraft Server data."""
 
+    # Common data
     latency: float
     motd: str
     players_max: int
     players_online: int
-    players_list: list[str]
     protocol_version: int
     version: str
+
+    # Data available only in 'Java Edition'
+    players_list: list[str] | None
+
+    # Data available only in 'Bedrock Edition'
+    edition: str | None
+    game_mode: str | None
+    map_name: str | None
 
 
 class MinecraftServerCoordinator(DataUpdateCoordinator[MinecraftServerData]):
@@ -38,6 +55,7 @@ class MinecraftServerCoordinator(DataUpdateCoordinator[MinecraftServerData]):
         """Initialize coordinator instance."""
         config_data = config_entry.data
         self.unique_id = config_entry.entry_id
+        self.server_type = config_data[CONF_TYPE]
 
         super().__init__(
             hass=hass,
@@ -46,8 +64,12 @@ class MinecraftServerCoordinator(DataUpdateCoordinator[MinecraftServerData]):
             update_interval=SCAN_INTERVAL,
         )
 
+        self._server: BedrockServer | JavaServer
         try:
-            self._server = JavaServer.lookup(config_data[CONF_ADDRESS])
+            if self.server_type == MinecraftServerType.JAVA_EDITION:
+                self._server = JavaServer.lookup(config_data[CONF_ADDRESS])
+            else:
+                self._server = BedrockServer.lookup(config_data[CONF_ADDRESS])
         except ValueError as error:
             raise HomeAssistantError(
                 f"Address in configuration entry cannot be parsed (error: {error}), please remove this device and add it again"
@@ -55,23 +77,57 @@ class MinecraftServerCoordinator(DataUpdateCoordinator[MinecraftServerData]):
 
     async def _async_update_data(self) -> MinecraftServerData:
         """Get server data from 3rd party library and update properties."""
+        status_response: BedrockStatusResponse | JavaStatusResponse
+
         try:
             status_response = await self._server.async_status()
         except OSError as error:
             raise UpdateFailed(error) from error
 
+        if isinstance(status_response, JavaStatusResponse):
+            data = self._extract_java_data(status_response)
+        else:
+            data = self._extract_bedrock_data(status_response)
+
+        return data
+
+    def _extract_java_data(
+        self, status_response: JavaStatusResponse
+    ) -> MinecraftServerData:
+        """Extract Java Edition server data out of status response."""
         players_list = []
+
         if players := status_response.players.sample:
             for player in players:
                 players_list.append(player.name)
             players_list.sort()
 
         return MinecraftServerData(
-            version=status_response.version.name,
-            protocol_version=status_response.version.protocol,
-            players_online=status_response.players.online,
-            players_max=status_response.players.max,
-            players_list=players_list,
             latency=status_response.latency,
             motd=status_response.motd.to_plain(),
+            players_max=status_response.players.max,
+            players_online=status_response.players.online,
+            protocol_version=status_response.version.protocol,
+            version=status_response.version.name,
+            players_list=players_list,
+            edition=None,
+            game_mode=None,
+            map_name=None,
+        )
+
+    def _extract_bedrock_data(
+        self, status_response: BedrockStatusResponse
+    ) -> MinecraftServerData:
+        """Extract Bedrock Edition server data out of status response."""
+        return MinecraftServerData(
+            latency=status_response.latency,
+            motd=status_response.motd.to_plain(),
+            players_max=status_response.players.max,
+            players_online=status_response.players.online,
+            protocol_version=status_response.version.protocol,
+            version=status_response.version.name,
+            players_list=None,
+            edition=status_response.version.brand,
+            game_mode=status_response.gamemode,
+            map_name=status_response.map_name,
         )

--- a/homeassistant/components/minecraft_server/entity.py
+++ b/homeassistant/components/minecraft_server/entity.py
@@ -20,10 +20,11 @@ class MinecraftServerEntity(CoordinatorEntity[MinecraftServerCoordinator]):
     ) -> None:
         """Initialize base entity."""
         super().__init__(coordinator)
+
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.unique_id)},
             manufacturer=MANUFACTURER,
-            model=f"Minecraft Server ({coordinator.data.version})",
+            model=f"Minecraft Server ({coordinator.server_type})",
             name=coordinator.name,
-            sw_version=str(coordinator.data.protocol_version),
+            sw_version=f"{coordinator.data.version} ({coordinator.data.protocol_version})",
         )

--- a/homeassistant/components/minecraft_server/entity.py
+++ b/homeassistant/components/minecraft_server/entity.py
@@ -5,6 +5,7 @@ from homeassistant.const import CONF_TYPE
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .api import MinecraftServerType
 from .const import DOMAIN
 from .coordinator import MinecraftServerCoordinator
 
@@ -27,7 +28,7 @@ class MinecraftServerEntity(CoordinatorEntity[MinecraftServerCoordinator]):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, config_entry.entry_id)},
             manufacturer=MANUFACTURER,
-            model=f"Minecraft Server ({config_entry.data[CONF_TYPE]})",
+            model=f"Minecraft Server ({config_entry.data.get(CONF_TYPE, MinecraftServerType.JAVA_EDITION)})",
             name=coordinator.name,
             sw_version=f"{coordinator.data.version} ({coordinator.data.protocol_version})",
         )

--- a/homeassistant/components/minecraft_server/entity.py
+++ b/homeassistant/components/minecraft_server/entity.py
@@ -1,5 +1,7 @@
 """Base entity for the Minecraft Server integration."""
 
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_TYPE
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -17,14 +19,15 @@ class MinecraftServerEntity(CoordinatorEntity[MinecraftServerCoordinator]):
     def __init__(
         self,
         coordinator: MinecraftServerCoordinator,
+        config_entry: ConfigEntry,
     ) -> None:
         """Initialize base entity."""
         super().__init__(coordinator)
 
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, coordinator.unique_id)},
+            identifiers={(DOMAIN, config_entry.entry_id)},
             manufacturer=MANUFACTURER,
-            model=f"Minecraft Server ({coordinator.server_type})",
+            model=f"Minecraft Server ({config_entry.data[CONF_TYPE]})",
             name=coordinator.name,
             sw_version=f"{coordinator.data.version} ({coordinator.data.protocol_version})",
         )

--- a/homeassistant/components/minecraft_server/sensor.py
+++ b/homeassistant/components/minecraft_server/sensor.py
@@ -187,7 +187,8 @@ async def async_setup_entry(
         [
             MinecraftServerSensorEntity(coordinator, description, config_entry)
             for description in SENSOR_DESCRIPTIONS
-            if config_entry.data[CONF_TYPE] in description.supported_server_types
+            if config_entry.data.get(CONF_TYPE, MinecraftServerType.JAVA_EDITION)
+            in description.supported_server_types
         ]
     )
 

--- a/homeassistant/components/minecraft_server/sensor.py
+++ b/homeassistant/components/minecraft_server/sensor.py
@@ -12,12 +12,9 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
+from .api import MinecraftServerData, MinecraftServerType
 from .const import DOMAIN, KEY_LATENCY, KEY_MOTD
-from .coordinator import (
-    MinecraftServerCoordinator,
-    MinecraftServerData,
-    MinecraftServerType,
-)
+from .coordinator import MinecraftServerCoordinator
 from .entity import MinecraftServerEntity
 
 ATTR_PLAYERS_LIST = "players_list"

--- a/homeassistant/components/minecraft_server/sensor.py
+++ b/homeassistant/components/minecraft_server/sensor.py
@@ -50,7 +50,7 @@ class MinecraftServerEntityDescriptionMixin:
 
     value_fn: Callable[[MinecraftServerData], StateType]
     attributes_fn: Callable[[MinecraftServerData], MutableMapping[str, Any]] | None
-    enabled_fn: Callable[[MinecraftServerType], bool]
+    supported_server_types: list[MinecraftServerType]
 
 
 @dataclass
@@ -80,10 +80,10 @@ SENSOR_DESCRIPTIONS = [
         icon=ICON_VERSION,
         value_fn=lambda data: data.version,
         attributes_fn=None,
-        enabled_fn=lambda server_type: (
-            server_type
-            in (MinecraftServerType.JAVA_EDITION, MinecraftServerType.BEDROCK_EDITION)
-        ),
+        supported_server_types=[
+            MinecraftServerType.JAVA_EDITION,
+            MinecraftServerType.BEDROCK_EDITION,
+        ],
     ),
     MinecraftServerSensorEntityDescription(
         key=KEY_PROTOCOL_VERSION,
@@ -91,10 +91,10 @@ SENSOR_DESCRIPTIONS = [
         icon=ICON_PROTOCOL_VERSION,
         value_fn=lambda data: data.protocol_version,
         attributes_fn=None,
-        enabled_fn=lambda server_type: (
-            server_type
-            in (MinecraftServerType.JAVA_EDITION, MinecraftServerType.BEDROCK_EDITION)
-        ),
+        supported_server_types=[
+            MinecraftServerType.JAVA_EDITION,
+            MinecraftServerType.BEDROCK_EDITION,
+        ],
     ),
     MinecraftServerSensorEntityDescription(
         key=KEY_PLAYERS_MAX,
@@ -103,10 +103,10 @@ SENSOR_DESCRIPTIONS = [
         icon=ICON_PLAYERS_MAX,
         value_fn=lambda data: data.players_max,
         attributes_fn=None,
-        enabled_fn=lambda server_type: (
-            server_type
-            in (MinecraftServerType.JAVA_EDITION, MinecraftServerType.BEDROCK_EDITION)
-        ),
+        supported_server_types=[
+            MinecraftServerType.JAVA_EDITION,
+            MinecraftServerType.BEDROCK_EDITION,
+        ],
     ),
     MinecraftServerSensorEntityDescription(
         key=KEY_LATENCY,
@@ -116,10 +116,10 @@ SENSOR_DESCRIPTIONS = [
         icon=ICON_LATENCY,
         value_fn=lambda data: data.latency,
         attributes_fn=None,
-        enabled_fn=lambda server_type: (
-            server_type
-            in (MinecraftServerType.JAVA_EDITION, MinecraftServerType.BEDROCK_EDITION)
-        ),
+        supported_server_types=[
+            MinecraftServerType.JAVA_EDITION,
+            MinecraftServerType.BEDROCK_EDITION,
+        ],
     ),
     MinecraftServerSensorEntityDescription(
         key=KEY_MOTD,
@@ -127,10 +127,10 @@ SENSOR_DESCRIPTIONS = [
         icon=ICON_MOTD,
         value_fn=lambda data: data.motd,
         attributes_fn=None,
-        enabled_fn=lambda server_type: (
-            server_type
-            in (MinecraftServerType.JAVA_EDITION, MinecraftServerType.BEDROCK_EDITION)
-        ),
+        supported_server_types=[
+            MinecraftServerType.JAVA_EDITION,
+            MinecraftServerType.BEDROCK_EDITION,
+        ],
     ),
     MinecraftServerSensorEntityDescription(
         key=KEY_PLAYERS_ONLINE,
@@ -139,10 +139,10 @@ SENSOR_DESCRIPTIONS = [
         icon=ICON_PLAYERS_ONLINE,
         value_fn=lambda data: data.players_online,
         attributes_fn=get_extra_state_attributes_players_list,
-        enabled_fn=lambda server_type: (
-            server_type
-            in (MinecraftServerType.JAVA_EDITION, MinecraftServerType.BEDROCK_EDITION)
-        ),
+        supported_server_types=[
+            MinecraftServerType.JAVA_EDITION,
+            MinecraftServerType.BEDROCK_EDITION,
+        ],
     ),
     MinecraftServerSensorEntityDescription(
         key=KEY_EDITION,
@@ -150,9 +150,9 @@ SENSOR_DESCRIPTIONS = [
         icon=ICON_EDITION,
         value_fn=lambda data: data.edition,
         attributes_fn=None,
-        enabled_fn=lambda server_type: (
-            server_type == MinecraftServerType.BEDROCK_EDITION
-        ),
+        supported_server_types=[
+            MinecraftServerType.BEDROCK_EDITION,
+        ],
     ),
     MinecraftServerSensorEntityDescription(
         key=KEY_GAME_MODE,
@@ -160,9 +160,9 @@ SENSOR_DESCRIPTIONS = [
         icon=ICON_GAME_MODE,
         value_fn=lambda data: data.game_mode,
         attributes_fn=None,
-        enabled_fn=lambda server_type: (
-            server_type == MinecraftServerType.BEDROCK_EDITION
-        ),
+        supported_server_types=[
+            MinecraftServerType.BEDROCK_EDITION,
+        ],
     ),
     MinecraftServerSensorEntityDescription(
         key=KEY_MAP_NAME,
@@ -170,9 +170,9 @@ SENSOR_DESCRIPTIONS = [
         icon=ICON_MAP_NAME,
         value_fn=lambda data: data.map_name,
         attributes_fn=None,
-        enabled_fn=lambda server_type: (
-            server_type == MinecraftServerType.BEDROCK_EDITION
-        ),
+        supported_server_types=[
+            MinecraftServerType.BEDROCK_EDITION,
+        ],
     ),
 ]
 
@@ -190,7 +190,7 @@ async def async_setup_entry(
         [
             MinecraftServerSensorEntity(coordinator, description)
             for description in SENSOR_DESCRIPTIONS
-            if description.enabled_fn(coordinator.server_type)
+            if coordinator.server_type in description.supported_server_types
         ]
     )
 

--- a/homeassistant/components/minecraft_server/sensor.py
+++ b/homeassistant/components/minecraft_server/sensor.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfTime
+from homeassistant.const import CONF_TYPE, UnitOfTime
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
@@ -185,9 +185,9 @@ async def async_setup_entry(
     # Add sensor entities.
     async_add_entities(
         [
-            MinecraftServerSensorEntity(coordinator, description)
+            MinecraftServerSensorEntity(coordinator, description, config_entry)
             for description in SENSOR_DESCRIPTIONS
-            if coordinator.server_type in description.supported_server_types
+            if config_entry.data[CONF_TYPE] in description.supported_server_types
         ]
     )
 
@@ -201,11 +201,12 @@ class MinecraftServerSensorEntity(MinecraftServerEntity, SensorEntity):
         self,
         coordinator: MinecraftServerCoordinator,
         description: MinecraftServerSensorEntityDescription,
+        config_entry: ConfigEntry,
     ) -> None:
         """Initialize sensor base entity."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, config_entry)
         self.entity_description = description
-        self._attr_unique_id = f"{coordinator.unique_id}-{description.key}"
+        self._attr_unique_id = f"{config_entry.entry_id}-{description.key}"
         self._update_properties()
 
     @callback

--- a/homeassistant/components/minecraft_server/strings.json
+++ b/homeassistant/components/minecraft_server/strings.json
@@ -11,7 +11,7 @@
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect to server. Please check the address and try again. If a port was provided, it must be within a valid range. Also ensure that you are running at least version 1.7 of Minecraft Java Edition on your server."
+      "cannot_connect": "Failed to connect to server. Please check the address and try again. If a port was provided, it must be within a valid range. If you are running a Minecraft Java Edition server, ensure that it is at least version 1.7."
     }
   },
   "entity": {
@@ -38,6 +38,15 @@
       },
       "motd": {
         "name": "World message"
+      },
+      "game_mode": {
+        "name": "Game mode"
+      },
+      "map_name": {
+        "name": "Map name"
+      },
+      "edition": {
+        "name": "Edition"
       }
     }
   }

--- a/tests/components/minecraft_server/const.py
+++ b/tests/components/minecraft_server/const.py
@@ -1,6 +1,9 @@
 """Constants for Minecraft Server integration tests."""
 from mcstatus.motd import Motd
 from mcstatus.status_response import (
+    BedrockStatusPlayers,
+    BedrockStatusResponse,
+    BedrockStatusVersion,
     JavaStatusPlayers,
     JavaStatusResponse,
     JavaStatusVersion,
@@ -31,4 +34,13 @@ TEST_JAVA_STATUS_RESPONSE = JavaStatusResponse(
     motd=Motd.parse(TEST_JAVA_STATUS_RESPONSE_RAW["description"], bedrock=False),
     icon=None,
     latency=5,
+)
+
+TEST_BEDROCK_STATUS_RESPONSE = BedrockStatusResponse(
+    players=BedrockStatusPlayers(online=3, max=10),
+    version=BedrockStatusVersion(brand="MCPE", name="Dummy Version", protocol=123),
+    motd=Motd.parse("Dummy Description", bedrock=True),
+    latency=5,
+    gamemode="Dummy Game Mode",
+    map_name="Dummy Map Name",
 )

--- a/tests/components/minecraft_server/const.py
+++ b/tests/components/minecraft_server/const.py
@@ -9,6 +9,8 @@ from mcstatus.status_response import (
     JavaStatusVersion,
 )
 
+from homeassistant.components.minecraft_server.api import MinecraftServerData
+
 TEST_HOST = "mc.dummyserver.com"
 TEST_PORT = 25566
 TEST_ADDRESS = f"{TEST_HOST}:{TEST_PORT}"
@@ -36,11 +38,37 @@ TEST_JAVA_STATUS_RESPONSE = JavaStatusResponse(
     latency=5,
 )
 
+TEST_JAVA_DATA = MinecraftServerData(
+    latency=5,
+    motd="Dummy MOTD",
+    players_max=10,
+    players_online=3,
+    protocol_version=123,
+    version="Dummy Version",
+    players_list=["Player 1", "Player 2", "Player 3"],
+    edition=None,
+    game_mode=None,
+    map_name=None,
+)
+
 TEST_BEDROCK_STATUS_RESPONSE = BedrockStatusResponse(
     players=BedrockStatusPlayers(online=3, max=10),
     version=BedrockStatusVersion(brand="MCPE", name="Dummy Version", protocol=123),
     motd=Motd.parse("Dummy Description", bedrock=True),
     latency=5,
     gamemode="Dummy Game Mode",
+    map_name="Dummy Map Name",
+)
+
+TEST_BEDROCK_DATA = MinecraftServerData(
+    latency=5,
+    motd="Dummy MOTD",
+    players_max=10,
+    players_online=3,
+    protocol_version=123,
+    version="Dummy Version",
+    players_list=None,
+    edition="Dummy Edition",
+    game_mode="Dummy Game Mode",
     map_name="Dummy Map Name",
 )

--- a/tests/components/minecraft_server/test_config_flow.py
+++ b/tests/components/minecraft_server/test_config_flow.py
@@ -82,10 +82,14 @@ async def test_bedrock_connection_failed(hass: HomeAssistant) -> None:
 
 
 async def test_java_connection_succeeded(hass: HomeAssistant) -> None:
-    """Test config entry in case of a successful connection with a host name."""
+    """Test config entry in case of a successful connection to a Java Edition server."""
     with patch(
         "homeassistant.components.minecraft_server.api.MinecraftServer.__init__",
-        side_effect=[MinecraftServerAddressError, None],
+        side_effect=[
+            MinecraftServerAddressError,  # async_step_user (Bedrock Edition)
+            None,  # async_step_user (Java Edition)
+            None,  # async_setup_entry
+        ],
         return_value=None,
     ), patch(
         "homeassistant.components.minecraft_server.api.MinecraftServer.async_is_online",
@@ -103,7 +107,7 @@ async def test_java_connection_succeeded(hass: HomeAssistant) -> None:
 
 
 async def test_bedrock_connection_succeeded(hass: HomeAssistant) -> None:
-    """Test config entry in case of a successful connection with a host name."""
+    """Test config entry in case of a successful connection to a Bedrock Edition server."""
     with patch(
         "homeassistant.components.minecraft_server.api.MinecraftServer.__init__",
         side_effect=None,

--- a/tests/components/minecraft_server/test_config_flow.py
+++ b/tests/components/minecraft_server/test_config_flow.py
@@ -2,11 +2,12 @@
 
 from unittest.mock import patch
 
-from mcstatus import JavaServer
+from mcstatus import BedrockServer, JavaServer
 
 from homeassistant.components.minecraft_server.const import DEFAULT_NAME, DOMAIN
+from homeassistant.components.minecraft_server.coordinator import MinecraftServerType
 from homeassistant.config_entries import SOURCE_USER
-from homeassistant.const import CONF_ADDRESS, CONF_NAME
+from homeassistant.const import CONF_ADDRESS, CONF_NAME, CONF_TYPE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -31,6 +32,9 @@ async def test_show_config_form(hass: HomeAssistant) -> None:
 async def test_lookup_failed(hass: HomeAssistant) -> None:
     """Test error in case of a failed connection."""
     with patch(
+        "mcstatus.server.BedrockServer.lookup",
+        side_effect=ValueError,
+    ), patch(
         "mcstatus.server.JavaServer.async_lookup",
         side_effect=ValueError,
     ):
@@ -42,9 +46,12 @@ async def test_lookup_failed(hass: HomeAssistant) -> None:
         assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_connection_failed(hass: HomeAssistant) -> None:
+async def test_java_connection_failed(hass: HomeAssistant) -> None:
     """Test error in case of a failed connection."""
     with patch(
+        "mcstatus.server.BedrockServer.lookup",
+        side_effect=ValueError,
+    ), patch(
         "mcstatus.server.JavaServer.async_lookup",
         return_value=JavaServer(host=TEST_HOST, port=TEST_PORT),
     ), patch("mcstatus.server.JavaServer.async_status", side_effect=OSError):
@@ -56,9 +63,26 @@ async def test_connection_failed(hass: HomeAssistant) -> None:
         assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_connection_succeeded(hass: HomeAssistant) -> None:
+async def test_bedrock_connection_failed(hass: HomeAssistant) -> None:
+    """Test error in case of a failed connection."""
+    with patch(
+        "mcstatus.server.BedrockServer.lookup",
+        return_value=BedrockServer(host=TEST_HOST, port=TEST_PORT),
+    ), patch("mcstatus.server.BedrockServer.async_status", side_effect=OSError):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT
+        )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_java_connection_succeeded(hass: HomeAssistant) -> None:
     """Test config entry in case of a successful connection with a host name."""
     with patch(
+        "mcstatus.server.BedrockServer.lookup",
+        side_effect=ValueError,
+    ), patch(
         "mcstatus.server.JavaServer.async_lookup",
         return_value=JavaServer(host=TEST_HOST, port=TEST_PORT),
     ), patch(
@@ -73,3 +97,24 @@ async def test_connection_succeeded(hass: HomeAssistant) -> None:
         assert result["title"] == USER_INPUT[CONF_ADDRESS]
         assert result["data"][CONF_NAME] == USER_INPUT[CONF_NAME]
         assert result["data"][CONF_ADDRESS] == TEST_ADDRESS
+        assert result["data"][CONF_TYPE] == MinecraftServerType.JAVA_EDITION
+
+
+async def test_bedrock_connection_succeeded(hass: HomeAssistant) -> None:
+    """Test config entry in case of a successful connection with a host name."""
+    with patch(
+        "mcstatus.server.BedrockServer.lookup",
+        return_value=BedrockServer(host=TEST_HOST, port=TEST_PORT),
+    ), patch(
+        "mcstatus.server.BedrockServer.async_status",
+        return_value=TEST_JAVA_STATUS_RESPONSE,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["title"] == USER_INPUT[CONF_ADDRESS]
+        assert result["data"][CONF_NAME] == USER_INPUT[CONF_NAME]
+        assert result["data"][CONF_ADDRESS] == TEST_ADDRESS
+        assert result["data"][CONF_TYPE] == MinecraftServerType.BEDROCK_EDITION

--- a/tests/components/minecraft_server/test_init.py
+++ b/tests/components/minecraft_server/test_init.py
@@ -2,13 +2,10 @@
 from unittest.mock import patch
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
-from homeassistant.components.minecraft_server.api import (
-    MinecraftServerAddressError,
-    MinecraftServerType,
-)
+from homeassistant.components.minecraft_server.api import MinecraftServerAddressError
 from homeassistant.components.minecraft_server.const import DEFAULT_NAME, DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.const import CONF_ADDRESS, CONF_HOST, CONF_NAME, CONF_PORT, CONF_TYPE
+from homeassistant.const import CONF_ADDRESS, CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -141,11 +138,10 @@ async def test_entry_migration(hass: HomeAssistant) -> None:
     # Test migrated config entry.
     config_entry = hass.config_entries.async_get_entry(config_entry_id)
     assert config_entry.unique_id is None
-    assert config_entry.data[CONF_NAME] == DEFAULT_NAME
-    assert config_entry.data[CONF_ADDRESS] == TEST_ADDRESS
-
-    if CONF_TYPE in config_entry.data:
-        assert config_entry.data[CONF_TYPE] == MinecraftServerType.JAVA_EDITION
+    assert config_entry.data == {
+        CONF_NAME: DEFAULT_NAME,
+        CONF_ADDRESS: TEST_ADDRESS,
+    }
 
     assert config_entry.version == 3
 
@@ -195,12 +191,10 @@ async def test_entry_migration_host_only(hass: HomeAssistant) -> None:
     # Test migrated config entry.
     config_entry = hass.config_entries.async_get_entry(config_entry_id)
     assert config_entry.unique_id is None
-    assert config_entry.data[CONF_NAME] == DEFAULT_NAME
-    assert config_entry.data[CONF_ADDRESS] == TEST_HOST
-
-    if CONF_TYPE in config_entry.data:
-        assert config_entry.data[CONF_TYPE] == MinecraftServerType.JAVA_EDITION
-
+    assert config_entry.data == {
+        CONF_NAME: DEFAULT_NAME,
+        CONF_ADDRESS: TEST_HOST,
+    }
     assert config_entry.version == 3
 
 

--- a/tests/components/minecraft_server/test_init.py
+++ b/tests/components/minecraft_server/test_init.py
@@ -141,11 +141,12 @@ async def test_entry_migration(hass: HomeAssistant) -> None:
     # Test migrated config entry.
     config_entry = hass.config_entries.async_get_entry(config_entry_id)
     assert config_entry.unique_id is None
-    assert config_entry.data == {
-        CONF_NAME: DEFAULT_NAME,
-        CONF_ADDRESS: TEST_ADDRESS,
-        CONF_TYPE: MinecraftServerType.JAVA_EDITION,
-    }
+    assert config_entry.data[CONF_NAME] == DEFAULT_NAME
+    assert config_entry.data[CONF_ADDRESS] == TEST_ADDRESS
+
+    if CONF_TYPE in config_entry.data:
+        assert config_entry.data[CONF_TYPE] == MinecraftServerType.JAVA_EDITION
+
     assert config_entry.version == 3
 
     # Test migrated device entry.
@@ -194,11 +195,12 @@ async def test_entry_migration_host_only(hass: HomeAssistant) -> None:
     # Test migrated config entry.
     config_entry = hass.config_entries.async_get_entry(config_entry_id)
     assert config_entry.unique_id is None
-    assert config_entry.data == {
-        CONF_NAME: DEFAULT_NAME,
-        CONF_ADDRESS: TEST_HOST,
-        CONF_TYPE: MinecraftServerType.JAVA_EDITION,
-    }
+    assert config_entry.data[CONF_NAME] == DEFAULT_NAME
+    assert config_entry.data[CONF_ADDRESS] == TEST_HOST
+
+    if CONF_TYPE in config_entry.data:
+        assert config_entry.data[CONF_TYPE] == MinecraftServerType.JAVA_EDITION
+
     assert config_entry.version == 3
 
 

--- a/tests/components/minecraft_server/test_init.py
+++ b/tests/components/minecraft_server/test_init.py
@@ -5,8 +5,9 @@ from mcstatus import JavaServer
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.minecraft_server.const import DEFAULT_NAME, DOMAIN
+from homeassistant.components.minecraft_server.coordinator import MinecraftServerType
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.const import CONF_ADDRESS, CONF_HOST, CONF_NAME, CONF_PORT
+from homeassistant.const import CONF_ADDRESS, CONF_HOST, CONF_NAME, CONF_PORT, CONF_TYPE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -141,8 +142,9 @@ async def test_entry_migration(hass: HomeAssistant) -> None:
     assert config_entry.data == {
         CONF_NAME: DEFAULT_NAME,
         CONF_ADDRESS: TEST_ADDRESS,
+        CONF_TYPE: MinecraftServerType.JAVA_EDITION,
     }
-    assert config_entry.version == 3
+    assert config_entry.version == 4
 
     # Test migrated device entry.
     device_registry = dr.async_get(hass)
@@ -192,8 +194,9 @@ async def test_entry_migration_host_only(hass: HomeAssistant) -> None:
     assert config_entry.data == {
         CONF_NAME: DEFAULT_NAME,
         CONF_ADDRESS: TEST_HOST,
+        CONF_TYPE: MinecraftServerType.JAVA_EDITION,
     }
-    assert config_entry.version == 3
+    assert config_entry.version == 4
 
 
 async def test_entry_migration_v3_failure(hass: HomeAssistant) -> None:

--- a/tests/components/minecraft_server/test_init.py
+++ b/tests/components/minecraft_server/test_init.py
@@ -144,7 +144,7 @@ async def test_entry_migration(hass: HomeAssistant) -> None:
         CONF_ADDRESS: TEST_ADDRESS,
         CONF_TYPE: MinecraftServerType.JAVA_EDITION,
     }
-    assert config_entry.version == 4
+    assert config_entry.version == 3
 
     # Test migrated device entry.
     device_registry = dr.async_get(hass)
@@ -196,7 +196,7 @@ async def test_entry_migration_host_only(hass: HomeAssistant) -> None:
         CONF_ADDRESS: TEST_HOST,
         CONF_TYPE: MinecraftServerType.JAVA_EDITION,
     }
-    assert config_entry.version == 4
+    assert config_entry.version == 3
 
 
 async def test_entry_migration_v3_failure(hass: HomeAssistant) -> None:

--- a/tests/components/minecraft_server/test_init.py
+++ b/tests/components/minecraft_server/test_init.py
@@ -1,17 +1,18 @@
 """Tests for the Minecraft Server integration."""
 from unittest.mock import patch
 
-from mcstatus import JavaServer
-
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
-from homeassistant.components.minecraft_server.api import MinecraftServerType
+from homeassistant.components.minecraft_server.api import (
+    MinecraftServerAddressError,
+    MinecraftServerType,
+)
 from homeassistant.components.minecraft_server.const import DEFAULT_NAME, DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import CONF_ADDRESS, CONF_HOST, CONF_NAME, CONF_PORT, CONF_TYPE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from .const import TEST_ADDRESS, TEST_HOST, TEST_JAVA_STATUS_RESPONSE, TEST_PORT
+from .const import TEST_ADDRESS, TEST_HOST, TEST_JAVA_DATA, TEST_PORT
 
 from tests.common import MockConfigEntry
 
@@ -123,15 +124,16 @@ async def test_entry_migration(hass: HomeAssistant) -> None:
 
     # Trigger migration.
     with patch(
-        "mcstatus.server.JavaServer.lookup",
+        "homeassistant.components.minecraft_server.api.MinecraftServer.__init__",
         side_effect=[
-            ValueError,
-            JavaServer(host=TEST_HOST, port=TEST_PORT),
-            JavaServer(host=TEST_HOST, port=TEST_PORT),
+            MinecraftServerAddressError,  # async_migrate_entry
+            None,  # async_migrate_entry
+            None,  # async_setup_entry
         ],
+        return_value=None,
     ), patch(
-        "mcstatus.server.JavaServer.async_status",
-        return_value=TEST_JAVA_STATUS_RESPONSE,
+        "homeassistant.components.minecraft_server.api.MinecraftServer.async_get_data",
+        return_value=TEST_JAVA_DATA,
     ):
         assert await hass.config_entries.async_setup(config_entry_id)
         await hass.async_block_till_done()
@@ -176,14 +178,15 @@ async def test_entry_migration_host_only(hass: HomeAssistant) -> None:
 
     # Trigger migration.
     with patch(
-        "mcstatus.server.JavaServer.lookup",
+        "homeassistant.components.minecraft_server.api.MinecraftServer.__init__",
         side_effect=[
-            JavaServer(host=TEST_HOST, port=TEST_PORT),
-            JavaServer(host=TEST_HOST, port=TEST_PORT),
+            None,  # async_migrate_entry
+            None,  # async_setup_entry
         ],
+        return_value=None,
     ), patch(
-        "mcstatus.server.JavaServer.async_status",
-        return_value=TEST_JAVA_STATUS_RESPONSE,
+        "homeassistant.components.minecraft_server.api.MinecraftServer.async_get_data",
+        return_value=TEST_JAVA_DATA,
     ):
         assert await hass.config_entries.async_setup(config_entry_id)
         await hass.async_block_till_done()
@@ -208,11 +211,12 @@ async def test_entry_migration_v3_failure(hass: HomeAssistant) -> None:
 
     # Trigger migration.
     with patch(
-        "mcstatus.server.JavaServer.lookup",
+        "homeassistant.components.minecraft_server.api.MinecraftServer.__init__",
         side_effect=[
-            ValueError,
-            ValueError,
+            MinecraftServerAddressError,  # async_migrate_entry
+            MinecraftServerAddressError,  # async_migrate_entry
         ],
+        return_value=None,
     ):
         assert not await hass.config_entries.async_setup(config_entry_id)
         await hass.async_block_till_done()

--- a/tests/components/minecraft_server/test_init.py
+++ b/tests/components/minecraft_server/test_init.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 from mcstatus import JavaServer
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.minecraft_server.api import MinecraftServerType
 from homeassistant.components.minecraft_server.const import DEFAULT_NAME, DOMAIN
-from homeassistant.components.minecraft_server.coordinator import MinecraftServerType
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import CONF_ADDRESS, CONF_HOST, CONF_NAME, CONF_PORT, CONF_TYPE
 from homeassistant.core import HomeAssistant


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for Minecraft Server Bedrock Edition (MCPE: Pocket Edition, MCEE: Education Edition).
- Add new config entry data `TYPE` with default fallback to Java Edition in case of old config entries
- Simplify coordinator by introduction of `MinecraftServer` within `api.py`, which centrally handles both Bedrock and Java Edition servers (used by coordinator, config flow and entry migration)
- Improve device info to easily distinguish between Java and Bedrock Edition
- Add new sensors of Bedrock Edition (edition, game mode and map name) 
- Catch timeout error

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #101545
- This PR is related to issue: n.a.
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29050

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
   - Only `config_flow` and migration part of `__init__`

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
