### PR TITLE
DO NOT MERGE: Add support for extra index url to the pip installer

### DIFF
--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -88,7 +88,9 @@ def pip_kwargs(config_dir: str | None) -> dict[str, Any]:
         "no_cache_dir": is_docker,
         "timeout": PIP_TIMEOUT,
     }
-    if "WHEELS_LINKS" in os.environ:
+    if "EXTRA_INDEX_URL" in os.environ:
+        kwargs["extra_index_url"] = os.environ["EXTRA_INDEX_URL"]
+    elif "WHEELS_LINKS" in os.environ:
         kwargs["find_links"] = os.environ["WHEELS_LINKS"]
     if not (config_dir is None or pkg_util.is_virtual_env()) and not is_docker:
         kwargs["target"] = os.path.join(config_dir, "deps")

--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -70,6 +70,7 @@ def install_package(
     find_links: str | None = None,
     timeout: int | None = None,
     no_cache_dir: bool | None = False,
+    extra_index_url: str | None = None,
 ) -> bool:
     """Install a package on PyPi. Accepts pip compatible package strings.
 
@@ -87,6 +88,8 @@ def install_package(
         args.append("--upgrade")
     if constraints is not None:
         args += ["--constraint", constraints]
+    if extra_index_url is not None:
+        args += ["--extra-index-url", extra_index_url, "--prefer-binary"]
     if find_links is not None:
         args += ["--find-links", find_links, "--prefer-binary"]
     if target:

--- a/tests/util/test_package.py
+++ b/tests/util/test_package.py
@@ -221,6 +221,35 @@ def test_install_find_links(mock_sys, mock_popen, mock_env_copy, mock_venv) -> N
     assert mock_popen.return_value.communicate.call_count == 1
 
 
+def test_install_extra_index_url(
+    mock_sys, mock_popen, mock_env_copy, mock_venv
+) -> None:
+    """Test install with extra_index_url on not installed package."""
+    env = mock_env_copy()
+    link = "https://wheels-repository"
+    assert package.install_package(TEST_NEW_REQ, False, extra_index_url=link)
+    assert mock_popen.call_count == 2
+    assert mock_popen.mock_calls[0] == call(
+        [
+            mock_sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--quiet",
+            TEST_NEW_REQ,
+            "--extra-index-url",
+            link,
+            "--prefer-binary",
+        ],
+        stdin=PIPE,
+        stdout=PIPE,
+        stderr=PIPE,
+        env=env,
+        close_fds=False,
+    )
+    assert mock_popen.return_value.communicate.call_count == 1
+
+
 async def test_async_get_user_site(mock_env_copy) -> None:
     """Test async get user site directory."""
     deps_dir = "/deps_dir"


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

needs https://github.com/home-assistant/docker/pull/297

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
