### PR TITLE
Bump pyOverkiz to  3.11 and migrate unique ids for select entries

### DIFF
--- a/homeassistant/components/overkiz/__init__.py
+++ b/homeassistant/components/overkiz/__init__.py
@@ -152,7 +152,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def _async_migrate_entries(
     hass: HomeAssistant, config_entry: ConfigEntry
 ) -> bool:
-    """Migrate old entry."""
+    """Migrate old entries to new unique IDs."""
     entity_registry = er.async_get(hass)
 
     @callback
@@ -174,10 +174,12 @@ async def _async_migrate_entries(
                 entry.domain, entry.platform, new_unique_id
             ):
                 LOGGER.debug(
-                    "Cannot migrate to unique_id '%s', already exists for '%s'",
+                    "Cannot migrate to unique_id '%s', already exists for '%s'. Entity will be removed",
                     new_unique_id,
                     existing_entity_id,
                 )
+                entity_registry.async_remove(existing_entity_id)
+
                 return None
 
             return {

--- a/homeassistant/components/overkiz/__init__.py
+++ b/homeassistant/components/overkiz/__init__.py
@@ -157,6 +157,8 @@ async def _async_migrate_entries(
 
     @callback
     def update_unique_id(entry: er.RegistryEntry) -> dict[str, str] | None:
+        # Python 3.11 treats (str, Enum) and StrEnum in a different way
+        # Since pyOverkiz switched to StrEnum, we need to rewrite the unique ids once to the new style
         if (key := entry.unique_id.split("-")[-1]).startswith("OverkizState"):
             state = key.split(".")[1]
             new_unique_id = entry.unique_id.replace(key, OverkizState[state])

--- a/homeassistant/components/overkiz/__init__.py
+++ b/homeassistant/components/overkiz/__init__.py
@@ -159,6 +159,7 @@ async def _async_migrate_entries(
     def update_unique_id(entry: er.RegistryEntry) -> dict[str, str] | None:
         # Python 3.11 treats (str, Enum) and StrEnum in a different way
         # Since pyOverkiz switched to StrEnum, we need to rewrite the unique ids once to the new style
+        # io://xxxx-xxxx-xxxx/3541212-OverkizState.CORE_DISCRETE_RSSI_LEVEL -> io://xxxx-xxxx-xxxx/3541212-core:DiscreteRSSILevelState
         if (key := entry.unique_id.split("-")[-1]).startswith("OverkizState"):
             state = key.split(".")[1]
             new_unique_id = entry.unique_id.replace(key, OverkizState[state])

--- a/homeassistant/components/overkiz/__init__.py
+++ b/homeassistant/components/overkiz/__init__.py
@@ -178,7 +178,7 @@ async def _async_migrate_entries(
                     new_unique_id,
                     existing_entity_id,
                 )
-                entity_registry.async_remove(existing_entity_id)
+                entity_registry.async_remove(entry.unique_id)
 
                 return None
 

--- a/homeassistant/components/overkiz/__init__.py
+++ b/homeassistant/components/overkiz/__init__.py
@@ -178,7 +178,7 @@ async def _async_migrate_entries(
                     new_unique_id,
                     existing_entity_id,
                 )
-                entity_registry.async_remove(entry.unique_id)
+                entity_registry.async_remove(entry.entity_id)
 
                 return None
 

--- a/homeassistant/components/overkiz/__init__.py
+++ b/homeassistant/components/overkiz/__init__.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from aiohttp import ClientError, ServerDisconnectedError
 from pyoverkiz.client import OverkizClient
 from pyoverkiz.const import SUPPORTED_SERVERS
+from pyoverkiz.enums import OverkizState
 from pyoverkiz.exceptions import (
     BadCredentialsException,
     MaintenanceException,
@@ -17,9 +18,9 @@ from pyoverkiz.models import Device, Scenario
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from .const import (
@@ -54,6 +55,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     client = OverkizClient(
         username=username, password=password, session=session, server=server
     )
+
+    await _async_migrate_entries(hass, entry)
 
     try:
         await client.login()
@@ -144,3 +147,43 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+
+async def _async_migrate_entries(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> bool:
+    """Migrate old entry."""
+    entity_registry = er.async_get(hass)
+
+    @callback
+    def update_unique_id(entry: er.RegistryEntry) -> dict[str, str] | None:
+        if (key := entry.unique_id.split("-")[-1]).startswith("OverkizState"):
+            state = key.split(".")[1]
+            new_unique_id = entry.unique_id.replace(key, OverkizState[state])
+
+            LOGGER.debug(
+                "Migrating entity '%s' unique_id from '%s' to '%s'",
+                entry.entity_id,
+                entry.unique_id,
+                new_unique_id,
+            )
+
+            if existing_entity_id := entity_registry.async_get_entity_id(
+                entry.domain, entry.platform, new_unique_id
+            ):
+                LOGGER.debug(
+                    "Cannot migrate to unique_id '%s', already exists for '%s'",
+                    new_unique_id,
+                    existing_entity_id,
+                )
+                return None
+
+            return {
+                "new_unique_id": new_unique_id,
+            }
+
+        return None
+
+    await er.async_migrate_entries(hass, config_entry.entry_id, update_unique_id)
+
+    return True

--- a/homeassistant/components/overkiz/manifest.json
+++ b/homeassistant/components/overkiz/manifest.json
@@ -13,7 +13,7 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "loggers": ["boto3", "botocore", "pyhumps", "pyoverkiz", "s3transfer"],
-  "requirements": ["pyoverkiz==1.9.0"],
+  "requirements": ["pyoverkiz==1.11.0"],
   "zeroconf": [
     {
       "type": "_kizbox._tcp.local.",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1925,7 +1925,7 @@ pyotgw==2.1.3
 pyotp==2.8.0
 
 # homeassistant.components.overkiz
-pyoverkiz==1.9.0
+pyoverkiz==1.11.0
 
 # homeassistant.components.openweathermap
 pyowm==3.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1450,7 +1450,7 @@ pyotgw==2.1.3
 pyotp==2.8.0
 
 # homeassistant.components.overkiz
-pyoverkiz==1.9.0
+pyoverkiz==1.11.0
 
 # homeassistant.components.openweathermap
 pyowm==3.2.0

--- a/tests/components/overkiz/test_init.py
+++ b/tests/components/overkiz/test_init.py
@@ -1,0 +1,94 @@
+"""Tests for Overkiz integration init."""
+from homeassistant.components.overkiz.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from .test_config_flow import TEST_EMAIL, TEST_GATEWAY_ID, TEST_HUB, TEST_PASSWORD
+
+from tests.common import MockConfigEntry, mock_registry
+
+ENTITY_SENSOR_DISCRETE_RSSI_LEVEL = "sensor.zipscreen_woonkamer_discrete_rssi_level"
+ENTITY_ALARM_CONTROL_PANEL = "alarm_control_panel.alarm"
+ENTITY_SWITCH_GARAGE = "switch.garage"
+ENTITY_SENSOR_TARGET_CLOSURE_STATE = "sensor.zipscreen_woonkamer_target_closure_state"
+ENTITY_SENSOR_TARGET_CLOSURE_STATE_2 = (
+    "sensor.zipscreen_woonkamer_target_closure_state_2"
+)
+
+
+async def test_unique_id_migration(hass: HomeAssistant) -> None:
+    """Test migration of sensor unique IDs."""
+
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_GATEWAY_ID,
+        data={"username": TEST_EMAIL, "password": TEST_PASSWORD, "hub": TEST_HUB},
+    )
+
+    mock_entry.add_to_hass(hass)
+
+    mock_registry(
+        hass,
+        {
+            ENTITY_SENSOR_DISCRETE_RSSI_LEVEL: er.RegistryEntry(
+                entity_id=ENTITY_SENSOR_DISCRETE_RSSI_LEVEL,
+                unique_id="io://1234-5678-1234/3541212-OverkizState.CORE_DISCRETE_RSSI_LEVEL",
+                platform=DOMAIN,
+                config_entry_id=mock_entry.entry_id,
+            ),
+            ENTITY_ALARM_CONTROL_PANEL: er.RegistryEntry(
+                entity_id=ENTITY_ALARM_CONTROL_PANEL,
+                unique_id="internal://1234-5678-1234/alarm/0-UIWidget.TSKALARM_CONTROLLER",
+                platform=DOMAIN,
+                config_entry_id=mock_entry.entry_id,
+            ),
+            ENTITY_SWITCH_GARAGE: er.RegistryEntry(
+                entity_id=ENTITY_SWITCH_GARAGE,
+                unique_id="io://1234-5678-1234/0-UIClass.ON_OFF",
+                platform=DOMAIN,
+                config_entry_id=mock_entry.entry_id,
+            ),
+            ENTITY_SENSOR_TARGET_CLOSURE_STATE: er.RegistryEntry(
+                entity_id=ENTITY_SENSOR_TARGET_CLOSURE_STATE,
+                unique_id="io://xxxx-xxxx-xxxx/3541212-OverkizState.CORE_TARGET_CLOSURE",
+                platform=DOMAIN,
+                config_entry_id=mock_entry.entry_id,
+            ),
+            ENTITY_SENSOR_TARGET_CLOSURE_STATE_2: er.RegistryEntry(
+                entity_id=ENTITY_SENSOR_TARGET_CLOSURE_STATE_2,
+                unique_id="io://xxxx-xxxx-xxxx/3541212-core:TargetClosureState",
+                platform=DOMAIN,
+                config_entry_id=mock_entry.entry_id,
+            ),
+        },
+    )
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    ent_reg = er.async_get(hass)
+
+    # Test entity migrations
+    # OverkizState enum
+    sensor_discrete_rssi_level = ent_reg.async_get(ENTITY_SENSOR_DISCRETE_RSSI_LEVEL)
+    assert (
+        sensor_discrete_rssi_level.unique_id
+        == "io://1234-5678-1234/3541212-core:DiscreteRSSILevelState"
+    )
+
+    # UIWidget enum
+    alarm_control_panel = ent_reg.async_get(ENTITY_ALARM_CONTROL_PANEL)
+    assert (
+        alarm_control_panel.unique_id
+        == "internal://1234-5678-1234/alarm/0-TSKAlarmController"
+    )
+
+    # UIClass enum
+    switch_garage = ent_reg.async_get(ENTITY_SWITCH_GARAGE)
+    assert switch_garage.unique_id == "io://1234-5678-1234/0-OnOff"
+
+    # Test if duplicate entities will be removed
+    duplicate_sensor_target_closure_state = ent_reg.async_get(
+        ENTITY_SENSOR_TARGET_CLOSURE_STATE
+    )
+    assert duplicate_sensor_target_closure_state is None

--- a/tests/components/overkiz/test_init.py
+++ b/tests/components/overkiz/test_init.py
@@ -31,33 +31,38 @@ async def test_unique_id_migration(hass: HomeAssistant) -> None:
     mock_registry(
         hass,
         {
+            # This entity will be migrated to "io://1234-5678-1234/3541212-core:DiscreteRSSILevelState"
             ENTITY_SENSOR_DISCRETE_RSSI_LEVEL: er.RegistryEntry(
                 entity_id=ENTITY_SENSOR_DISCRETE_RSSI_LEVEL,
                 unique_id="io://1234-5678-1234/3541212-OverkizState.CORE_DISCRETE_RSSI_LEVEL",
                 platform=DOMAIN,
                 config_entry_id=mock_entry.entry_id,
             ),
+            # This entity will be migrated to "internal://1234-5678-1234/alarm/0-TSKAlarmController"
             ENTITY_ALARM_CONTROL_PANEL: er.RegistryEntry(
                 entity_id=ENTITY_ALARM_CONTROL_PANEL,
                 unique_id="internal://1234-5678-1234/alarm/0-UIWidget.TSKALARM_CONTROLLER",
                 platform=DOMAIN,
                 config_entry_id=mock_entry.entry_id,
             ),
+            # This entity will be migrated to "io://1234-5678-1234/0-OnOff"
             ENTITY_SWITCH_GARAGE: er.RegistryEntry(
                 entity_id=ENTITY_SWITCH_GARAGE,
                 unique_id="io://1234-5678-1234/0-UIClass.ON_OFF",
                 platform=DOMAIN,
                 config_entry_id=mock_entry.entry_id,
             ),
+            # This entity will be removed since "io://1234-5678-1234/3541212-core:TargetClosureState" already exists
             ENTITY_SENSOR_TARGET_CLOSURE_STATE: er.RegistryEntry(
                 entity_id=ENTITY_SENSOR_TARGET_CLOSURE_STATE,
-                unique_id="io://xxxx-xxxx-xxxx/3541212-OverkizState.CORE_TARGET_CLOSURE",
+                unique_id="io://1234-5678-1234/3541212-OverkizState.CORE_TARGET_CLOSURE",
                 platform=DOMAIN,
                 config_entry_id=mock_entry.entry_id,
             ),
+            # This entity will not be migrated"
             ENTITY_SENSOR_TARGET_CLOSURE_STATE_2: er.RegistryEntry(
                 entity_id=ENTITY_SENSOR_TARGET_CLOSURE_STATE_2,
-                unique_id="io://xxxx-xxxx-xxxx/3541212-core:TargetClosureState",
+                unique_id="io://1234-5678-1234/3541212-core:TargetClosureState",
                 platform=DOMAIN,
                 config_entry_id=mock_entry.entry_id,
             ),

--- a/tests/components/overkiz/test_init.py
+++ b/tests/components/overkiz/test_init.py
@@ -73,27 +73,17 @@ async def test_unique_id_migration(hass: HomeAssistant) -> None:
 
     ent_reg = er.async_get(hass)
 
-    # Test entity migrations
-    # OverkizState enum
-    sensor_discrete_rssi_level = ent_reg.async_get(ENTITY_SENSOR_DISCRETE_RSSI_LEVEL)
-    assert (
-        sensor_discrete_rssi_level.unique_id
-        == "io://1234-5678-1234/3541212-core:DiscreteRSSILevelState"
-    )
+    unique_id_map = {
+        ENTITY_SENSOR_DISCRETE_RSSI_LEVEL: "io://1234-5678-1234/3541212-core:DiscreteRSSILevelState",
+        ENTITY_ALARM_CONTROL_PANEL: "internal://1234-5678-1234/alarm/0-TSKAlarmController",
+        ENTITY_SWITCH_GARAGE: "io://1234-5678-1234/0-OnOff",
+        ENTITY_SENSOR_TARGET_CLOSURE_STATE_2: "io://1234-5678-1234/3541212-core:TargetClosureState",
+    }
 
-    # UIWidget enum
-    alarm_control_panel = ent_reg.async_get(ENTITY_ALARM_CONTROL_PANEL)
-    assert (
-        alarm_control_panel.unique_id
-        == "internal://1234-5678-1234/alarm/0-TSKAlarmController"
-    )
+    # Test if entities will be removed
+    assert set(ent_reg.entities.keys()) == set(unique_id_map)
 
-    # UIClass enum
-    switch_garage = ent_reg.async_get(ENTITY_SWITCH_GARAGE)
-    assert switch_garage.unique_id == "io://1234-5678-1234/0-OnOff"
-
-    # Test if duplicate entities will be removed
-    duplicate_sensor_target_closure_state = ent_reg.async_get(
-        ENTITY_SENSOR_TARGET_CLOSURE_STATE
-    )
-    assert duplicate_sensor_target_closure_state is None
+    # Test if unique ids are migrated
+    for entity_id, unique_id in unique_id_map.items():
+        entry = ent_reg.async_get(entity_id)
+        assert entry.unique_id == unique_id


### PR DESCRIPTION
## Proposed change
This PR is an alternative approach to the fix in https://github.com/home-assistant/core/pull/99765. This PR will update pyOverkiz to the latest version, where `StrEnum` is used instead of `(Str, Enum)`.


### Background
The unique ids were messed up in the Overkiz integration in the last months. We didn't catch a breaking change in Python 3.11 in how (str, Enum) are handled. See https://blog.pecar.me/python-enum for more details.

Entity id history in last HA updates:
\< 2023.3: `unique_id="io://XXXX-XXXX-XXXX/XXXXXXX-core:DiscreteRSSILevelState"`
\> 2023.3 (with Python 3.11): `unique_id="io://XXXX-XXXX-XXXX/XXXXXXX-OverkizState.CORE_DISCRETE_RSSI_LEVEL"`
2023.9.0 (move to StrEnum in pyOverkiz): `unique_id="io://XXXX-XXXX-XXXX/XXXXXXX-core:DiscreteRSSILevelState"`
2023.9.1 (revert pyOverkiz): `unique_id="io://XXXX-XXXX-XXXX/XXXXXXX-OverkizState.CORE_DISCRETE_RSSI_LEVEL"`

So by not catching it, we actually broke the entity registry multiple times for our users. This happens to entities that I am not actively using myself, thus I didn't spot it earlier. Would be good to fix it now once and for all and move back to the original unique id.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
