### PR TITLE
Update fitbit error handling

### DIFF
--- a/homeassistant/components/fitbit/__init__.py
+++ b/homeassistant/components/fitbit/__init__.py
@@ -1,8 +1,5 @@
 """The fitbit component."""
 
-from http import HTTPStatus
-
-import aiohttp
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -12,6 +9,7 @@ from homeassistant.helpers import config_entry_oauth2_flow
 
 from . import api
 from .const import DOMAIN
+from .exceptions import FitbitApiException, FitbitAuthException
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
 
@@ -31,11 +29,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     try:
         await fitbit_api.async_get_access_token()
-    except aiohttp.ClientResponseError as err:
-        if err.status == HTTPStatus.UNAUTHORIZED:
-            raise ConfigEntryAuthFailed from err
-        raise ConfigEntryNotReady from err
-    except aiohttp.ClientError as err:
+    except FitbitAuthException as err:
+        raise ConfigEntryAuthFailed from err
+    except FitbitApiException as err:
         raise ConfigEntryNotReady from err
 
     hass.data[DOMAIN][entry.entry_id] = fitbit_api

--- a/homeassistant/components/fitbit/api.py
+++ b/homeassistant/components/fitbit/api.py
@@ -1,10 +1,12 @@
 """API for fitbit bound to Home Assistant OAuth."""
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 import logging
-from typing import Any, cast
+from typing import Any, TypeVar, cast
 
 from fitbit import Fitbit
+from fitbit.exceptions import HTTPException, HTTPUnauthorized
 
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
@@ -12,12 +14,16 @@ from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.util.unit_system import METRIC_SYSTEM
 
 from .const import FitbitUnitSystem
+from .exceptions import FitbitApiException, FitbitAuthException
 from .model import FitbitDevice, FitbitProfile
 
 _LOGGER = logging.getLogger(__name__)
 
 CONF_REFRESH_TOKEN = "refresh_token"
 CONF_EXPIRES_AT = "expires_at"
+
+
+_T = TypeVar("_T")
 
 
 class FitbitApi(ABC):
@@ -58,9 +64,7 @@ class FitbitApi(ABC):
         """Return the user profile from the API."""
         if self._profile is None:
             client = await self._async_get_client()
