### PR TITLE
Remove NONE_SENTINEL in favor of optional select in workday

### DIFF
--- a/homeassistant/components/workday/config_flow.py
+++ b/homeassistant/components/workday/config_flow.py
@@ -262,6 +262,9 @@ class WorkdayOptionsFlowHandler(OptionsFlowWithConfigEntry):
 
         if user_input is not None:
             combined_input: dict[str, Any] = {**self.options, **user_input}
+            if CONF_PROVINCE not in user_input:
+                # Province not present, delete old value (if present) too
+                combined_input.pop(CONF_PROVINCE, None)
 
             try:
                 await self.hass.async_add_executor_job(

--- a/homeassistant/components/workday/config_flow.py
+++ b/homeassistant/components/workday/config_flow.py
@@ -90,7 +90,7 @@ def validate_custom_dates(user_input: dict[str, Any]) -> None:
             raise AddDatesError("Incorrect date")
 
     year: int = dt_util.now().year
-    if country := user_input[CONF_COUNTRY]:
+    if country := user_input.get(CONF_COUNTRY):
         cls = country_holidays(country)
         obj_holidays = country_holidays(
             country=country,
@@ -202,9 +202,6 @@ class WorkdayConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             combined_input: dict[str, Any] = {**self.data, **user_input}
 
-            combined_input.setdefault(CONF_COUNTRY, None)
-            combined_input.setdefault(CONF_PROVINCE, None)
-
             try:
                 await self.hass.async_add_executor_job(
                     validate_custom_dates, combined_input
@@ -219,13 +216,13 @@ class WorkdayConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["remove_holidays"] = "remove_holiday_range_error"
 
             abort_match = {
-                CONF_COUNTRY: combined_input[CONF_COUNTRY],
+                CONF_COUNTRY: combined_input.get(CONF_COUNTRY),
                 CONF_EXCLUDES: combined_input[CONF_EXCLUDES],
                 CONF_OFFSET: combined_input[CONF_OFFSET],
                 CONF_WORKDAYS: combined_input[CONF_WORKDAYS],
                 CONF_ADD_HOLIDAYS: combined_input[CONF_ADD_HOLIDAYS],
                 CONF_REMOVE_HOLIDAYS: combined_input[CONF_REMOVE_HOLIDAYS],
-                CONF_PROVINCE: combined_input[CONF_PROVINCE],
+                CONF_PROVINCE: combined_input.get(CONF_PROVINCE),
             }
             LOGGER.debug("abort_check in options with %s", combined_input)
             self._async_abort_entries_match(abort_match)
@@ -265,7 +262,6 @@ class WorkdayOptionsFlowHandler(OptionsFlowWithConfigEntry):
 
         if user_input is not None:
             combined_input: dict[str, Any] = {**self.options, **user_input}
-            combined_input.setdefault(CONF_PROVINCE, None)
 
             try:
                 await self.hass.async_add_executor_job(
@@ -284,13 +280,13 @@ class WorkdayOptionsFlowHandler(OptionsFlowWithConfigEntry):
                 try:
                     self._async_abort_entries_match(
                         {
-                            CONF_COUNTRY: self._config_entry.options[CONF_COUNTRY],
+                            CONF_COUNTRY: self._config_entry.options.get(CONF_COUNTRY),
                             CONF_EXCLUDES: combined_input[CONF_EXCLUDES],
                             CONF_OFFSET: combined_input[CONF_OFFSET],
                             CONF_WORKDAYS: combined_input[CONF_WORKDAYS],
                             CONF_ADD_HOLIDAYS: combined_input[CONF_ADD_HOLIDAYS],
                             CONF_REMOVE_HOLIDAYS: combined_input[CONF_REMOVE_HOLIDAYS],
-                            CONF_PROVINCE: combined_input[CONF_PROVINCE],
+                            CONF_PROVINCE: combined_input.get(CONF_PROVINCE),
                         }
                     )
                 except AbortFlow as err:

--- a/homeassistant/components/workday/repairs.py
+++ b/homeassistant/components/workday/repairs.py
@@ -18,7 +18,6 @@ from homeassistant.helpers.selector import (
     SelectSelectorMode,
 )
 
-from .config_flow import NONE_SENTINEL
 from .const import CONF_PROVINCE
 
 
@@ -75,9 +74,8 @@ class CountryFixFlow(RepairsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> data_entry_flow.FlowResult:
         """Handle the province step of a fix flow."""
-        if user_input and user_input.get(CONF_PROVINCE):
-            if user_input.get(CONF_PROVINCE, NONE_SENTINEL) == NONE_SENTINEL:
-                user_input[CONF_PROVINCE] = None
+        if user_input is not None:
+            user_input.setdefault(CONF_PROVINCE, None)
             options = dict(self.entry.options)
             new_options = {**options, **user_input, CONF_COUNTRY: self.country}
             self.hass.config_entries.async_update_entry(self.entry, options=new_options)
@@ -90,9 +88,9 @@ class CountryFixFlow(RepairsFlow):
             step_id="province",
             data_schema=vol.Schema(
                 {
-                    vol.Optional(CONF_PROVINCE, default=NONE_SENTINEL): SelectSelector(
+                    vol.Optional(CONF_PROVINCE): SelectSelector(
                         SelectSelectorConfig(
-                            options=[NONE_SENTINEL, *country_provinces],
+                            options=country_provinces,
                             mode=SelectSelectorMode.DROPDOWN,
                             translation_key=CONF_PROVINCE,
                         )

--- a/tests/components/workday/test_config_flow.py
+++ b/tests/components/workday/test_config_flow.py
@@ -63,7 +63,6 @@ async def test_form(hass: HomeAssistant) -> None:
         "workdays": ["mon", "tue", "wed", "thu", "fri"],
         "add_holidays": [],
         "remove_holidays": [],
-        "province": None,
     }
 
 
@@ -98,13 +97,11 @@ async def test_form_no_country(hass: HomeAssistant) -> None:
     assert result3["title"] == "Workday Sensor"
     assert result3["options"] == {
         "name": "Workday Sensor",
-        "country": None,
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,
         "workdays": ["mon", "tue", "wed", "thu", "fri"],
         "add_holidays": [],
         "remove_holidays": [],
-        "province": None,
     }
 
 
@@ -146,7 +143,6 @@ async def test_form_no_subdivision(hass: HomeAssistant) -> None:
         "workdays": ["mon", "tue", "wed", "thu", "fri"],
         "add_holidays": [],
         "remove_holidays": [],
-        "province": None,
     }
 
 
@@ -163,7 +159,6 @@ async def test_options_form(hass: HomeAssistant) -> None:
             "workdays": ["mon", "tue", "wed", "thu", "fri"],
             "add_holidays": [],
             "remove_holidays": [],
-            "province": None,
         },
     )
 
@@ -259,7 +254,6 @@ async def test_form_incorrect_dates(hass: HomeAssistant) -> None:
         "workdays": ["mon", "tue", "wed", "thu", "fri"],
         "add_holidays": ["2022-12-12"],
         "remove_holidays": ["Weihnachtstag"],
-        "province": None,
     }
 
 
@@ -276,7 +270,6 @@ async def test_options_form_incorrect_dates(hass: HomeAssistant) -> None:
             "workdays": ["mon", "tue", "wed", "thu", "fri"],
             "add_holidays": [],
             "remove_holidays": [],
-            "province": None,
         },
     )
 
@@ -449,7 +442,6 @@ async def test_form_incorrect_date_range(hass: HomeAssistant) -> None:
         "workdays": ["mon", "tue", "wed", "thu", "fri"],
         "add_holidays": ["2022-12-12", "2022-12-01,2022-12-10"],
         "remove_holidays": ["2022-12-25", "2022-12-30,2022-12-31"],
-        "province": None,
     }
 
 
@@ -466,7 +458,6 @@ async def test_options_form_incorrect_date_ranges(hass: HomeAssistant) -> None:
             "workdays": ["mon", "tue", "wed", "thu", "fri"],
             "add_holidays": [],
             "remove_holidays": [],
-            "province": None,
         },
     )
 

