### PR TITLE
Update fitbit client to use asyncio

### DIFF
--- a/homeassistant/components/fitbit/api.py
+++ b/homeassistant/components/fitbit/api.py
@@ -1,7 +1,7 @@
 """API for fitbit bound to Home Assistant OAuth."""
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from fitbit import Fitbit
 
@@ -34,10 +34,12 @@ class FitbitApi:
         """Property to expose the underlying client library."""
         return self._client
 
-    def get_user_profile(self) -> FitbitProfile:
+    async def async_get_user_profile(self) -> FitbitProfile:
         """Return the user profile from the API."""
         if self._profile is None:
-            response: dict[str, Any] = self._client.user_profile_get()
+            response: dict[str, Any] = await self._hass.async_add_executor_job(
+                self._client.user_profile_get
+            )
             _LOGGER.debug("user_profile_get=%s", response)
             profile = response["user"]
             self._profile = FitbitProfile(
@@ -47,7 +49,7 @@ class FitbitApi:
             )
         return self._profile
 
-    def get_unit_system(self) -> FitbitUnitSystem:
+    async def async_get_unit_system(self) -> FitbitUnitSystem:
         """Get the unit system to use when fetching timeseries.
 
         This is used in a couple ways. The first is to determine the request
@@ -62,16 +64,18 @@ class FitbitApi:
             return self._unit_system
         # Use units consistent with the account user profile or fallback to the
         # home assistant unit settings.
-        profile = self.get_user_profile()
+        profile = await self.async_get_user_profile()
         if profile.locale == FitbitUnitSystem.EN_GB:
             return FitbitUnitSystem.EN_GB
         if self._hass.config.units is METRIC_SYSTEM:
             return FitbitUnitSystem.METRIC
         return FitbitUnitSystem.EN_US
 
-    def get_devices(self) -> list[FitbitDevice]:
+    async def async_get_devices(self) -> list[FitbitDevice]:
         """Return available devices."""
-        devices: list[dict[str, str]] = self._client.get_devices()
+        devices: list[dict[str, str]] = await self._hass.async_add_executor_job(
+            self._client.get_devices
+        )
         _LOGGER.debug("get_devices=%s", devices)
         return [
             FitbitDevice(
@@ -84,13 +88,18 @@ class FitbitApi:
             for device in devices
         ]
 
-    def get_latest_time_series(self, resource_type: str) -> dict[str, Any]:
+    async def async_get_latest_time_series(self, resource_type: str) -> dict[str, Any]:
         """Return the most recent value from the time series for the specified resource type."""
 
         # Set request header based on the configured unit system
-        self._client.system = self.get_unit_system()
+        self._client.system = await self.async_get_unit_system()
 
-        response: dict[str, Any] = self._client.time_series(resource_type, period="7d")
+        def _time_series() -> dict[str, Any]:
+            return cast(
+                dict[str, Any], self._client.time_series(resource_type, period="7d")
+            )
+
+        response: dict[str, Any] = await self._hass.async_add_executor_job(_time_series)
         _LOGGER.debug("time_series(%s)=%s", resource_type, response)
         key = resource_type.replace("/", "-")
         dated_results: list[dict[str, Any]] = response[key]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Update fitbit client to use asyncio, pulled out from a larger set of changes to modernize the fitbit integration.

This moves the client to asyncio in preparation for making the client work more like other OAuth clients that use asyncio and support token refresh so we can use the common OAuth implementations.


This is pulled out of a larger overhaul to modernize the fitbit integration and make it configurable from the UI and following current design standards, similar to previous approach on Google calendar :
- [X] Add test harness #100765
- [X] #100766
- [X] Increase test coverage #100776
- [X] Simplify response parsing and entity descriptions #100782
- [X] Refactor unit system #100825
- [X] Ascynio client library #100933
- [X] Config flow and UI based configuration, application credentials, import of existing credentials #100897
- [x] Reauth support in config flow #101178
- [X] Additional oauth error handling with improved error messages in the UI #101304
- [ ] Split battery device level into another entity
- [X] Modernize entities to current design standards (battery, time, etc) #101179

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
