### PR TITLE
Increase update interval of update platform in devolo_home_network

### DIFF
--- a/homeassistant/components/devolo_home_network/__init__.py
+++ b/homeassistant/components/devolo_home_network/__init__.py
@@ -35,6 +35,7 @@ from .const import (
     CONNECTED_PLC_DEVICES,
     CONNECTED_WIFI_CLIENTS,
     DOMAIN,
+    FIRMWARE_UPDATE_INTERVAL,
     LONG_UPDATE_INTERVAL,
     NEIGHBORING_WIFI_NETWORKS,
     REGULAR_FIRMWARE,
@@ -146,7 +147,7 @@ async def async_setup_entry(  # noqa: C901
             _LOGGER,
             name=REGULAR_FIRMWARE,
             update_method=async_update_firmware_available,
-            update_interval=LONG_UPDATE_INTERVAL,
+            update_interval=FIRMWARE_UPDATE_INTERVAL,
         )
     if device.device and "wifi1" in device.device.features:
         coordinators[CONNECTED_WIFI_CLIENTS] = DataUpdateCoordinator(

--- a/homeassistant/components/devolo_home_network/const.py
+++ b/homeassistant/components/devolo_home_network/const.py
@@ -14,6 +14,7 @@ PRODUCT = "product"
 SERIAL_NUMBER = "serial_number"
 TITLE = "title"
 
+FIRMWARE_UPDATE_INTERVAL = timedelta(hours=5)
 LONG_UPDATE_INTERVAL = timedelta(minutes=5)
 SHORT_UPDATE_INTERVAL = timedelta(seconds=15)
 

--- a/tests/components/devolo_home_network/test_update.py
+++ b/tests/components/devolo_home_network/test_update.py
@@ -6,7 +6,7 @@ import pytest
 
 from homeassistant.components.devolo_home_network.const import (
     DOMAIN,
-    LONG_UPDATE_INTERVAL,
+    FIRMWARE_UPDATE_INTERVAL,
 )
 from homeassistant.components.update import (
     DOMAIN as PLATFORM,
@@ -78,7 +78,7 @@ async def test_update_firmware(
     mock_device.device.async_check_firmware_available.return_value = (
         UpdateFirmwareCheck(result=UPDATE_NOT_AVAILABLE)
     )
-    freezer.tick(LONG_UPDATE_INTERVAL)
+    freezer.tick(FIRMWARE_UPDATE_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -106,7 +106,7 @@ async def test_device_failure_check(
     assert state is not None
 
     mock_device.device.async_check_firmware_available.side_effect = DeviceUnavailable
-    freezer.tick(LONG_UPDATE_INTERVAL)
+    freezer.tick(FIRMWARE_UPDATE_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In #100350 I tried to fix #100310 by increasing the timeout the update call may take. This helped a lot, but didn't fix the issue completely as other calls way load longer while the update call is running. After watching Wireshark for a while I am almost certain, that I cannot prevent the timeouts completely, but I can lower the probability of occurrence by reducing the update interval. So I changed from 5 minutes to 5 hours, which is basically a suggestion from devolo.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #100310
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
