### PR TITLE
Remove NONE_SENTINEL in favor of optional select in scrape

### DIFF
--- a/homeassistant/components/scrape/config_flow.py
+++ b/homeassistant/components/scrape/config_flow.py
@@ -204,10 +204,10 @@ async def validate_sensor_edit(
     # In this case, we want to add a sub-item so we update the options directly.
     idx: int = handler.flow_state["_idx"]
     handler.options[SENSOR_DOMAIN][idx].update(user_input)
-    for key in DATA_SCHEMA_EDIT_SENSOR.schema.keys() - user_input.keys():
-        # Not selecting any option for a optional select results that the key is not
-        # present in user_input. As dict.update does not delete them, we do it manually here
-        handler.options[SENSOR_DOMAIN][idx].pop(key, None)
+    for key in DATA_SCHEMA_EDIT_SENSOR.schema:
+        if isinstance(key, vol.Optional) and key not in user_input:
+            # Key not present, delete keys old value (if present) too
+            handler.options[SENSOR_DOMAIN][idx].pop(key, None)
     return {}
 
 

--- a/homeassistant/components/scrape/config_flow.py
+++ b/homeassistant/components/scrape/config_flow.py
@@ -97,8 +97,6 @@ RESOURCE_SETUP = {
     vol.Optional(CONF_ENCODING, default=DEFAULT_ENCODING): TextSelector(),
 }
 
-NONE_SENTINEL = "none"
-
 SENSOR_SETUP = {
     vol.Required(CONF_SELECT): TextSelector(),
     vol.Optional(CONF_INDEX, default=0): NumberSelector(
@@ -106,43 +104,34 @@ SENSOR_SETUP = {
     ),
     vol.Optional(CONF_ATTRIBUTE): TextSelector(),
     vol.Optional(CONF_VALUE_TEMPLATE): TemplateSelector(),
-    vol.Required(CONF_DEVICE_CLASS, default=NONE_SENTINEL): SelectSelector(
+    vol.Optional(CONF_DEVICE_CLASS): SelectSelector(
         SelectSelectorConfig(
-            options=[NONE_SENTINEL]
-            + sorted(
-                [
-                    cls.value
-                    for cls in SensorDeviceClass
-                    if cls != SensorDeviceClass.ENUM
-                ]
-            ),
+            options=[
+                cls.value for cls in SensorDeviceClass if cls != SensorDeviceClass.ENUM
+            ],
             mode=SelectSelectorMode.DROPDOWN,
             translation_key="device_class",
+            sort=True,
         )
     ),
-    vol.Required(CONF_STATE_CLASS, default=NONE_SENTINEL): SelectSelector(
+    vol.Optional(CONF_STATE_CLASS): SelectSelector(
         SelectSelectorConfig(
-            options=[NONE_SENTINEL] + sorted([cls.value for cls in SensorStateClass]),
+            options=[cls.value for cls in SensorStateClass],
             mode=SelectSelectorMode.DROPDOWN,
             translation_key="state_class",
+            sort=True,
         )
     ),
-    vol.Required(CONF_UNIT_OF_MEASUREMENT, default=NONE_SENTINEL): SelectSelector(
+    vol.Optional(CONF_UNIT_OF_MEASUREMENT): SelectSelector(
         SelectSelectorConfig(
-            options=[NONE_SENTINEL] + sorted([cls.value for cls in UnitOfTemperature]),
+            options=[cls.value for cls in UnitOfTemperature],
             custom_value=True,
             mode=SelectSelectorMode.DROPDOWN,
             translation_key="unit_of_measurement",
+            sort=True,
         )
     ),
 }
-
-
-def _strip_sentinel(options: dict[str, Any]) -> None:
-    """Convert sentinel to None."""
-    for key in (CONF_DEVICE_CLASS, CONF_STATE_CLASS, CONF_UNIT_OF_MEASUREMENT):
-        if options[key] == NONE_SENTINEL:
-            options.pop(key)
 
 
 async def validate_rest_setup(
@@ -171,7 +160,6 @@ async def validate_sensor_setup(
     # Standard behavior is to merge the result with the options.
     # In this case, we want to add a sub-item so we update the options directly.
     sensors: list[dict[str, Any]] = handler.options.setdefault(SENSOR_DOMAIN, [])
-    _strip_sentinel(user_input)
     sensors.append(user_input)
     return {}
 
@@ -203,11 +191,7 @@ async def get_edit_sensor_suggested_values(
 ) -> dict[str, Any]:
     """Return suggested values for sensor editing."""
     idx: int = handler.flow_state["_idx"]
-    suggested_values: dict[str, Any] = dict(handler.options[SENSOR_DOMAIN][idx])
-    for key in (CONF_DEVICE_CLASS, CONF_STATE_CLASS, CONF_UNIT_OF_MEASUREMENT):
-        if not suggested_values.get(key):
-            suggested_values[key] = NONE_SENTINEL
-    return suggested_values
+    return dict(handler.options[SENSOR_DOMAIN][idx])
 
 
 async def validate_sensor_edit(
@@ -220,7 +204,10 @@ async def validate_sensor_edit(
     # In this case, we want to add a sub-item so we update the options directly.
     idx: int = handler.flow_state["_idx"]
     handler.options[SENSOR_DOMAIN][idx].update(user_input)
-    _strip_sentinel(handler.options[SENSOR_DOMAIN][idx])
+    for key in DATA_SCHEMA_EDIT_SENSOR.schema.keys() - user_input.keys():
+        # Not selecting any option for a optional select results that the key is not
+        # present in user_input. As dict.update does not delete them, we do it manually here
+        handler.options[SENSOR_DOMAIN][idx].pop(key, None)
     return {}
 
 

--- a/homeassistant/components/scrape/config_flow.py
+++ b/homeassistant/components/scrape/config_flow.py
@@ -201,7 +201,8 @@ async def validate_sensor_edit(
     user_input[CONF_INDEX] = int(user_input[CONF_INDEX])
 
     # Standard behavior is to merge the result with the options.
-    # In this case, we want to add a sub-item so we update the options directly.
+    # In this case, we want to add a sub-item so we update the options directly,
+    # including popping omitted optional schema items.
     idx: int = handler.flow_state["_idx"]
     handler.options[SENSOR_DOMAIN][idx].update(user_input)
     for key in DATA_SCHEMA_EDIT_SENSOR.schema:

--- a/homeassistant/components/scrape/strings.json
+++ b/homeassistant/components/scrape/strings.json
@@ -133,7 +133,6 @@
   "selector": {
     "device_class": {
       "options": {
-        "none": "No device class",
         "date": "[%key:component::sensor::entity_component::date::name%]",
         "duration": "[%key:component::sensor::entity_component::duration::name%]",
         "apparent_power": "[%key:component::sensor::entity_component::apparent_power::name%]",
@@ -187,7 +186,6 @@
     },
     "state_class": {
       "options": {
-        "none": "No state class",
         "measurement": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::measurement%]",
         "total": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::total%]",
         "total_increasing": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::total_increasing%]"

--- a/tests/components/scrape/test_config_flow.py
+++ b/tests/components/scrape/test_config_flow.py
@@ -8,7 +8,6 @@ from homeassistant import config_entries
 from homeassistant.components.rest.data import DEFAULT_TIMEOUT
 from homeassistant.components.rest.schema import DEFAULT_METHOD
 from homeassistant.components.scrape import DOMAIN
-from homeassistant.components.scrape.config_flow import NONE_SENTINEL
 from homeassistant.components.scrape.const import (
     CONF_ENCODING,
     CONF_INDEX,
@@ -71,9 +70,6 @@ async def test_form(
                 CONF_NAME: "Current version",
                 CONF_SELECT: ".current-version h1",
                 CONF_INDEX: 0.0,
-                CONF_DEVICE_CLASS: NONE_SENTINEL,
-                CONF_STATE_CLASS: NONE_SENTINEL,
-                CONF_UNIT_OF_MEASUREMENT: NONE_SENTINEL,
             },
         )
         await hass.async_block_till_done()
@@ -132,9 +128,6 @@ async def test_form_with_post(
                 CONF_NAME: "Current version",
                 CONF_SELECT: ".current-version h1",
                 CONF_INDEX: 0.0,
-                CONF_DEVICE_CLASS: NONE_SENTINEL,
-                CONF_STATE_CLASS: NONE_SENTINEL,
-                CONF_UNIT_OF_MEASUREMENT: NONE_SENTINEL,
             },
         )
         await hass.async_block_till_done()
@@ -226,9 +219,6 @@ async def test_flow_fails(
                 CONF_NAME: "Current version",
                 CONF_SELECT: ".current-version h1",
                 CONF_INDEX: 0.0,
-                CONF_DEVICE_CLASS: NONE_SENTINEL,
-                CONF_STATE_CLASS: NONE_SENTINEL,
-                CONF_UNIT_OF_MEASUREMENT: NONE_SENTINEL,
             },
         )
         await hass.async_block_till_done()
@@ -350,9 +340,6 @@ async def test_options_add_remove_sensor_flow(
                 CONF_NAME: "Template",
                 CONF_SELECT: "template",
                 CONF_INDEX: 0.0,
-                CONF_DEVICE_CLASS: NONE_SENTINEL,
-                CONF_STATE_CLASS: NONE_SENTINEL,
-                CONF_UNIT_OF_MEASUREMENT: NONE_SENTINEL,
             },
         )
         await hass.async_block_till_done()
@@ -480,9 +467,6 @@ async def test_options_edit_sensor_flow(
             user_input={
                 CONF_SELECT: "template",
                 CONF_INDEX: 0.0,
-                CONF_DEVICE_CLASS: NONE_SENTINEL,
-                CONF_STATE_CLASS: NONE_SENTINEL,
-                CONF_UNIT_OF_MEASUREMENT: NONE_SENTINEL,
             },
         )
         await hass.async_block_till_done()
@@ -646,9 +630,6 @@ async def test_sensor_options_remove_device_class(
             CONF_SELECT: ".current-temp h3",
             CONF_INDEX: 0.0,
             CONF_VALUE_TEMPLATE: "{{ value.split(':')[1] }}",
-            CONF_DEVICE_CLASS: NONE_SENTINEL,
-            CONF_STATE_CLASS: NONE_SENTINEL,
-            CONF_UNIT_OF_MEASUREMENT: NONE_SENTINEL,
         },
     )
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The frontend support with https://github.com/home-assistant/frontend/pull/18047 deselecting an optional SelectSelector. No need anymore for the `NONE_SENTINEL` and sorting is done now by the frontend for all languages.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
