### PR TITLE
Notify users when zwave device gets reset

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -454,12 +454,12 @@ class ControllerEvents:
             identifier = get_network_identifier_for_notification(
                 self.hass, self.config_entry, self.driver_events.driver.controller
             )
-            # Remove trailing comma if it's there
             notification_msg = (
-                f"`{device_name}` has been factory reset and removed from the Z-Wave "
-                "network"
+                f"`{device_name}` has been factory reset "
+                "and removed from the Z-Wave network"
             )
             if identifier:
+                # Remove trailing comma if it's there
                 if identifier[-1] == ",":
                     identifier = identifier[:-1]
                 notification_msg = f"{notification_msg} {identifier}."

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -113,6 +113,7 @@ from .helpers import (
     async_enable_statistics,
     get_device_id,
     get_device_id_ext,
+    get_network_identifier_for_notification,
     get_unique_id,
     get_valueless_base_unique_id,
 )
@@ -448,6 +449,28 @@ class ControllerEvents:
                     "remove_entity"
                 ),
             )
+        elif reason == RemoveNodeReason.RESET:
+            device_name = device.name_by_user or device.name or f"Node {node.node_id}"
+            identifier = get_network_identifier_for_notification(
+                self.hass, self.config_entry, self.driver_events.driver.controller
+            )
+            # Remove trailing comma if it's there
+            notification_msg = (
+                f"`{device_name}` has been factory reset and removed from the Z-Wave "
+                "network"
+            )
+            if identifier:
+                if identifier[-1] == ",":
+                    identifier = identifier[:-1]
+                notification_msg = f"{notification_msg} {identifier}."
+            else:
+                notification_msg = f"{notification_msg}."
+            async_create(
+                self.hass,
+                notification_msg,
+                "Device Was Factory Reset!",
+                f"{DOMAIN}.node_reset_and_removed.{dev_id[1]}",
+            )
         else:
             self.remove_device(device)
 
@@ -459,26 +482,17 @@ class ControllerEvents:
         dev_id = get_device_id(self.driver_events.driver, node)
         device = self.dev_reg.async_get_device(identifiers={dev_id})
         assert device
-        device_name = device.name_by_user or device.name
-        home_id = self.driver_events.driver.controller.home_id
-        # We do this because we know at this point the controller has its home ID as
-        # as it is part of the device ID
-        assert home_id
+        device_name = device.name_by_user or device.name or f"Node {node.node_id}"
         # In case the user has multiple networks, we should give them more information
         # about the network for the controller being identified.
-        identifier = ""
-        if len(self.hass.config_entries.async_entries(DOMAIN)) > 1:
-            if str(home_id) != self.config_entry.title:
-                identifier = (
-                    f"`{self.config_entry.title}`, with the home ID `{home_id}`, "
-                )
-            else:
-                identifier = f"with the home ID `{home_id}` "
+        identifier = get_network_identifier_for_notification(
+            self.hass, self.config_entry, self.driver_events.driver.controller
+        )
         async_create(
             self.hass,
             (
                 f"`{device_name}` has just requested the controller for your Z-Wave "
-                f"network {identifier}to identify itself. No action is needed from "
+                f"network {identifier} to identify itself. No action is needed from "
                 "you other than to note the source of the request, and you can safely "
                 "dismiss this notification when ready."
             ),

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -14,6 +14,7 @@ from zwave_js_server.const import (
     ConfigurationValueType,
     LogLevel,
 )
+from zwave_js_server.model.controller import Controller
 from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.log_config import LogConfig
 from zwave_js_server.model.node import Node as ZwaveNode
@@ -512,3 +513,15 @@ def get_device_info(driver: Driver, node: ZwaveNode) -> DeviceInfo:
         manufacturer=node.device_config.manufacturer,
         suggested_area=node.location if node.location else None,
     )
+
+
+def get_network_identifier_for_notification(
+    hass: HomeAssistant, config_entry: ConfigEntry, controller: Controller
+) -> str:
+    """Return the network identifier string for persistent notifications."""
+    home_id = str(controller.home_id)
+    if len(hass.config_entries.async_entries(DOMAIN)) > 1:
+        if str(home_id) != config_entry.title:
+            return f"`{config_entry.title}`, with the home ID `{home_id}`,"
+        return f"with the home ID `{home_id}`"
+    return ""

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -1644,3 +1644,61 @@ async def test_server_logging(hass: HomeAssistant, client) -> None:
     assert len(client.async_send_command.call_args_list) == 0
     assert not client.enable_server_logging.called
     assert not client.disable_server_logging.called
+
+
+async def test_factory_reset_node(
+    hass: HomeAssistant, client, multisensor_6, multisensor_6_state, integration
+) -> None:
+    """Test when a node is removed because it was reset."""
+    # One config entry scenario
+    remove_event = Event(
+        type="node removed",
+        data={
+            "source": "controller",
+            "event": "node removed",
+            "reason": 5,
+            "node": deepcopy(multisensor_6_state),
+        },
+    )
+    dev_id = get_device_id(client.driver, multisensor_6)
+    msg_id = f"{DOMAIN}.node_reset_and_removed.{dev_id[1]}"
+
+    client.driver.controller.receive_event(remove_event)
+    notifications = async_get_persistent_notifications(hass)
+    assert len(notifications) == 1
+    assert list(notifications)[0] == msg_id
+    assert notifications[msg_id]["message"].startswith("`Multisensor 6`")
+    assert "with the home ID" not in notifications[msg_id]["message"]
+    async_dismiss(hass, msg_id)
+
+    # Add mock config entry to simulate having multiple entries
+    new_entry = MockConfigEntry(domain=DOMAIN)
+    new_entry.add_to_hass(hass)
+
+    # Re-add the node then remove it again
+    client.driver.controller.nodes[multisensor_6_state["nodeId"]] = Node(
+        client, deepcopy(multisensor_6_state)
+    )
+    remove_event.data["node"] = deepcopy(multisensor_6_state)
+    client.driver.controller.receive_event(remove_event)
+    # Test case where config entry title and home ID don't match
+    notifications = async_get_persistent_notifications(hass)
+    assert len(notifications) == 1
+    assert list(notifications)[0] == msg_id
+    assert (
+        "network `Mock Title`, with the home ID `3245146787`."
+        in notifications[msg_id]["message"]
+    )
+    async_dismiss(hass, msg_id)
+
+    # Test case where config entry title and home ID do match
+    hass.config_entries.async_update_entry(integration, title="3245146787")
+    client.driver.controller.nodes[multisensor_6_state["nodeId"]] = Node(
+        client, deepcopy(multisensor_6_state)
+    )
+    remove_event.data["node"] = deepcopy(multisensor_6_state)
+    client.driver.controller.receive_event(remove_event)
+    notifications = async_get_persistent_notifications(hass)
+    assert len(notifications) == 1
+    assert list(notifications)[0] == msg_id
+    assert "network with the home ID `3245146787`" in notifications[msg_id]["message"]


### PR DESCRIPTION
## Proposed change
Addresses this certification requirement which requires the controlling software to notify the user when a device was removed because it was reset (fixes https://github.com/zwave-js/certification-backlog/issues/6)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
