### PR TITLE
Make Basic CC Z-Wave values a light

### DIFF
--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -853,26 +853,6 @@ DISCOVERY_SCHEMAS = [
         allow_multi=True,
         entity_registry_enabled_default=False,
     ),
-    # number for Basic CC
-    ZWaveDiscoverySchema(
-        platform=Platform.NUMBER,
-        hint="Basic",
-        primary_value=ZWaveValueDiscoverySchema(
-            command_class={CommandClass.BASIC},
-            type={ValueType.NUMBER},
-            property={CURRENT_VALUE_PROPERTY},
-        ),
-        required_values=[
-            ZWaveValueDiscoverySchema(
-                command_class={
-                    CommandClass.BASIC,
-                },
-                type={ValueType.NUMBER},
-                property={TARGET_VALUE_PROPERTY},
-            )
-        ],
-        entity_registry_enabled_default=False,
-    ),
     # number for Indicator CC (exclude property keys 3-5)
     ZWaveDiscoverySchema(
         platform=Platform.NUMBER,
@@ -996,6 +976,25 @@ DISCOVERY_SCHEMAS = [
     ZWaveDiscoverySchema(
         platform=Platform.LIGHT,
         primary_value=SWITCH_MULTILEVEL_CURRENT_VALUE_SCHEMA,
+    ),
+    # light for Basic CC
+    ZWaveDiscoverySchema(
+        platform=Platform.LIGHT,
+        hint="Basic",
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.BASIC},
+            type={ValueType.NUMBER},
+            property={CURRENT_VALUE_PROPERTY},
+        ),
+        required_values=[
+            ZWaveValueDiscoverySchema(
+                command_class={
+                    CommandClass.BASIC,
+                },
+                type={ValueType.NUMBER},
+                property={TARGET_VALUE_PROPERTY},
+            )
+        ],
     ),
     # sirens
     ZWaveDiscoverySchema(

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -980,7 +980,6 @@ DISCOVERY_SCHEMAS = [
     # light for Basic CC
     ZWaveDiscoverySchema(
         platform=Platform.LIGHT,
-        hint="Basic",
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.BASIC},
             type={ValueType.NUMBER},

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -77,6 +77,8 @@ async def async_setup_entry(
 
         if info.platform_hint == "black_is_off":
             async_add_entities([ZwaveBlackIsOffLight(config_entry, driver, info)])
+        elif info.platform_hint == "Basic":
+            async_add_entities([ZwaveBasicLight(config_entry, driver, info)])
         else:
             async_add_entities([ZwaveLight(config_entry, driver, info)])
 
@@ -449,6 +451,79 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
             self._rgbw_color = (red, green, blue, white)
             # Light supports rgbw, set color mode to rgbw
             self._color_mode = ColorMode.RGBW
+
+
+class ZwaveBasicLight(ZWaveBaseEntity, LightEntity):
+    """Representation of a Z-Wave light for the Basic CC."""
+
+    def __init__(
+        self, config_entry: ConfigEntry, driver: Driver, info: ZwaveDiscoveryInfo
+    ) -> None:
+        """Initialize the light."""
+        super().__init__(config_entry, driver, info)
+
+        # get additional (optional) values and set features
+        target_brightness = self.get_zwave_value(
+            TARGET_VALUE_PROPERTY,
+            CommandClass.BASIC,
+            add_to_watched_value_ids=False,
+        )
+        assert target_brightness
+        self._target_brightness = target_brightness
+
+        self._set_optimistic_state: bool = False
+
+        self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
+
+        # Entity class attributes
+        self._attr_name = self.generate_name(
+            include_value_name=True, alternate_value_name=info.platform_hint
+        )
+
+    @property
+    def brightness(self) -> int | None:
+        """Return the brightness of this light between 0..255.
+
+        Z-Wave multilevel switches use a range of [0, 99] to control brightness.
+        """
+        if self.info.primary_value.value is None:
+            return None
+        return round((cast(int, self.info.primary_value.value) / 99) * 255)
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if device is on (brightness above 0)."""
+        if self._set_optimistic_state:
+            self._set_optimistic_state = False
+            return True
+        brightness = self.brightness
+        return brightness > 0 if brightness is not None else None
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the device on."""
+        # set brightness
+        await self._async_set_brightness(kwargs.get(ATTR_BRIGHTNESS))
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the light off."""
+        await self._async_set_brightness(0)
+
+    async def _async_set_brightness(self, brightness: int | None) -> None:
+        """Set new brightness to light."""
+        if brightness is None:
+            zwave_brightness = SET_TO_PREVIOUS_VALUE
+        else:
+            # Zwave multilevel switches use a range of [0, 99] to control brightness.
+            zwave_brightness = byte_to_zwave_brightness(brightness)
+
+        # setting a value requires setting targetValue
+        await self._async_set_value(self._target_brightness, zwave_brightness)
+        # We do an optimistic state update when setting to a previous value
+        # to avoid waiting for the value to be updated from the device which is
+        # typically delayed and causes a confusing UX.
+        if zwave_brightness == SET_TO_PREVIOUS_VALUE:
+            self._set_optimistic_state = True
+            self.async_write_ha_state()
 
 
 class ZwaveBlackIsOffLight(ZwaveLight):

--- a/tests/components/zwave_js/common.py
+++ b/tests/components/zwave_js/common.py
@@ -26,7 +26,7 @@ DISABLED_LEGACY_BINARY_SENSOR = "binary_sensor.multisensor_6_any"
 NOTIFICATION_MOTION_BINARY_SENSOR = "binary_sensor.multisensor_6_motion_detection"
 NOTIFICATION_MOTION_SENSOR = "sensor.multisensor_6_home_security_motion_sensor_status"
 INDICATOR_SENSOR = "sensor.z_wave_thermostat_indicator_value"
-BASIC_NUMBER_ENTITY = "number.livingroomlight_basic"
+BASIC_LIGHT_ENTITY = "light.livingroomlight_basic"
 PROPERTY_DOOR_STATUS_BINARY_SENSOR = (
     "binary_sensor.august_smart_lock_pro_3rd_gen_the_current_status_of_the_door"
 )

--- a/tests/components/zwave_js/test_light.py
+++ b/tests/components/zwave_js/test_light.py
@@ -26,9 +26,11 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from .common import (
     AEON_SMART_SWITCH_LIGHT_ENTITY,
+    BASIC_LIGHT_ENTITY,
     BULB_6_MULTI_COLOR_LIGHT_ENTITY,
     EATON_RF9640_ENTITY,
     ZEN_31_ENTITY,
@@ -859,3 +861,143 @@ async def test_black_is_off_zdb5100(
         "property": "targetColor",
     }
     assert args["value"] == {"red": 255, "green": 76, "blue": 255}
+
+
+async def test_basic_light(
+    hass: HomeAssistant, client, ge_in_wall_dimmer_switch, integration
+) -> None:
+    """Test light is created from Basic CC."""
+    node = ge_in_wall_dimmer_switch
+
+    ent_reg = er.async_get(hass)
+    entity_entry = ent_reg.async_get(BASIC_LIGHT_ENTITY)
+
+    assert entity_entry
+    assert not entity_entry.disabled
+
+    state = hass.states.get(BASIC_LIGHT_ENTITY)
+    assert state
+    assert state.state == STATE_UNKNOWN
+
+    # Send value to 0
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": 2,
+            "args": {
+                "commandClassName": "Basic",
+                "commandClass": 32,
+                "endpoint": 0,
+                "property": "currentValue",
+                "newValue": 0,
+                "prevValue": None,
+                "propertyName": "currentValue",
+            },
+        },
+    )
+    node.receive_event(event)
+
+    state = hass.states.get(BASIC_LIGHT_ENTITY)
+    assert state
+    assert state.state == STATE_OFF
+
+    # Turn on light
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": BASIC_LIGHT_ENTITY},
+        blocking=True,
+    )
+
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == 2
+    assert args["valueId"] == {
+        "commandClass": 32,
+        "endpoint": 0,
+        "property": "targetValue",
+    }
+    assert args["value"] == 255
+
+    # Due to optimistic updates, the state should be on even though the Z-Wave state
+    # hasn't been updated yet
+    state = hass.states.get(BASIC_LIGHT_ENTITY)
+
+    assert state
+    assert state.state == STATE_ON
+
+    client.async_send_command.reset_mock()
+
+    # Send value to 0
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": 2,
+            "args": {
+                "commandClassName": "Basic",
+                "commandClass": 32,
+                "endpoint": 0,
+                "property": "currentValue",
+                "newValue": 0,
+                "prevValue": None,
+                "propertyName": "currentValue",
+            },
+        },
+    )
+    node.receive_event(event)
+
+    state = hass.states.get(BASIC_LIGHT_ENTITY)
+    assert state
+    assert state.state == STATE_OFF
+
+    # Turn on light with brightness
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": BASIC_LIGHT_ENTITY, ATTR_BRIGHTNESS: 128},
+        blocking=True,
+    )
+
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == 2
+    assert args["valueId"] == {
+        "commandClass": 32,
+        "endpoint": 0,
+        "property": "targetValue",
+    }
+    assert args["value"] == 50
+
+    # Since we specified a brightness, there is no optimistic update so the state
+    # should be off
+    state = hass.states.get(BASIC_LIGHT_ENTITY)
+
+    assert state
+    assert state.state == STATE_OFF
+
+    client.async_send_command.reset_mock()
+
+    # Turn off light
+    await hass.services.async_call(
+        "light",
+        "turn_off",
+        {"entity_id": BASIC_LIGHT_ENTITY},
+        blocking=True,
+    )
+
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == 2
+    assert args["valueId"] == {
+        "commandClass": 32,
+        "endpoint": 0,
+        "property": "targetValue",
+    }
+    assert args["value"] == 0

--- a/tests/components/zwave_js/test_light.py
+++ b/tests/components/zwave_js/test_light.py
@@ -863,7 +863,7 @@ async def test_black_is_off_zdb5100(
     assert args["value"] == {"red": 255, "green": 76, "blue": 255}
 
 
-async def test_basic_light(
+async def test_basic_cc_light(
     hass: HomeAssistant, client, ge_in_wall_dimmer_switch, integration
 ) -> None:
     """Test light is created from Basic CC."""
@@ -878,6 +878,7 @@ async def test_basic_light(
     state = hass.states.get(BASIC_LIGHT_ENTITY)
     assert state
     assert state.state == STATE_UNKNOWN
+    assert state.attributes["supported_features"] == 0
 
     # Send value to 0
     event = Event(

--- a/tests/components/zwave_js/test_number.py
+++ b/tests/components/zwave_js/test_number.py
@@ -9,8 +9,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
-from .common import BASIC_NUMBER_ENTITY
-
 from tests.common import MockConfigEntry
 
 NUMBER_ENTITY = "number.thermostat_hvac_valve_control"
@@ -217,18 +215,6 @@ async def test_volume_number(
 
     state = hass.states.get(VOLUME_NUMBER_ENTITY)
     assert state.state == STATE_UNKNOWN
-
-
-async def test_disabled_basic_number(
-    hass: HomeAssistant, ge_in_wall_dimmer_switch, integration
-) -> None:
-    """Test number is created from Basic CC and is disabled."""
-    ent_reg = er.async_get(hass)
-    entity_entry = ent_reg.async_get(BASIC_NUMBER_ENTITY)
-
-    assert entity_entry
-    assert entity_entry.disabled
-    assert entity_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
 async def test_config_parameter_number(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Basic Command Class values were previously exposed as `number` entities and were disabled by default. They are now exposed as `light` entities and are enabled by default. If you have scripts or automations that use any of these `number` entities, they should be updated to use the new `light` entities instead. Any previously created `number` entities for this Command Class can safely be deleted once you have validated that your scripts and automations are up to date.


## Proposed change
Per [this certification task](https://github.com/zwave-js/certification-backlog/issues/7), instead of exposing the Basic CC as a disabled by default `number`, we expose it as a `light`. @AlCalzone @marcelveldt - does this need to be enabled by default or can we keep it disabled by default? Users will still be able to use it, they will just have to enable it, but I personally feel like enabling it by default may be confusing if there are other entities created in parallel.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/zwave-js/certification-backlog/issues/7
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
