### PR TITLE
Avoid updating hassio addon data when there are no entities consuming it

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -966,7 +966,6 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
         """Update single addon stats."""
         try:
             stats = await self.hassio.get_addon_stats(slug)
-            _LOGGER.warning("Addon stats: %s %s", slug, stats)
             return (slug, stats)
         except HassioAPIError as err:
             _LOGGER.warning("Could not fetch stats for %s: %s", slug, err)
@@ -976,7 +975,6 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
         """Return the changelog for an add-on."""
         try:
             changelog = await self.hassio.get_addon_changelog(slug)
-            _LOGGER.warning("Addon change: %s %s", slug, changelog)
             return (slug, changelog)
         except HassioAPIError as err:
             _LOGGER.warning("Could not fetch changelog for %s: %s", slug, err)
@@ -986,7 +984,6 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
         """Return the info for an add-on."""
         try:
             info = await self.hassio.get_addon_info(slug)
-            _LOGGER.warning("Addon info: %s %s", slug, info)
             return (slug, info)
         except HassioAPIError as err:
             _LOGGER.warning("Could not fetch info for %s: %s", slug, err)

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -910,23 +910,25 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def force_data_refresh(self, first_update: bool) -> None:
         """Force update of the addon info."""
+        data = self.hass.data
+        hassio = self.hassio
         (
-            self.hass.data[DATA_INFO],
-            self.hass.data[DATA_CORE_INFO],
-            self.hass.data[DATA_CORE_STATS],
-            self.hass.data[DATA_SUPERVISOR_INFO],
-            self.hass.data[DATA_SUPERVISOR_STATS],
-            self.hass.data[DATA_OS_INFO],
+            data[DATA_INFO],
+            data[DATA_CORE_INFO],
+            data[DATA_CORE_STATS],
+            data[DATA_SUPERVISOR_INFO],
+            data[DATA_SUPERVISOR_STATS],
+            data[DATA_OS_INFO],
         ) = await asyncio.gather(
-            self.hassio.get_info(),
-            self.hassio.get_core_info(),
-            self.hassio.get_core_stats(),
-            self.hassio.get_supervisor_info(),
-            self.hassio.get_supervisor_stats(),
-            self.hassio.get_os_info(),
+            hassio.get_info(),
+            hassio.get_core_info(),
+            hassio.get_core_stats(),
+            hassio.get_supervisor_info(),
+            hassio.get_supervisor_stats(),
+            hassio.get_os_info(),
         )
 
-        _addon_data = self.hass.data[DATA_SUPERVISOR_INFO].get("addons", [])
+        _addon_data = data[DATA_SUPERVISOR_INFO].get("addons", [])
         all_addons: list[str] = []
         started_addons: list[str] = []
         for addon in _addon_data:
@@ -942,8 +944,8 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
                 if first_update or ADDON_UPDATE_STATS in enabled_updates_by_addon[slug]
             ]
         )
