### PR TITLE
Remove "none" in favor of optional select in brottsplatskartan

### DIFF
--- a/homeassistant/components/brottsplatskartan/config_flow.py
+++ b/homeassistant/components/brottsplatskartan/config_flow.py
@@ -18,11 +18,10 @@ DATA_SCHEMA = vol.Schema(
         vol.Optional(CONF_LOCATION): selector.LocationSelector(
             selector.LocationSelectorConfig(radius=False, icon="")
         ),
-        vol.Optional(CONF_AREA, default="none"): selector.SelectSelector(
+        vol.Optional(CONF_AREA): selector.SelectSelector(
             selector.SelectSelectorConfig(
                 options=AREAS,
                 mode=selector.SelectSelectorMode.DROPDOWN,
-                translation_key="areas",
             )
         ),
     }
@@ -43,9 +42,7 @@ class BPKConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             latitude: float | None = None
             longitude: float | None = None
-            area: str | None = (
-                user_input[CONF_AREA] if user_input[CONF_AREA] != "none" else None
-            )
+            area: str | None = user_input.get(CONF_AREA)
 
             if area:
                 name = f"{DEFAULT_NAME} {area}"

--- a/homeassistant/components/brottsplatskartan/const.py
+++ b/homeassistant/components/brottsplatskartan/const.py
@@ -14,7 +14,6 @@ CONF_APP_ID = "app_id"
 DEFAULT_NAME = "Brottsplatskartan"
 
 AREAS = [
-    "none",
     "Blekinge län",
     "Dalarnas län",
     "Gotlands län",

--- a/homeassistant/components/brottsplatskartan/strings.json
+++ b/homeassistant/components/brottsplatskartan/strings.json
@@ -15,12 +15,5 @@
         }
       }
     }
-  },
-  "selector": {
-    "areas": {
-      "options": {
-        "none": "No area"
-      }
-    }
   }
 }

--- a/tests/components/brottsplatskartan/test_config_flow.py
+++ b/tests/components/brottsplatskartan/test_config_flow.py
@@ -23,9 +23,7 @@ async def test_form(hass: HomeAssistant) -> None:
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {
-            CONF_AREA: "none",
-        },
+        {},
     )
     await hass.async_block_till_done()
 
@@ -51,7 +49,6 @@ async def test_form_location(hass: HomeAssistant) -> None:
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_AREA: "none",
             CONF_LOCATION: {
                 CONF_LATITUDE: 59.32,
                 CONF_LONGITUDE: 18.06,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The frontend support with https://github.com/home-assistant/frontend/pull/18047 deselecting an optional SelectSelector. No need anymore for the `"none"`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
