### PR TITLE
knx: don't set tilt support for short commands

### DIFF
--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -29,8 +29,6 @@ from .const import DATA_KNX_CONFIG, DOMAIN
 from .knx_entity import KnxEntity
 from .schema import CoverSchema
 
-_TILTABLE_DEVICE_CLASSES = {CoverDeviceClass.BLIND, CoverDeviceClass.SHUTTER, None}
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -82,15 +80,13 @@ class KNXCover(KnxEntity, CoverEntity):
             | CoverEntityFeature.OPEN
             | CoverEntityFeature.SET_POSITION
         )
-        _device_class = config.get(CONF_DEVICE_CLASS)
-        if self._device.step.writable and _device_class in _TILTABLE_DEVICE_CLASSES:
+        if self._device.step.writable and config[CoverSchema.CONF_ANGLE_ON_MOVE_SHORT]:
             _supports_tilt = True
             self._attr_supported_features |= (
                 CoverEntityFeature.CLOSE_TILT
                 | CoverEntityFeature.OPEN_TILT
                 | CoverEntityFeature.STOP_TILT
             )
-
         if self._device.supports_angle:
             _supports_tilt = True
             self._attr_supported_features |= (
@@ -104,7 +100,7 @@ class KNXCover(KnxEntity, CoverEntity):
             if _supports_tilt:
                 self._attr_supported_features |= CoverEntityFeature.STOP_TILT
 
-        self._attr_device_class = _device_class or (
+        self._attr_device_class = config.get(CONF_DEVICE_CLASS) or (
             CoverDeviceClass.BLIND if _supports_tilt else None
         )
         self._attr_unique_id = (

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -148,12 +148,7 @@ class KNXCover(KnxEntity, CoverEntity):
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
-        if self._device.supports_stop:
-            await self._device.stop()
-        elif self._device.is_opening():
-            await self._device.set_short_up()
-        elif self._device.is_closing():
-            await self._device.set_short_down()
+        await self._device.stop()
 
     @property
     def current_cover_tilt_position(self) -> int | None:

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -508,6 +508,7 @@ class CoverSchema(KNXPlatformSchema):
     CONF_POSITION_STATE_ADDRESS = "position_state_address"
     CONF_ANGLE_ADDRESS = "angle_address"
     CONF_ANGLE_STATE_ADDRESS = "angle_state_address"
+    CONF_ANGLE_ON_MOVE_SHORT = "angle_on_move_short"
     CONF_TRAVELLING_TIME_DOWN = "travelling_time_down"
     CONF_TRAVELLING_TIME_UP = "travelling_time_up"
     CONF_INVERT_UPDOWN = "invert_updown"
@@ -540,6 +541,7 @@ class CoverSchema(KNXPlatformSchema):
                 vol.Optional(CONF_POSITION_STATE_ADDRESS): ga_list_validator,
                 vol.Optional(CONF_ANGLE_ADDRESS): ga_list_validator,
                 vol.Optional(CONF_ANGLE_STATE_ADDRESS): ga_list_validator,
+                vol.Optional(CONF_ANGLE_ON_MOVE_SHORT, default=True): cv.boolean,
                 vol.Optional(
                     CONF_TRAVELLING_TIME_DOWN, default=DEFAULT_TRAVEL_TIME
                 ): cv.positive_float,

--- a/tests/components/knx/test_cover.py
+++ b/tests/components/knx/test_cover.py
@@ -2,9 +2,9 @@
 
 import pytest
 
-from homeassistant.components.cover import CoverDeviceClass, CoverEntityFeature
+from homeassistant.components.cover import CoverEntityFeature
 from homeassistant.components.knx.schema import CoverSchema
-from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME, STATE_CLOSING
+from homeassistant.const import CONF_NAME, STATE_CLOSING
 from homeassistant.core import HomeAssistant
 
 from .conftest import KNXTestKit
@@ -105,11 +105,11 @@ async def test_cover_basic(hass: HomeAssistant, knx: KNXTestKit) -> None:
     [
         (
             {
-                CONF_DEVICE_CLASS: CoverDeviceClass.SHADE,
                 CoverSchema.CONF_MOVE_LONG_ADDRESS: "1/0/0",
                 CoverSchema.CONF_MOVE_SHORT_ADDRESS: "1/0/1",
                 CoverSchema.CONF_POSITION_STATE_ADDRESS: "1/0/2",
                 CoverSchema.CONF_POSITION_ADDRESS: "1/0/3",
+                CoverSchema.CONF_ANGLE_ON_MOVE_SHORT: False,
             },
             CoverEntityFeature.OPEN
             | CoverEntityFeature.CLOSE
@@ -118,11 +118,11 @@ async def test_cover_basic(hass: HomeAssistant, knx: KNXTestKit) -> None:
         ),
         (
             {
-                CONF_DEVICE_CLASS: CoverDeviceClass.BLIND,
                 CoverSchema.CONF_MOVE_LONG_ADDRESS: "1/0/0",
                 CoverSchema.CONF_MOVE_SHORT_ADDRESS: "1/0/1",
                 CoverSchema.CONF_POSITION_STATE_ADDRESS: "1/0/2",
                 CoverSchema.CONF_POSITION_ADDRESS: "1/0/3",
+                CoverSchema.CONF_ANGLE_ON_MOVE_SHORT: True,
             },
             CoverEntityFeature.OPEN
             | CoverEntityFeature.CLOSE
@@ -134,10 +134,10 @@ async def test_cover_basic(hass: HomeAssistant, knx: KNXTestKit) -> None:
         ),
         (
             {
-                CONF_DEVICE_CLASS: CoverDeviceClass.BLIND,
                 CoverSchema.CONF_MOVE_LONG_ADDRESS: "1/0/0",
                 CoverSchema.CONF_POSITION_STATE_ADDRESS: "1/0/2",
                 CoverSchema.CONF_POSITION_ADDRESS: "1/0/3",
+                CoverSchema.CONF_ANGLE_ON_MOVE_SHORT: True,
             },
             CoverEntityFeature.OPEN
             | CoverEntityFeature.CLOSE
@@ -204,6 +204,7 @@ async def test_cover_tilt_absolute(hass: HomeAssistant, knx: KNXTestKit) -> None
                 CoverSchema.CONF_POSITION_ADDRESS: "1/0/3",
                 CoverSchema.CONF_ANGLE_STATE_ADDRESS: "1/0/4",
                 CoverSchema.CONF_ANGLE_ADDRESS: "1/0/5",
+                CoverSchema.CONF_ANGLE_ON_MOVE_SHORT: False,
             }
         }
     )
@@ -242,6 +243,7 @@ async def test_cover_tilt_short(hass: HomeAssistant, knx: KNXTestKit) -> None:
                 CONF_NAME: "test",
                 CoverSchema.CONF_MOVE_LONG_ADDRESS: "1/0/0",
                 CoverSchema.CONF_MOVE_SHORT_ADDRESS: "1/0/1",
+                CoverSchema.CONF_ANGLE_ON_MOVE_SHORT: True,
             }
         }
     )

--- a/tests/components/knx/test_cover.py
+++ b/tests/components/knx/test_cover.py
@@ -91,7 +91,7 @@ async def test_cover_basic(hass: HomeAssistant, knx: KNXTestKit) -> None:
     await hass.services.async_call(
         "cover", "stop_cover", target={"entity_id": "cover.test"}, blocking=True
     )
-    await knx.assert_write("1/0/1", False)
+    await knx.assert_write("1/0/1", True)
 
     assert len(events) == 1
     events.pop()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Allow disabling the link between between tilt angle and short moves.

Currently short moves are linked to tilting of cover. This is somewhat confusing when used in combination of awnings (and other device classes), which don't exhibit such behaviour on short presses. More problematic is that the concept of UP for an awning is to close /retract it. Lovelace will add buttons for UP (for tilt open) for covers with tilt function, leading to UP being displayed to Open/Extend the the awning. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