-        self.hass.data[DATA_ADDONS_STATS] = dict(stats_data)
-        self.hass.data[DATA_ADDONS_CHANGELOGS] = dict(
+        data[DATA_ADDONS_STATS] = dict(stats_data)
+        data[DATA_ADDONS_CHANGELOGS] = dict(
             await asyncio.gather(
                 *[
                     self._update_addon_changelog(slug)
@@ -953,7 +955,7 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
                 ]
             )
         )
-        self.hass.data[DATA_ADDONS_INFO] = dict(
+        data[DATA_ADDONS_INFO] = dict(
             await asyncio.gather(
                 *[
                     self._update_addon_info(slug)

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -962,6 +962,7 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
         """Update single addon stats."""
         try:
             stats = await self.hassio.get_addon_stats(slug)
+            _LOGGER.warning("Addon stats: %s %s", slug, stats)
             return (slug, stats)
         except HassioAPIError as err:
             _LOGGER.warning("Could not fetch stats for %s: %s", slug, err)
@@ -971,6 +972,7 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
         """Return the changelog for an add-on."""
         try:
             changelog = await self.hassio.get_addon_changelog(slug)
+            _LOGGER.warning("Addon change: %s %s", slug, changelog)
             return (slug, changelog)
         except HassioAPIError as err:
             _LOGGER.warning("Could not fetch changelog for %s: %s", slug, err)
@@ -980,6 +982,7 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
         """Return the info for an add-on."""
         try:
             info = await self.hassio.get_addon_info(slug)
+            _LOGGER.warning("Addon info: %s %s", slug, info)
             return (slug, info)
         except HassioAPIError as err:
             _LOGGER.warning("Could not fetch info for %s: %s", slug, err)

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -936,6 +936,17 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
             all_addons.append(slug)
             if addon[ATTR_STATE] == ATTR_STARTED:
                 started_addons.append(slug)
+        #
+        # Update add-on info if its the first update or
+        # there is at least one entity that needs the data.
+        #
+        # When entities are added they call async_enable_addon_updates
+        # to enable updates for the endpoints they need via
+        # async_added_to_hass. This ensures that we only update
+        # the data for the endpoints that are needed to avoid unnecessary
+        # API calls since otherwise we would fetch stats for all add-ons
+        # and throw them away.
+        #
         enabled_updates_by_addon = self._enabled_updates_by_addon
         stats_data = await asyncio.gather(
             *[

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -963,13 +963,16 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
             ),
             (DATA_ADDONS_INFO, self._update_addon_info, ADDON_UPDATE_INFO, all_addons),
         ):
-            data[data_key] = dict(
-                await asyncio.gather(
-                    *[
-                        update_func(slug)
-                        for slug in wanted_addons
-                        if first_update or enabled_key in enabled_updates_by_addon[slug]
-                    ]
+            data.setdefault(data_key, {}).update(
+                dict(
+                    await asyncio.gather(
+                        *[
+                            update_func(slug)
+                            for slug in wanted_addons
+                            if first_update
+                            or enabled_key in enabled_updates_by_addon[slug]
+                        ]
+                    )
                 )
             )
 

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -948,20 +948,26 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
         # and throw them away.
         #
         enabled_updates_by_addon = self._enabled_updates_by_addon
-        for data_key, update_func, enabled_key in (
-            (DATA_ADDONS_STATS, self._update_addon_stats, ADDON_UPDATE_STATS),
+        for data_key, update_func, enabled_key, wanted_addons in (
+            (
+                DATA_ADDONS_STATS,
+                self._update_addon_stats,
+                ADDON_UPDATE_STATS,
+                started_addons,
+            ),
             (
                 DATA_ADDONS_CHANGELOGS,
                 self._update_addon_changelog,
                 ADDON_UPDATE_CHANGELOG,
+                all_addons,
             ),
-            (DATA_ADDONS_INFO, self._update_addon_info, ADDON_UPDATE_INFO),
+            (DATA_ADDONS_INFO, self._update_addon_info, ADDON_UPDATE_INFO, all_addons),
         ):
             data[data_key] = dict(
                 await asyncio.gather(
                     *[
                         update_func(slug)
-                        for slug in started_addons
+                        for slug in wanted_addons
                         if first_update or enabled_key in enabled_updates_by_addon[slug]
                     ]
                 )

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -989,9 +989,8 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.warning("Could not fetch info for %s: %s", slug, err)
         return (slug, None)
 
-    async def async_enable_addon_updates(
-        self, slug: str, types: set[str]
-    ) -> CALLBACK_TYPE:
+    @callback
+    def async_enable_addon_updates(self, slug: str, types: set[str]) -> CALLBACK_TYPE:
         """Enable updates for an add-on."""
         enabled_updates = self._enabled_updates_by_addon[slug]
         for key in types:

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -809,8 +809,10 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
+        is_first_update = not self.data
+
         try:
-            await self.force_data_refresh(self.data is None)
+            await self.force_data_refresh(is_first_update)
         except HassioAPIError as err:
             raise UpdateFailed(f"Error on Supervisor API: {err}") from err
 
@@ -854,7 +856,7 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
         new_data[DATA_KEY_HOST] = get_host_info(self.hass) or {}
 
         # If this is the initial refresh, register all addons and return the dict
-        if not self.data:
+        if is_first_update:
             async_register_addons_in_dev_reg(
                 self.entry_id, self.dev_reg, new_data[DATA_KEY_ADDONS].values()
             )

--- a/homeassistant/components/hassio/const.py
+++ b/homeassistant/components/hassio/const.py
@@ -86,6 +86,17 @@ ADDON_UPDATE_STATS = "stats"
 ADDON_UPDATE_CHANGELOG = "changelog"
 ADDON_UPDATE_INFO = "info"
 
+# This is a mapping of which endpoint the key in the addon data
+# is obtained from so we know which endpoint to update when the
+# coordinator polls for updates.
+KEY_TO_UPDATE_TYPES: dict[str, set[str]] = {
+    ATTR_VERSION_LATEST: {ADDON_UPDATE_INFO, ADDON_UPDATE_CHANGELOG},
+    ATTR_MEMORY_PERCENT: {ADDON_UPDATE_STATS},
+    ATTR_CPU_PERCENT: {ADDON_UPDATE_STATS},
+    ATTR_VERSION: {ADDON_UPDATE_INFO},
+    ATTR_STATE: {ADDON_UPDATE_INFO},
+}
+
 
 class SupervisorEntityModel(StrEnum):
     """Supervisor entity model."""

--- a/homeassistant/components/hassio/const.py
+++ b/homeassistant/components/hassio/const.py
@@ -82,6 +82,10 @@ PLACEHOLDER_KEY_COMPONENTS = "components"
 
 ISSUE_KEY_SYSTEM_DOCKER_CONFIG = "issue_system_docker_config"
 
+ADDON_UPDATE_STATS = "stats"
+ADDON_UPDATE_CHANGELOG = "changelog"
+ADDON_UPDATE_INFO = "info"
+
 
 class SupervisorEntityModel(StrEnum):
     """Supervisor entity model."""

--- a/homeassistant/components/hassio/entity.py
+++ b/homeassistant/components/hassio/entity.py
@@ -16,9 +16,8 @@ from .const import (
     DATA_KEY_HOST,
     DATA_KEY_OS,
     DATA_KEY_SUPERVISOR,
+    KEY_TO_UPDATE_TYPES,
 )
-
-KEY_TO_UPDATE_TYPE: dict[str, str] = {}
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,13 +52,9 @@ class HassioAddonEntity(CoordinatorEntity[HassioDataUpdateCoordinator]):
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to updates."""
-        try:
-            update_type = KEY_TO_UPDATE_TYPE[self.entity_description.key]
-        except KeyError:
-            _LOGGER.warning("No update type for %s", self.entity_description.key)
-            return await super().async_added_to_hass()
+        update_types = KEY_TO_UPDATE_TYPES[self.entity_description.key]
         self.async_on_remove(
-            self.coordinator.async_enable_addon_updates(self._addon_slug, update_type)
+            self.coordinator.async_enable_addon_updates(self._addon_slug, update_types)
         )
         return await super().async_added_to_hass()
 

--- a/homeassistant/components/hassio/entity.py
+++ b/homeassistant/components/hassio/entity.py
@@ -1,7 +1,6 @@
 """Base for Hass.io entities."""
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -18,8 +17,6 @@ from .const import (
     DATA_KEY_SUPERVISOR,
     KEY_TO_UPDATE_TYPES,
 )
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class HassioAddonEntity(CoordinatorEntity[HassioDataUpdateCoordinator]):

--- a/homeassistant/components/hassio/entity.py
+++ b/homeassistant/components/hassio/entity.py
@@ -49,11 +49,13 @@ class HassioAddonEntity(CoordinatorEntity[HassioDataUpdateCoordinator]):
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to updates."""
+        await super().async_added_to_hass()
         update_types = KEY_TO_UPDATE_TYPES[self.entity_description.key]
         self.async_on_remove(
-            self.coordinator.async_enable_addon_updates(self._addon_slug, update_types)
+            self.coordinator.async_enable_addon_updates(
+                self._addon_slug, self.entity_id, update_types
+            )
         )
-        return await super().async_added_to_hass()
 
 
 class HassioOSEntity(CoordinatorEntity[HassioDataUpdateCoordinator]):

--- a/homeassistant/components/hassio/update.py
+++ b/homeassistant/components/hassio/update.py
@@ -130,19 +130,13 @@ class SupervisorAddonUpdateEntity(HassioAddonEntity, UpdateEntity):
         """Return the icon of the add-on if any."""
         if not self.available:
             return None
-        # The icon may not be available right away after
-        # manually enabling an entity. So we need use .get()
-        # here to avoid a KeyError.
-        if self._addon_data.get(ATTR_ICON):
+        if self._addon_data[ATTR_ICON]:
             return f"/api/hassio/addons/{self._addon_slug}/icon"
         return None
 
     def _strip_release_notes(self) -> str | None:
         """Strip the release notes to contain the needed sections."""
-        # The changelog may not be available right away after
-        # manually enabling an entity. So we need use .get()
-        # here to avoid a KeyError.
-        if (notes := self._addon_data.get(ATTR_CHANGELOG)) is None:
+        if (notes := self._addon_data[ATTR_CHANGELOG]) is None:
             return None
 
         if (

--- a/homeassistant/components/hassio/update.py
+++ b/homeassistant/components/hassio/update.py
@@ -130,13 +130,19 @@ class SupervisorAddonUpdateEntity(HassioAddonEntity, UpdateEntity):
         """Return the icon of the add-on if any."""
         if not self.available:
             return None
-        if self._addon_data[ATTR_ICON]:
+        # The icon may not be available right away after
+        # manually enabling an entity. So we need use .get()
+        # here to avoid a KeyError.
+        if self._addon_data.get(ATTR_ICON):
             return f"/api/hassio/addons/{self._addon_slug}/icon"
         return None
 
     def _strip_release_notes(self) -> str | None:
         """Strip the release notes to contain the needed sections."""
-        if (notes := self._addon_data[ATTR_CHANGELOG]) is None:
+        # The changelog may not be available right away after
+        # manually enabling an entity. So we need use .get()
+        # here to avoid a KeyError.
+        if (notes := self._addon_data.get(ATTR_CHANGELOG)) is None:
             return None
 
         if (

--- a/tests/components/hassio/test_sensor.py
+++ b/tests/components/hassio/test_sensor.py
@@ -29,7 +29,7 @@ def mock_all(aioclient_mock: AiohttpClientMocker, request):
 
 
 def _install_test_addon_stats_mock(aioclient_mock: AiohttpClientMocker):
-    """Install mocks."""
+    """Install mock to provide valid stats for the test addon."""
     aioclient_mock.get(
         "http://127.0.0.1/addons/test/stats",
         json={
@@ -49,7 +49,7 @@ def _install_test_addon_stats_mock(aioclient_mock: AiohttpClientMocker):
 
 
 def _install_test_addon_stats_failure_mock(aioclient_mock: AiohttpClientMocker):
-    """Install mocks."""
+    """Install mocks to raise an exception when fetching stats for the test addon."""
     aioclient_mock.get(
         "http://127.0.0.1/addons/test/stats",
         exc=HassioAPIError,
@@ -57,7 +57,7 @@ def _install_test_addon_stats_failure_mock(aioclient_mock: AiohttpClientMocker):
 
 
 def _install_default_mocks(aioclient_mock: AiohttpClientMocker):
-    """Install mocks."""
+    """Install default mocks."""
     aioclient_mock.post("http://127.0.0.1/homeassistant/options", json={"result": "ok"})
     aioclient_mock.get("http://127.0.0.1/supervisor/ping", json={"result": "ok"})
     aioclient_mock.post("http://127.0.0.1/supervisor/options", json={"result": "ok"})

--- a/tests/components/hassio/test_sensor.py
+++ b/tests/components/hassio/test_sensor.py
@@ -119,6 +119,7 @@ def _install_default_mocks(aioclient_mock: AiohttpClientMocker):
                         "version_latest": "2.0.1",
                         "repository": "core",
                         "url": "https://github.com/home-assistant/addons/test",
+                        "icon": False,
                     },
                     {
                         "name": "test2",
@@ -130,6 +131,7 @@ def _install_default_mocks(aioclient_mock: AiohttpClientMocker):
                         "version_latest": "3.2.0",
                         "repository": "core",
                         "url": "https://github.com",
+                        "icon": False,
                     },
                 ],
             },

--- a/tests/components/hassio/test_sensor.py
+++ b/tests/components/hassio/test_sensor.py
@@ -1,23 +1,63 @@
 """The tests for the hassio sensors."""
+from datetime import timedelta
 import os
 from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.hassio import DOMAIN
+from homeassistant.components.hassio import (
+    DOMAIN,
+    HASSIO_UPDATE_INTERVAL,
+    HassioAPIError,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
+import homeassistant.util.dt as dt_util
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 MOCK_ENVIRON = {"SUPERVISOR": "127.0.0.1", "SUPERVISOR_TOKEN": "abcdefgh"}
 
 
 @pytest.fixture(autouse=True)
-def mock_all(aioclient_mock, request):
+def mock_all(aioclient_mock: AiohttpClientMocker, request):
     """Mock all setup requests."""
+    _install_default_mocks(aioclient_mock)
+    _install_test_addon_stats_mock(aioclient_mock)
+
+
+def _install_test_addon_stats_mock(aioclient_mock: AiohttpClientMocker):
+    """Install mocks."""
+    aioclient_mock.get(
+        "http://127.0.0.1/addons/test/stats",
+        json={
+            "result": "ok",
+            "data": {
+                "cpu_percent": 0.99,
+                "memory_usage": 182611968,
+                "memory_limit": 3977146368,
+                "memory_percent": 4.59,
+                "network_rx": 362570232,
+                "network_tx": 82374138,
+                "blk_read": 46010945536,
+                "blk_write": 15051526144,
+            },
+        },
+    )
+
+
+def _install_test_addon_stats_failure_mock(aioclient_mock: AiohttpClientMocker):
+    """Install mocks."""
+    aioclient_mock.get(
+        "http://127.0.0.1/addons/test/stats",
+        exc=HassioAPIError,
+    )
+
+
+def _install_default_mocks(aioclient_mock: AiohttpClientMocker):
+    """Install mocks."""
     aioclient_mock.post("http://127.0.0.1/homeassistant/options", json={"result": "ok"})
     aioclient_mock.get("http://127.0.0.1/supervisor/ping", json={"result": "ok"})
     aioclient_mock.post("http://127.0.0.1/supervisor/options", json={"result": "ok"})
@@ -92,22 +132,6 @@ def mock_all(aioclient_mock, request):
                         "url": "https://github.com",
                     },
                 ],
-            },
-        },
-    )
-    aioclient_mock.get(
-        "http://127.0.0.1/addons/test/stats",
-        json={
-            "result": "ok",
-            "data": {
-                "cpu_percent": 0.99,
-                "memory_usage": 182611968,
-                "memory_limit": 3977146368,
-                "memory_percent": 4.59,
-                "network_rx": 362570232,
-                "network_tx": 82374138,
-                "blk_read": 46010945536,
-                "blk_write": 15051526144,
             },
         },
     )
@@ -196,6 +220,7 @@ async def test_sensor(
     expected,
     aioclient_mock: AiohttpClientMocker,
     entity_registry: er.EntityRegistry,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test hassio OS and addons sensor."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
@@ -221,3 +246,75 @@ async def test_sensor(
     # Verify that the entity have the expected state.
     state = hass.states.get(entity_id)
     assert state.state == expected
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "expected"),
+    [
+        ("sensor.test_cpu_percent", "0.99"),
+        ("sensor.test_memory_percent", "4.59"),
+    ],
+)
+async def test_stats_addon_sensor(
+    hass: HomeAssistant,
+    entity_id,
+    expected,
+    aioclient_mock: AiohttpClientMocker,
+    entity_registry: er.EntityRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test stats addons sensor."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
+    config_entry.add_to_hass(hass)
+
+    with patch.dict(os.environ, MOCK_ENVIRON):
+        result = await async_setup_component(
+            hass,
+            "hassio",
+            {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
+        )
+        assert result
+    await hass.async_block_till_done()
+
+    # Verify that the entity is disabled by default.
+    assert hass.states.get(entity_id) is None
+
+    aioclient_mock.clear_requests()
+    _install_default_mocks(aioclient_mock)
+    _install_test_addon_stats_failure_mock(aioclient_mock)
+
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + HASSIO_UPDATE_INTERVAL + timedelta(seconds=1)
+    )
+    await hass.async_block_till_done()
+
+    assert "Could not fetch stats" not in caplog.text
+
+    aioclient_mock.clear_requests()
+    _install_default_mocks(aioclient_mock)
+    _install_test_addon_stats_mock(aioclient_mock)
+
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + HASSIO_UPDATE_INTERVAL + timedelta(seconds=1)
+    )
+    await hass.async_block_till_done()
+
+    # Enable the entity.
+    entity_registry.async_update_entity(entity_id, disabled_by=None)
+    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Verify that the entity have the expected state.
+    state = hass.states.get(entity_id)
+    assert state.state == expected
+
+    aioclient_mock.clear_requests()
+    _install_default_mocks(aioclient_mock)
+    _install_test_addon_stats_failure_mock(aioclient_mock)
+
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + HASSIO_UPDATE_INTERVAL + timedelta(seconds=1)
+    )
+    await hass.async_block_till_done()
+
+    assert "Could not fetch stats" in caplog.text


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We would pull stats for every addon each time the coordinator updated and since the entities are disabled by default we would most likely throw them away. Pulling docker stats is not a cheap operation and when coupled with the number of other api calls supervisor is making, this leads to a cpu spike during each update cycle.  We now only update the hassio addon data when there are entities consuming it.

This was reported again in `#beta` 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
