### PR TITLE
Use dataclasses instead of attrs in stream

### DIFF
--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 import asyncio
 from collections import deque
 from collections.abc import Callable, Coroutine, Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import datetime
 from enum import IntEnum
 import logging
 from typing import TYPE_CHECKING, Any
 
 from aiohttp import web
-import attr
 import numpy as np
 
 from homeassistant.components.http.view import HomeAssistantView
@@ -51,15 +50,15 @@ class Orientation(IntEnum):
     ROTATE_RIGHT = 8
 
 
-@attr.s(slots=True)
+@dataclass(slots=True)
 class StreamSettings:
     """Stream settings."""
 
-    ll_hls: bool = attr.ib()
-    min_segment_duration: float = attr.ib()
-    part_target_duration: float = attr.ib()
-    hls_advance_part_limit: int = attr.ib()
-    hls_part_timeout: float = attr.ib()
+    ll_hls: bool
+    min_segment_duration: float
+    part_target_duration: float
+    hls_advance_part_limit: int
+    hls_part_timeout: float
 
 
 STREAM_SETTINGS_NON_LL_HLS = StreamSettings(
@@ -81,29 +80,29 @@ class Part:
     data: bytes
 
 
-@attr.s(slots=True)
+@dataclass(slots=True)
 class Segment:
     """Represent a segment."""
 
-    sequence: int = attr.ib()
+    sequence: int
     # the init of the mp4 the segment is based on
-    init: bytes = attr.ib()
+    init: bytes
     # For detecting discontinuities across stream restarts
-    stream_id: int = attr.ib()
-    start_time: datetime.datetime = attr.ib()
-    _stream_outputs: Iterable[StreamOutput] = attr.ib()
-    duration: float = attr.ib(default=0)
-    parts: list[Part] = attr.ib(factory=list)
+    stream_id: int
+    start_time: datetime.datetime
+    _stream_outputs: Iterable[StreamOutput]
+    duration: float = 0
+    parts: list[Part] = field(default_factory=list)
     # Store text of this segment's hls playlist for reuse
     # Use list[str] for easy appends
-    hls_playlist_template: list[str] = attr.ib(factory=list)
-    hls_playlist_parts: list[str] = attr.ib(factory=list)
+    hls_playlist_template: list[str] = field(default_factory=list)
+    hls_playlist_parts: list[str] = field(default_factory=list)
     # Number of playlist parts rendered so far
-    hls_num_parts_rendered: int = attr.ib(default=0)
+    hls_num_parts_rendered: int = 0
     # Set to true when all the parts are rendered
-    hls_playlist_complete: bool = attr.ib(default=False)
+    hls_playlist_complete: bool = False
 
-    def __attrs_post_init__(self) -> None:
+    def __post_init__(self) -> None:
         """Run after init."""
         for output in self._stream_outputs:
             output.put(self)

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 from collections import defaultdict, deque
 from collections.abc import Callable, Generator, Iterator, Mapping
 import contextlib
+from dataclasses import fields
 import datetime
 from io import SEEK_END, BytesIO
 import logging
 from threading import Event
 from typing import Any, Self, cast
 
-import attr
 import av
 
 from homeassistant.core import HomeAssistant
@@ -283,7 +283,7 @@ class StreamMuxer:
             init=read_init(self._memory_file),
             # Fetch the latest StreamOutputs, which may have changed since the
             # worker started.
-            stream_outputs=self._stream_state.outputs,
+            _stream_outputs=self._stream_state.outputs,
             start_time=self._start_time,
         )
         self._memory_file_pos = self._memory_file.tell()
@@ -537,7 +537,7 @@ def stream_worker(
         audio_stream = None
     # Disable ll-hls for hls inputs
     if container.format.name == "hls":
-        for field in attr.fields(StreamSettings):
+        for field in fields(StreamSettings):
             setattr(
                 stream_settings,
                 field.name,

--- a/tests/components/stream/common.py
+++ b/tests/components/stream/common.py
@@ -24,7 +24,7 @@ DefaultSegment = partial(
     init=None,
     stream_id=0,
     start_time=FAKE_TIME,
-    stream_outputs=[],
+    _stream_outputs=[],
 )
 
 AUDIO_SAMPLE_RATE = 8000


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow up to #101128. Replace remaining usages of attrs with dataclasses.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
