### PR TITLE
Fix delta calculation for fossil energy consumption

### DIFF
--- a/homeassistant/components/energy/websocket_api.py
+++ b/homeassistant/components/energy/websocket_api.py
@@ -294,12 +294,11 @@ async def ws_get_fossil_energy_consumption(
         return {key: result[key] for key in sorted(result)}
 
     def _calculate_deltas(sums: dict[float, float]) -> dict[float, float]:
-        prev: float | None = None
+        prev: float = 0.0
         result: dict[float, float] = {}
         for period, sum_ in sums.items():
-            if prev is not None:
-                result[period] = sum_ - prev
-            prev = sum_
+            result[period] = sum_ - prev
+            prev = sum_ if sum_ is not None else 0.0
         return result
 
     def _reduce_deltas(

--- a/tests/components/energy/test_websocket_api.py
+++ b/tests/components/energy/test_websocket_api.py
@@ -423,6 +423,7 @@ async def test_fossil_energy_consumption_no_co2(
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == {
+        period1.isoformat(): pytest.approx(33.0 - 11.0),
         period2.isoformat(): pytest.approx(33.0 - 22.0),
         period3.isoformat(): pytest.approx(55.0 - 33.0),
         period4.isoformat(): pytest.approx(88.0 - 55.0),
@@ -445,6 +446,7 @@ async def test_fossil_energy_consumption_no_co2(
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == {
+        period1.isoformat(): pytest.approx(33.0 - 11.0),
         period2_day_start.isoformat(): pytest.approx(33.0 - 22.0),
         period3.isoformat(): pytest.approx(55.0 - 33.0),
         period4_day_start.isoformat(): pytest.approx(88.0 - 55.0),
@@ -467,7 +469,7 @@ async def test_fossil_energy_consumption_no_co2(
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == {
-        period1.isoformat(): pytest.approx(33.0 - 22.0),
+        period1.isoformat(): pytest.approx(33.0),
         period3.isoformat(): pytest.approx((55.0 - 33.0) + (88.0 - 55.0)),
     }
 
@@ -586,6 +588,7 @@ async def test_fossil_energy_consumption_hole(
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == {
+        period1.isoformat(): pytest.approx(20.0),
         period2.isoformat(): pytest.approx(3.0 - 20.0),
         period3.isoformat(): pytest.approx(55.0 - 3.0),
         period4.isoformat(): pytest.approx(88.0 - 55.0),
@@ -608,6 +611,7 @@ async def test_fossil_energy_consumption_hole(
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == {
+        period1.isoformat(): pytest.approx(20.0),
         period2_day_start.isoformat(): pytest.approx(3.0 - 20.0),
         period3.isoformat(): pytest.approx(55.0 - 3.0),
         period4_day_start.isoformat(): pytest.approx(88.0 - 55.0),
@@ -630,7 +634,7 @@ async def test_fossil_energy_consumption_hole(
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == {
-        period1.isoformat(): pytest.approx(3.0 - 20.0),
+        period1.isoformat(): pytest.approx(3.0),
         period3.isoformat(): pytest.approx((55.0 - 3.0) + (88.0 - 55.0)),
     }
 
@@ -930,6 +934,7 @@ async def test_fossil_energy_consumption(
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == {
+        period1.isoformat(): pytest.approx((33.0 - 22.0) * 0.2),
         period2.isoformat(): pytest.approx((33.0 - 22.0) * 0.3),
         period3.isoformat(): pytest.approx((44.0 - 33.0) * 0.6),
         period4.isoformat(): pytest.approx((55.0 - 44.0) * 0.9),
@@ -952,6 +957,7 @@ async def test_fossil_energy_consumption(
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == {
+        period1.isoformat(): pytest.approx((33.0 - 22.0) * 0.2),
         period2_day_start.isoformat(): pytest.approx((33.0 - 22.0) * 0.3),
         period3.isoformat(): pytest.approx((44.0 - 33.0) * 0.6),
         period4_day_start.isoformat(): pytest.approx((55.0 - 44.0) * 0.9),
@@ -974,7 +980,7 @@ async def test_fossil_energy_consumption(
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == {
-        period1.isoformat(): pytest.approx((33.0 - 22.0) * 0.3),
+        period1.isoformat(): pytest.approx((33.0 - 22.0) * 0.5),
         period3.isoformat(): pytest.approx(
             ((44.0 - 33.0) * 0.6) + ((55.0 - 44.0) * 0.9)
         ),


### PR DESCRIPTION
## Proposed change

As described in #93771 and #79774, the calculation of fossil energy consumed is sometimes wrong.
The reason is that `_calculate_deltas` drops the first hour of the requested period, since the initial value of `prev` is `None`, which is then checked in the loop, which then skips this hour.
For example, if there is only one hour of data, `_calculate_deltas` will drop that hour, resulting in 100% low carbon energy. 

Also, checking for `None` will lead to miscalculations if the grid sensor has not retrieved any data and thus it is `None` in the database.

Therefore, this PR suggests not dropping periods with `None` but treating them as `0.0`. Also set the initial value to `0.0` to correctly calculate the delta for the first hour.

I hope the explanation is understandable :)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #79774 #93771
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
