### PR TITLE
Update opencv-python-headless to 4.8.1.78

### DIFF
--- a/homeassistant/components/opencv/manifest.json
+++ b/homeassistant/components/opencv/manifest.json
@@ -4,5 +4,5 @@
   "codeowners": [],
   "documentation": "https://www.home-assistant.io/integrations/opencv",
   "iot_class": "local_push",
-  "requirements": ["numpy==1.26.0", "opencv-python-headless==4.6.0.66"]
+  "requirements": ["numpy==1.26.0", "opencv-python-headless==4.8.1.78"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1359,7 +1359,7 @@ open-meteo==0.2.1
 openai==0.27.2
 
 # homeassistant.components.opencv
-opencv-python-headless==4.8.0.76
+opencv-python-headless==4.8.1.78
 
 # homeassistant.components.openerz
 openerz-api==0.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1359,7 +1359,7 @@ open-meteo==0.2.1
 openai==0.27.2
 
 # homeassistant.components.opencv
-# opencv-python-headless==4.6.0.66
+# opencv-python-headless==4.8.0.76
 
 # homeassistant.components.openerz
 openerz-api==0.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1359,7 +1359,7 @@ open-meteo==0.2.1
 openai==0.27.2
 
 # homeassistant.components.opencv
-# opencv-python-headless==4.8.0.76
+opencv-python-headless==4.8.0.76
 
 # homeassistant.components.openerz
 openerz-api==0.2.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -28,7 +28,6 @@ COMMENT_REQUIREMENTS = (
     "decora-wifi",
     "evdev",
     "face-recognition",
-    "opencv-python-headless",
     "pybluez",
     "pycocotools",
     "pycups",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**Update `opencv-python-headless` to 4.8.1.78**

I noted myself after https://github.com/home-assistant/core/pull/100468 to visit this again, bumping `numpy` in https://github.com/home-assistant/core/pull/100512 fixes the issue with wheels building for `opencv-python`. I made the PR on branch directly in core repo so I could run the action to verify that a wheel was built.
Link to a run on the branch: https://github.com/home-assistant/core/actions/runs/6397665594
Built wheel: https://wheels.home-assistant.io/musllinux/opencv_python_headless-4.8.1.78-cp311-cp311-musllinux_1_2_x86_64.whl

Release notes:
- https://github.com/opencv/opencv-python/releases/tag/68
- https://github.com/opencv/opencv-python/releases/tag/70
- https://github.com/opencv/opencv-python/releases/tag/72
- https://github.com/opencv/opencv-python/releases/tag/74
- https://github.com/opencv/opencv-python/releases/tag/76
- https://github.com/opencv/opencv-python/releases/tag/77
- https://github.com/opencv/opencv-python/releases/tag/78

GitHub diff: https://github.com/opencv/opencv-python/compare/66...78

Redo the dependency update which was done in https://github.com/home-assistant/core/pull/91802 and reverted in https://github.com/home-assistant/core/pull/91871 due to breaking the wheels build failure.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/94617
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