--- a/tests/components/workday/test_config_flow.py
+++ b/tests/components/workday/test_config_flow.py
@@ -9,7 +9,6 @@ from homeassistant.components.workday.const import (
     CONF_COUNTRY,
     CONF_EXCLUDES,
     CONF_OFFSET,
-    CONF_PROVINCE,
     CONF_REMOVE_HOLIDAYS,
     CONF_WORKDAYS,
     DEFAULT_EXCLUDES,
@@ -50,7 +49,6 @@ async def test_form(hass: HomeAssistant) -> None:
             CONF_WORKDAYS: DEFAULT_WORKDAYS,
             CONF_ADD_HOLIDAYS: [],
             CONF_REMOVE_HOLIDAYS: [],
-            CONF_PROVINCE: "none",
         },
     )
     await hass.async_block_till_done()
@@ -81,7 +79,6 @@ async def test_form_no_country(hass: HomeAssistant) -> None:
         result["flow_id"],
         {
             CONF_NAME: "Workday Sensor",
-            CONF_COUNTRY: "none",
         },
     )
     await hass.async_block_till_done()
@@ -221,7 +218,6 @@ async def test_form_incorrect_dates(hass: HomeAssistant) -> None:
             CONF_WORKDAYS: DEFAULT_WORKDAYS,
             CONF_ADD_HOLIDAYS: ["2022-xx-12"],
             CONF_REMOVE_HOLIDAYS: [],
