### PR TITLE
Refactor frame.get_integration_frame

### DIFF
--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -133,7 +133,7 @@ def _print_deprecation_warning(obj: Any, replacement: str, description: str) -> 
     logger = logging.getLogger(obj.__module__)
     try:
         integration_frame = get_integration_frame()
-        if integration_frame.custom_component:
+        if integration_frame.custom_integration:
             logger.warning(
                 (
                     "%s was called from %s, this is a deprecated %s. Use %s instead,"

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -132,24 +132,24 @@ def deprecated_function(
 def _print_deprecation_warning(obj: Any, replacement: str, description: str) -> None:
     logger = logging.getLogger(obj.__module__)
     try:
-        _, integration, path = get_integration_frame()
-        if path == "custom_components/":
+        integration_frame = get_integration_frame()
+        if integration_frame.custom_component:
             logger.warning(
                 (
                     "%s was called from %s, this is a deprecated %s. Use %s instead,"
                     " please report this to the maintainer of %s"
                 ),
                 obj.__name__,
-                integration,
+                integration_frame.integration,
                 description,
                 replacement,
-                integration,
+                integration_frame.integration,
             )
         else:
             logger.warning(
                 "%s was called from %s, this is a deprecated %s. Use %s instead",
                 obj.__name__,
-                integration,
+                integration_frame.integration,
                 description,
                 replacement,
             )

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -57,7 +57,7 @@ def get_integration_frame(exclude_integrations: set | None = None) -> Integratio
 
     return IntegrationFrame(
         path == "custom_components/",
-        found_frame.filename[start:],
+        found_frame.filename[index:],
         found_frame,
         integration,
     )

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
+from dataclasses import dataclass
 import functools
 import logging
 from traceback import FrameSummary, extract_stack
@@ -18,9 +19,17 @@ _REPORTED_INTEGRATIONS: set[str] = set()
 _CallableT = TypeVar("_CallableT", bound=Callable)
 
 
-def get_integration_frame(
-    exclude_integrations: set | None = None,
-) -> tuple[FrameSummary, str, str]:
+@dataclass
+class IntegrationFrame:
+    """Integration frame container."""
+
+    custom_component: bool
+    filename: str
+    frame: FrameSummary
+    integration: str
+
+
+def get_integration_frame(exclude_integrations: set | None = None) -> IntegrationFrame:
     """Return the frame, integration and integration path of the current stack frame."""
     found_frame = None
     if not exclude_integrations:
@@ -46,7 +55,12 @@ def get_integration_frame(
     if found_frame is None:
         raise MissingIntegrationFrame
 
-    return found_frame, integration, path
+    return IntegrationFrame(
+        path == "custom_components/",
+        found_frame.filename[start:],
+        found_frame,
+        integration,
+    )
 
 
 class MissingIntegrationFrame(HomeAssistantError):
@@ -74,28 +88,26 @@ def report(
         _LOGGER.warning(msg, stack_info=True)
         return
 
-    report_integration(what, integration_frame, level)
+    _report_integration(what, integration_frame, level)
 
 
-def report_integration(
+def _report_integration(
     what: str,
-    integration_frame: tuple[FrameSummary, str, str],
+    integration_frame: IntegrationFrame,
     level: int = logging.WARNING,
 ) -> None:
     """Report incorrect usage in an integration.
 
     Async friendly.
     """
-    found_frame, integration, path = integration_frame
-
+    found_frame = integration_frame.frame
     # Keep track of integrations already reported to prevent flooding
     key = f"{found_frame.filename}:{found_frame.lineno}"
     if key in _REPORTED_INTEGRATIONS:
         return
     _REPORTED_INTEGRATIONS.add(key)
 
-    index = found_frame.filename.index(path)
-    if path == "custom_components/":
+    if integration_frame.custom_component:
         extra = " to the custom integration author"
     else:
         extra = ""
@@ -108,8 +120,8 @@ def report_integration(
         ),
         what,
         extra,
-        integration,
-        found_frame.filename[index:],
+        integration_frame.integration,
+        integration_frame.filename,
         found_frame.lineno,
         (found_frame.line or "?").strip(),
     )

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -23,7 +23,7 @@ _CallableT = TypeVar("_CallableT", bound=Callable)
 class IntegrationFrame:
     """Integration frame container."""
 
-    custom_component: bool
+    custom_integration: bool
     filename: str
     frame: FrameSummary
     integration: str
@@ -107,7 +107,7 @@ def _report_integration(
         return
     _REPORTED_INTEGRATIONS.add(key)
 
-    if integration_frame.custom_component:
+    if integration_frame.custom_integration:
         extra = " to the custom integration author"
     else:
         extra = ""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1515,33 +1515,6 @@ async def recorder_mock(
     return await async_setup_recorder_instance(hass, recorder_config)
 
 
-@pytest.fixture
-def mock_integration_frame() -> Generator[Mock, None, None]:
-    """Mock as if we're calling code from inside an integration."""
-    correct_frame = Mock(
-        filename="/home/paulus/homeassistant/components/hue/light.py",
-        lineno="23",
-        line="self.light.is_on",
-    )
-    with patch(
-        "homeassistant.helpers.frame.extract_stack",
-        return_value=[
-            Mock(
-                filename="/home/paulus/homeassistant/core.py",
-                lineno="23",
-                line="do_something()",
-            ),
-            correct_frame,
-            Mock(
-                filename="/home/paulus/aiohue/lights.py",
-                lineno="2",
-                line="something()",
-            ),
-        ],
-    ):
-        yield correct_frame
-
-
 @pytest.fixture(name="enable_bluetooth")
 async def mock_enable_bluetooth(
     hass: HomeAssistant,

--- a/tests/helpers/test_frame.py
+++ b/tests/helpers/test_frame.py
@@ -1,5 +1,6 @@
 """Test the frame helper."""
 
+from collections.abc import Generator
 from unittest.mock import Mock, patch
 
 import pytest
@@ -7,15 +8,41 @@ import pytest
 from homeassistant.helpers import frame
 
 
+@pytest.fixture
+def mock_integration_frame() -> Generator[Mock, None, None]:
+    """Mock as if we're calling code from inside an integration."""
+    correct_frame = Mock(
+        filename="/home/paulus/homeassistant/components/hue/light.py",
+        lineno="23",
+        line="self.light.is_on",
+    )
+    with patch(
+        "homeassistant.helpers.frame.extract_stack",
+        return_value=[
+            Mock(
+                filename="/home/paulus/homeassistant/core.py",
+                lineno="23",
+                line="do_something()",
+            ),
+            correct_frame,
+            Mock(
+                filename="/home/paulus/aiohue/lights.py",
+                lineno="2",
+                line="something()",
+            ),
+        ],
+    ):
+        yield correct_frame
+
+
 async def test_extract_frame_integration(
     caplog: pytest.LogCaptureFixture, mock_integration_frame: Mock
 ) -> None:
     """Test extracting the current frame from integration context."""
-    found_frame, integration, path = frame.get_integration_frame()
-
-    assert integration == "hue"
-    assert path == "homeassistant/components/"
-    assert found_frame == mock_integration_frame
+    integration_frame = frame.get_integration_frame()
+    assert integration_frame == frame.IntegrationFrame(
+        False, "hue/light.py", mock_integration_frame, "hue"
+    )
 
 
 async def test_extract_frame_integration_with_excluded_integration(
@@ -48,13 +75,13 @@ async def test_extract_frame_integration_with_excluded_integration(
             ),
         ],
     ):
-        found_frame, integration, path = frame.get_integration_frame(
+        integration_frame = frame.get_integration_frame(
             exclude_integrations={"zeroconf"}
         )
 
-    assert integration == "mdns"
-    assert path == "homeassistant/components/"
-    assert found_frame == correct_frame
+    assert integration_frame == frame.IntegrationFrame(
+        False, "mdns/light.py", correct_frame, "mdns"
+    )
 
 
 async def test_extract_frame_no_integration(caplog: pytest.LogCaptureFixture) -> None:
@@ -77,23 +104,32 @@ async def test_extract_frame_no_integration(caplog: pytest.LogCaptureFixture) ->
         frame.get_integration_frame()
 
 
-@pytest.mark.usefixtures("mock_integration_frame")
 @patch.object(frame, "_REPORTED_INTEGRATIONS", set())
-async def test_prevent_flooding(caplog: pytest.LogCaptureFixture) -> None:
+async def test_prevent_flooding(
+    caplog: pytest.LogCaptureFixture, mock_integration_frame: Mock
+) -> None:
     """Test to ensure a report is only written once to the log."""
 
     what = "accessed hi instead of hello"
     key = "/home/paulus/homeassistant/components/hue/light.py:23"
+    integration = "hue"
+    filename = "hue/light.py"
+
+    expected_message = (
+        f"Detected integration that {what}. Please report issue for {integration} using"
+        f" this method at {filename}, line "
+        f"{mock_integration_frame.lineno}: {mock_integration_frame.line}"
+    )
 
     frame.report(what, error_if_core=False)
-    assert what in caplog.text
+    assert expected_message in caplog.text
     assert key in frame._REPORTED_INTEGRATIONS
     assert len(frame._REPORTED_INTEGRATIONS) == 1
 
     caplog.clear()
 
     frame.report(what, error_if_core=False)
-    assert what not in caplog.text
+    assert expected_message not in caplog.text
     assert key in frame._REPORTED_INTEGRATIONS
     assert len(frame._REPORTED_INTEGRATIONS) == 1
 

--- a/tests/helpers/test_frame.py
+++ b/tests/helpers/test_frame.py
@@ -41,7 +41,7 @@ async def test_extract_frame_integration(
     """Test extracting the current frame from integration context."""
     integration_frame = frame.get_integration_frame()
     assert integration_frame == frame.IntegrationFrame(
-        False, "hue/light.py", mock_integration_frame, "hue"
+        False, "homeassistant/components/hue/light.py", mock_integration_frame, "hue"
     )
 
 
@@ -80,7 +80,7 @@ async def test_extract_frame_integration_with_excluded_integration(
         )
 
     assert integration_frame == frame.IntegrationFrame(
-        False, "mdns/light.py", correct_frame, "mdns"
+        False, "homeassistant/components/mdns/light.py", correct_frame, "mdns"
     )
 
 
@@ -113,7 +113,7 @@ async def test_prevent_flooding(
     what = "accessed hi instead of hello"
     key = "/home/paulus/homeassistant/components/hue/light.py:23"
     integration = "hue"
-    filename = "hue/light.py"
+    filename = "homeassistant/components/hue/light.py"
 
     expected_message = (
         f"Detected integration that {what}. Please report issue for {integration} using"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor `frame.get_integration_frame` to return an object instead of an unnamed tuple and move the logic for detecting custom components to inside `frame.get_integration_frame`.

There are no custom integrations published on HACS using this API sot I don't think it will a lot of problems for custom integration authors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
