### PR TITLE
Remove NONE_SENTINEL in favor of optional select in sql

### DIFF
--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -32,7 +32,6 @@ from .util import resolve_db_url
 
 _LOGGER = logging.getLogger(__name__)
 
-NONE_SENTINEL = "none"
 
 OPTIONS_SCHEMA: vol.Schema = vol.Schema(
     {
@@ -51,32 +50,24 @@ OPTIONS_SCHEMA: vol.Schema = vol.Schema(
         vol.Optional(
             CONF_VALUE_TEMPLATE,
         ): selector.TemplateSelector(),
-        vol.Optional(
-            CONF_DEVICE_CLASS,
-            default=NONE_SENTINEL,
-        ): selector.SelectSelector(
+        vol.Optional(CONF_DEVICE_CLASS): selector.SelectSelector(
             selector.SelectSelectorConfig(
-                options=[NONE_SENTINEL]
-                + sorted(
-                    [
-                        cls.value
-                        for cls in SensorDeviceClass
-                        if cls != SensorDeviceClass.ENUM
-                    ]
-                ),
+                options=[
+                    cls.value
+                    for cls in SensorDeviceClass
+                    if cls != SensorDeviceClass.ENUM
+                ],
                 mode=selector.SelectSelectorMode.DROPDOWN,
                 translation_key="device_class",
+                sort=True,
             )
         ),
-        vol.Optional(
-            CONF_STATE_CLASS,
-            default=NONE_SENTINEL,
-        ): selector.SelectSelector(
+        vol.Optional(CONF_STATE_CLASS): selector.SelectSelector(
             selector.SelectSelectorConfig(
-                options=[NONE_SENTINEL]
-                + sorted([cls.value for cls in SensorStateClass]),
+                options=[cls.value for cls in SensorStateClass],
                 mode=selector.SelectSelectorMode.DROPDOWN,
                 translation_key="state_class",
+                sort=True,
             )
         ),
     }
@@ -179,9 +170,9 @@ class SQLConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 options[CONF_UNIT_OF_MEASUREMENT] = uom
             if value_template := user_input.get(CONF_VALUE_TEMPLATE):
                 options[CONF_VALUE_TEMPLATE] = value_template
-            if (device_class := user_input[CONF_DEVICE_CLASS]) != NONE_SENTINEL:
+            if device_class := user_input.get(CONF_DEVICE_CLASS):
                 options[CONF_DEVICE_CLASS] = device_class
-            if (state_class := user_input[CONF_STATE_CLASS]) != NONE_SENTINEL:
+            if state_class := user_input.get(CONF_STATE_CLASS):
                 options[CONF_STATE_CLASS] = state_class
             if db_url_for_validation != get_instance(self.hass).db_url:
                 options[CONF_DB_URL] = db_url_for_validation
@@ -248,9 +239,9 @@ class SQLOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
                     options[CONF_UNIT_OF_MEASUREMENT] = uom
                 if value_template := user_input.get(CONF_VALUE_TEMPLATE):
                     options[CONF_VALUE_TEMPLATE] = value_template
-                if (device_class := user_input[CONF_DEVICE_CLASS]) != NONE_SENTINEL:
+                if device_class := user_input.get(CONF_DEVICE_CLASS):
                     options[CONF_DEVICE_CLASS] = device_class
-                if (state_class := user_input[CONF_STATE_CLASS]) != NONE_SENTINEL:
+                if state_class := user_input.get(CONF_STATE_CLASS):
                     options[CONF_STATE_CLASS] = state_class
                 if db_url_for_validation != get_instance(self.hass).db_url:
                     options[CONF_DB_URL] = db_url_for_validation

--- a/homeassistant/components/sql/strings.json
+++ b/homeassistant/components/sql/strings.json
@@ -67,7 +67,6 @@
   "selector": {
     "device_class": {
       "options": {
-        "none": "No device class",
         "date": "[%key:component::sensor::entity_component::date::name%]",
         "duration": "[%key:component::sensor::entity_component::duration::name%]",
         "apparent_power": "[%key:component::sensor::entity_component::apparent_power::name%]",
@@ -121,7 +120,6 @@
     },
     "state_class": {
       "options": {
-        "none": "No state class",
         "measurement": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::measurement%]",
         "total": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::total%]",
         "total_increasing": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::total_increasing%]"

--- a/tests/components/sql/test_config_flow.py
+++ b/tests/components/sql/test_config_flow.py
@@ -8,7 +8,6 @@ from sqlalchemy.exc import SQLAlchemyError
 from homeassistant import config_entries
 from homeassistant.components.recorder import Recorder
 from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
-from homeassistant.components.sql.config_flow import NONE_SENTINEL
 from homeassistant.components.sql.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -669,8 +668,6 @@ async def test_device_state_class(recorder_mock: Recorder, hass: HomeAssistant) 
                 "query": "SELECT 5 as value",
                 "column": "value",
                 "unit_of_measurement": "MiB",
-                "device_class": NONE_SENTINEL,
-                "state_class": NONE_SENTINEL,
             },
         )
         await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The frontend support with https://github.com/home-assistant/frontend/pull/18047 deselecting an optional SelectSelector. No need anymore for the `NONE_SENTINEL` and sorting is done now by the frontend for all languages.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
