### PR TITLE
Send Wyoming Detect message during wake word detection

### DIFF
--- a/homeassistant/components/wyoming/manifest.json
+++ b/homeassistant/components/wyoming/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/wyoming",
   "iot_class": "local_push",
-  "requirements": ["wyoming==1.1.0"]
+  "requirements": ["wyoming==1.2.0"]
 }

--- a/homeassistant/components/wyoming/wake_word.py
+++ b/homeassistant/components/wyoming/wake_word.py
@@ -112,6 +112,8 @@ class WyomingWakeWordProvider(wake_word.WakeWordDetectionEntity):
                                         wake_word_id,
                                         detection.name,
                                     )
+                                    wake_task = asyncio.create_task(client.read_event())
+                                    pending.add(wake_task)
                                     continue
 
                                 # Retrieve queued audio

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2718,7 +2718,7 @@ wled==0.16.0
 wolf-smartset==0.1.11
 
 # homeassistant.components.wyoming
-wyoming==1.1.0
+wyoming==1.2.0
 
 # homeassistant.components.xbox
 xbox-webapi==2.0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2021,7 +2021,7 @@ wled==0.16.0
 wolf-smartset==0.1.11
 
 # homeassistant.components.wyoming
-wyoming==1.1.0
+wyoming==1.2.0
 
 # homeassistant.components.xbox
 xbox-webapi==2.0.11

--- a/tests/components/wyoming/__init__.py
+++ b/tests/components/wyoming/__init__.py
@@ -92,7 +92,11 @@ class MockAsyncTcpClient:
     async def read_event(self):
         """Receive."""
         await asyncio.sleep(0)  # force context switch
-        return self.responses.pop(0)
+
+        if self.responses:
+            return self.responses.pop(0)
+
+        return None
 
     async def __aenter__(self):
         """Enter."""

--- a/tests/components/wyoming/test_wake_word.py
+++ b/tests/components/wyoming/test_wake_word.py
@@ -106,3 +106,54 @@ async def test_streaming_audio_oserror(
         result = await entity.async_process_audio_stream(audio_stream(), None)
 
     assert result is None
+
+
+async def test_detect_message_with_wake_word(
+    hass: HomeAssistant, init_wyoming_wake_word
+) -> None:
+    """Test that specifying a wake word id produces a Detect message with that id."""
+    entity = wake_word.async_get_wake_word_detection_entity(
+        hass, "wake_word.test_wake_word"
+    )
+    assert entity is not None
+
+    async def audio_stream():
+        yield b"chunk1", 1000
+
+    mock_client = MockAsyncTcpClient(
+        [Detection(name="my-wake-word", timestamp=1000).event()]
+    )
+
+    with patch(
+        "homeassistant.components.wyoming.wake_word.AsyncTcpClient",
+        mock_client,
+    ):
+        result = await entity.async_process_audio_stream(audio_stream(), "my-wake-word")
+
+    assert isinstance(result, wake_word.DetectionResult)
+    assert result.wake_word_id == "my-wake-word"
+
+
+async def test_detect_message_with_wrong_wake_word(
+    hass: HomeAssistant, init_wyoming_wake_word
+) -> None:
+    """Test that specifying a wake word id filters invalid detections."""
+    entity = wake_word.async_get_wake_word_detection_entity(
+        hass, "wake_word.test_wake_word"
+    )
+    assert entity is not None
+
+    async def audio_stream():
+        yield b"chunk1", 1000
+
+    mock_client = MockAsyncTcpClient(
+        [Detection(name="not-my-wake-word", timestamp=1000).event()]
+    )
+
+    with patch(
+        "homeassistant.components.wyoming.wake_word.AsyncTcpClient",
+        mock_client,
+    ):
+        result = await entity.async_process_audio_stream(audio_stream(), "my-wake-word")
+
+    assert result is None

--- a/tests/components/wyoming/test_wake_word.py
+++ b/tests/components/wyoming/test_wake_word.py
@@ -147,7 +147,7 @@ async def test_detect_message_with_wrong_wake_word(
         yield b"chunk1", 1000
 
     mock_client = MockAsyncTcpClient(
-        [Detection(name="not-my-wake-word", timestamp=1000).event()]
+        [Detection(name="not-my-wake-word", timestamp=1000).event()],
     )
 
     with patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump to Wyoming 1.2.0 and send `Detect` message during wake word detection.
This allows the desired wake word to be selected dynamically (from a pipeline).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
