### PR TITLE
SMA add missing entity descriptions

### DIFF
--- a/homeassistant/components/sma/sensor.py
+++ b/homeassistant/components/sma/sensor.py
@@ -141,7 +141,7 @@ SENSOR_ENTITIES: dict[str, SensorEntityDescription] = {
     ),
     "pv_isolation_resistance": SensorEntityDescription(
         key="pv_isolation_resistance",
-        name="PV Insulation Resistance",
+        name="PV Isolation Resistance",
         native_unit_of_measurement="kOhms",
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,

--- a/homeassistant/components/sma/sensor.py
+++ b/homeassistant/components/sma/sensor.py
@@ -139,6 +139,13 @@ SENSOR_ENTITIES: dict[str, SensorEntityDescription] = {
         device_class=SensorDeviceClass.CURRENT,
         entity_registry_enabled_default=False,
     ),
+    "pv_isolation_resistance": SensorEntityDescription(
+        key="pv_isolation_resistance",
+        name="PV Insulation Resistance",
+        native_unit_of_measurement="kOhms",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
     "insulation_residual_current": SensorEntityDescription(
         key="insulation_residual_current",
         name="Insulation Residual Current",
@@ -146,6 +153,13 @@ SENSOR_ENTITIES: dict[str, SensorEntityDescription] = {
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.CURRENT,
         entity_registry_enabled_default=False,
+    ),
+    "pv_power": SensorEntityDescription(
+        key="pv_power",
+        name="PV Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
     ),
     "grid_power": SensorEntityDescription(
         key="grid_power",
@@ -478,6 +492,30 @@ SENSOR_ENTITIES: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
         device_class=SensorDeviceClass.ENERGY,
+    ),
+    "sps_voltage": SensorEntityDescription(
+        key="sps_voltage",
+        name="Secure Power Supply Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        entity_registry_enabled_default=False,
+    ),
+    "sps_current": SensorEntityDescription(
+        key="sps_current",
+        name="Secure Power Supply Current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.CURRENT,
+        entity_registry_enabled_default=False,
+    ),
+    "sps_power": SensorEntityDescription(
+        key="sps_power",
+        name="Secure Power Supply Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        entity_registry_enabled_default=False,
     ),
     "optimizer_power": SensorEntityDescription(
         key="optimizer_power",

--- a/tests/components/sma/test_sensor.py
+++ b/tests/components/sma/test_sensor.py
@@ -25,7 +25,6 @@ async def test_sensor_entities(hass: HomeAssistant, init_integration) -> None:
         + sensor_map[OPTIMIZERS_VIA_INVERTER]
         + sensor_map[ENERGY_METER_VIA_INVERTER]
     )
-    sma_sensor_entities = SENSOR_ENTITIES.keys()
 
     for sensor in pysma_sensor_definitions:
-        assert sensor.name in sma_sensor_entities
+        assert sensor.name in SENSOR_ENTITIES

--- a/tests/components/sma/test_sensor.py
+++ b/tests/components/sma/test_sensor.py
@@ -18,7 +18,7 @@ async def test_sensors(hass: HomeAssistant, init_integration) -> None:
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPower.WATT
 
 
-async def test_SENSOR_ENTITIES(hass: HomeAssistant, init_integration) -> None:
+async def test_sensor_entities(hass: HomeAssistant, init_integration) -> None:
     """Test SENSOR_ENTITIES contains a SensorEntityDescription for each pysma sensor."""
     pysma_sensor_definitions = (
         sensor_map[GENERIC_SENSORS]

--- a/tests/components/sma/test_sensor.py
+++ b/tests/components/sma/test_sensor.py
@@ -1,6 +1,13 @@
 """Test the sma sensor platform."""
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, UnitOfPower
 from homeassistant.core import HomeAssistant
+from homeassistant.components.sma.sensor import SENSOR_ENTITIES
+from pysma.definitions import sensor_map
+from pysma.const import (
+    ENERGY_METER_VIA_INVERTER,
+    GENERIC_SENSORS,
+    OPTIMIZERS_VIA_INVERTER,
+)
 
 
 async def test_sensors(hass: HomeAssistant, init_integration) -> None:
@@ -8,3 +15,16 @@ async def test_sensors(hass: HomeAssistant, init_integration) -> None:
     state = hass.states.get("sensor.sma_device_grid_power")
     assert state
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPower.WATT
+
+
+async def test_SENSOR_ENTITIES(hass: HomeAssistant, init_integration) -> None:
+    """Test SENSOR_ENTITIES contains a SensorEntityDescription for each pysma sensor"""
+    pysma_sensor_definitions = (
+        sensor_map[GENERIC_SENSORS]
+        + sensor_map[OPTIMIZERS_VIA_INVERTER]
+        + sensor_map[ENERGY_METER_VIA_INVERTER]
+    )
+    sma_sensor_entities = SENSOR_ENTITIES.keys()
+
+    for sensor in pysma_sensor_definitions:
+        assert sensor.name in sma_sensor_entities

--- a/tests/components/sma/test_sensor.py
+++ b/tests/components/sma/test_sensor.py
@@ -1,13 +1,14 @@
 """Test the sma sensor platform."""
-from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, UnitOfPower
-from homeassistant.core import HomeAssistant
-from homeassistant.components.sma.sensor import SENSOR_ENTITIES
-from pysma.definitions import sensor_map
 from pysma.const import (
     ENERGY_METER_VIA_INVERTER,
     GENERIC_SENSORS,
     OPTIMIZERS_VIA_INVERTER,
 )
+from pysma.definitions import sensor_map
+
+from homeassistant.components.sma.sensor import SENSOR_ENTITIES
+from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, UnitOfPower
+from homeassistant.core import HomeAssistant
 
 
 async def test_sensors(hass: HomeAssistant, init_integration) -> None:
@@ -18,7 +19,7 @@ async def test_sensors(hass: HomeAssistant, init_integration) -> None:
 
 
 async def test_SENSOR_ENTITIES(hass: HomeAssistant, init_integration) -> None:
-    """Test SENSOR_ENTITIES contains a SensorEntityDescription for each pysma sensor"""
+    """Test SENSOR_ENTITIES contains a SensorEntityDescription for each pysma sensor."""
     pysma_sensor_definitions = (
         sensor_map[GENERIC_SENSORS]
         + sensor_map[OPTIMIZERS_VIA_INVERTER]


### PR DESCRIPTION
## Proposed change
Adds missing `SensorEntityDescription` introduced in 2023.10.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #101446
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
