### PR TITLE
Add support for Levoit Vital 100S Purifier

### DIFF
--- a/homeassistant/components/vesync/const.py
+++ b/homeassistant/components/vesync/const.py
@@ -36,9 +36,12 @@ SKU_TO_BASE_DEVICE = {
     "LAP-C601S-WUS": "Core600S",  # Alt ID Model Core600S
     "LAP-C601S-WUSR": "Core600S",  # Alt ID Model Core600S
     "LAP-C601S-WEU": "Core600S",  # Alt ID Model Core600S,
-    "LAP-V201S-AASR": "Vital200S",
-    "LAP-V201S-WJP": "Vital200S",
-    "LAP-V201S-WEU": "Vital200S",
-    "LAP-V201S-WUS": "Vital200S",
-    "LAP-V201-AUSR": "Vital200S",
+    "Vital200S": "Vital200S",
+    "LAP-V201S-AASR": "Vital200S",  # Alt ID Model Vital200S
+    "LAP-V201S-WJP": "Vital200S",  # Alt ID Model Vital200S
+    "LAP-V201S-WEU": "Vital200S",  # Alt ID Model Vital200S
+    "LAP-V201S-WUS": "Vital200S",  # Alt ID Model Vital200S
+    "LAP-V201-AUSR": "Vital200S",  # Alt ID Model Vital200S
+    "Vital100S": "Vital100S",
+    "LAP-V102S-WUS": "Vital100S",  # Alt ID Model Vital100S,
 }

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -28,6 +28,7 @@ DEV_TYPE_TO_HA = {
     "Core400S": "fan",
     "Core600S": "fan",
     "Vital200S": "fan",
+    "Vital100S": "fan",
 }
 
 FAN_MODE_AUTO = "auto"
@@ -41,6 +42,7 @@ PRESET_MODES = {
     "Core400S": [FAN_MODE_AUTO, FAN_MODE_SLEEP],
     "Core600S": [FAN_MODE_AUTO, FAN_MODE_SLEEP],
     "Vital200S": [FAN_MODE_AUTO, FAN_MODE_SLEEP, FAN_MODE_PET],
+    "Vital100S": [FAN_MODE_AUTO, FAN_MODE_SLEEP, FAN_MODE_PET],
 }
 SPEED_RANGE = {  # off is not included
     "LV-PUR131S": (1, 3),
@@ -49,6 +51,7 @@ SPEED_RANGE = {  # off is not included
     "Core400S": (1, 4),
     "Core600S": (1, 4),
     "Vital200S": (1, 4),
+    "Vital100S": (1, 4),
 }
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
 N/A

## Proposed change

Add support for Levoit Vital 100s. See: #91987 

## Type of change

Add device support in vesync integration for Levoit Vital 100s Purifier.

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #91987 
- This PR is related to issue:  #91987 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
