### PR TITLE
Add reauth support in fitbit

### DIFF
--- a/homeassistant/components/fitbit/__init__.py
+++ b/homeassistant/components/fitbit/__init__.py
@@ -1,5 +1,7 @@
 """The fitbit component."""
 
+from http import HTTPStatus
+
 import aiohttp
 
 from homeassistant.config_entries import ConfigEntry
@@ -30,7 +32,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         await fitbit_api.async_get_access_token()
     except aiohttp.ClientResponseError as err:
-        if 400 <= err.status < 500:
+        if err.status == HTTPStatus.UNAUTHORIZED:
             raise ConfigEntryAuthFailed from err
         raise ConfigEntryNotReady from err
     except aiohttp.ClientError as err:

--- a/homeassistant/components/fitbit/__init__.py
+++ b/homeassistant/components/fitbit/__init__.py
@@ -5,7 +5,7 @@ import aiohttp
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from . import api
@@ -29,6 +29,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     try:
         await fitbit_api.async_get_access_token()
+    except aiohttp.ClientResponseError as err:
+        if 400 <= err.status < 500:
+            raise ConfigEntryAuthFailed from err
+        raise ConfigEntryNotReady from err
     except aiohttp.ClientError as err:
         raise ConfigEntryNotReady from err
 

--- a/homeassistant/components/fitbit/config_flow.py
+++ b/homeassistant/components/fitbit/config_flow.py
@@ -1,10 +1,12 @@
 """Config flow for fitbit."""
 
