### PR TITLE
Discover switch entities from Hue behavior_script instances

### DIFF
--- a/homeassistant/components/hue/strings.json
+++ b/homeassistant/components/hue/strings.json
@@ -109,8 +109,8 @@
       "automation": {
         "name": "Automation",
         "state": {
-          "on": "Enabled",
-          "off": "Disabled"
+          "on": "[%key:common::state::enabled%",
+          "off": "[%key:common::state::disabled%"
         }
       }
     }

--- a/homeassistant/components/hue/strings.json
+++ b/homeassistant/components/hue/strings.json
@@ -107,7 +107,6 @@
     },
     "switch": {
       "automation": {
-        "name": "Automation",
         "state": {
           "on": "[%key:common::state::enabled%",
           "off": "[%key:common::state::disabled%"

--- a/homeassistant/components/hue/strings.json
+++ b/homeassistant/components/hue/strings.json
@@ -104,6 +104,15 @@
           "unidirectional_incoming": "Unidirectional incoming"
         }
       }
+    },
+    "switch": {
+      "automation": {
+        "name": "Automation",
+        "state": {
+          "on": "Enabled",
+          "off": "Disabled"
+        }
+      }
     }
   },
   "options": {

--- a/homeassistant/components/hue/switch.py
+++ b/homeassistant/components/hue/switch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Any, TypeAlias
 
 from aiohue.v2 import HueBridgeV2
+from aiohue.v2.controllers.config import BehaviorInstance, BehaviorInstanceController
 from aiohue.v2.controllers.events import EventType
 from aiohue.v2.controllers.sensors import (
     LightLevel,
@@ -12,7 +13,11 @@ from aiohue.v2.controllers.sensors import (
     MotionController,
 )
 
-from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
+from homeassistant.components.switch import (
+    SwitchDeviceClass,
+    SwitchEntity,
+    SwitchEntityDescription,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
@@ -22,7 +27,9 @@ from .bridge import HueBridge
 from .const import DOMAIN
 from .v2.entity import HueBaseEntity
 
-ControllerType: TypeAlias = LightLevelController | MotionController
+ControllerType: TypeAlias = (
+    BehaviorInstanceController | LightLevelController | MotionController
+)
 
 SensingService: TypeAlias = LightLevel | Motion
 
@@ -43,11 +50,18 @@ async def async_setup_entry(
     @callback
     def register_items(controller: ControllerType):
         @callback
-        def async_add_entity(event_type: EventType, resource: SensingService) -> None:
+        def async_add_entity(
+            event_type: EventType, resource: SensingService | BehaviorInstance
+        ) -> None:
             """Add entity from Hue resource."""
-            async_add_entities(
-                [HueSensingServiceEnabledEntity(bridge, controller, resource)]
-            )
+            if isinstance(resource, BehaviorInstance):
+                async_add_entities(
+                    [HueBehaviorInstanceEnabledEntity(bridge, controller, resource)]
+                )
+            else:
+                async_add_entities(
+                    [HueSensingServiceEnabledEntity(bridge, controller, resource)]
+                )
 
         # add all current items in controller
         for item in controller:
@@ -63,24 +77,13 @@ async def async_setup_entry(
     # setup for each switch-type hue resource
     register_items(api.sensors.motion)
     register_items(api.sensors.light_level)
+    register_items(api.config.behavior_instance)
 
 
-class HueSensingServiceEnabledEntity(HueBaseEntity, SwitchEntity):
-    """Representation of a Switch entity from Hue SensingService."""
+class HueResourceEnabledEntity(HueBaseEntity, SwitchEntity):
+    """Representation of a Switch entity from a Hue resource that can be toggled enabled."""
 
-    _attr_entity_category = EntityCategory.CONFIG
-    _attr_device_class = SwitchDeviceClass.SWITCH
-
-    def __init__(
-        self,
-        bridge: HueBridge,
-        controller: LightLevelController | MotionController,
-        resource: SensingService,
-    ) -> None:
-        """Initialize the entity."""
-        super().__init__(bridge, controller, resource)
-        self.resource = resource
-        self.controller = controller
+    controller: BehaviorInstanceController | LightLevelController | MotionController
 
     @property
     def is_on(self) -> bool:
@@ -98,3 +101,31 @@ class HueSensingServiceEnabledEntity(HueBaseEntity, SwitchEntity):
         await self.bridge.async_request_call(
             self.controller.set_enabled, self.resource.id, enabled=False
         )
+
+
+class HueSensingServiceEnabledEntity(HueResourceEnabledEntity):
+    """Representation of a Switch entity from Hue SensingService."""
+
+    entity_description = SwitchEntityDescription(
+        key="behavior_instance",
+        device_class=SwitchDeviceClass.SWITCH,
+        entity_category=EntityCategory.CONFIG,
+    )
+
+
+class HueBehaviorInstanceEnabledEntity(HueResourceEnabledEntity):
+    """Representation of a Switch entity to enable/disable a Hue Behavior Instance."""
+
+    resource: BehaviorInstance
+
+    entity_description = SwitchEntityDescription(
+        key="behavior_instance",
+        device_class=SwitchDeviceClass.SWITCH,
+        entity_category=EntityCategory.CONFIG,
+        has_entity_name=False,
+    )
+
+    @property
+    def name(self) -> str:
+        """Return name for this entity."""
+        return f"Automation: {self.resource.metadata.name}"

--- a/homeassistant/components/hue/switch.py
+++ b/homeassistant/components/hue/switch.py
@@ -123,6 +123,7 @@ class HueBehaviorInstanceEnabledEntity(HueResourceEnabledEntity):
         device_class=SwitchDeviceClass.SWITCH,
         entity_category=EntityCategory.CONFIG,
         has_entity_name=False,
+        translation_key="automation",
     )
 
     @property

--- a/tests/components/hue/fixtures/v2_resources.json
+++ b/tests/components/hue/fixtures/v2_resources.json
@@ -2050,37 +2050,53 @@
     "type": "temperature"
   },
   {
+    "id": "9ad57767-e622-4f91-9086-2e5573bc781b",
+    "type": "behavior_instance",
+    "script_id": "e73bc72d-96b1-46f8-aa57-729861f80c78",
+    "enabled": true,
+    "state": {
+      "timer_state": "stopped"
+    },
     "configuration": {
-      "end_state": "last_state",
+      "duration": {
+        "seconds": 60
+      },
+      "what": [
+        {
+          "group": {
+            "rid": "5e799732-e82e-46ab-b5d9-52b701bd7cbc",
+            "rtype": "room"
+          },
+          "recall": {
+            "rid": "732ff1d9-76a7-4630-aad0-c8acc499bb0b",
+            "rtype": "recipe"
+          }
+        }
+      ],
       "where": [
         {
           "group": {
-            "rid": "c14cf1cf-6c7a-4984-b8bb-c5b71aeb70fc",
-            "rtype": "entertainment_configuration"
+            "rid": "5e799732-e82e-46ab-b5d9-52b701bd7cbc",
+            "rtype": "room"
           }
         }
       ]
     },
     "dependees": [
       {
-        "level": "critical",
         "target": {
-          "rid": "c14cf1cf-6c7a-4984-b8bb-c5b71aeb70fc",
-          "rtype": "entertainment_configuration"
+          "rid": "5e799732-e82e-46ab-b5d9-52b701bd7cbc",
+          "rtype": "room"
         },
+        "level": "critical",
         "type": "ResourceDependee"
       }
     ],
-    "enabled": true,
-    "id": "0670cfb1-2bd7-4237-a0e3-1827a44d7231",
+    "status": "running",
     "last_error": "",
     "metadata": {
-      "name": "state_after_streaming"
-    },
-    "migrated_from": "/resourcelinks/47450",
-    "script_id": "7719b841-6b3d-448d-a0e7-601ae9edb6a2",
-    "status": "running",
-    "type": "behavior_instance"
+      "name": "Timer Test"
+    }
   },
   {
     "configuration_schema": {

--- a/tests/components/hue/test_switch.py
+++ b/tests/components/hue/test_switch.py
@@ -14,13 +14,20 @@ async def test_switch(
     await setup_platform(hass, mock_bridge_v2, "switch")
     # there shouldn't have been any requests at this point
     assert len(mock_bridge_v2.mock_requests) == 0
-    # 3 entities should be created from test data
-    assert len(hass.states.async_all()) == 3
+    # 4 entities should be created from test data
+    assert len(hass.states.async_all()) == 4
 
     # test config switch to enable/disable motion sensor
     test_entity = hass.states.get("switch.hue_motion_sensor_motion")
     assert test_entity is not None
     assert test_entity.name == "Hue motion sensor Motion"
+    assert test_entity.state == "on"
+    assert test_entity.attributes["device_class"] == "switch"
+
+    # test config switch to enable/disable a behavior_instance resource (=builtin automation)
+    test_entity = hass.states.get("switch.automation_timer_test")
+    assert test_entity is not None
+    assert test_entity.name == "Automation: Timer Test"
     assert test_entity.state == "on"
     assert test_entity.attributes["device_class"] == "switch"
 


### PR DESCRIPTION
## Proposed change
Discover HA entities from Hue resources of type "behavior_instances", which basically are just automations that run on the bridge. With these switch entities you can enable/disable automations on the Hue bridge.

NOTE: The entities created are for enabling/disabling the builtin Hue automations, not for actually running/activating them.
Although this should be possible to execute over the api, the documentation is still a bit vague hence this will be something to add on another day im a follow-up PR.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
