### PR TITLE
Move poolsense coordinator to its own file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -978,6 +978,7 @@ omit =
     homeassistant/components/point/sensor.py
     homeassistant/components/poolsense/__init__.py
     homeassistant/components/poolsense/binary_sensor.py
+    homeassistant/components/poolsense/coordinator.py
     homeassistant/components/poolsense/sensor.py
     homeassistant/components/powerwall/__init__.py
     homeassistant/components/progettihwsw/__init__.py

--- a/homeassistant/components/poolsense/__init__.py
+++ b/homeassistant/components/poolsense/__init__.py
@@ -1,23 +1,17 @@
 """The PoolSense integration."""
-import asyncio
-from datetime import timedelta
 import logging
 
 from poolsense import PoolSense
-from poolsense.exceptions import PoolSenseError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.entity import EntityDescription
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-    UpdateFailed,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import ATTRIBUTION, DOMAIN
+from .coordinator import PoolSenseDataUpdateCoordinator
 
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
@@ -70,31 +64,3 @@ class PoolSenseEntity(CoordinatorEntity):
         self.entity_description = description
         self._attr_name = f"PoolSense {description.name}"
         self._attr_unique_id = f"{email}-{description.key}"
-
-
-class PoolSenseDataUpdateCoordinator(DataUpdateCoordinator):
-    """Define an object to hold PoolSense data."""
-
-    def __init__(self, hass, entry):
-        """Initialize."""
-        self.poolsense = PoolSense(
-            aiohttp_client.async_get_clientsession(hass),
-            entry.data[CONF_EMAIL],
-            entry.data[CONF_PASSWORD],
-        )
-        self.hass = hass
-        self.entry = entry
-
-        super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=timedelta(hours=1))
-
-    async def _async_update_data(self):
-        """Update data via library."""
-        data = {}
-        async with asyncio.timeout(10):
-            try:
-                data = await self.poolsense.get_poolsense_data()
-            except PoolSenseError as error:
-                _LOGGER.error("PoolSense query did not complete")
-                raise UpdateFailed(error) from error
-
-        return data

--- a/homeassistant/components/poolsense/coordinator.py
+++ b/homeassistant/components/poolsense/coordinator.py
@@ -1,0 +1,43 @@
+"""DataUpdateCoordinator for poolsense integration."""
+import asyncio
+from datetime import timedelta
+import logging
+
+from poolsense import PoolSense
+from poolsense.exceptions import PoolSenseError
+
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.helpers import aiohttp_client
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class PoolSenseDataUpdateCoordinator(DataUpdateCoordinator):
+    """Define an object to hold PoolSense data."""
+
+    def __init__(self, hass, entry):
+        """Initialize."""
+        self.poolsense = PoolSense(
+            aiohttp_client.async_get_clientsession(hass),
+            entry.data[CONF_EMAIL],
+            entry.data[CONF_PASSWORD],
+        )
+        self.hass = hass
+        self.entry = entry
+
+        super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=timedelta(hours=1))
+
+    async def _async_update_data(self):
+        """Update data via library."""
+        data = {}
+        async with asyncio.timeout(10):
+            try:
+                data = await self.poolsense.get_poolsense_data()
+            except PoolSenseError as error:
+                _LOGGER.error("PoolSense query did not complete")
+                raise UpdateFailed(error) from error
+
+        return data


### PR DESCRIPTION
## Proposed change
Move the data update coordinator to its own file to follow the recommended way, introduced in https://github.com/home-assistant/developers.home-assistant/pull/1895.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
