### PR TITLE
Fix ZHA exception when writing `cie_addr` during configuration

### DIFF
--- a/homeassistant/components/zha/core/cluster_handlers/security.py
+++ b/homeassistant/components/zha/core/cluster_handlers/security.py
@@ -369,12 +369,11 @@ class IASZoneClusterHandler(ClusterHandler):
         ieee = self.cluster.endpoint.device.application.state.node_info.ieee
 
         try:
-            res = await self.write_attributes_safe({"cie_addr": ieee})
+            await self.write_attributes_safe({"cie_addr": ieee})
             self.debug(
-                "wrote cie_addr: %s to '%s' cluster: %s",
+                "wrote cie_addr: %s to '%s' cluster",
                 str(ieee),
                 self._cluster.ep_attribute,
-                res[0],
             )
         except HomeAssistantError as ex:
             self.debug(


### PR DESCRIPTION
## Proposed change
https://github.com/home-assistant/core/pull/98421 migrated ZHA exceptions to throw a `HomeAssistantError` and changed the code for writing the `cie_addr` (during pairing/configuration) to use `write_attributes_safe`.

This method doesn't return anything anymore (no result/`res[0]`). This always causes a `TypeError` to be thrown when the attribute is successfully written. See https://github.com/home-assistant/core/issues/100519 for reference.

To fix this, it should be enough to remove printing the now non-existent result from the debug log message.
The text in the message makes it clear that the write succeeded.
If the write didn't succeed, the lines changed are never reached (since https://github.com/home-assistant/core/pull/98421), as a `HomeAssistantError` is thrown.

--

IMO, this should be cherry-picked into 2023.10.x, as the `TypeError` caused the IasZone cluster handler configuration to be aborted, so a "pro-active IAS enroll response" was never sent (and the status wasn't changed to "CONFIGURED").

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #100519
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
