### PR TITLE
Do not fail MQTT setup if alarm control panels configured via yaml can't be validated

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -223,8 +223,8 @@ def _async_remove_mqtt_issues(hass: HomeAssistant, mqtt_data: MqttData) -> None:
         for (domain, issue_id), issue_entry in issue_registry.issues.items()
         if domain == DOMAIN and issue_entry.translation_key == "invalid_platform_config"
     ]
-    while open_issues:
-        async_delete_issue(hass, DOMAIN, open_issues.pop())
+    for issue in open_issues:
+        async_delete_issue(hass, DOMAIN, issue)
 
 
 async def async_check_config_schema(

--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -1,7 +1,6 @@
 """Control a MQTT alarm."""
 from __future__ import annotations
 
-import functools
 import logging
 
 import voluptuous as vol
@@ -27,7 +26,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.typing import ConfigType
 
 from . import subscription
 from .config import DEFAULT_RETAIN, MQTT_BASE_SCHEMA
@@ -44,7 +43,7 @@ from .debug_info import log_messages
 from .mixins import (
     MQTT_ENTITY_COMMON_SCHEMA,
     MqttEntity,
-    async_setup_entry_helper,
+    async_mqtt_entry_helper,
     write_state_on_attr_change,
 )
 from .models import MqttCommandTemplate, MqttValueTemplate, ReceiveMessage
@@ -133,21 +132,15 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up MQTT alarm control panel through YAML and through MQTT discovery."""
-    setup = functools.partial(
-        _async_setup_entity, hass, async_add_entities, config_entry=config_entry
+    await async_mqtt_entry_helper(
+        hass,
+        config_entry,
+        MqttAlarm,
+        alarm.DOMAIN,
+        async_add_entities,
+        DISCOVERY_SCHEMA,
+        PLATFORM_SCHEMA_MODERN,
     )
-    await async_setup_entry_helper(hass, alarm.DOMAIN, setup, DISCOVERY_SCHEMA)
-
-
-async def _async_setup_entity(
-    hass: HomeAssistant,
-    async_add_entities: AddEntitiesCallback,
-    config: ConfigType,
-    config_entry: ConfigEntry,
-    discovery_data: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the MQTT Alarm Control Panel platform."""
-    async_add_entities([MqttAlarm(hass, config, config_entry, discovery_data)])
 
 
 class MqttAlarm(MqttEntity, alarm.AlarmControlPanelEntity):

--- a/homeassistant/components/mqtt/config_integration.py
+++ b/homeassistant/components/mqtt/config_integration.py
@@ -15,7 +15,6 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv
 
 from . import (
-    alarm_control_panel as alarm_control_panel_platform,
     binary_sensor as binary_sensor_platform,
     button as button_platform,
     camera as camera_platform,
@@ -56,10 +55,7 @@ DEFAULT_TLS_PROTOCOL = "auto"
 
 CONFIG_SCHEMA_BASE = vol.Schema(
     {
-        Platform.ALARM_CONTROL_PANEL.value: vol.All(
-            cv.ensure_list,
-            [alarm_control_panel_platform.PLATFORM_SCHEMA_MODERN],  # type: ignore[has-type] # noqa: E501
-        ),
+        Platform.ALARM_CONTROL_PANEL.value: vol.All(cv.ensure_list, [dict]),
         Platform.BINARY_SENSOR.value: vol.All(
             cv.ensure_list,
             [binary_sensor_platform.PLATFORM_SCHEMA_MODERN],  # type: ignore[has-type]

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -443,6 +443,9 @@ async def async_mqtt_entry_helper(
 
         async_add_entities(entities)
 
+    # When reloading we check manual configured items against the schema
+    # before reloading
+    mqtt_data.reload_schema[domain] = platform_schema_modern
     # discover manual configured MQTT items
     mqtt_data.reload_handlers[domain] = _async_setup_entities
     await _async_setup_entities()

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -431,7 +431,6 @@ async def async_mqtt_entry_helper(
                     },
                     translation_key="invalid_platform_config",
                 )
-                mqtt_data.open_config_issues.add(issue_id)
                 _LOGGER.error(
                     "%s for manual configured MQTT %s item, in %s, line %s Got %s",
                     error,

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -345,4 +345,5 @@ class MqttData:
     )
     state_write_requests: EntityTopicState = field(default_factory=EntityTopicState)
     subscriptions_to_restore: list[Subscription] = field(default_factory=list)
+    open_config_issues: set[str] = field(default_factory=set)
     tags: dict[str, dict[str, MQTTTagScanner]] = field(default_factory=dict)

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -11,6 +11,8 @@ from enum import StrEnum
 import logging
 from typing import TYPE_CHECKING, Any, TypedDict
 
+import voluptuous as vol
+
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_NAME
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers import template
@@ -343,6 +345,7 @@ class MqttData:
     reload_handlers: dict[str, Callable[[], Coroutine[Any, Any, None]]] = field(
         default_factory=dict
     )
+    reload_schema: dict[str, vol.Schema] = field(default_factory=dict)
     state_write_requests: EntityTopicState = field(default_factory=EntityTopicState)
     subscriptions_to_restore: list[Subscription] = field(default_factory=list)
     open_config_issues: set[str] = field(default_factory=set)

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -348,5 +348,4 @@ class MqttData:
     reload_schema: dict[str, vol.Schema] = field(default_factory=dict)
     state_write_requests: EntityTopicState = field(default_factory=EntityTopicState)
     subscriptions_to_restore: list[Subscription] = field(default_factory=list)
-    open_config_issues: set[str] = field(default_factory=set)
     tags: dict[str, dict[str, MQTTTagScanner]] = field(default_factory=dict)

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -19,6 +19,10 @@
     "deprecated_climate_aux_property": {
       "title": "MQTT entities with auxiliary heat support found",
       "description": "Entity `{entity_id}` has auxiliary heat support enabled, which has been deprecated for MQTT climate devices. Please adjust your configuration and remove deprecated config options from your configuration and restart Home Assistant to fix this issue."
+    },
+    "invalid_platform_config": {
+      "title": "Invalid configured MQTT {domain} item",
+      "description": "Home Assistant detected an invalid config for a manual configured item.\n\nPlatform domain: **{domain}**\nConfiguration file: **{config_file}**\nNear line: **{line}**\nConfiguration found:\n```yaml\n{config}\n```\nError: **{error}**.\n\nMake sure the configuration is valid and [reload](/developer-tools/yaml) the manually configured MQTT items or restart Home Assistant to fix this issue."
     }
   },
   "config": {

--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     SERVICE_ALARM_ARM_VACATION,
     SERVICE_ALARM_DISARM,
     SERVICE_ALARM_TRIGGER,
+    SERVICE_RELOAD,
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_CUSTOM_BYPASS,
     STATE_ALARM_ARMED_HOME,
@@ -184,11 +185,9 @@ async def test_fail_setup_without_state_or_command_topic(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator, valid
 ) -> None:
     """Test for failing setup with no state or command topic."""
-    if valid:
-        await mqtt_mock_entry()
-        return
-    with pytest.raises(AssertionError):
-        await mqtt_mock_entry()
+    assert await mqtt_mock_entry()
+    state = hass.states.get(f"{alarm_control_panel.DOMAIN}.test")
+    assert (state is not None) == valid
 
 
 @pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
@@ -306,15 +305,13 @@ async def test_supported_features(
     valid: bool,
 ) -> None:
     """Test conditional enablement of supported features."""
+    assert await mqtt_mock_entry()
+    state = hass.states.get("alarm_control_panel.test")
     if valid:
-        await mqtt_mock_entry()
-        assert (
-            hass.states.get("alarm_control_panel.test").attributes["supported_features"]
-            == expected_features
-        )
+        assert state is not None
+        assert state.attributes["supported_features"] == expected_features
     else:
-        with pytest.raises(AssertionError):
-            await mqtt_mock_entry()
+        assert state is None
 
 
 @pytest.mark.parametrize(
@@ -1269,3 +1266,69 @@ async def test_skipped_async_ha_write_state(
     """Test a write state command is only called when there is change."""
     await mqtt_mock_entry()
     await help_test_skipped_async_ha_write_state(hass, topic, payload1, payload2)
+
+
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            "mqtt": [
+                {
+                    "alarm_control_panel": {
+                        "name": "test",
+                        "invalid_topic": "test-topic",
+                    }
+                },
+            ]
+        }
+    ],
+)
+async def test_reload_after_invalid_config(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test reloading yaml config fails."""
+    with patch(
+        "homeassistant.components.mqtt.mixins.async_create_issue"
+    ) as mock_async_create_issue, patch(
+        "homeassistant.components.mqtt.async_delete_issue"
+    ) as mock_async_remove_issue:
+        assert await mqtt_mock_entry()
+        assert hass.states.get("alarm_control_panel.test") is None
+        assert (
+            "extra keys not allowed @ data['invalid_topic'] for "
+            "manual configured MQTT alarm_control_panel item, "
+            "in ?, line ? Got {'name': 'test', 'invalid_topic': 'test-topic'}"
+            in caplog.text
+        )
+        assert mock_async_create_issue.call_count == 1
+        assert mock_async_remove_issue.call_count == 0
+
+        # Reload with an valid config
+        valid_config = {
+            "mqtt": [
+                {
+                    "alarm_control_panel": {
+                        "name": "test",
+                        "command_topic": "test-topic",
+                        "state_topic": "alarm/state",
+                    }
+                },
+            ]
+        }
+        with patch(
+            "homeassistant.config.load_yaml_config_file", return_value=valid_config
+        ):
+            await hass.services.async_call(
+                "mqtt",
+                SERVICE_RELOAD,
+                {},
+                blocking=True,
+            )
+            await hass.async_block_till_done()
+
+        # Make sure the config is loaded now
+        assert hass.states.get("alarm_control_panel.test") is not None
+        assert mock_async_create_issue.call_count == 1
+        assert mock_async_remove_issue.call_count == 1

--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -1291,8 +1291,6 @@ async def test_reload_after_invalid_config(
 ) -> None:
     """Test reloading yaml config fails."""
     with patch(
-        "homeassistant.components.mqtt.mixins.async_create_issue"
-    ) as mock_async_create_issue, patch(
         "homeassistant.components.mqtt.async_delete_issue"
     ) as mock_async_remove_issue:
         assert await mqtt_mock_entry()
@@ -1303,8 +1301,6 @@ async def test_reload_after_invalid_config(
             "in ?, line ? Got {'name': 'test', 'invalid_topic': 'test-topic'}"
             in caplog.text
         )
-        assert mock_async_create_issue.call_count == 1
-        assert mock_async_remove_issue.call_count == 0
 
         # Reload with an valid config
         valid_config = {
@@ -1329,9 +1325,8 @@ async def test_reload_after_invalid_config(
             )
             await hass.async_block_till_done()
 
-        # Make sure the config is loaded now
+        # Test the config is loaded now and that the existing issue is removed
         assert hass.states.get("alarm_control_panel.test") is not None
-        assert mock_async_create_issue.call_count == 1
         assert mock_async_remove_issue.call_count == 1
 
         # Reload with an invalid config
@@ -1359,6 +1354,3 @@ async def test_reload_after_invalid_config(
 
         # Make sure the config is loaded now
         assert hass.states.get("alarm_control_panel.test") is not None
-        # Existing items are not effected and
-        # no new issues are created at this time
-        assert mock_async_create_issue.call_count == 1

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -145,6 +145,25 @@ async def test_discovery_schema_error(
         assert "AttributeError: Attribute abc not found" in caplog.text
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.ALARM_CONTROL_PANEL])
+async def test_invalid_config(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test sending in JSON that violates the platform schema."""
+    await mqtt_mock_entry()
+    async_fire_mqtt_message(
+        hass,
+        "homeassistant/alarm_control_panel/bla/config",
+        '{"name": "abc", "state_topic": "home/alarm", '
+        '"command_topic": "home/alarm/set", '
+        '"qos": "some_invalid_value"}',
+    )
+    await hass.async_block_till_done()
+    assert "Error 'expected int for dictionary value @ data['qos']'" in caplog.text
+
+
 async def test_only_valid_components(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
MQTT platform configs will be validated apart from from the config schema.
The config schema only checks of the config is a mapping (dict). If the platform config fails during startup or when the config entry is reloaded an issue will be registrered, but other entities with a valid schema will be setup correctly.

Note that:
- when a user tries to reload an invalid config, the reload will still fail and the loaded MQTT items will not be affected.
- the global config validation will no longer check the individual items any more. The user will see the repairs if the config fails against the platform schema after MQTT was started.

When in the future deprecated options are removed, this new feature will no longer fail starting MQTT, all valid entities will be set up as expected.

Only `alarm_control_panel` is implemented with this PR. Other platforms  based on `MqttEntity` should follow in separate PR's.

With this PR a misconfiguration of an manual added `mqtt` item will no longer be revealed using the `Check Configuration` option at the `Developer tools`. This behavior changed since a single misconfiguration will no longer prevent `mqtt` from starting. Instead an issue is registered for each misconfiguration.

Shows how the rest of the implementation looks like. To make reviews easier implementation will be split up. Planned (and prepared) PR's are:
- `alarm_control_panel`: #101373 (this PR)
- `binary_sensor`: #102300
- `button`: #102301
- `camera`: #102302
- `climate`: #102303
- `cover`:  #102304
- `device_tracker`: #102308
- `event` and `sensor`: #102309 (to be merged as last)
- `fan`: #102310
- `humidifier`: #102312
- `image`: #102313
- `lawn_mower`: #102314
- `light`: #101649 (also does de-duplication rework of helper code)
- `lock`: #102315
- `number`: #102316
- `scene`: #102317
- `select`: #102318
- `siren`: #102319
- `switch`: #102320
- `text`: #102322
- `update`: #102324
- `vacuum`: #102325, also needs #101649
- `water_heater`: #102326

![afbeelding](https://github.com/home-assistant/core/assets/7188918/abfe0563-747f-4272-95ec-e5a01c247d46)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
