### PR TITLE
Fix rainbird entity unique ids

### DIFF
--- a/homeassistant/components/rainbird/binary_sensor.py
+++ b/homeassistant/components/rainbird/binary_sensor.py
@@ -48,11 +48,11 @@ class RainBirdSensor(CoordinatorEntity[RainbirdUpdateCoordinator], BinarySensorE
         """Initialize the Rain Bird sensor."""
         super().__init__(coordinator)
         self.entity_description = description
-        if coordinator.serial_number:
-            self._attr_unique_id = f"{coordinator.serial_number}-{description.key}"
+        if coordinator.unique_id:
+            self._attr_unique_id = f"{coordinator.unique_id}-{description.key}"
             self._attr_device_info = coordinator.device_info
         else:
-            self._attr_name = f"{coordinator.device_info['name']} Rainsensor"
+            self._attr_name = f"{coordinator.device_name} Rainsensor"
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/rainbird/binary_sensor.py
+++ b/homeassistant/components/rainbird/binary_sensor.py
@@ -48,8 +48,11 @@ class RainBirdSensor(CoordinatorEntity[RainbirdUpdateCoordinator], BinarySensorE
         """Initialize the Rain Bird sensor."""
         super().__init__(coordinator)
         self.entity_description = description
-        self._attr_unique_id = f"{coordinator.serial_number}-{description.key}"
-        self._attr_device_info = coordinator.device_info
+        if coordinator.serial_number:
+            self._attr_unique_id = f"{coordinator.serial_number}-{description.key}"
+            self._attr_device_info = coordinator.device_info
+        else:
+            self._attr_name = f"{coordinator.device_info['name']} Rainsensor"
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/rainbird/calendar.py
+++ b/homeassistant/components/rainbird/calendar.py
@@ -47,7 +47,7 @@ class RainBirdCalendarEntity(
     """A calendar event entity."""
 
     _attr_has_entity_name = True
-    _attr_name = None
+    _attr_name: str | None = None
     _attr_icon = "mdi:sprinkler"
 
     def __init__(
@@ -59,8 +59,11 @@ class RainBirdCalendarEntity(
         """Create the Calendar event device."""
         super().__init__(coordinator)
         self._event: CalendarEvent | None = None
-        self._attr_unique_id = serial_number
-        self._attr_device_info = device_info
+        if serial_number:
+            self._attr_unique_id = serial_number
+            self._attr_device_info = device_info
+        else:
+            self._attr_name = device_info["name"]
 
     @property
     def event(self) -> CalendarEvent | None:

--- a/homeassistant/components/rainbird/calendar.py
+++ b/homeassistant/components/rainbird/calendar.py
@@ -34,8 +34,9 @@ async def async_setup_entry(
         [
             RainBirdCalendarEntity(
                 data.schedule_coordinator,
-                data.coordinator.serial_number,
+                data.coordinator.unique_id,
                 data.coordinator.device_info,
+                data.coordinator.device_name,
             )
         ]
     )
@@ -53,17 +54,18 @@ class RainBirdCalendarEntity(
     def __init__(
         self,
         coordinator: RainbirdScheduleUpdateCoordinator,
-        serial_number: str,
-        device_info: DeviceInfo,
+        unique_id: str | None,
+        device_info: DeviceInfo | None,
+        device_name: str,
     ) -> None:
         """Create the Calendar event device."""
         super().__init__(coordinator)
         self._event: CalendarEvent | None = None
-        if serial_number:
-            self._attr_unique_id = serial_number
+        if unique_id:
+            self._attr_unique_id = unique_id
             self._attr_device_info = device_info
         else:
-            self._attr_name = device_info["name"]
+            self._attr_name = device_name
 
     @property
     def event(self) -> CalendarEvent | None:

--- a/homeassistant/components/rainbird/coordinator.py
+++ b/homeassistant/components/rainbird/coordinator.py
@@ -21,7 +21,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import CONF_SERIAL_NUMBER, DOMAIN, MANUFACTURER, TIMEOUT_SECONDS
+from .const import DOMAIN, MANUFACTURER, TIMEOUT_SECONDS
 
 UPDATE_INTERVAL = datetime.timedelta(minutes=1)
 # The calendar data requires RPCs for each program/zone, and the data rarely
@@ -51,7 +51,7 @@ class RainbirdUpdateCoordinator(DataUpdateCoordinator[RainbirdDeviceState]):
         hass: HomeAssistant,
         name: str,
         controller: AsyncRainbirdController,
-        serial_number: str,
+        unique_id: str | None,
         model_info: ModelAndVersion,
     ) -> None:
         """Initialize RainbirdUpdateCoordinator."""
@@ -62,7 +62,7 @@ class RainbirdUpdateCoordinator(DataUpdateCoordinator[RainbirdDeviceState]):
             update_interval=UPDATE_INTERVAL,
         )
         self._controller = controller
-        self._serial_number = serial_number
+        self._unique_id = unique_id
         self._zones: set[int] | None = None
         self._model_info = model_info
 
@@ -72,16 +72,23 @@ class RainbirdUpdateCoordinator(DataUpdateCoordinator[RainbirdDeviceState]):
         return self._controller
 
     @property
-    def serial_number(self) -> str:
-        """Return the device serial number."""
-        return self._serial_number
+    def unique_id(self) -> str | None:
+        """Return the config entry unique id."""
+        return self._unique_id
 
     @property
-    def device_info(self) -> DeviceInfo:
+    def device_name(self) -> str:
+        """Device name for the rainbird controller."""
+        return f"{MANUFACTURER} Controller"
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
         """Return information about the device."""
+        if not self._unique_id:
+            return None
         return DeviceInfo(
-            name=f"{MANUFACTURER} Controller",
-            identifiers={(DOMAIN, self._serial_number)},
+            name=self.device_name,
+            identifiers={(DOMAIN, self._unique_id)},
             manufacturer=MANUFACTURER,
             model=self._model_info.model_name,
             sw_version=f"{self._model_info.major}.{self._model_info.minor}",
@@ -164,7 +171,7 @@ class RainbirdData:
             self.hass,
             name=self.entry.title,
             controller=self.controller,
-            serial_number=self.entry.data[CONF_SERIAL_NUMBER],
+            unique_id=self.entry.unique_id,
             model_info=self.model_info,
         )
 

--- a/homeassistant/components/rainbird/number.py
+++ b/homeassistant/components/rainbird/number.py
@@ -51,11 +51,11 @@ class RainDelayNumber(CoordinatorEntity[RainbirdUpdateCoordinator], NumberEntity
     ) -> None:
         """Initialize the Rain Bird sensor."""
         super().__init__(coordinator)
-        if coordinator.serial_number:
-            self._attr_unique_id = f"{coordinator.serial_number}-rain-delay"
+        if coordinator.unique_id:
+            self._attr_unique_id = f"{coordinator.unique_id}-rain-delay"
             self._attr_device_info = coordinator.device_info
         else:
-            self._attr_name = f"{coordinator.device_info['name']} Rain delay"
+            self._attr_name = f"{coordinator.device_name} Rain delay"
 
     @property
     def native_value(self) -> float | None:

--- a/homeassistant/components/rainbird/number.py
+++ b/homeassistant/components/rainbird/number.py
@@ -51,8 +51,11 @@ class RainDelayNumber(CoordinatorEntity[RainbirdUpdateCoordinator], NumberEntity
     ) -> None:
         """Initialize the Rain Bird sensor."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{coordinator.serial_number}-rain-delay"
-        self._attr_device_info = coordinator.device_info
+        if coordinator.serial_number:
+            self._attr_unique_id = f"{coordinator.serial_number}-rain-delay"
+            self._attr_device_info = coordinator.device_info
+        else:
+            self._attr_name = f"{coordinator.device_info['name']} Rain delay"
 
     @property
     def native_value(self) -> float | None:

--- a/homeassistant/components/rainbird/sensor.py
+++ b/homeassistant/components/rainbird/sensor.py
@@ -52,12 +52,12 @@ class RainBirdSensor(CoordinatorEntity[RainbirdUpdateCoordinator], SensorEntity)
         """Initialize the Rain Bird sensor."""
         super().__init__(coordinator)
         self.entity_description = description
-        if coordinator.serial_number:
-            self._attr_unique_id = f"{coordinator.serial_number}-{description.key}"
+        if coordinator.unique_id:
+            self._attr_unique_id = f"{coordinator.unique_id}-{description.key}"
             self._attr_device_info = coordinator.device_info
         else:
             self._attr_name = (
-                f"{coordinator.device_info['name']} {description.key.capitalize()}"
+                f"{coordinator.device_name} {description.key.capitalize()}"
             )
 
     @property

--- a/homeassistant/components/rainbird/sensor.py
+++ b/homeassistant/components/rainbird/sensor.py
@@ -52,8 +52,13 @@ class RainBirdSensor(CoordinatorEntity[RainbirdUpdateCoordinator], SensorEntity)
         """Initialize the Rain Bird sensor."""
         super().__init__(coordinator)
         self.entity_description = description
-        self._attr_unique_id = f"{coordinator.serial_number}-{description.key}"
-        self._attr_device_info = coordinator.device_info
+        if coordinator.serial_number:
+            self._attr_unique_id = f"{coordinator.serial_number}-{description.key}"
+            self._attr_device_info = coordinator.device_info
+        else:
+            self._attr_name = (
+                f"{coordinator.device_info['name']} {description.key.capitalize()}"
+            )
 
     @property
     def native_value(self) -> StateType:

--- a/homeassistant/components/rainbird/switch.py
+++ b/homeassistant/components/rainbird/switch.py
@@ -65,22 +65,22 @@ class RainBirdSwitch(CoordinatorEntity[RainbirdUpdateCoordinator], SwitchEntity)
         """Initialize a Rain Bird Switch Device."""
         super().__init__(coordinator)
         self._zone = zone
-        if coordinator.serial_number:
-            self._attr_unique_id = f"{coordinator.serial_number}-{zone}"
+        if coordinator.unique_id:
+            self._attr_unique_id = f"{coordinator.unique_id}-{zone}"
         device_name = f"{MANUFACTURER} Sprinkler {zone}"
         if imported_name:
             self._attr_name = imported_name
             self._attr_has_entity_name = False
         else:
-            self._attr_name = None if coordinator.serial_number else device_name
+            self._attr_name = None if coordinator.unique_id else device_name
             self._attr_has_entity_name = True
         self._duration_minutes = duration_minutes
-        if self._attr_unique_id:
+        if coordinator.unique_id and self._attr_unique_id:
             self._attr_device_info = DeviceInfo(
                 name=device_name,
                 identifiers={(DOMAIN, self._attr_unique_id)},
                 manufacturer=MANUFACTURER,
-                via_device=(DOMAIN, coordinator.serial_number),
+                via_device=(DOMAIN, coordinator.unique_id),
             )
 
     @property

--- a/homeassistant/components/rainbird/switch.py
+++ b/homeassistant/components/rainbird/switch.py
@@ -65,20 +65,23 @@ class RainBirdSwitch(CoordinatorEntity[RainbirdUpdateCoordinator], SwitchEntity)
         """Initialize a Rain Bird Switch Device."""
         super().__init__(coordinator)
         self._zone = zone
+        if coordinator.serial_number:
+            self._attr_unique_id = f"{coordinator.serial_number}-{zone}"
+        device_name = f"{MANUFACTURER} Sprinkler {zone}"
         if imported_name:
             self._attr_name = imported_name
             self._attr_has_entity_name = False
         else:
-            self._attr_name = None
+            self._attr_name = None if coordinator.serial_number else device_name
             self._attr_has_entity_name = True
         self._duration_minutes = duration_minutes
-        self._attr_unique_id = f"{coordinator.serial_number}-{zone}"
-        self._attr_device_info = DeviceInfo(
-            name=f"{MANUFACTURER} Sprinkler {zone}",
-            identifiers={(DOMAIN, self._attr_unique_id)},
-            manufacturer=MANUFACTURER,
-            via_device=(DOMAIN, coordinator.serial_number),
-        )
+        if self._attr_unique_id:
+            self._attr_device_info = DeviceInfo(
+                name=device_name,
+                identifiers={(DOMAIN, self._attr_unique_id)},
+                manufacturer=MANUFACTURER,
+                via_device=(DOMAIN, coordinator.serial_number),
+            )
 
     @property
     def extra_state_attributes(self):

--- a/tests/components/rainbird/conftest.py
+++ b/tests/components/rainbird/conftest.py
@@ -86,7 +86,7 @@ def yaml_config() -> dict[str, Any]:
 
 
 @pytest.fixture
-async def unique_id() -> str:
+async def config_entry_unique_id() -> str:
     """Fixture for serial number used in the config entry."""
     return SERIAL_NUMBER
 
@@ -100,13 +100,13 @@ async def config_entry_data() -> dict[str, Any]:
 @pytest.fixture
 async def config_entry(
     config_entry_data: dict[str, Any] | None,
-    unique_id: str,
+    config_entry_unique_id: str | None,
 ) -> MockConfigEntry | None:
     """Fixture for MockConfigEntry."""
     if config_entry_data is None:
         return None
     return MockConfigEntry(
-        unique_id=unique_id,
+        unique_id=config_entry_unique_id,
         domain=DOMAIN,
         data=config_entry_data,
         options={ATTR_DURATION: DEFAULT_TRIGGER_TIME_MINUTES},

--- a/tests/components/rainbird/test_binary_sensor.py
+++ b/tests/components/rainbird/test_binary_sensor.py
@@ -7,7 +7,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import CONFIG_ENTRY_DATA, RAIN_SENSOR_OFF, RAIN_SENSOR_ON, ComponentSetup
+from .conftest import RAIN_SENSOR_OFF, RAIN_SENSOR_ON, ComponentSetup
 
 from tests.test_util.aiohttp import AiohttpClientMockResponse
 
@@ -47,9 +47,9 @@ async def test_rainsensor(
 
 
 @pytest.mark.parametrize(
-    ("config_entry_data"),
+    ("config_entry_unique_id"),
     [
-        ({**CONFIG_ENTRY_DATA, "serial_number": 0}),
+        (None),
     ],
 )
 async def test_no_unique_id(

--- a/tests/components/rainbird/test_binary_sensor.py
+++ b/tests/components/rainbird/test_binary_sensor.py
@@ -41,9 +41,11 @@ async def test_rainsensor(
         "icon": "mdi:water",
     }
 
-    entity = entity_registry.async_get("binary_sensor.rain_bird_controller_rainsensor")
-    assert entity
-    assert entity.unique_id == "1263613994342-rainsensor"
+    entity_entry = entity_registry.async_get(
+        "binary_sensor.rain_bird_controller_rainsensor"
+    )
+    assert entity_entry
+    assert entity_entry.unique_id == "1263613994342-rainsensor"
 
 
 @pytest.mark.parametrize(
@@ -68,5 +70,7 @@ async def test_no_unique_id(
         rainsensor.attributes.get("friendly_name") == "Rain Bird Controller Rainsensor"
     )
 
-    entity_entry = entity_registry.async_get("binary_sensor.rain_bird_controller_rainsensor")
-    assert not entity
+    entity_entry = entity_registry.async_get(
+        "binary_sensor.rain_bird_controller_rainsensor"
+    )
+    assert not entity_entry

--- a/tests/components/rainbird/test_binary_sensor.py
+++ b/tests/components/rainbird/test_binary_sensor.py
@@ -68,5 +68,5 @@ async def test_no_unique_id(
         rainsensor.attributes.get("friendly_name") == "Rain Bird Controller Rainsensor"
     )
 
-    entity = entity_registry.async_get("binary_sensor.rain_bird_controller_rainsensor")
+    entity_entry = entity_registry.async_get("binary_sensor.rain_bird_controller_rainsensor")
     assert not entity

--- a/tests/components/rainbird/test_calendar.py
+++ b/tests/components/rainbird/test_calendar.py
@@ -16,12 +16,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import (
-    CONFIG_ENTRY_DATA,
-    ComponentSetup,
-    mock_response,
-    mock_response_error,
-)
+from .conftest import ComponentSetup, mock_response, mock_response_error
 
 from tests.test_util.aiohttp import AiohttpClientMockResponse
 
@@ -284,9 +279,9 @@ async def test_program_schedule_disabled(
 
 
 @pytest.mark.parametrize(
-    ("config_entry_data"),
+    ("config_entry_unique_id"),
     [
-        ({**CONFIG_ENTRY_DATA, "serial_number": 0}),
+        (None),
     ],
 )
 async def test_no_unique_id(

--- a/tests/components/rainbird/test_calendar.py
+++ b/tests/components/rainbird/test_calendar.py
@@ -298,5 +298,5 @@ async def test_no_unique_id(
     assert state is not None
     assert state.attributes.get("friendly_name") == "Rain Bird Controller"
 
-    entity = entity_registry.async_get(TEST_ENTITY)
-    assert not entity
+    entity_entry = entity_registry.async_get(TEST_ENTITY)
+    assert not entity_entry

--- a/tests/components/rainbird/test_config_flow.py
+++ b/tests/components/rainbird/test_config_flow.py
@@ -106,7 +106,7 @@ async def test_controller_flow(
 
 @pytest.mark.parametrize(
     (
-        "unique_id",
+        "config_entry_unique_id",
         "config_entry_data",
         "config_flow_responses",
         "expected_config_entry",
@@ -154,7 +154,7 @@ async def test_multiple_config_entries(
 
 @pytest.mark.parametrize(
     (
-        "unique_id",
+        "config_entry_unique_id",
         "config_entry_data",
         "config_flow_responses",
     ),

--- a/tests/components/rainbird/test_number.py
+++ b/tests/components/rainbird/test_number.py
@@ -58,9 +58,9 @@ async def test_number_values(
         "unit_of_measurement": "d",
     }
 
-    entity = entity_registry.async_get("number.rain_bird_controller_rain_delay")
-    assert entity
-    assert entity.unique_id == "1263613994342-rain-delay"
+    entity_entry = entity_registry.async_get("number.rain_bird_controller_rain_delay")
+    assert entity_entry
+    assert entity_entry.unique_id == "1263613994342-rain-delay"
 
 
 async def test_set_value(
@@ -155,5 +155,5 @@ async def test_no_unique_id(
         raindelay.attributes.get("friendly_name") == "Rain Bird Controller Rain delay"
     )
 
-    entity = entity_registry.async_get("number.rain_bird_controller_rain_delay")
-    assert not entity
+    entity_entry = entity_registry.async_get("number.rain_bird_controller_rain_delay")
+    assert not entity_entry

--- a/tests/components/rainbird/test_number.py
+++ b/tests/components/rainbird/test_number.py
@@ -14,7 +14,6 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .conftest import (
     ACK_ECHO,
-    CONFIG_ENTRY_DATA,
     RAIN_DELAY,
     RAIN_DELAY_OFF,
     SERIAL_NUMBER,
@@ -136,9 +135,9 @@ async def test_set_value_error(
 
 
 @pytest.mark.parametrize(
-    ("config_entry_data"),
+    ("config_entry_unique_id"),
     [
-        ({**CONFIG_ENTRY_DATA, "serial_number": 0}),
+        (None),
     ],
 )
 async def test_no_unique_id(

--- a/tests/components/rainbird/test_sensor.py
+++ b/tests/components/rainbird/test_sensor.py
@@ -5,8 +5,9 @@ import pytest
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
-from .conftest import RAIN_DELAY, RAIN_DELAY_OFF, ComponentSetup
+from .conftest import CONFIG_ENTRY_DATA, RAIN_DELAY, RAIN_DELAY_OFF, ComponentSetup
 
 
 @pytest.fixture
@@ -22,6 +23,7 @@ def platforms() -> list[str]:
 async def test_sensors(
     hass: HomeAssistant,
     setup_integration: ComponentSetup,
+    entity_registry: er.EntityRegistry,
     expected_state: str,
 ) -> None:
     """Test sensor platform."""
@@ -35,3 +37,30 @@ async def test_sensors(
         "friendly_name": "Rain Bird Controller Raindelay",
         "icon": "mdi:water-off",
     }
+
+    entity = entity_registry.async_get("sensor.rain_bird_controller_raindelay")
+    assert entity
+    assert entity.unique_id == "1263613994342-raindelay"
+
+
+@pytest.mark.parametrize(
+    ("config_entry_data"),
+    [
+        ({**CONFIG_ENTRY_DATA, "serial_number": 0}),
+    ],
+)
+async def test_sensor_no_unique_id(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test sensor platform with no unique id."""
+
+    assert await setup_integration()
+
+    raindelay = hass.states.get("sensor.rain_bird_controller_raindelay")
+    assert raindelay is not None
+    assert raindelay.attributes.get("friendly_name") == "Rain Bird Controller Raindelay"
+
+    entity = entity_registry.async_get("sensor.rain_bird_controller_raindelay")
+    assert entity is None

--- a/tests/components/rainbird/test_sensor.py
+++ b/tests/components/rainbird/test_sensor.py
@@ -54,7 +54,7 @@ async def test_sensors(
                 "serial_number": 0,
             },
         ),
-        # Legacy case where we used to set unique ids for serial number 0 will preserve existing behavior
+        # Legacy case for old config entries with serial number 0 preserves old behavior
         (
             "0",
             {

--- a/tests/components/rainbird/test_sensor.py
+++ b/tests/components/rainbird/test_sensor.py
@@ -38,9 +38,9 @@ async def test_sensors(
         "icon": "mdi:water-off",
     }
 
-    entity = entity_registry.async_get("sensor.rain_bird_controller_raindelay")
-    assert entity
-    assert entity.unique_id == "1263613994342-raindelay"
+    entity_entry = entity_registry.async_get("sensor.rain_bird_controller_raindelay")
+    assert entity_entry
+    assert entity_entry.unique_id == "1263613994342-raindelay"
 
 
 @pytest.mark.parametrize(
@@ -78,5 +78,5 @@ async def test_sensor_no_unique_id(
     assert raindelay is not None
     assert raindelay.attributes.get("friendly_name") == "Rain Bird Controller Raindelay"
 
-    entity = entity_registry.async_get("sensor.rain_bird_controller_raindelay")
-    assert (entity is None) == (config_entry_unique_id is None)
+    entity_entry = entity_registry.async_get("sensor.rain_bird_controller_raindelay")
+    assert (entity_entry is None) == (config_entry_unique_id is None)

--- a/tests/components/rainbird/test_sensor.py
+++ b/tests/components/rainbird/test_sensor.py
@@ -44,15 +44,31 @@ async def test_sensors(
 
 
 @pytest.mark.parametrize(
-    ("config_entry_data"),
+    ("config_entry_unique_id", "config_entry_data"),
     [
-        ({**CONFIG_ENTRY_DATA, "serial_number": 0}),
+        # Config entry setup without a unique id since it had no serial number
+        (
+            None,
+            {
+                **CONFIG_ENTRY_DATA,
+                "serial_number": 0,
+            },
+        ),
+        # Legacy case where we used to set unique ids for serial number 0 will preserve existing behavior
+        (
+            "0",
+            {
+                **CONFIG_ENTRY_DATA,
+                "serial_number": 0,
+            },
+        ),
     ],
 )
 async def test_sensor_no_unique_id(
     hass: HomeAssistant,
     setup_integration: ComponentSetup,
     entity_registry: er.EntityRegistry,
+    config_entry_unique_id: str | None,
 ) -> None:
     """Test sensor platform with no unique id."""
 
@@ -63,4 +79,4 @@ async def test_sensor_no_unique_id(
     assert raindelay.attributes.get("friendly_name") == "Rain Bird Controller Raindelay"
 
     entity = entity_registry.async_get("sensor.rain_bird_controller_raindelay")
-    assert entity is None
+    assert (entity is None) == (config_entry_unique_id is None)

--- a/tests/components/rainbird/test_switch.py
+++ b/tests/components/rainbird/test_switch.py
@@ -12,7 +12,6 @@ from homeassistant.helpers import entity_registry as er
 
 from .conftest import (
     ACK_ECHO,
-    CONFIG_ENTRY_DATA,
     EMPTY_STATIONS_RESPONSE,
     HOST,
     PASSWORD,
@@ -285,9 +284,9 @@ async def test_switch_error(
 
 
 @pytest.mark.parametrize(
-    ("config_entry_data"),
+    ("config_entry_unique_id"),
     [
-        ({**CONFIG_ENTRY_DATA, "serial_number": 0}),
+        None,
     ],
 )
 async def test_no_unique_id(

--- a/tests/components/rainbird/test_switch.py
+++ b/tests/components/rainbird/test_switch.py
@@ -103,8 +103,8 @@ async def test_zones(
     assert not hass.states.get("switch.rain_bird_sprinkler_8")
 
     # Verify unique id for one of the switches
-    entity = entity_registry.async_get("switch.rain_bird_sprinkler_3")
-    assert entity.unique_id == "1263613994342-3"
+    entity_entry = entity_registry.async_get("switch.rain_bird_sprinkler_3")
+    assert entity_entry.unique_id == "1263613994342-3"
 
 
 async def test_switch_on(
@@ -305,5 +305,5 @@ async def test_no_unique_id(
     assert zone.attributes.get("friendly_name") == "Rain Bird Sprinkler 3"
     assert zone.state == "off"
 
-    entity = entity_registry.async_get("switch.rain_bird_sprinkler_3")
-    assert entity is None
+    entity_entry = entity_registry.async_get("switch.rain_bird_sprinkler_3")
+    assert entity_entry is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix unique ids for rainbird entities as a follow up from #99704 which fixed the config entry unique ids to fix the error message:
```
2023-09-30 12:37:42.638 ERROR (MainThread) [homeassistant.components.sensor] Platform rainbird does not generate unique IDs. ID 0-raindelay already exists - ignoring sensor.rain_bird_controller_regenverzogerung_l
```

This happens because it is using the device serial number for the entity unique id, which may be "0". With this PR, only create an entity unique id when there is a config entry unique id.  This changes the logic from checking the serial number for existing config entries that may already have a "0" unique id so they keep working as is.

This adds additional tests to verify that the unique ids are not created and the entity names are consistent with the previous names.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #99240
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
