### PR TITLE
Implement Airzone Cloud Group climate support

### DIFF
--- a/homeassistant/components/airzone_cloud/entity.py
+++ b/homeassistant/components/airzone_cloud/entity.py
@@ -9,6 +9,7 @@ from aioairzone_cloud.const import (
     AZD_AIDOOS,
     AZD_AVAILABLE,
     AZD_FIRMWARE,
+    AZD_GROUPS,
     AZD_NAME,
     AZD_SYSTEM_ID,
     AZD_SYSTEMS,
@@ -80,6 +81,48 @@ class AirzoneAidooEntity(AirzoneEntity):
         try:
             await self.coordinator.airzone.api_set_aidoo_id_params(
                 self.aidoo_id, params
+            )
+        except AirzoneCloudError as error:
+            raise HomeAssistantError(
+                f"Failed to set {self.name} params: {error}"
+            ) from error
+
+        self.coordinator.async_set_updated_data(self.coordinator.airzone.data())
+
+
+class AirzoneGroupEntity(AirzoneEntity):
+    """Define an Airzone Cloud Group entity."""
+
+    def __init__(
+        self,
+        coordinator: AirzoneUpdateCoordinator,
+        group_id: str,
+        group_data: dict[str, Any],
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+
+        self.group_id = group_id
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, group_id)},
+            manufacturer=MANUFACTURER,
+            name=group_data[AZD_NAME],
+        )
+
+    def get_airzone_value(self, key: str) -> Any:
+        """Return Group value by key."""
+        value = None
+        if group := self.coordinator.data[AZD_GROUPS].get(self.group_id):
+            value = group.get(key)
+        return value
+
+    async def _async_update_params(self, params: dict[str, Any]) -> None:
+        """Send Group parameters to Cloud API."""
+        _LOGGER.debug("group=%s: update_params=%s", self.name, params)
+        try:
+            await self.coordinator.airzone.api_set_group_id_params(
+                self.group_id, params
             )
         except AirzoneCloudError as error:
             raise HomeAssistantError(


### PR DESCRIPTION
## Proposed change
Implement climate support for Airzone Cloud Groups.
Groups are defined in the Airzone Cloud app and allow controlling multiple devices as a single entity. Group entities allow reducing the number of API calls needed for making changes to multiple devices at the same time.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
