### PR TITLE
Fix caching of latest short term stats after insertion of external stats

### DIFF
--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -1924,7 +1924,13 @@ def get_latest_short_term_statistics(
                 for metadata_id in missing_metadata_ids
                 if (
                     latest_id := cache_latest_short_term_statistic_id_for_metadata_id(
-                        run_cache, session, metadata_id, orm_rows=False
+                        # orm_rows=False is used here because we are in
+                        # a read-only session, and there will never be
+                        # any pending inserts in the session.
+                        run_cache,
+                        session,
+                        metadata_id,
+                        orm_rows=False,
                     )
                 )
                 is not None
@@ -2309,13 +2315,13 @@ def _import_statistics_with_session(
 
     # We just inserted new short term statistics, so we need to update the
     # ShortTermStatisticsRunCache with the latest id for the metadata_id
+    run_cache = get_short_term_statistics_run_cache(instance.hass)
     #
     # Because we are in the same session and we want to read rows
     # that have not been flushed yet, we need to pass orm_rows=True
     # to cache_latest_short_term_statistic_id_for_metadata_id
     # to ensure that it gets the rows that were just inserted
     #
-    run_cache = get_short_term_statistics_run_cache(instance.hass)
     cache_latest_short_term_statistic_id_for_metadata_id(
         run_cache, session, metadata_id, orm_rows=True
     )

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -14,6 +14,7 @@ from homeassistant.components.recorder.db_schema import Statistics, StatisticsSh
 from homeassistant.components.recorder.statistics import (
     async_add_external_statistics,
     get_last_statistics,
+    get_latest_short_term_statistics,
     get_metadata,
     get_short_term_statistics_run_cache,
     list_statistic_ids,
@@ -634,6 +635,23 @@ async def test_statistic_during_period(
         "min": min(stat["min"] for stat in imported_stats_5min[:]) * 1000,
         "change": (imported_stats_5min[-1]["sum"] - imported_stats_5min[0]["sum"])
         * 1000,
+    }
+    stats = get_latest_short_term_statistics(
+        hass, {"sensor.test"}, {"last_reset", "max", "mean", "min", "state", "sum"}
+    )
+    offset * 5 * 60
+    start = imported_stats_5min[-1]["start"].timestamp()
+    end = start + (5 * 60)
+    assert stats == {
+        "sensor.test": [
+            {
+                "end": start,
+                "last_reset": None,
+                "start": end,
+                "state": None,
+                "sum": 38.0,
+            }
+        ]
     }
 
 

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -639,15 +639,14 @@ async def test_statistic_during_period(
     stats = get_latest_short_term_statistics(
         hass, {"sensor.test"}, {"last_reset", "max", "mean", "min", "state", "sum"}
     )
-    offset * 5 * 60
     start = imported_stats_5min[-1]["start"].timestamp()
     end = start + (5 * 60)
     assert stats == {
         "sensor.test": [
             {
-                "end": start,
+                "end": end,
                 "last_reset": None,
-                "start": end,
+                "start": start,
                 "state": None,
                 "sum": 38.0,
             }


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Because there is no flush and we need to read back rows
in the same session that we add them, we need to enable
orm_rows for the cache_latest_short_term_statistic_id_for_metadata_id
query when called from _import_statistics_with_session to
ensure the query can see the new rows that
were just inserted from external stats

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