-            response: dict[str, Any] = await self._hass.async_add_executor_job(
-                client.user_profile_get
-            )
+            response: dict[str, Any] = await self._run(client.user_profile_get)
             _LOGGER.debug("user_profile_get=%s", response)
             profile = response["user"]
             self._profile = FitbitProfile(
@@ -95,9 +99,7 @@ class FitbitApi(ABC):
     async def async_get_devices(self) -> list[FitbitDevice]:
         """Return available devices."""
         client = await self._async_get_client()
-        devices: list[dict[str, str]] = await self._hass.async_add_executor_job(
-            client.get_devices
-        )
+        devices: list[dict[str, str]] = await self._run(client.get_devices)
         _LOGGER.debug("get_devices=%s", devices)
         return [
             FitbitDevice(
@@ -120,11 +122,22 @@ class FitbitApi(ABC):
         def _time_series() -> dict[str, Any]:
             return cast(dict[str, Any], client.time_series(resource_type, period="7d"))
 
-        response: dict[str, Any] = await self._hass.async_add_executor_job(_time_series)
+        response: dict[str, Any] = await self._run(_time_series)
         _LOGGER.debug("time_series(%s)=%s", resource_type, response)
         key = resource_type.replace("/", "-")
         dated_results: list[dict[str, Any]] = response[key]
         return dated_results[-1]
+
+    async def _run(self, func: Callable[[], _T]) -> _T:
+        """Run client command."""
+        try:
+            return await self._hass.async_add_executor_job(func)
+        except HTTPUnauthorized as err:
+            _LOGGER.debug("Unauthorized error from fitbit API: %s", err)
+            raise FitbitAuthException from err
+        except HTTPException as err:
+            _LOGGER.debug("Error from fitbit API: %s", err)
+            raise FitbitApiException from err
 
 
 class OAuthFitbitApi(FitbitApi):

--- a/homeassistant/components/fitbit/application_credentials.py
+++ b/homeassistant/components/fitbit/application_credentials.py
@@ -5,8 +5,11 @@ details on Fitbit authorization.
 """
 
 import base64
+from http import HTTPStatus
 import logging
 from typing import Any, cast
+
+import aiohttp
 
 from homeassistant.components.application_credentials import (
     AuthImplementation,
@@ -18,6 +21,7 @@ from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import CONF_CLIENT_ID, CONF_CLIENT_SECRET, OAUTH2_AUTHORIZE, OAUTH2_TOKEN
+from .exceptions import FitbitApiException, FitbitAuthException
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,26 +35,37 @@ class FitbitOAuth2Implementation(AuthImplementation):
 
     async def async_resolve_external_data(self, external_data: dict[str, Any]) -> dict:
         """Resolve the authorization code to tokens."""
-        session = async_get_clientsession(self.hass)
-        data = {
-            "grant_type": "authorization_code",
-            "code": external_data["code"],
-            "redirect_uri": external_data["state"]["redirect_uri"],
-        }
-        resp = await session.post(self.token_url, data=data, headers=self._headers)
-        resp.raise_for_status()
-        return cast(dict, await resp.json())
+        return await self._post(
+            {
+                "grant_type": "authorization_code",
+                "code": external_data["code"],
+                "redirect_uri": external_data["state"]["redirect_uri"],
+            }
+        )
 
     async def _token_request(self, data: dict) -> dict:
         """Make a token request."""
+        return await self._post(
+            {
+                **data,
+                CONF_CLIENT_ID: self.client_id,
+                CONF_CLIENT_SECRET: self.client_secret,
+            }
+        )
+
+    async def _post(self, data: dict[str, Any]) -> dict[str, Any]:
         session = async_get_clientsession(self.hass)
-        body = {
-            **data,
-            CONF_CLIENT_ID: self.client_id,
-            CONF_CLIENT_SECRET: self.client_secret,
-        }
-        resp = await session.post(self.token_url, data=body, headers=self._headers)
-        resp.raise_for_status()
+        try:
+            resp = await session.post(self.token_url, data=data, headers=self._headers)
+            resp.raise_for_status()
+        except aiohttp.ClientResponseError as err:
+            error_body = await resp.text()
+            _LOGGER.debug("Client response error body: %s", error_body)
+            if err.status == HTTPStatus.UNAUTHORIZED:
+                raise FitbitAuthException from err
+            raise FitbitApiException from err
+        except aiohttp.ClientError as err:
+            raise FitbitApiException from err
         return cast(dict, await resp.json())
 
     @property

--- a/homeassistant/components/fitbit/config_flow.py
+++ b/homeassistant/components/fitbit/config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.helpers import config_entry_oauth2_flow
 
 from . import api
 from .const import DOMAIN, OAUTH_SCOPES
-from .exceptions import FitbitApiException, FitbitAuthException
+from .exceptions import FitbitApiException
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,12 +59,9 @@ class OAuth2FlowHandler(
         client = api.ConfigFlowFitbitApi(self.hass, data[CONF_TOKEN])
         try:
             profile = await client.async_get_user_profile()
-        except FitbitAuthException as err:
-            _LOGGER.error("Failed to authenticate with Fitbit API: %s", err)
-            return self.async_abort(reason="invalid_access_token")
         except FitbitApiException as err:
             _LOGGER.error("Failed to fetch user profile for Fitbit API: %s", err)
-            return self.async_abort(reason="cannot_connect")
+            return self.async_abort(reason=err.reason)
 
         if self.reauth_entry:
             if self.reauth_entry.unique_id != profile.encoded_id:

--- a/homeassistant/components/fitbit/exceptions.py
+++ b/homeassistant/components/fitbit/exceptions.py
@@ -3,10 +3,16 @@
 These exceptions exist to provide common exceptions for the async and sync client libraries.
 """
 
+from homeassistant.exceptions import HomeAssistantError
 
-class FitbitApiException(Exception):
+
+class FitbitApiException(HomeAssistantError):
     """Error talking to the fitbit API."""
+
+    reason = "cannot_connect"
 
 
 class FitbitAuthException(FitbitApiException):
     """Authentication related error talking to the fitbit API."""
+
+    reason = "invalid_access_token"

--- a/homeassistant/components/fitbit/exceptions.py
+++ b/homeassistant/components/fitbit/exceptions.py
@@ -9,10 +9,6 @@ from homeassistant.exceptions import HomeAssistantError
 class FitbitApiException(HomeAssistantError):
     """Error talking to the fitbit API."""
 
-    reason = "cannot_connect"
-
 
 class FitbitAuthException(FitbitApiException):
     """Authentication related error talking to the fitbit API."""
-
-    reason = "invalid_access_token"

--- a/homeassistant/components/fitbit/exceptions.py
+++ b/homeassistant/components/fitbit/exceptions.py
@@ -1,0 +1,12 @@
+"""Exceptions for fitbit API calls.
+
+These exceptions exist to provide common exceptions for the async and sync client libraries.
+"""
+
+
+class FitbitApiException(Exception):
+    """Error talking to the fitbit API."""
+
+
+class FitbitAuthException(FitbitApiException):
+    """Authentication related error talking to the fitbit API."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update fitbit error handling code and improve test coverage for errors. This is a step before moving some of the calls to device update coordinators to exercise the existing behavior. Introduces some exception classes that hide the differences between the asyncio OAuth code and the sync fitbit python library.

The fitbit exceptions currently have friendly error messages that parse server error responses, which is exercised with the structured failure messages.

Note that this currently shows that the device call happens multiple times on startup, which will be removed in a follow up PR.  Additionally, log messages will be improved in the future when moving to an update coordinator.

This is pulled out of a larger overhaul to modernize the fitbit integration and make it configurable from the UI and following current design standards, similar to previous approach on Google calendar :
- [X] Add test harness #100765
- [X] #100766
- [X] Increase test coverage #100776
- [X] Simplify response parsing and entity descriptions #100782
- [X] Refactor unit system #100825
- [X] Ascynio client library #100933
- [X] Config flow and UI based configuration, application credentials, import of existing credentials #100897
- [x] Reauth support in config flow #101178
- [X] Additional oauth error handling with improved error messages in the UI #101304
- [ ] Split battery device level into another entity
- [X] Modernize entities to current design standards (battery, time, etc) #101179
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