-            CONF_PROVINCE: "none",
         },
     )
     await hass.async_block_till_done()
@@ -235,7 +231,6 @@ async def test_form_incorrect_dates(hass: HomeAssistant) -> None:
             CONF_WORKDAYS: DEFAULT_WORKDAYS,
             CONF_ADD_HOLIDAYS: ["2022-12-12"],
             CONF_REMOVE_HOLIDAYS: ["Does not exist"],
-            CONF_PROVINCE: "none",
         },
     )
     await hass.async_block_till_done()
@@ -250,7 +245,6 @@ async def test_form_incorrect_dates(hass: HomeAssistant) -> None:
             CONF_WORKDAYS: DEFAULT_WORKDAYS,
             CONF_ADD_HOLIDAYS: ["2022-12-12"],
             CONF_REMOVE_HOLIDAYS: ["Weihnachtstag"],
-            CONF_PROVINCE: "none",
         },
     )
     await hass.async_block_till_done()
@@ -383,7 +377,6 @@ async def test_options_form_abort_duplicate(hass: HomeAssistant) -> None:
             "workdays": ["mon", "tue", "wed", "thu", "fri"],
             "add_holidays": [],
             "remove_holidays": [],
-            "province": "none",
         },
     )
 
@@ -415,7 +408,6 @@ async def test_form_incorrect_date_range(hass: HomeAssistant) -> None:
             CONF_WORKDAYS: DEFAULT_WORKDAYS,
             CONF_ADD_HOLIDAYS: ["2022-12-12", "2022-12-30,2022-12-32"],
             CONF_REMOVE_HOLIDAYS: [],
-            CONF_PROVINCE: "none",
         },
     )
     await hass.async_block_till_done()
@@ -429,7 +421,6 @@ async def test_form_incorrect_date_range(hass: HomeAssistant) -> None:
             CONF_WORKDAYS: DEFAULT_WORKDAYS,
             CONF_ADD_HOLIDAYS: ["2022-12-12"],
             CONF_REMOVE_HOLIDAYS: ["2022-12-25", "2022-12-30,2022-12-32"],
-            CONF_PROVINCE: "none",
         },
     )
     await hass.async_block_till_done()
@@ -444,7 +435,6 @@ async def test_form_incorrect_date_range(hass: HomeAssistant) -> None:
             CONF_WORKDAYS: DEFAULT_WORKDAYS,
             CONF_ADD_HOLIDAYS: ["2022-12-12", "2022-12-01,2022-12-10"],
             CONF_REMOVE_HOLIDAYS: ["2022-12-25", "2022-12-30,2022-12-31"],
-            CONF_PROVINCE: "none",
         },
     )
     await hass.async_block_till_done()

--- a/tests/components/workday/test_repairs.py
+++ b/tests/components/workday/test_repairs.py
@@ -126,7 +126,7 @@ async def test_bad_country_none(
     data = await resp.json()
 
     url = RepairsFlowResourceView.url.format(flow_id=flow_id)
-    resp = await client.post(url, json={"province": "none"})
+    resp = await client.post(url, json={})
     assert resp.status == HTTPStatus.OK
     data = await resp.json()
 
@@ -303,7 +303,7 @@ async def test_bad_province_none(
     assert data["step_id"] == "province"
 
     url = RepairsFlowResourceView.url.format(flow_id=flow_id)
-    resp = await client.post(url, json={"province": "none"})
+    resp = await client.post(url, json={})
     assert resp.status == HTTPStatus.OK
     data = await resp.json()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The frontend support with https://github.com/home-assistant/frontend/pull/18047 deselecting an optional SelectSelector. No need anymore for the `NONE_SENTINEL` .

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
