### PR TITLE
Add tests to Hydrawise

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -541,12 +541,6 @@ omit =
     homeassistant/components/hvv_departures/__init__.py
     homeassistant/components/hvv_departures/binary_sensor.py
     homeassistant/components/hvv_departures/sensor.py
-    homeassistant/components/hydrawise/__init__.py
-    homeassistant/components/hydrawise/binary_sensor.py
-    homeassistant/components/hydrawise/const.py
-    homeassistant/components/hydrawise/coordinator.py
-    homeassistant/components/hydrawise/sensor.py
-    homeassistant/components/hydrawise/switch.py
     homeassistant/components/ialarm/alarm_control_panel.py
     homeassistant/components/iammeter/sensor.py
     homeassistant/components/iaqualink/binary_sensor.py

--- a/homeassistant/components/hydrawise/binary_sensor.py
+++ b/homeassistant/components/hydrawise/binary_sensor.py
@@ -57,7 +57,7 @@ def setup_platform(
 ) -> None:
     """Set up a sensor for a Hydrawise device."""
     # We don't need to trigger import flow from here as it's triggered from `__init__.py`
-    return
+    return  # pragma: no cover
 
 
 async def async_setup_entry(

--- a/homeassistant/components/hydrawise/sensor.py
+++ b/homeassistant/components/hydrawise/sensor.py
@@ -59,7 +59,7 @@ def setup_platform(
 ) -> None:
     """Set up a sensor for a Hydrawise device."""
     # We don't need to trigger import flow from here as it's triggered from `__init__.py`
-    return
+    return  # pragma: no cover
 
 
 async def async_setup_entry(

--- a/homeassistant/components/hydrawise/switch.py
+++ b/homeassistant/components/hydrawise/switch.py
@@ -65,7 +65,7 @@ def setup_platform(
 ) -> None:
     """Set up a sensor for a Hydrawise device."""
     # We don't need to trigger import flow from here as it's triggered from `__init__.py`
-    return
+    return  # pragma: no cover
 
 
 async def async_setup_entry(

--- a/tests/components/hydrawise/conftest.py
+++ b/tests/components/hydrawise/conftest.py
@@ -33,6 +33,9 @@ def mock_pydrawise(
         mock_pydrawise.return_value.current_controller = mock_controller
         mock_pydrawise.return_value.controller_status = {"relays": mock_zones}
         mock_pydrawise.return_value.relays = mock_zones
+        mock_pydrawise.return_value.relays_by_zone_number = {
+            r["relay"]: r for r in mock_zones
+        }
         yield mock_pydrawise.return_value
 
 

--- a/tests/components/hydrawise/test_binary_sensor.py
+++ b/tests/components/hydrawise/test_binary_sensor.py
@@ -1,0 +1,45 @@
+"""Test Hydrawise binary_sensor."""
+
+from datetime import timedelta
+from unittest.mock import Mock
+
+from homeassistant.components.hydrawise.const import SCAN_INTERVAL
+from homeassistant.core import HomeAssistant
+from homeassistant.util.dt import utcnow
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_states(
+    hass: HomeAssistant, mock_added_config_entry: MockConfigEntry
+) -> None:
+    """Test binary_sensor states."""
+    # Make the coordinator refresh data.
+    async_fire_time_changed(hass, utcnow() + SCAN_INTERVAL + timedelta(seconds=30))
+    await hass.async_block_till_done()
+
+    connectivity = hass.states.get("binary_sensor.home_controller_connectivity")
+    assert connectivity is not None
+    assert connectivity.state == "on"
+
+    watering1 = hass.states.get("binary_sensor.zone_one_watering")
+    assert watering1 is not None
+    assert watering1.state == "off"
+
+    watering2 = hass.states.get("binary_sensor.zone_two_watering")
+    assert watering2 is not None
+    assert watering2.state == "on"
+
+
+async def test_update_data_fails(
+    hass: HomeAssistant, mock_added_config_entry: MockConfigEntry, mock_pydrawise: Mock
+) -> None:
+    """Test that no data from the API sets the correct connectivity."""
+    # Make the coordinator refresh data.
+    mock_pydrawise.update_controller_info.return_value = None
+    async_fire_time_changed(hass, utcnow() + SCAN_INTERVAL + timedelta(seconds=30))
+    await hass.async_block_till_done()
+
+    connectivity = hass.states.get("binary_sensor.home_controller_connectivity")
+    assert connectivity is not None
+    assert connectivity.state == "unavailable"

--- a/tests/components/hydrawise/test_binary_sensor.py
+++ b/tests/components/hydrawise/test_binary_sensor.py
@@ -3,9 +3,10 @@
 from datetime import timedelta
 from unittest.mock import Mock
 
+from freezegun.api import FrozenDateTimeFactory
+
 from homeassistant.components.hydrawise.const import SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
-from homeassistant.util.dt import utcnow
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -35,12 +36,16 @@ async def test_states(
 
 
 async def test_update_data_fails(
-    hass: HomeAssistant, mock_added_config_entry: MockConfigEntry, mock_pydrawise: Mock
+    hass: HomeAssistant,
+    mock_added_config_entry: MockConfigEntry,
+    mock_pydrawise: Mock,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test that no data from the API sets the correct connectivity."""
     # Make the coordinator refresh data.
     mock_pydrawise.update_controller_info.return_value = None
-    async_fire_time_changed(hass, utcnow() + SCAN_INTERVAL + timedelta(seconds=30))
+    freezer.tick(SCAN_INTERVAL + timedelta(seconds=30))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     connectivity = hass.states.get("binary_sensor.home_controller_connectivity")

--- a/tests/components/hydrawise/test_binary_sensor.py
+++ b/tests/components/hydrawise/test_binary_sensor.py
@@ -11,11 +11,14 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_states(
-    hass: HomeAssistant, mock_added_config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    mock_added_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test binary_sensor states."""
     # Make the coordinator refresh data.
-    async_fire_time_changed(hass, utcnow() + SCAN_INTERVAL + timedelta(seconds=30))
+    freezer.tick(SCAN_INTERVAL + timedelta(seconds=30))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     connectivity = hass.states.get("binary_sensor.home_controller_connectivity")

--- a/tests/components/hydrawise/test_init.py
+++ b/tests/components/hydrawise/test_init.py
@@ -1,0 +1,57 @@
+"""Tests for the Hydrawise integration."""
+
+from unittest.mock import Mock, patch
+
+from requests.exceptions import HTTPError
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_ACCESS_TOKEN
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+import homeassistant.helpers.issue_registry as ir
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_import_success(hass: HomeAssistant, mock_pydrawise: Mock) -> None:
+    """Test that setup with a YAML config triggers an import and warning."""
+    mock_pydrawise.customer_id = 12345
+    mock_pydrawise.status = "unknown"
+    config = {"hydrawise": {CONF_ACCESS_TOKEN: "_access-token_"}}
+    assert await async_setup_component(hass, "hydrawise", config)
+    await hass.async_block_till_done()
+
+    issue_registry = ir.async_get(hass)
+    issue = issue_registry.async_get_issue(
+        HOMEASSISTANT_DOMAIN, "deprecated_yaml_hydrawise"
+    )
+    assert issue.translation_key == "deprecated_yaml"
+
+
+async def test_connect_retry(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test that a connection error triggers a retry."""
+    with patch("pydrawise.legacy.LegacyHydrawise") as mock_api:
+        mock_api.side_effect = HTTPError
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        mock_api.assert_called_once()
+        assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_no_data(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test that no data from the API triggers a retry."""
+    with patch("pydrawise.legacy.LegacyHydrawise") as mock_api:
+        mock_api.return_value.controller_info = {}
+        mock_api.return_value.controller_status = None
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        mock_api.assert_called_once()
+        assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/hydrawise/test_sensor.py
+++ b/tests/components/hydrawise/test_sensor.py
@@ -2,22 +2,25 @@
 
 from datetime import timedelta
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.hydrawise.const import SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
-from homeassistant.util.dt import utcnow
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 @pytest.mark.freeze_time("2023-10-01 00:00:00+00:00")
 async def test_states(
-    hass: HomeAssistant, mock_added_config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    mock_added_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test sensor states."""
     # Make the coordinator refresh data.
-    async_fire_time_changed(hass, utcnow() + SCAN_INTERVAL + timedelta(seconds=30))
+    freezer.tick(SCAN_INTERVAL + timedelta(seconds=30))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     watering_time1 = hass.states.get("sensor.zone_one_watering_time")
@@ -30,4 +33,4 @@ async def test_states(
 
     next_cycle = hass.states.get("sensor.zone_one_next_cycle")
     assert next_cycle is not None
-    assert next_cycle.state == (utcnow() + timedelta(seconds=330597)).isoformat()
+    assert next_cycle.state == "2023-10-04T19:52:27+00:00"

--- a/tests/components/hydrawise/test_sensor.py
+++ b/tests/components/hydrawise/test_sensor.py
@@ -1,0 +1,33 @@
+"""Test Hydrawise sensor."""
+
+from datetime import timedelta
+
+import pytest
+
+from homeassistant.components.hydrawise.const import SCAN_INTERVAL
+from homeassistant.core import HomeAssistant
+from homeassistant.util.dt import utcnow
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+@pytest.mark.freeze_time("2023-10-01 00:00:00+00:00")
+async def test_states(
+    hass: HomeAssistant, mock_added_config_entry: MockConfigEntry
+) -> None:
+    """Test sensor states."""
+    # Make the coordinator refresh data.
+    async_fire_time_changed(hass, utcnow() + SCAN_INTERVAL + timedelta(seconds=30))
+    await hass.async_block_till_done()
+
+    watering_time1 = hass.states.get("sensor.zone_one_watering_time")
+    assert watering_time1 is not None
+    assert watering_time1.state == "0"
+
+    watering_time2 = hass.states.get("sensor.zone_two_watering_time")
+    assert watering_time2 is not None
+    assert watering_time2.state == "29"
+
+    next_cycle = hass.states.get("sensor.zone_one_next_cycle")
+    assert next_cycle is not None
+    assert next_cycle.state == (utcnow() + timedelta(seconds=330597)).isoformat()

--- a/tests/components/hydrawise/test_switch.py
+++ b/tests/components/hydrawise/test_switch.py
@@ -3,21 +3,25 @@
 from datetime import timedelta
 from unittest.mock import Mock
 
+from freezegun.api import FrozenDateTimeFactory
+
 from homeassistant.components.hydrawise.const import SCAN_INTERVAL
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant
-from homeassistant.util.dt import utcnow
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_states(
-    hass: HomeAssistant, mock_added_config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    mock_added_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test switch states."""
     # Make the coordinator refresh data.
-    async_fire_time_changed(hass, utcnow() + SCAN_INTERVAL + timedelta(seconds=30))
+    freezer.tick(SCAN_INTERVAL + timedelta(seconds=30))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     watering1 = hass.states.get("switch.zone_one_manual_watering")

--- a/tests/components/hydrawise/test_switch.py
+++ b/tests/components/hydrawise/test_switch.py
@@ -1,0 +1,81 @@
+"""Test Hydrawise switch."""
+
+from datetime import timedelta
+from unittest.mock import Mock
+
+from homeassistant.components.hydrawise.const import SCAN_INTERVAL
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.util.dt import utcnow
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_states(
+    hass: HomeAssistant, mock_added_config_entry: MockConfigEntry
+) -> None:
+    """Test switch states."""
+    # Make the coordinator refresh data.
+    async_fire_time_changed(hass, utcnow() + SCAN_INTERVAL + timedelta(seconds=30))
+    await hass.async_block_till_done()
+
+    watering1 = hass.states.get("switch.zone_one_manual_watering")
+    assert watering1 is not None
+    assert watering1.state == "off"
+
+    watering2 = hass.states.get("switch.zone_two_manual_watering")
+    assert watering2 is not None
+    assert watering2.state == "on"
+
+    auto_watering1 = hass.states.get("switch.zone_one_automatic_watering")
+    assert auto_watering1 is not None
+    assert auto_watering1.state == "on"
+
+    auto_watering2 = hass.states.get("switch.zone_two_automatic_watering")
+    assert auto_watering2 is not None
+    assert auto_watering2.state == "off"
+
+
+async def test_manual_watering_services(
+    hass: HomeAssistant, mock_added_config_entry: MockConfigEntry, mock_pydrawise: Mock
+) -> None:
+    """Test Manual Watering services."""
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        service_data={ATTR_ENTITY_ID: "switch.zone_one_manual_watering"},
+        blocking=True,
+    )
+    mock_pydrawise.run_zone.assert_called_once_with(15, 1)
+    mock_pydrawise.reset_mock()
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        service_data={ATTR_ENTITY_ID: "switch.zone_one_manual_watering"},
+        blocking=True,
+    )
+    mock_pydrawise.run_zone.assert_called_once_with(0, 1)
+
+
+async def test_auto_watering_services(
+    hass: HomeAssistant, mock_added_config_entry: MockConfigEntry, mock_pydrawise: Mock
+) -> None:
+    """Test Automatic Watering services."""
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        service_data={ATTR_ENTITY_ID: "switch.zone_one_automatic_watering"},
+        blocking=True,
+    )
+    mock_pydrawise.suspend_zone.assert_called_once_with(365, 1)
+    mock_pydrawise.reset_mock()
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        service_data={ATTR_ENTITY_ID: "switch.zone_one_automatic_watering"},
+        blocking=True,
+    )
+    mock_pydrawise.suspend_zone.assert_called_once_with(0, 1)


### PR DESCRIPTION
## Proposed change
Add tests to Hydrawise, updating `.coveragerc` to remove the integration from the omissions.

This gets coverage to 100% for all files, with the exception of the `setup_platform()` functions in entity files. I added `# pragma: no cover` to these functions, as I don't see a way to test them: since we added config flow with automatic YAML migration to the integration, I don't think these can get triggered. (Plus they don't do anything) I'm happy to add tests for these if there's a reasonable way of doing so.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
