### PR TITLE
Remove NONE_SENTINEL in favor of optional select in template

### DIFF
--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -37,8 +37,6 @@ from .const import DOMAIN
 from .sensor import async_create_preview_sensor
 from .template_entity import TemplateEntity
 
-NONE_SENTINEL = "none"
-
 
 def generate_schema(domain: str, flow_type: str) -> dict[vol.Marker, Any]:
     """Generate schema."""
@@ -48,71 +46,48 @@ def generate_schema(domain: str, flow_type: str) -> dict[vol.Marker, Any]:
         schema = {
             vol.Optional(CONF_DEVICE_CLASS): selector.SelectSelector(
                 selector.SelectSelectorConfig(
-                    options=[
-                        NONE_SENTINEL,
-                        *sorted(
-                            [cls.value for cls in BinarySensorDeviceClass],
-                            key=str.casefold,
-                        ),
-                    ],
+                    options=[cls.value for cls in BinarySensorDeviceClass],
                     mode=selector.SelectSelectorMode.DROPDOWN,
                     translation_key="binary_sensor_device_class",
+                    sort=True,
                 ),
             )
         }
 
     if domain == Platform.SENSOR:
         schema = {
-            vol.Optional(
-                CONF_UNIT_OF_MEASUREMENT, default=NONE_SENTINEL
-            ): selector.SelectSelector(
+            vol.Optional(CONF_UNIT_OF_MEASUREMENT): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=[
-                        NONE_SENTINEL,
-                        *sorted(
-                            {
-                                str(unit)
-                                for units in DEVICE_CLASS_UNITS.values()
-                                for unit in units
-                                if unit is not None
-                            },
-                            key=str.casefold,
-                        ),
+                        str(unit)
+                        for units in DEVICE_CLASS_UNITS.values()
+                        for unit in units
+                        if unit is not None
                     ],
                     mode=selector.SelectSelectorMode.DROPDOWN,
                     translation_key="sensor_unit_of_measurement",
                     custom_value=True,
+                    sort=True,
                 ),
             ),
-            vol.Optional(
-                CONF_DEVICE_CLASS, default=NONE_SENTINEL
-            ): selector.SelectSelector(
+            vol.Optional(CONF_DEVICE_CLASS): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=[
-                        NONE_SENTINEL,
-                        *sorted(
-                            [
-                                cls.value
-                                for cls in SensorDeviceClass
-                                if cls != SensorDeviceClass.ENUM
-                            ],
-                            key=str.casefold,
-                        ),
+                        cls.value
+                        for cls in SensorDeviceClass
+                        if cls != SensorDeviceClass.ENUM
                     ],
                     mode=selector.SelectSelectorMode.DROPDOWN,
                     translation_key="sensor_device_class",
+                    sort=True,
                 ),
             ),
-            vol.Optional(
-                CONF_STATE_CLASS, default=NONE_SENTINEL
-            ): selector.SelectSelector(
+            vol.Optional(CONF_STATE_CLASS): selector.SelectSelector(
                 selector.SelectSelectorConfig(
-                    options=[
-                        NONE_SENTINEL,
-                        *sorted([cls.value for cls in SensorStateClass]),
-                    ],
+                    options=[cls.value for cls in SensorStateClass],
                     mode=selector.SelectSelectorMode.DROPDOWN,
                     translation_key="sensor_state_class",
+                    sort=True,
                 ),
             ),
         }
@@ -142,15 +117,6 @@ def config_schema(domain: str) -> vol.Schema:
 async def choose_options_step(options: dict[str, Any]) -> str:
     """Return next step_id for options flow according to template_type."""
     return cast(str, options["template_type"])
-
-
-def _strip_sentinel(options: dict[str, Any]) -> None:
-    """Convert sentinel to None."""
-    for key in (CONF_DEVICE_CLASS, CONF_STATE_CLASS, CONF_UNIT_OF_MEASUREMENT):
-        if key not in options:
-            continue
-        if options[key] == NONE_SENTINEL:
-            options.pop(key)
 
 
 def _validate_unit(options: dict[str, Any]) -> None:
@@ -218,8 +184,6 @@ def validate_user_input(
         user_input: dict[str, Any],
     ) -> dict[str, Any]:
         """Add template type to user input."""
-        if template_type in (Platform.BINARY_SENSOR, Platform.SENSOR):
-            _strip_sentinel(user_input)
         if template_type == Platform.SENSOR:
             _validate_unit(user_input)
             _validate_state_class(user_input)
@@ -316,7 +280,6 @@ def ws_start_preview(
                 errors[key.schema] = str(ex.msg)
 
         if domain == Platform.SENSOR:
-            _strip_sentinel(user_input)
             try:
                 _validate_unit(user_input)
             except vol.Invalid as ex:
@@ -386,7 +349,6 @@ def ws_start_preview(
         )
         return
 
-    _strip_sentinel(msg["user_input"])
     preview_entity = CREATE_PREVIEW_ENTITY[template_type](hass, name, msg["user_input"])
     preview_entity.hass = hass
     preview_entity.registry_entry = entity_registry_entry

--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -58,12 +58,14 @@ def generate_schema(domain: str, flow_type: str) -> dict[vol.Marker, Any]:
         schema = {
             vol.Optional(CONF_UNIT_OF_MEASUREMENT): selector.SelectSelector(
                 selector.SelectSelectorConfig(
-                    options=[
-                        str(unit)
-                        for units in DEVICE_CLASS_UNITS.values()
-                        for unit in units
-                        if unit is not None
-                    ],
+                    options=list(
+                        {
+                            str(unit)
+                            for units in DEVICE_CLASS_UNITS.values()
+                            for unit in units
+                            if unit is not None
+                        }
+                    ),
                     mode=selector.SelectSelectorMode.DROPDOWN,
                     translation_key="sensor_unit_of_measurement",
                     custom_value=True,

--- a/homeassistant/components/template/strings.json
+++ b/homeassistant/components/template/strings.json
@@ -51,7 +51,6 @@
   "selector": {
     "binary_sensor_device_class": {
       "options": {
-        "none": "[%key:component::template::selector::sensor_device_class::options::none%]",
         "battery": "[%key:component::binary_sensor::entity_component::battery::name%]",
         "battery_charging": "[%key:component::binary_sensor::entity_component::battery_charging::name%]",
         "carbon_monoxide": "[%key:component::binary_sensor::entity_component::carbon_monoxide::name%]",
@@ -83,7 +82,6 @@
     },
     "sensor_device_class": {
       "options": {
-        "none": "No device class",
         "apparent_power": "[%key:component::sensor::entity_component::apparent_power::name%]",
         "aqi": "[%key:component::sensor::entity_component::aqi::name%]",
         "atmospheric_pressure": "[%key:component::sensor::entity_component::atmospheric_pressure::name%]",
@@ -137,7 +135,6 @@
     },
     "sensor_state_class": {
       "options": {
-        "none": "No state class",
         "measurement": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::measurement%]",
         "total": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::total%]",
         "total_increasing": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::total_increasing%]"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The frontend support with https://github.com/home-assistant/frontend/pull/18047 deselecting an optional SelectSelector. No need anymore for the `NONE_SENTINEL` and sorting is done now by the frontend for all languages.

In addition remove duplicates from the unit of measurement selector.

Requires #101755

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
