### PR TITLE
Add weather forecast service to get highest/lowest value of an attribute

### DIFF
--- a/homeassistant/components/weather/services.yaml
+++ b/homeassistant/components/weather/services.yaml
@@ -16,3 +16,39 @@ get_forecast:
             - "hourly"
             - "twice_daily"
           translation_key: forecast_type
+
+get_forecast_value:
+  target:
+    entity:
+      domain: weather
+      supported_features:
+        - weather.WeatherEntityFeature.FORECAST_HOURLY
+  fields:
+    attribute:
+      required: true
+      selector:
+        select:
+          options:
+            - "temperature"
+            - "templow"
+            - "precipitation"
+            - "precipitation_probability"
+            - "wind_speed"
+            - "humidity"
+          translation_key: forecast_value_attribute
+    limit_hours:
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 216
+          mode: slider
+          unit_of_measurement: hours
+    min_max:
+      required: false
+      selector:
+        select:
+          options:
+            - "min"
+            - "max"
+          translation_key: forecast_value_min_max

--- a/homeassistant/components/weather/strings.json
+++ b/homeassistant/components/weather/strings.json
@@ -85,6 +85,22 @@
         "hourly": "Hourly",
         "twice_daily": "Twice daily"
       }
+    },
+    "forecast_value_attribute": {
+      "options": {
+        "temperature": "Temperature High",
+        "templow": "Temperature Low",
+        "precipitation": "Precipitation",
+        "precipitation_probability": "Precipitation probability",
+        "wind_speed": "Wind speed",
+        "humidity": "Humidity"
+      }
+    },
+    "forecast_value_min_max": {
+      "options": {
+        "min": "Min",
+        "max": "Max"
+      }
     }
   },
   "services": {
@@ -95,6 +111,24 @@
         "type": {
           "name": "Forecast type",
           "description": "Forecast type: daily, hourly or twice daily."
+        }
+      }
+    },
+    "get_forecast_value": {
+      "name": "Get forecast value",
+      "description": "Get the min or max value of a weather forecast field within the next hours.",
+      "fields": {
+        "attribute": {
+          "name": "Weather attribute",
+          "description": "Weather attribute: temperature, humidity ..."
+        },
+        "limit_hours": {
+          "name": "Next hours",
+          "description": "Next hours: time range between 1-216 hours. Leave blank to not filter by time."
+        },
+        "min_max": {
+          "name": "Min or max value",
+          "description": "Min or max value: highest or lowest seen value within the next hours."
         }
       }
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added weather forecast service to get the highest/lowest value of an attribute within the next hours.
Examples:
- Get the highest temperature forecasted in the next 24h
- Get the lowest wind speed forecasted in the next 78h

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
