### PR TITLE
Add an XY light to Demo

### DIFF
--- a/homeassistant/components/demo/light.py
+++ b/homeassistant/components/demo/light.py
@@ -12,6 +12,7 @@ from homeassistant.components.light import (
     ATTR_RGBW_COLOR,
     ATTR_RGBWW_COLOR,
     ATTR_WHITE,
+    ATTR_XY_COLOR,
     ColorMode,
     LightEntity,
     LightEntityFeature,
@@ -88,6 +89,14 @@ async def async_setup_entry(
                 supported_color_modes=SUPPORT_DEMO_HS_WHITE,
                 unique_id="light_6",
             ),
+            DemoLight(
+                available=True,
+                device_name="Lamp XY Lights",
+                xy_color=(0.73, 0.22),
+                state=True,
+                supported_color_modes={ColorMode.XY},
+                unique_id="light_7",
+            ),
         ]
     )
 
@@ -112,6 +121,7 @@ class DemoLight(LightEntity):
         hs_color: tuple[int, int] | None = None,
         rgbw_color: tuple[int, int, int, int] | None = None,
         rgbww_color: tuple[int, int, int, int, int] | None = None,
+        xy_color: tuple[float, float] | None = None,
         supported_color_modes: set[ColorMode] | None = None,
     ) -> None:
         """Initialize the light."""
@@ -123,6 +133,7 @@ class DemoLight(LightEntity):
         self._hs_color = hs_color
         self._rgbw_color = rgbw_color
         self._rgbww_color = rgbww_color
+        self._xy_color = xy_color
         self._state = state
         self._unique_id = unique_id
         if hs_color:
@@ -131,6 +142,8 @@ class DemoLight(LightEntity):
             self._color_mode = ColorMode.RGBW
         elif rgbww_color:
             self._color_mode = ColorMode.RGBWW
+        elif xy_color:
+            self._color_mode = ColorMode.XY
         else:
             self._color_mode = ColorMode.COLOR_TEMP
         if not supported_color_modes:
@@ -184,6 +197,11 @@ class DemoLight(LightEntity):
         return self._rgbww_color
 
     @property
+    def xy_color(self) -> tuple[float, float] | None:
+        """Return the xy color value."""
+        return self._xy_color
+
+    @property
     def color_temp(self) -> int:
         """Return the CT color temperature."""
         return self._ct
@@ -233,6 +251,10 @@ class DemoLight(LightEntity):
         if ATTR_RGBWW_COLOR in kwargs:
             self._color_mode = ColorMode.RGBWW
             self._rgbww_color = kwargs[ATTR_RGBWW_COLOR]
+
+        if ATTR_XY_COLOR in kwargs:
+            self._color_mode = ColorMode.XY
+            self._xy_color = kwargs[ATTR_XY_COLOR]
 
         if ATTR_WHITE in kwargs:
             self._color_mode = ColorMode.WHITE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

When developing some frontend UI, didn't have any XY-mode lights to test. Create a simple one for demo. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
