### PR TITLE
Add RestoreEntity to Comelit cover

### DIFF
--- a/homeassistant/components/comelit/cover.py
+++ b/homeassistant/components/comelit/cover.py
@@ -6,13 +6,14 @@ from typing import Any
 from aiocomelit import ComelitSerialBridgeObject
 from aiocomelit.const import COVER, COVER_CLOSE, COVER_OPEN, COVER_STATUS
 
-from homeassistant.components.cover import CoverDeviceClass, CoverEntity
+from homeassistant.components.cover import STATE_CLOSED, CoverDeviceClass, CoverEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import _LOGGER, DOMAIN
 from .coordinator import ComelitSerialBridge
 
 
@@ -32,7 +33,9 @@ async def async_setup_entry(
     )
 
 
-class ComelitCoverEntity(CoordinatorEntity[ComelitSerialBridge], CoverEntity):
+class ComelitCoverEntity(
+    CoordinatorEntity[ComelitSerialBridge], RestoreEntity, CoverEntity
+):
     """Cover device."""
 
     _attr_device_class = CoverDeviceClass.SHUTTER
@@ -51,8 +54,9 @@ class ComelitCoverEntity(CoordinatorEntity[ComelitSerialBridge], CoverEntity):
         super().__init__(coordinator)
         self._attr_unique_id = f"{config_entry_entry_id}-{device.index}"
         self._attr_device_info = coordinator.platform_device_info(device, COVER)
-        # Device doesn't provide a status so we assume CLOSE at startup
-        self._last_action = COVER_STATUS.index("closing")
+        # Device doesn't provide a status so we assume UNKNOWN at first startup
+        self._last_action: int | None = None
+        self._last_state: str | None = None
 
     def _current_action(self, action: str) -> bool:
         """Return the current cover action."""
@@ -67,12 +71,19 @@ class ComelitCoverEntity(CoordinatorEntity[ComelitSerialBridge], CoverEntity):
         return self.coordinator.data[COVER][self._device.index].status
 
     @property
-    def is_closed(self) -> bool:
-        """Return True if cover is closed."""
+    def is_closed(self) -> bool | None:
+        """Return if the cover is closed."""
+
+        if self._last_state in [None, "unknown"]:
+            return None
+
         if self.device_status != COVER_STATUS.index("stopped"):
             return False
 
-        return bool(self._last_action == COVER_STATUS.index("closing"))
+        if self._last_action:
+            return self._last_action == COVER_STATUS.index("closing")
+
+        return self._last_state == STATE_CLOSED
 
     @property
     def is_closing(self) -> bool:
@@ -99,3 +110,18 @@ class ComelitCoverEntity(CoordinatorEntity[ComelitSerialBridge], CoverEntity):
 
         action = COVER_OPEN if self.is_closing else COVER_CLOSE
         await self._api.cover_move(self._device.index, action)
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle device update."""
+        self._last_state = self.state
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Handle entity which will be added."""
+        _LOGGER.info("Restoring entity %s", self._device.name)
+
+        await super().async_added_to_hass()
+
+        if last_state := await self.async_get_last_state():
+            self._last_state = last_state.state

--- a/homeassistant/components/comelit/cover.py
+++ b/homeassistant/components/comelit/cover.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import _LOGGER, DOMAIN
+from .const import DOMAIN
 from .coordinator import ComelitSerialBridge
 
 
@@ -119,7 +119,6 @@ class ComelitCoverEntity(
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
-        _LOGGER.info("Restoring entity %s", self._device.name)
 
         await super().async_added_to_hass()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Unfortunately Comelit Bridge doesn't provide a status for covers.
This PR add the `RestoreEntity` to keep the status in sync between HA restarts.
It also assumes state unknown at first startup to allow user to easily sync HA to the physical status.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
