### PR TITLE
Migrate WAQI unique id

### DIFF
--- a/homeassistant/components/waqi/__init__.py
+++ b/homeassistant/components/waqi/__init__.py
@@ -41,6 +41,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def _migrate_unique_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Migrate pre-config flow unique ids."""
     entity_registry = er.async_get(hass)
     registry_entries = er.async_entries_for_config_entry(
         entity_registry, entry.entry_id

--- a/homeassistant/components/waqi/__init__.py
+++ b/homeassistant/components/waqi/__init__.py
@@ -7,6 +7,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.entity_registry as er
 
 from .const import DOMAIN
 from .coordinator import WAQIDataUpdateCoordinator
@@ -16,6 +17,8 @@ PLATFORMS: list[Platform] = [Platform.SENSOR]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up World Air Quality Index (WAQI) from a config entry."""
+
+    await _migrate_unique_ids(hass, entry)
 
     client = WAQIClient(session=async_get_clientsession(hass))
     client.authenticate(entry.data[CONF_API_KEY])
@@ -35,3 +38,15 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+
+async def _migrate_unique_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    entity_registry = er.async_get(hass)
+    registry_entries = er.async_entries_for_config_entry(
+        entity_registry, entry.entry_id
+    )
+    for reg_entry in registry_entries:
+        if isinstance(reg_entry.unique_id, int):
+            entity_registry.async_update_entity(
+                reg_entry.entity_id, new_unique_id=f"{reg_entry.unique_id}_air_quality"
+            )

--- a/homeassistant/components/waqi/sensor.py
+++ b/homeassistant/components/waqi/sensor.py
@@ -159,7 +159,7 @@ class WaqiSensor(CoordinatorEntity[WAQIDataUpdateCoordinator], SensorEntity):
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._attr_name = f"WAQI {self.coordinator.data.city.name}"
-        self._attr_unique_id = str(coordinator.data.station_id)
+        self._attr_unique_id = f"{coordinator.data.station_id}_air_quality"
 
     @property
     def native_value(self) -> int | None:

--- a/tests/components/waqi/test_sensor.py
+++ b/tests/components/waqi/test_sensor.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from aiowaqi import WAQIAirQuality, WAQIError, WAQISearchResult
 
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.waqi.const import CONF_STATION_NUMBER, DOMAIN
 from homeassistant.components.waqi.sensor import CONF_LOCATIONS, CONF_STATIONS
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntryState
@@ -15,7 +16,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, load_fixture
@@ -91,6 +92,32 @@ async def test_legacy_migration_already_imported(
     assert entries[0].state is ConfigEntryState.LOADED
     issue_registry = ir.async_get(hass)
     assert len(issue_registry.issues) == 1
+
+
+async def test_sensor_id_migration(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test migrating unique id for original sensor."""
+    mock_config_entry.add_to_hass(hass)
+    entity_registry = er.async_get(hass)
+    entity_registry.async_get_or_create(
+        SENSOR_DOMAIN, DOMAIN, 4584, config_entry=mock_config_entry
+    )
+    with patch(
+        "aiowaqi.WAQIClient.get_by_station_number",
+        return_value=WAQIAirQuality.from_dict(
+            json.loads(load_fixture("waqi/air_quality_sensor.json"))
+        ),
+    ):
+        assert await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+    entities = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    assert len(entities) == 1
+    assert hass.states.get("sensor.waqi_4584")
+    assert hass.states.get("sensor.waqi_de_jongweg_utrecht") is None
+    assert entities[0].unique_id == "4584_air_quality"
 
 
 async def test_sensor(hass: HomeAssistant, mock_config_entry: MockConfigEntry) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Apparently in #98220, the unique_id went from int to a str. This is causing duplicate entities.

Since in the future I want to introduce more sensors, I wanted to migrate the entities instead of setting unique_id back to int and then surpress mypy who is complaining `_attr_unique_id` should be str or None.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
