### PR TITLE
Add weather forecast service to get a single attribute within a time limit

### DIFF
--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -1245,7 +1245,7 @@ async def async_get_forecast_attribute_service(
         # Cut list length according to forecast_limit
         converted_forecast_list = converted_forecast_list[:forecast_limit]
 
-    if forecast_attribute not in converted_forecast_list[0]:
+    if converted_forecast_list and forecast_attribute not in converted_forecast_list[0]:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="invalid_attribute",

--- a/homeassistant/components/weather/icons.json
+++ b/homeassistant/components/weather/icons.json
@@ -22,6 +22,7 @@
   },
   "services": {
     "get_forecast": "mdi:weather-cloudy-clock",
-    "get_forecasts": "mdi:weather-cloudy-clock"
+    "get_forecasts": "mdi:weather-cloudy-clock",
+    "get_forecast_attribute": "mdi:weather-cloudy-clock"
   }
 }

--- a/homeassistant/components/weather/services.yaml
+++ b/homeassistant/components/weather/services.yaml
@@ -34,3 +34,49 @@ get_forecasts:
             - "hourly"
             - "twice_daily"
           translation_key: forecast_type
+get_forecast_attr:
+  target:
+    entity:
+      domain: weather
+      supported_features:
+        - weather.WeatherEntityFeature.FORECAST_HOURLY
+        - weather.WeatherEntityFeature.FORECAST_TWICE_DAILY
+        - weather.WeatherEntityFeature.FORECAST_DAILY
+  fields:
+    type:
+      required: true
+      selector:
+        select:
+          options:
+            - "daily"
+            - "hourly"
+            - "twice_daily"
+          translation_key: forecast_type
+    attribute:
+      required: true
+      example: temperature
+      selector:
+        select:
+          options:
+            - "condition"
+            - "humidity"
+            - "precipitation"
+            - "precipitation_probability"
+            - "pressure"
+            - "apparent_temperature"
+            - "temperature"
+            - "templow"
+            - "wind_bearing"
+            - "wind_gust_speed"
+            - "wind_speed"
+            - "dew_point"
+            - "cloud_coverage"
+            - "uv_index"
+          translation_key: forecast_attr_attribute
+    limit:
+      required: false
+      example: 10
+      selector:
+        number:
+          min: 1
+          mode: box

--- a/homeassistant/components/weather/services.yaml
+++ b/homeassistant/components/weather/services.yaml
@@ -34,7 +34,7 @@ get_forecasts:
             - "hourly"
             - "twice_daily"
           translation_key: forecast_type
-get_forecast_attr:
+get_forecast_attribute:
   target:
     entity:
       domain: weather

--- a/homeassistant/components/weather/strings.json
+++ b/homeassistant/components/weather/strings.json
@@ -85,6 +85,24 @@
         "hourly": "Hourly",
         "twice_daily": "Twice daily"
       }
+    },
+    "forecast_attr_attribute": {
+      "options": {
+        "condition": "Condition",
+        "humidity": "Humidity",
+        "precipitation": "Precipitation",
+        "precipitation_probability": "Precipitation probability",
+        "pressure": "Pressure",
+        "apparent_temperature": "Apparent temperature",
+        "temperature": "Temperature high",
+        "templow": "Temperature low",
+        "wind_bearing": "Wind bearing",
+        "wind_gust_speed": "Wind gust speed",
+        "wind_speed": "Wind speed",
+        "dew_point": "Dew point",
+        "cloud_coverage": "Cloud coverage",
+        "uv_index": "UV index"
+      }
     }
   },
   "services": {
@@ -105,6 +123,24 @@
         "type": {
           "name": "[%key:component::weather::services::get_forecasts::fields::type::name%]",
           "description": "[%key:component::weather::services::get_forecasts::fields::type::description%]"
+        }
+      }
+    },
+    "get_forecast_attr": {
+      "name": "Get forecast attribute values",
+      "description": "Get a single attribute within a time limit from the weather forecast.",
+      "fields": {
+        "type": {
+          "name": "[%key:component::weather::services::get_forecasts::fields::type::name%]",
+          "description": "[%key:component::weather::services::get_forecasts::fields::type::description%]"
+        },
+        "attribute": {
+          "name": "Weather attribute",
+          "description": "Weather attribute: temperature, humidity ..."
+        },
+        "limit": {
+          "name": "Limit values",
+          "description": "Limit number of values in output. Leave blank to get all available values."
         }
       }
     }

--- a/homeassistant/components/weather/strings.json
+++ b/homeassistant/components/weather/strings.json
@@ -89,19 +89,19 @@
     "forecast_attr_attribute": {
       "options": {
         "condition": "Condition",
-        "humidity": "Humidity",
+        "humidity": "[%key:component::weather::entity_component::_::state_attributes::humidity::name%]",
         "precipitation": "Precipitation",
         "precipitation_probability": "Precipitation probability",
-        "pressure": "Pressure",
-        "apparent_temperature": "Apparent temperature",
-        "temperature": "Temperature high",
+        "pressure": "[%key:component::weather::entity_component::_::state_attributes::pressure::name%]",
+        "apparent_temperature": "[%key:component::weather::entity_component::_::state_attributes::apparent_temperature::name%]",
+        "temperature": "[%key:component::weather::entity_component::_::state_attributes::temperature::name%]",
         "templow": "Temperature low",
-        "wind_bearing": "Wind bearing",
-        "wind_gust_speed": "Wind gust speed",
-        "wind_speed": "Wind speed",
-        "dew_point": "Dew point",
-        "cloud_coverage": "Cloud coverage",
-        "uv_index": "UV index"
+        "wind_bearing": "[%key:component::weather::entity_component::_::state_attributes::wind_bearing::name%]",
+        "wind_gust_speed": "[%key:component::weather::entity_component::_::state_attributes::wind_gust_speed::name%]",
+        "wind_speed": "[%key:component::weather::entity_component::_::state_attributes::wind_speed::name%]",
+        "dew_point": "[%key:component::weather::entity_component::_::state_attributes::dew_point::name%]",
+        "cloud_coverage": "[%key:component::weather::entity_component::_::state_attributes::cloud_coverage::name%]",
+        "uv_index": "[%key:component::weather::entity_component::_::state_attributes::uv_index::name%]"
       }
     }
   },
