### PR TITLE
Fix most sphinx documentation warnings

### DIFF
--- a/docs/source/api/data_entry_flow.rst
+++ b/docs/source/api/data_entry_flow.rst
@@ -1,7 +1,7 @@
 .. _data_entry_flow_module:
 
 :mod:`homeassistant.data_entry_flow`
------------------------------
+------------------------------------
 
 .. automodule:: homeassistant.data_entry_flow
     :members:

--- a/docs/source/api/helpers.rst
+++ b/docs/source/api/helpers.rst
@@ -214,14 +214,6 @@ homeassistant.helpers.location
    :undoc-members:
    :show-inheritance:
 
-homeassistant.helpers.logging
------------------------------
-
-.. automodule:: homeassistant.helpers.logging
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 homeassistant.helpers.network
 -----------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -139,7 +139,7 @@ def linkcode_resolve(domain, info):
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -72,7 +72,8 @@ class AbstractOAuth2Implementation(ABC):
         Pass external data in with:
 
         await hass.config_entries.flow.async_configure(
-            flow_id=flow_id, user_input={'code': 'abcd', 'state': { … }
+            flow_id=flow_id, user_input={'code': 'abcd', 'state': … }
+
         )
 
         """

--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -115,7 +115,7 @@ def json_bytes_strip_null(data: Any) -> bytes:
 
 
 def json_dumps(data: Any) -> str:
-    """Dump json string.
+    r"""Dump json string.
 
     orjson supports serializing dataclasses natively which
     eliminates the need to implement as_dict in many places
@@ -124,7 +124,7 @@ def json_dumps(data: Any) -> str:
     be serialized.
 
     If it turns out to be a problem we can disable this
-    with option |= orjson.OPT_PASSTHROUGH_DATACLASS and it
+    with option \|= orjson.OPT_PASSTHROUGH_DATACLASS and it
     will fallback to as_dict
     """
     return json_bytes(data).decode("utf-8")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
On the current dev branch, several sphinx documentation warnings are generated.

These minor changes to the config and source files remove all but 2 of these errors.

Remaining errors:
```
WARNING: while setting up extension sphinx_autodoc_annotation: directive 'autofunction' is already registered, it will be overridden
WARNING: while setting up extension sphinx_autodoc_annotation: directive 'automethod' is already registered, it will be overridden
``` 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #101220
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
