### PR TITLE
Fix ZHA device diagnostics error for unknown unsupported attributes

### DIFF
--- a/homeassistant/components/zha/diagnostics.py
+++ b/homeassistant/components/zha/diagnostics.py
@@ -147,8 +147,6 @@ def get_cluster_attr_data(cluster: Cluster) -> dict:
                 ATTR_ATTRIBUTE_NAME: u_attr_def.name
             }
         except KeyError:
-            pass
-        else:
             if isinstance(u_attr, int):
                 unsupported_attributes[f"0x{u_attr:04x}"] = {}
             else:

--- a/homeassistant/components/zha/diagnostics.py
+++ b/homeassistant/components/zha/diagnostics.py
@@ -139,6 +139,21 @@ def get_endpoint_cluster_attr_data(zha_device: ZHADevice) -> dict:
 
 def get_cluster_attr_data(cluster: Cluster) -> dict:
     """Return cluster attribute data."""
+    unsupported_attributes = {}
+    for u_attr in cluster.unsupported_attributes:
+        try:
+            u_attr_def = cluster.find_attribute(u_attr)
+            unsupported_attributes[f"0x{u_attr_def.id:04x}"] = {
+                ATTR_ATTRIBUTE_NAME: u_attr_def.name
+            }
+        except KeyError:
+            pass
+        else:
+            if isinstance(u_attr, int):
+                unsupported_attributes[f"0x{u_attr:04x}"] = {}
+            else:
+                unsupported_attributes[u_attr] = {}
+
     return {
         ATTRIBUTES: {
             f"0x{attr_id:04x}": {
@@ -148,10 +163,5 @@ def get_cluster_attr_data(cluster: Cluster) -> dict:
             for attr_id, attr_def in cluster.attributes.items()
             if (attr_value := cluster.get(attr_def.name)) is not None
         },
-        UNSUPPORTED_ATTRIBUTES: {
-            f"0x{cluster.find_attribute(u_attr).id:04x}": {
-                ATTR_ATTRIBUTE_NAME: cluster.find_attribute(u_attr).name
-            }
-            for u_attr in cluster.unsupported_attributes
-        },
+        UNSUPPORTED_ATTRIBUTES: unsupported_attributes,
     }

--- a/tests/components/zha/test_diagnostics.py
+++ b/tests/components/zha/test_diagnostics.py
@@ -93,6 +93,12 @@ async def test_diagnostics_for_device(
 ) -> None:
     """Test diagnostics for device."""
     zha_device: ZHADevice = await zha_device_joined(zigpy_device)
+
+    # add an unsupported attribute to the device to verify diagnostics handles it
+    zha_device.device.endpoints[1].in_clusters[
+        security.IasAce.cluster_id
+    ].unsupported_attributes.add(0x1000)
+
     dev_reg = async_get(hass)
     device = dev_reg.async_get_device(identifiers={("zha", str(zha_device.ieee))})
     assert device

--- a/tests/components/zha/test_diagnostics.py
+++ b/tests/components/zha/test_diagnostics.py
@@ -44,7 +44,7 @@ def zigpy_device(zigpy_device_mock):
     """Device tracker zigpy device."""
     endpoints = {
         1: {
-            SIG_EP_INPUT: [security.IasAce.cluster_id],
+            SIG_EP_INPUT: [security.IasAce.cluster_id, security.IasZone.cluster_id],
             SIG_EP_OUTPUT: [],
             SIG_EP_TYPE: zha.DeviceType.IAS_ANCILLARY_CONTROL,
             SIG_EP_PROFILE: zha.PROFILE_ID,
@@ -94,10 +94,20 @@ async def test_diagnostics_for_device(
     """Test diagnostics for device."""
     zha_device: ZHADevice = await zha_device_joined(zigpy_device)
 
-    # add an unknown unsupported attribute to the device to verify diagnostics handles it
+    # add unknown unsupported attribute with id and name
     zha_device.device.endpoints[1].in_clusters[
         security.IasAce.cluster_id
-    ].unsupported_attributes.add(0x1000)
+    ].unsupported_attributes.update({0x1000, "unknown_attribute_name"})
+
+    # add known unsupported attributes with id and name
+    zha_device.device.endpoints[1].in_clusters[
+        security.IasZone.cluster_id
+    ].unsupported_attributes.update(
+        {
+            security.IasZone.AttributeDefs.num_zone_sensitivity_levels_supported.id,
+            security.IasZone.AttributeDefs.current_zone_sensitivity_level.name,
+        }
+    )
 
     dev_reg = async_get(hass)
     device = dev_reg.async_get_device(identifiers={("zha", str(zha_device.ieee))})

--- a/tests/components/zha/test_diagnostics.py
+++ b/tests/components/zha/test_diagnostics.py
@@ -94,7 +94,7 @@ async def test_diagnostics_for_device(
     """Test diagnostics for device."""
     zha_device: ZHADevice = await zha_device_joined(zigpy_device)
 
-    # add an unsupported attribute to the device to verify diagnostics handles it
+    # add an unknown unsupported attribute to the device to verify diagnostics handles it
     zha_device.device.endpoints[1].in_clusters[
         security.IasAce.cluster_id
     ].unsupported_attributes.add(0x1000)


### PR DESCRIPTION
## Proposed change
This PR introduces error checking for finding attribute name/id when downloading ZHA device diagnostics for (unknown) unsupported attributes.

Previously, downloading diagnostics would fail, as seen in:
- https://github.com/home-assistant/core/issues/100520
- https://github.com/home-assistant/core/issues/81047#issuecomment-1325571812
- https://github.com/zigpy/zha-device-handlers/issues/2574#issuecomment-1723508357
- https://github.com/zigpy/zha-device-handlers/issues/2359
- https://github.com/zigpy/zha-device-handlers/issues/2106#issuecomment-1385840356
- https://github.com/zigpy/zha-device-handlers/issues/1960

<br/>

<details>
<summary>Exception/log snippet (click to expand) (or see any of the above mentioned issues for a stack trace)</summary>

```python
  File "/Users/devm/python_projects/ha_core/homeassistant/components/diagnostics/__init__.py", line 268, in get
    data = await info.device_diagnostics(hass, config_entry, device)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/devm/python_projects/ha_core/homeassistant/components/zha/diagnostics.py", line 100, in async_get_device_diagnostics
    device_info[CLUSTER_DETAILS] = get_endpoint_cluster_attr_data(zha_device)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/devm/python_projects/ha_core/homeassistant/components/zha/diagnostics.py", line 122, in get_endpoint_cluster_attr_data
    ATTR_IN_CLUSTERS: {
                      ^
  File "/Users/devm/python_projects/ha_core/homeassistant/components/zha/diagnostics.py", line 125, in <dictcomp>
    **get_cluster_attr_data(cluster),
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/devm/python_projects/ha_core/homeassistant/components/zha/diagnostics.py", line 151, in get_cluster_attr_data
    UNSUPPORTED_ATTRIBUTES: {
                            ^
  File "/Users/devm/python_projects/ha_core/homeassistant/components/zha/diagnostics.py", line 152, in <dictcomp>
    f"0x{cluster.find_attribute(u_attr).id:04x}": {
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/devm/python_projects/ha_core/venv/lib/python3.11/site-packages/zigpy/zcl/__init__.py", line 233, in find_attribute
    return self.attributes[name_or_id]
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^
KeyError: 4096
```

</details>

The code might not be as clean looking as before, but I can't think of a "better way" to handle all scenarios.
At least the relevant lines are now actually covered (which they technically weren't before really).

Possible questions:
1. Can `u_attr: int | str` actually be a `str` or is it always an `int` for unsupported attributes? (typed as `int | str`)
2. Should `ATTR_ATTRIBUTE_NAME` be set to something? (or something else?)


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #100520
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
