### PR TITLE
Add WS command sensor/numeric_device_classes

### DIFF
--- a/homeassistant/components/sensor/websocket_api.py
+++ b/homeassistant/components/sensor/websocket_api.py
@@ -53,7 +53,7 @@ def ws_device_class_units(
 def ws_numeric_device_classes(
     hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
-    """Return supported units for a device class."""
+    """Return numeric sensor device classes."""
     numeric_device_classes = set(SensorDeviceClass) - NON_NUMERIC_DEVICE_CLASSES
     connection.send_result(
         msg["id"], {"numeric_device_classes": list(numeric_device_classes)}

--- a/homeassistant/components/sensor/websocket_api.py
+++ b/homeassistant/components/sensor/websocket_api.py
@@ -8,13 +8,19 @@ import voluptuous as vol
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
 
-from .const import DEVICE_CLASS_UNITS, UNIT_CONVERTERS
+from .const import (
+    DEVICE_CLASS_UNITS,
+    NON_NUMERIC_DEVICE_CLASSES,
+    UNIT_CONVERTERS,
+    SensorDeviceClass,
+)
 
 
 @callback
 def async_setup(hass: HomeAssistant) -> None:
     """Set up the sensor websocket API."""
     websocket_api.async_register_command(hass, ws_device_class_units)
+    websocket_api.async_register_command(hass, ws_numeric_device_classes)
 
 
 @callback
@@ -36,3 +42,19 @@ def ws_device_class_units(
             key=lambda s: str.casefold(str(s)),
         )
     connection.send_result(msg["id"], {"units": convertible_units})
+
+
+@callback
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "sensor/numeric_device_classes",
+    }
+)
+def ws_numeric_device_classes(
+    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
+) -> None:
+    """Return supported units for a device class."""
+    numeric_device_classes = set(SensorDeviceClass) - NON_NUMERIC_DEVICE_CLASSES
+    connection.send_result(
+        msg["id"], {"numeric_device_classes": list(numeric_device_classes)}
+    )

--- a/tests/components/sensor/test_websocket_api.py
+++ b/tests/components/sensor/test_websocket_api.py
@@ -1,5 +1,11 @@
 """Test the sensor websocket API."""
-from homeassistant.components.sensor.const import DOMAIN
+from pytest_unordered import unordered
+
+from homeassistant.components.sensor.const import (
+    DOMAIN,
+    NON_NUMERIC_DEVICE_CLASSES,
+    SensorDeviceClass,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -59,3 +65,22 @@ async def test_device_class_units(
     msg = await client.receive_json()
     assert msg["success"]
     assert msg["result"] == {"units": []}
+
+
+async def test_numeric_device_classes(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Test we can get numeric device classes."""
+    numeric_device_classes = set(SensorDeviceClass) - NON_NUMERIC_DEVICE_CLASSES
+
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    client = await hass_ws_client(hass)
+
+    # Device class with units which sensor allows customizing & converting
+    await client.send_json_auto_id({"type": "sensor/numeric_device_classes"})
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"] == {
+        "numeric_device_classes": unordered(list(numeric_device_classes))
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add WS command `sensor/numeric_device_classes`

Needed by frontend PR https://github.com/home-assistant/frontend/pull/18099


### Background
If either of the following is true, frontend should plot a graph for sensor history:
- A sensor has a unit of measurement which is not None
- A sensor has a state class which is not None
- A sensor has a device_class which is numeric

The third check is enabled by the command added in this PR

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
