### PR TITLE
Remove deprecated DEVICE_CLASS_x for binary sensor

### DIFF
--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -117,38 +117,7 @@ class BinarySensorDeviceClass(StrEnum):
 
 
 DEVICE_CLASSES_SCHEMA = vol.All(vol.Lower, vol.Coerce(BinarySensorDeviceClass))
-
-# DEVICE_CLASS* below are deprecated as of 2021.12
-# use the BinarySensorDeviceClass enum instead.
 DEVICE_CLASSES = [cls.value for cls in BinarySensorDeviceClass]
-DEVICE_CLASS_BATTERY = BinarySensorDeviceClass.BATTERY.value
-DEVICE_CLASS_BATTERY_CHARGING = BinarySensorDeviceClass.BATTERY_CHARGING.value
-DEVICE_CLASS_CO = BinarySensorDeviceClass.CO.value
-DEVICE_CLASS_COLD = BinarySensorDeviceClass.COLD.value
-DEVICE_CLASS_CONNECTIVITY = BinarySensorDeviceClass.CONNECTIVITY.value
-DEVICE_CLASS_DOOR = BinarySensorDeviceClass.DOOR.value
-DEVICE_CLASS_GARAGE_DOOR = BinarySensorDeviceClass.GARAGE_DOOR.value
-DEVICE_CLASS_GAS = BinarySensorDeviceClass.GAS.value
-DEVICE_CLASS_HEAT = BinarySensorDeviceClass.HEAT.value
-DEVICE_CLASS_LIGHT = BinarySensorDeviceClass.LIGHT.value
-DEVICE_CLASS_LOCK = BinarySensorDeviceClass.LOCK.value
-DEVICE_CLASS_MOISTURE = BinarySensorDeviceClass.MOISTURE.value
-DEVICE_CLASS_MOTION = BinarySensorDeviceClass.MOTION.value
-DEVICE_CLASS_MOVING = BinarySensorDeviceClass.MOVING.value
-DEVICE_CLASS_OCCUPANCY = BinarySensorDeviceClass.OCCUPANCY.value
-DEVICE_CLASS_OPENING = BinarySensorDeviceClass.OPENING.value
-DEVICE_CLASS_PLUG = BinarySensorDeviceClass.PLUG.value
-DEVICE_CLASS_POWER = BinarySensorDeviceClass.POWER.value
-DEVICE_CLASS_PRESENCE = BinarySensorDeviceClass.PRESENCE.value
-DEVICE_CLASS_PROBLEM = BinarySensorDeviceClass.PROBLEM.value
-DEVICE_CLASS_RUNNING = BinarySensorDeviceClass.RUNNING.value
-DEVICE_CLASS_SAFETY = BinarySensorDeviceClass.SAFETY.value
-DEVICE_CLASS_SMOKE = BinarySensorDeviceClass.SMOKE.value
-DEVICE_CLASS_SOUND = BinarySensorDeviceClass.SOUND.value
-DEVICE_CLASS_TAMPER = BinarySensorDeviceClass.TAMPER.value
-DEVICE_CLASS_UPDATE = BinarySensorDeviceClass.UPDATE.value
-DEVICE_CLASS_VIBRATION = BinarySensorDeviceClass.VIBRATION.value
-DEVICE_CLASS_WINDOW = BinarySensorDeviceClass.WINDOW.value
 
 # mypy: disallow-any-generics
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Should not be a breaking change for HA core users.  
Could impact HACS/custom integrations that have ignored the deprecation period.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The binary sensor DEVICE_CLASS_* constants have been [deprecated](https://github.com/home-assistant/core/pull/60651) for almost 2 years, so I expect they can now be removed.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:  #60651
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
