### PR TITLE
Fix zha CI test might fail on changing time

### DIFF
--- a/tests/components/zha/test_websocket_api.py
+++ b/tests/components/zha/test_websocket_api.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from typing import TYPE_CHECKING
 from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
+from freezegun import freeze_time
 import pytest
 import voluptuous as vol
 import zigpy.backups
@@ -227,6 +228,7 @@ async def test_device_cluster_commands(zha_client) -> None:
         assert command[TYPE] is not None
 
 
+@freeze_time("2023-09-23 20:16:00+00:00")
 async def test_list_devices(zha_client) -> None:
     """Test getting ZHA devices."""
     await zha_client.send_json({ID: 5, TYPE: "zha/devices"})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

It seems `test_devices_device` can fail on time comparison. @freeze_time prevents the CI test from failing on that.

```log
FAILED tests/components/zha/test_websocket_api.py::test_list_devices - AssertionError: assert {'active_coor...74209c3', ...} == {'active_coor...74209c3', ...}
  Omitting 22 identical items, use -vv to show
  Differing items:
  {'last_seen': '2023-09-29T18:11:47'} != {'last_seen': '2023-09-29T18:11:48'}
  Full diff:
    {
     'active_coordinator': True,
     'area_id': None,
     'available': False,
     'device_reg_id': '2ca08732727649d840f8b49d874209c3',
     'device_type': 'Coordinator',
     'endpoint_names': [{'name': 'unknown None device_type of 0xffff profile id'}],
     'entities': [],
     'ieee': '00:15:8d:00:02:32:4f:32',
  -  'last_seen': '2023-09-29T18:11:48',
  ?                                  ^
  +  'last_seen': '2023-09-29T18:11:47',
  ?                                  ^
     'lqi': None,
     'manufacturer': 'Coordinator Manufacturer',
     'manufacturer_code': None,
     'model': 'Coordinator Model',
     'name': 'Coordinator Manufacturer Coordinator Model',
     'neighbors': [],
     'nwk': 0,
     'power_source': 'Battery or Unknown',
     'quirk_applied': False,
     'quirk_class': 'zigpy.device.Device',
     'routes': [],
     'rssi': None,
     'signature': {'endpoints': {'1': {'device_type': '',
                                       'input_clusters': ['0x0000', '0x0004'],
                                       'output_clusters': [],
                                       'profile_id': ''}},
                   'manufacturer': 'Coordinator Manufacturer',
                   'model': 'Coordinator Model',
                   'node_descriptor': 'NodeDescriptor(logical_type=<LogicalType.Coordinator: '
                                      '0>, *is_coordinator=True, '
                                      '*is_end_device=False, *is_router=False)'},
     'user_given_name': None,
    }
Error: Process completed with exit code 1.
```

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
