### PR TITLE
Remove "none" in favor of optional select in derivate

### DIFF
--- a/homeassistant/components/derivative/config_flow.py
+++ b/homeassistant/components/derivative/config_flow.py
@@ -24,7 +24,6 @@ from .const import (
 )
 
 UNIT_PREFIXES = [
-    selector.SelectOptionDict(value="none", label="none"),
     selector.SelectOptionDict(value="n", label="n (nano)"),
     selector.SelectOptionDict(value="µ", label="µ (micro)"),
     selector.SelectOptionDict(value="m", label="m (milli)"),
@@ -52,7 +51,7 @@ OPTIONS_SCHEMA = vol.Schema(
             ),
         ),
         vol.Required(CONF_TIME_WINDOW): selector.DurationSelector(),
-        vol.Required(CONF_UNIT_PREFIX, default="none"): selector.SelectSelector(
+        vol.Optional(CONF_UNIT_PREFIX, default=None): selector.SelectSelector(
             selector.SelectSelectorConfig(options=UNIT_PREFIXES),
         ),
         vol.Required(CONF_UNIT_TIME, default=UnitOfTime.HOURS): selector.SelectSelector(

--- a/homeassistant/components/derivative/config_flow.py
+++ b/homeassistant/components/derivative/config_flow.py
@@ -51,7 +51,7 @@ OPTIONS_SCHEMA = vol.Schema(
             ),
         ),
         vol.Required(CONF_TIME_WINDOW): selector.DurationSelector(),
-        vol.Optional(CONF_UNIT_PREFIX, default=None): selector.SelectSelector(
+        vol.Optional(CONF_UNIT_PREFIX): selector.SelectSelector(
             selector.SelectSelectorConfig(options=UNIT_PREFIXES),
         ),
         vol.Required(CONF_UNIT_TIME, default=UnitOfTime.HOURS): selector.SelectSelector(

--- a/homeassistant/components/derivative/sensor.py
+++ b/homeassistant/components/derivative/sensor.py
@@ -116,10 +116,6 @@ async def async_setup_entry(
     else:
         device_info = None
 
-    unit_prefix = config_entry.options[CONF_UNIT_PREFIX]
-    if unit_prefix == "none":
-        unit_prefix = None
-
     derivative_sensor = DerivativeSensor(
         name=config_entry.title,
         round_digits=int(config_entry.options[CONF_ROUND_DIGITS]),
@@ -127,7 +123,7 @@ async def async_setup_entry(
         time_window=cv.time_period_dict(config_entry.options[CONF_TIME_WINDOW]),
         unique_id=config_entry.entry_id,
         unit_of_measurement=None,
-        unit_prefix=unit_prefix,
+        unit_prefix=config_entry.options[CONF_UNIT_PREFIX],
         unit_time=config_entry.options[CONF_UNIT_TIME],
         device_info=device_info,
     )

--- a/homeassistant/components/derivative/sensor.py
+++ b/homeassistant/components/derivative/sensor.py
@@ -123,7 +123,7 @@ async def async_setup_entry(
         time_window=cv.time_period_dict(config_entry.options[CONF_TIME_WINDOW]),
         unique_id=config_entry.entry_id,
         unit_of_measurement=None,
-        unit_prefix=config_entry.options[CONF_UNIT_PREFIX],
+        unit_prefix=config_entry.options.get(CONF_UNIT_PREFIX),
         unit_time=config_entry.options[CONF_UNIT_TIME],
         device_info=device_info,
     )

--- a/tests/components/derivative/test_config_flow.py
+++ b/tests/components/derivative/test_config_flow.py
@@ -33,7 +33,6 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
                 "round": 1,
                 "source": input_sensor_entity_id,
                 "time_window": {"seconds": 0},
-                "unit_prefix": "none",
                 "unit_time": "min",
             },
         )
@@ -47,7 +46,6 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
         "round": 1.0,
         "source": "sensor.input",
         "time_window": {"seconds": 0.0},
-        "unit_prefix": "none",
         "unit_time": "min",
     }
     assert len(mock_setup_entry.mock_calls) == 1
@@ -59,7 +57,6 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
         "round": 1.0,
         "source": "sensor.input",
         "time_window": {"seconds": 0.0},
-        "unit_prefix": "none",
         "unit_time": "min",
     }
     assert config_entry.title == "My derivative"
@@ -111,7 +108,6 @@ async def test_options(hass: HomeAssistant, platform) -> None:
         user_input={
             "round": 2.0,
             "time_window": {"seconds": 10.0},
-            "unit_prefix": "none",
             "unit_time": "h",
         },
     )