+from collections.abc import Mapping
 import logging
 from typing import Any
 
 from fitbit.exceptions import HTTPException
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_TOKEN
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_entry_oauth2_flow
@@ -22,6 +24,8 @@ class OAuth2FlowHandler(
 
     DOMAIN = DOMAIN
 
+    reauth_entry: ConfigEntry | None = None
+
     @property
     def logger(self) -> logging.Logger:
         """Return logger."""
@@ -32,8 +36,23 @@ class OAuth2FlowHandler(
         """Extra data that needs to be appended to the authorize url."""
         return {
             "scope": " ".join(OAUTH_SCOPES),
-            "prompt": "consent",
+            "prompt": "consent" if not self.reauth_entry else "none",
         }
+
+    async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> FlowResult:
+        """Perform reauth upon an API authentication error."""
+        self.reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Confirm reauth dialog."""
+        if user_input is None:
+            return self.async_show_form(step_id="reauth_confirm")
+        return await self.async_step_user()
 
     async def async_oauth_create_entry(self, data: dict[str, Any]) -> FlowResult:
         """Create an entry for the flow, or update existing entry."""
@@ -44,6 +63,13 @@ class OAuth2FlowHandler(
         except HTTPException as err:
             _LOGGER.error("Failed to fetch user profile for Fitbit API: %s", err)
             return self.async_abort(reason="cannot_connect")
+
+        if self.reauth_entry:
+            if self.reauth_entry.unique_id != profile.encoded_id:
+                return self.async_abort(reason="wrong_account")
+            self.hass.config_entries.async_update_entry(self.reauth_entry, data=data)
+            await self.hass.config_entries.async_reload(self.reauth_entry.entry_id)
+            return self.async_abort(reason="reauth_successful")
 
         await self.async_set_unique_id(profile.encoded_id)
         self._abort_if_unique_id_configured()

--- a/homeassistant/components/fitbit/strings.json
+++ b/homeassistant/components/fitbit/strings.json
@@ -6,6 +6,10 @@
       },
       "auth": {
         "title": "Link Fitbit"
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "The Fitbit integration needs to re-authenticate your account"
       }
     },
     "abort": {
@@ -15,7 +19,9 @@
       "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
       "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
       "invalid_access_token": "[%key:common::config_flow::error::invalid_access_token%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "wrong_account": "The user credentials provided do not match this Fitbit account."
     },
     "create_entry": {
       "default": "[%key:common::config_flow::create_entry::authenticated%]"

--- a/tests/components/fitbit/test_config_flow.py
+++ b/tests/components/fitbit/test_config_flow.py
@@ -325,7 +325,7 @@ async def test_reauth_flow(
     profile: None,
     setup_credentials: None,
 ) -> None:
-    """Test OAuth reauthentication flow will upedate existing config entry."""
+    """Test OAuth reauthentication flow will update existing config entry."""
     config_entry.add_to_hass(hass)
 
     entries = hass.config_entries.async_entries(DOMAIN)

--- a/tests/components/fitbit/test_config_flow.py
+++ b/tests/components/fitbit/test_config_flow.py
@@ -4,6 +4,7 @@ from collections.abc import Awaitable, Callable
 from http import HTTPStatus
 from unittest.mock import patch
 
+import pytest
 from requests_mock.mocker import Mocker
 
 from homeassistant import config_entries
@@ -313,3 +314,148 @@ async def test_platform_setup_without_import(
     issue = issue_registry.issues.get((DOMAIN, "deprecated_yaml"))
     assert issue
     assert issue.translation_key == "deprecated_yaml_no_import"
+
+
+async def test_reauth_flow(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+    profile: None,
+    setup_credentials: None,
+) -> None:
+    """Test OAuth reauthentication flow will upedate existing config entry."""
+    config_entry.add_to_hass(hass)
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+
+    # config_entry.req initiates reauth
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": config_entry.entry_id,
+        },
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id=result["flow_id"],
+        user_input={},
+    )
+    assert result["type"] == FlowResultType.EXTERNAL_STEP
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": REDIRECT_URL,
+        },
+    )
+    assert result["url"] == (
+        f"{OAUTH2_AUTHORIZE}?response_type=code&client_id={CLIENT_ID}"
+        f"&redirect_uri={REDIRECT_URL}"
+        f"&state={state}"
+        "&scope=activity+heartrate+nutrition+profile+settings+sleep+weight&prompt=none"
+    )
+
+    client = await hass_client_no_auth()
+    resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
+    assert resp.status == 200
+    assert resp.headers["content-type"] == "text/html; charset=utf-8"
+
+    aioclient_mock.post(
+        OAUTH2_TOKEN,
+        json={
+            "refresh_token": "updated-refresh-token",
+            "access_token": "updated-access-token",
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    with patch(
+        "homeassistant.components.fitbit.async_setup_entry", return_value=True
+    ) as mock_setup:
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result.get("type") == FlowResultType.ABORT
+    assert result.get("reason") == "reauth_successful"
+
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert len(mock_setup.mock_calls) == 1
+
+    assert config_entry.data["token"]["refresh_token"] == "updated-refresh-token"
+
+
+@pytest.mark.parametrize("profile_id", ["other-user-id"])
+async def test_reauth_wrong_user_id(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+    profile: None,
+    setup_credentials: None,
+) -> None:
+    """Test OAuth reauthentication where the wrong user is selected."""
+    config_entry.add_to_hass(hass)
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": config_entry.entry_id,
+        },
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id=result["flow_id"],
+        user_input={},
+    )
+    assert result["type"] == FlowResultType.EXTERNAL_STEP
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": REDIRECT_URL,
+        },
+    )
+    assert result["url"] == (
+        f"{OAUTH2_AUTHORIZE}?response_type=code&client_id={CLIENT_ID}"
+        f"&redirect_uri={REDIRECT_URL}"
+        f"&state={state}"
+        "&scope=activity+heartrate+nutrition+profile+settings+sleep+weight&prompt=none"
+    )
+
+    client = await hass_client_no_auth()
+    resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
+    assert resp.status == 200
+    assert resp.headers["content-type"] == "text/html; charset=utf-8"
+
+    aioclient_mock.post(
+        OAUTH2_TOKEN,
+        json={
+            "refresh_token": "updated-refresh-token",
+            "access_token": "updated-access-token",
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    with patch(
+        "homeassistant.components.fitbit.async_setup_entry", return_value=True
+    ) as mock_setup:
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result.get("type") == FlowResultType.ABORT
+    assert result.get("reason") == "wrong_account"
+
+    assert len(mock_setup.mock_calls) == 0

--- a/tests/components/fitbit/test_init.py
+++ b/tests/components/fitbit/test_init.py
@@ -43,18 +43,26 @@ async def test_setup(
     assert config_entry.state == ConfigEntryState.NOT_LOADED
 
 
-@pytest.mark.parametrize("token_expiration_time", [12345])
+@pytest.mark.parametrize(
+    ("token_expiration_time", "server_status"),
+    [
+        (12345, HTTPStatus.INTERNAL_SERVER_ERROR),
+        (12345, HTTPStatus.FORBIDDEN),
+        (12345, HTTPStatus.NOT_FOUND),
+    ],
+)
 async def test_token_refresh_failure(
     integration_setup: Callable[[], Awaitable[bool]],
     config_entry: MockConfigEntry,
     aioclient_mock: AiohttpClientMocker,
     setup_credentials: None,
+    server_status: HTTPStatus,
 ) -> None:
     """Test where token is expired and the refresh attempt fails and will be retried."""
 
     aioclient_mock.post(
         OAUTH2_TOKEN,
-        status=HTTPStatus.INTERNAL_SERVER_ERROR,
+        status=server_status,
     )
 
     assert not await integration_setup()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add reauth support in fitbit initiating the config flow when getting a forbidden response from the token refresh step on startup.

This sets the oauth prompt to "none" to avoid re-asking for consent on each scope since it defaults to not populated, to preserve all existing scopes.


This is pulled out of a larger overhaul to modernize the fitbit integration and make it configurable from the UI and following current design standards, similar to previous approach on Google calendar :
- [X] Add test harness #100765
- [X] #100766
- [X] Increase test coverage #100776
- [X] Simplify response parsing and entity descriptions #100782
- [X] Refactor unit system #100825
- [X] Ascynio client library #100933
- [X] Config flow and UI based configuration, application credentials, import of existing credentials #100897
- [x] Reauth support in config flow #101178
- [X] Additional oauth error handling with improved error messages in the UI #101304
- [ ] Split battery device level into another entity
- [X] Modernize entities to current design standards (battery, time, etc) #101179

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