@@ -126,9 +126,9 @@
         }
       }
     },
-    "get_forecast_attr": {
+    "get_forecast_attribute": {
       "name": "Get forecast attribute values",
-      "description": "Get a single attribute within a time limit from the weather forecast.",
+      "description": "Get a single attribute from the weather forecast and specify the number of records to return.",
       "fields": {
         "type": {
           "name": "[%key:component::weather::services::get_forecasts::fields::type::name%]",
@@ -164,6 +164,11 @@
           }
         }
       }
+    }
+  },
+  "exceptions": {
+    "invalid_attribute": {
+      "message": "Forecast attribute {forecast_attribute} does not exist in forecast"
     }
   }
 }

--- a/tests/components/weather/__init__.py
+++ b/tests/components/weather/__init__.py
@@ -32,6 +32,33 @@ from tests.common import (
 )
 from tests.testing_config.custom_components.test import weather as WeatherPlatform
 
+DAILY_FORECAST_LIST = [
+    Forecast(datetime="2024-03-01T12:00:00.578422", native_temperature=10.0),
+    Forecast(datetime="2024-03-02T12:00:00.578422", native_temperature=11.0),
+    Forecast(datetime="2024-03-03T12:00:00.578422", native_temperature=12.0),
+    Forecast(datetime="2024-03-04T12:00:00.578422", native_temperature=13.0),
+]
+HOURLY_FORECAST_LIST = [
+    Forecast(datetime="2024-03-01T12:00:00.578422", native_temperature=10.0),
+    Forecast(datetime="2024-03-01T13:00:00.578422", native_temperature=11.0),
+    Forecast(datetime="2024-03-01T14:00:00.578422", native_temperature=12.0),
+    Forecast(datetime="2024-03-01T15:00:00.578422", native_temperature=13.0),
+]
+TWICE_DAILY_FORECAST_LIST = [
+    Forecast(
+        datetime="2024-03-01T11:00:00.578422", native_temperature=10.0, is_daytime=True
+    ),
+    Forecast(
+        datetime="2024-03-01T23:00:00.578422", native_temperature=11.0, is_daytime=False
+    ),
+    Forecast(
+        datetime="2024-03-02T11:00:00.578422", native_temperature=12.0, is_daytime=True
+    ),
+    Forecast(
+        datetime="2024-03-02T23:00:00.578422", native_temperature=13.0, is_daytime=False
+    ),
+]
+
 
 class MockWeatherTest(WeatherPlatform.MockWeather):
     """Mock weather class."""

--- a/tests/components/weather/test_init.py
+++ b/tests/components/weather/test_init.py
@@ -35,7 +35,7 @@ from homeassistant.components.weather import (
     DOMAIN,
     LEGACY_SERVICE_GET_FORECAST,
     ROUNDING_PRECISION,
-    SERVICE_GET_FORECAST_ATTR,
+    SERVICE_GET_FORECAST_ATTRIBUTE,
     SERVICE_GET_FORECASTS,
     Forecast,
     WeatherEntity,
@@ -1358,7 +1358,7 @@ async def test_issue_deprecated_service_weather_get_forecast(
         ),
     ],
 )
-async def test_get_forecast_attr(
+async def test_get_forecast_attribute(
     hass: HomeAssistant,
     config_flow_fixture: None,
     forecast_type: str,
@@ -1388,7 +1388,7 @@ async def test_get_forecast_attr(
 
     response = await hass.services.async_call(
         DOMAIN,
-        SERVICE_GET_FORECAST_ATTR,
+        SERVICE_GET_FORECAST_ATTRIBUTE,
         {
             "entity_id": entity0.entity_id,
             "type": forecast_type,
@@ -1414,7 +1414,7 @@ async def test_get_forecast_attr(
         ),
     ],
 )
-async def test_get_forecast_attr_limit(
+async def test_get_forecast_attribute_limit(
     hass: HomeAssistant,
     config_flow_fixture: None,
     forecast_type: str,
@@ -1445,7 +1445,7 @@ async def test_get_forecast_attr_limit(
 
     response = await hass.services.async_call(
         DOMAIN,
-        SERVICE_GET_FORECAST_ATTR,
+        SERVICE_GET_FORECAST_ATTRIBUTE,
         {
             "entity_id": entity0.entity_id,
             "type": forecast_type,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added weather forecast service to get a single attribute within a time limit.
Examples:
- Get the temperature forecasts in the next 24h
- Get the wind speed forecasts in the next 3d

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/32012

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