@@ -121,7 +117,6 @@ async def test_options(hass: HomeAssistant, platform) -> None:
         "round": 2.0,
         "source": "sensor.input",
         "time_window": {"seconds": 10.0},
-        "unit_prefix": "none",
         "unit_time": "h",
     }
     assert config_entry.data == {}
@@ -130,7 +125,6 @@ async def test_options(hass: HomeAssistant, platform) -> None:
         "round": 2.0,
         "source": "sensor.input",
         "time_window": {"seconds": 10.0},
-        "unit_prefix": "none",
         "unit_time": "h",
     }
     assert config_entry.title == "My derivative"

--- a/tests/components/derivative/test_config_flow.py
+++ b/tests/components/derivative/test_config_flow.py
@@ -46,6 +46,7 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
         "round": 1.0,
         "source": "sensor.input",
         "time_window": {"seconds": 0.0},
+        "unit_prefix": None,
         "unit_time": "min",
     }
     assert len(mock_setup_entry.mock_calls) == 1
@@ -57,6 +58,7 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
         "round": 1.0,
         "source": "sensor.input",
         "time_window": {"seconds": 0.0},
+        "unit_prefix": None,
         "unit_time": "min",
     }
     assert config_entry.title == "My derivative"
@@ -117,6 +119,7 @@ async def test_options(hass: HomeAssistant, platform) -> None:
         "round": 2.0,
         "source": "sensor.input",
         "time_window": {"seconds": 10.0},
+        "unit_prefix": None,
         "unit_time": "h",
     }
     assert config_entry.data == {}
@@ -125,6 +128,7 @@ async def test_options(hass: HomeAssistant, platform) -> None:
         "round": 2.0,
         "source": "sensor.input",
         "time_window": {"seconds": 10.0},
+        "unit_prefix": None,
         "unit_time": "h",
     }
     assert config_entry.title == "My derivative"

--- a/tests/components/derivative/test_config_flow.py
+++ b/tests/components/derivative/test_config_flow.py
@@ -46,7 +46,6 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
         "round": 1.0,
         "source": "sensor.input",
         "time_window": {"seconds": 0.0},
-        "unit_prefix": None,
         "unit_time": "min",
     }
     assert len(mock_setup_entry.mock_calls) == 1
@@ -58,7 +57,6 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
         "round": 1.0,
         "source": "sensor.input",
         "time_window": {"seconds": 0.0},
-        "unit_prefix": None,
         "unit_time": "min",
     }
     assert config_entry.title == "My derivative"
@@ -119,7 +117,6 @@ async def test_options(hass: HomeAssistant, platform) -> None:
         "round": 2.0,
         "source": "sensor.input",
         "time_window": {"seconds": 10.0},
-        "unit_prefix": None,
         "unit_time": "h",
     }
     assert config_entry.data == {}
@@ -128,7 +125,6 @@ async def test_options(hass: HomeAssistant, platform) -> None:
         "round": 2.0,
         "source": "sensor.input",
         "time_window": {"seconds": 10.0},
-        "unit_prefix": None,
         "unit_time": "h",
     }
     assert config_entry.title == "My derivative"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The frontend support with https://github.com/home-assistant/frontend/pull/18047 deselecting an optional SelectSelector. No need anymore for the `"none"`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
