### PR TITLE
Add sensor platform to Proximity

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -980,8 +980,6 @@ omit =
     homeassistant/components/progettihwsw/switch.py
     homeassistant/components/proliphix/climate.py
     homeassistant/components/prowl/notify.py
-    homeassistant/components/proximity/__init__.py
-    homeassistant/components/proximity/coordinator.py
     homeassistant/components/proxmoxve/*
     homeassistant/components/proxy/camera.py
     homeassistant/components/pulseaudio_loopback/switch.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -981,8 +981,7 @@ omit =
     homeassistant/components/proliphix/climate.py
     homeassistant/components/prowl/notify.py
     homeassistant/components/proximity/__init__.py
-    homeassistant/components/proximity/const.py
-    homeassistant/components/proximity/sensor.py
+    homeassistant/components/proximity/coordinator.py
     homeassistant/components/proxmoxve/*
     homeassistant/components/proxy/camera.py
     homeassistant/components/pulseaudio_loopback/switch.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -980,6 +980,9 @@ omit =
     homeassistant/components/progettihwsw/switch.py
     homeassistant/components/proliphix/climate.py
     homeassistant/components/prowl/notify.py
+    homeassistant/components/proximity/__init__.py
+    homeassistant/components/proximity/const.py
+    homeassistant/components/proximity/sensor.py
     homeassistant/components/proxmoxve/*
     homeassistant/components/proxy/camera.py
     homeassistant/components/pulseaudio_loopback/switch.py

--- a/homeassistant/components/proximity/__init__.py
+++ b/homeassistant/components/proximity/__init__.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     ATTR_DIR_OF_TRAVEL,
+    ATTR_DIST_TO_CONVERTED,
     ATTR_NEAREST,
     CONF_IGNORED_ZONES,
     CONF_TOLERANCE,
@@ -104,12 +105,12 @@ class Proximity(CoordinatorEntity[ProximityDataUpdateCoordinator]):
     @property
     def state(self) -> str | int | float:
         """Return the state."""
-        return self.coordinator.data["dist_to_zone_converted"]
+        return self.coordinator.data[ATTR_DIST_TO_CONVERTED]
 
     @property
     def extra_state_attributes(self) -> dict[str, str]:
         """Return the state attributes."""
         return {
-            ATTR_DIR_OF_TRAVEL: str(self.coordinator.data["dir_of_travel"]),
-            ATTR_NEAREST: str(self.coordinator.data["nearest"]),
+            ATTR_DIR_OF_TRAVEL: str(self.coordinator.data[ATTR_DIR_OF_TRAVEL]),
+            ATTR_NEAREST: str(self.coordinator.data[ATTR_NEAREST]),
         }

--- a/homeassistant/components/proximity/__init__.py
+++ b/homeassistant/components/proximity/__init__.py
@@ -56,7 +56,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     for friendly_name, proximity_config in config[DOMAIN].items():
         _LOGGER.debug("setup %s with config:%s", friendly_name, proximity_config)
 
-        coordinator = ProximityDataUpdateCoordinator(hass, friendly_name, proximity_config)
+        coordinator = ProximityDataUpdateCoordinator(
+            hass, friendly_name, proximity_config
+        )
 
         async_track_state_change(
             hass,

--- a/homeassistant/components/proximity/__init__.py
+++ b/homeassistant/components/proximity/__init__.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     ATTR_DIR_OF_TRAVEL,
-    ATTR_DIST_TO_CONVERTED,
+    ATTR_DIST_TO,
     ATTR_NEAREST,
     CONF_IGNORED_ZONES,
     CONF_TOLERANCE,
@@ -107,12 +107,14 @@ class Proximity(CoordinatorEntity[ProximityDataUpdateCoordinator]):
     @property
     def state(self) -> str | int | float:
         """Return the state."""
-        return self.coordinator.data[ATTR_DIST_TO_CONVERTED]
+        return self.coordinator.data.proximity[ATTR_DIST_TO]
 
     @property
     def extra_state_attributes(self) -> dict[str, str]:
         """Return the state attributes."""
         return {
-            ATTR_DIR_OF_TRAVEL: str(self.coordinator.data[ATTR_DIR_OF_TRAVEL]),
-            ATTR_NEAREST: str(self.coordinator.data[ATTR_NEAREST]),
+            ATTR_DIR_OF_TRAVEL: str(
+                self.coordinator.data.proximity[ATTR_DIR_OF_TRAVEL]
+            ),
+            ATTR_NEAREST: str(self.coordinator.data.proximity[ATTR_NEAREST]),
         }

--- a/homeassistant/components/proximity/__init__.py
+++ b/homeassistant/components/proximity/__init__.py
@@ -104,7 +104,7 @@ class Proximity(CoordinatorEntity[ProximityDataUpdateCoordinator]):
     @property
     def state(self) -> str | int | float:
         """Return the state."""
-        return self.coordinator.data["dist_to_zone"]
+        return self.coordinator.data["dist_to_zone_converted"]
 
     @property
     def extra_state_attributes(self) -> dict[str, str]:

--- a/homeassistant/components/proximity/const.py
+++ b/homeassistant/components/proximity/const.py
@@ -4,6 +4,7 @@ from homeassistant.const import UnitOfLength
 
 ATTR_DIR_OF_TRAVEL = "dir_of_travel"
 ATTR_DIST_TO = "dist_to_zone"
+ATTR_DIST_TO_CONVERTED = "dist_to_zone_converted"
 ATTR_NEAREST = "nearest"
 
 CONF_IGNORED_ZONES = "ignored_zones"

--- a/homeassistant/components/proximity/const.py
+++ b/homeassistant/components/proximity/const.py
@@ -4,11 +4,12 @@ from typing import Final
 
 from homeassistant.const import UnitOfLength
 
-ATTR_PROXIMITY_DATA: Final = "proximity_data"
-ATTR_ENTITIES_DATA: Final = "entities_data"
 ATTR_DIR_OF_TRAVEL: Final = "dir_of_travel"
 ATTR_DIST_TO: Final = "dist_to_zone"
+ATTR_ENTITIES_DATA: Final = "entities_data"
+ATTR_IN_IGNORED_ZONE: Final = "is_in_ignored_zone"
 ATTR_NEAREST: Final = "nearest"
+ATTR_PROXIMITY_DATA: Final = "proximity_data"
 
 CONF_IGNORED_ZONES = "ignored_zones"
 CONF_TOLERANCE = "tolerance"

--- a/homeassistant/components/proximity/const.py
+++ b/homeassistant/components/proximity/const.py
@@ -1,11 +1,13 @@
 """Constants for Proximity integration."""
 
+from typing import Final
+
 from homeassistant.const import UnitOfLength
 
-ATTR_DIR_OF_TRAVEL = "dir_of_travel"
-ATTR_DIST_TO = "dist_to_zone"
-ATTR_DIST_TO_CONVERTED = "dist_to_zone_converted"
-ATTR_NEAREST = "nearest"
+ATTR_DIR_OF_TRAVEL: Final = "dir_of_travel"
+ATTR_DIST_TO: Final = "dist_to_zone"
+ATTR_DIST_TO_CONVERTED: Final = "dist_to_zone_converted"
+ATTR_NEAREST: Final = "nearest"
 
 CONF_IGNORED_ZONES = "ignored_zones"
 CONF_TOLERANCE = "tolerance"

--- a/homeassistant/components/proximity/const.py
+++ b/homeassistant/components/proximity/const.py
@@ -4,9 +4,10 @@ from typing import Final
 
 from homeassistant.const import UnitOfLength
 
+ATTR_PROXIMITY_DATA: Final = "proximity_data"
+ATTR_ENTITIES_DATA: Final = "entities_data"
 ATTR_DIR_OF_TRAVEL: Final = "dir_of_travel"
 ATTR_DIST_TO: Final = "dist_to_zone"
-ATTR_DIST_TO_CONVERTED: Final = "dist_to_zone_converted"
 ATTR_NEAREST: Final = "nearest"
 
 CONF_IGNORED_ZONES = "ignored_zones"

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -204,38 +204,38 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         entities_data = self.data.entities
 
         # calculate distance for all tracked entities
-        for device in self.tracked_entities:
-            if (device_state := self.hass.states.get(device)) is None:
-                if entities_data.pop(device, None) is not None:
+        for entity_id in self.tracked_entities:
+            if (device_state := self.hass.states.get(entity_id)) is None:
+                if entities_data.pop(entity_id, None) is not None:
                     _LOGGER.debug(
-                        "%s: %s does not exist -> remove", self.friendly_name, device
+                        "%s: %s does not exist -> remove", self.friendly_name, entity_id
                     )
                 continue
 
-            if device not in entities_data:
-                _LOGGER.debug("%s: %s is new -> add", self.friendly_name, device)
-                entities_data[device] = {
+            if entity_id not in entities_data:
+                _LOGGER.debug("%s: %s is new -> add", self.friendly_name, entity_id)
+                entities_data[entity_id] = {
                     ATTR_DIST_TO: None,
                     ATTR_DIR_OF_TRAVEL: None,
                     ATTR_NAME: device_state.name,
                     ATTR_IN_IGNORED_ZONE: False,
                 }
-            entities_data[device][ATTR_IN_IGNORED_ZONE] = (
+            entities_data[entity_id][ATTR_IN_IGNORED_ZONE] = (
                 device_state.state.lower() in self.ignored_zones
             )
-            entities_data[device][ATTR_DIST_TO] = self._calc_distance_to_zone(
+            entities_data[entity_id][ATTR_DIST_TO] = self._calc_distance_to_zone(
                 zone_state,
                 device_state,
                 device_state.attributes.get(ATTR_LATITUDE),
                 device_state.attributes.get(ATTR_LONGITUDE),
             )
-            if entities_data[device][ATTR_DIST_TO] is None:
+            if entities_data[entity_id][ATTR_DIST_TO] is None:
                 _LOGGER.debug(
                     "%s: %s has unknown distance got -> direction_of_travel=None",
                     self.friendly_name,
-                    device,
+                    entity_id,
                 )
-                entities_data[device][ATTR_DIR_OF_TRAVEL] = None
+                entities_data[entity_id][ATTR_DIR_OF_TRAVEL] = None
 
         # calculate direction of travel only for last updated tracked entity
         if (state_change_data := self.state_change_data) is not None and (

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -205,7 +205,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
 
         # calculate distance for all tracked entities
         for entity_id in self.tracked_entities:
-            if (device_state := self.hass.states.get(entity_id)) is None:
+            if (tracked_entity_state := self.hass.states.get(entity_id)) is None:
                 if entities_data.pop(entity_id, None) is not None:
                     _LOGGER.debug(
                         "%s: %s does not exist -> remove", self.friendly_name, entity_id
@@ -217,17 +217,17 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
                 entities_data[entity_id] = {
                     ATTR_DIST_TO: None,
                     ATTR_DIR_OF_TRAVEL: None,
-                    ATTR_NAME: device_state.name,
+                    ATTR_NAME: tracked_entity_state.name,
                     ATTR_IN_IGNORED_ZONE: False,
                 }
             entities_data[entity_id][ATTR_IN_IGNORED_ZONE] = (
-                device_state.state.lower() in self.ignored_zones
+                tracked_entity_state.state.lower() in self.ignored_zones
             )
             entities_data[entity_id][ATTR_DIST_TO] = self._calc_distance_to_zone(
                 zone_state,
-                device_state,
-                device_state.attributes.get(ATTR_LATITUDE),
-                device_state.attributes.get(ATTR_LONGITUDE),
+                tracked_entity_state,
+                tracked_entity_state.attributes.get(ATTR_LATITUDE),
+                tracked_entity_state.attributes.get(ATTR_LONGITUDE),
             )
             if entities_data[entity_id][ATTR_DIST_TO] is None:
                 _LOGGER.debug(

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -68,7 +68,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
     ) -> None:
         """Initialize the Proximity coordinator."""
         self.ignored_zones: list[str] = config[CONF_IGNORED_ZONES]
-        self.proximity_devices: list[str] = config[CONF_DEVICES]
+        self.tracked_entities: list[str] = config[CONF_DEVICES]
         self.tolerance: int = config[CONF_TOLERANCE]
         self.proximity_zone: str = config[CONF_ZONE]
         self.unit_of_measurement: str = config.get(
@@ -204,7 +204,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         entities_data = self.data.entities
 
         # calculate distance for all tracked entities
-        for device in self.proximity_devices:
+        for device in self.tracked_entities:
             if (device_state := self.hass.states.get(device)) is None:
                 if entities_data.pop(device, None) is not None:
                     _LOGGER.debug(

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -201,7 +201,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
             )
             return DEFAULT_DATA
 
-        entities_data: dict[str, dict[str, str | int | None]] = self.data.entities
+        entities_data = self.data.entities
 
         # calculate distance for all tracked entities
         for device in self.proximity_devices:

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -2,7 +2,6 @@
 
 from dataclasses import dataclass
 import logging
-from typing import TypedDict
 
 from homeassistant.const import (
     ATTR_LATITUDE,
@@ -42,16 +41,7 @@ class StateChangedData:
     new_state: State | None
 
 
-class ProximityData(TypedDict):
-    """ProximityData type class."""
-
-    dist_to_zone: str | float
-    dist_to_zone_converted: str | float
-    dir_of_travel: str | float
-    nearest: str | float
-
-
-class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
+class ProximityDataUpdateCoordinator(DataUpdateCoordinator[dict[str, str | float]]):
     """Proximity data update coordinator."""
 
     def __init__(
@@ -104,7 +94,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
             )
         )
 
-    async def _async_update_data(self) -> ProximityData:
+    async def _async_update_data(self) -> dict[str, str | float]:
         """Calculate Proximity data."""
         if (
             state_change_data := self.state_change_data

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -238,39 +238,36 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
                 )
                 entities_data[device][ATTR_DIR_OF_TRAVEL] = None
 
-            # calculate drection of travel only for last updated tracked entity
-            if (
-                (state_change_data := self.state_change_data) is not None
-                and device == state_change_data.entity_id
-                and device_state.state.lower() == self.proximity_zone.lower()
-            ):
-                _LOGGER.debug(
-                    "%s: %s in zone -> direction_of_travel=arrived",
-                    self.friendly_name,
-                    device_state.entity_id,
-                )
-                entities_data[device][ATTR_DIR_OF_TRAVEL] = "arrived"
-            elif (
-                state_change_data is not None
-                and device == state_change_data.entity_id
-                and (old_state := state_change_data.old_state) is not None
-                and (new_state := state_change_data.new_state) is not None
-            ):
-                _LOGGER.debug(
-                    "%s: calculate direction of travel for %s",
-                    self.friendly_name,
-                    device,
-                )
-                entities_data[device][
-                    ATTR_DIR_OF_TRAVEL
-                ] = self._calc_direction_of_travel(
-                    zone_state,
-                    device_state,
-                    old_state.attributes.get(ATTR_LATITUDE),
-                    old_state.attributes.get(ATTR_LONGITUDE),
-                    new_state.attributes.get(ATTR_LATITUDE),
-                    new_state.attributes.get(ATTR_LONGITUDE),
-                )
+        # calculate direction of travel only for last updated tracked entity
+        if (state_change_data := self.state_change_data) is not None and entities_data[
+            state_change_data.entity_id
+        ][ATTR_DIST_TO] == 0:
+            _LOGGER.debug(
+                "%s: %s in zone -> direction_of_travel=arrived",
+                self.friendly_name,
+                state_change_data.entity_id,
+            )
+            entities_data[state_change_data.entity_id][ATTR_DIR_OF_TRAVEL] = "arrived"
+        elif (
+            state_change_data is not None
+            and (old_state := state_change_data.old_state) is not None
+            and (new_state := state_change_data.new_state) is not None
+        ):
+            _LOGGER.debug(
+                "%s: calculate direction of travel for %s",
+                self.friendly_name,
+                state_change_data.entity_id,
+            )
+            entities_data[state_change_data.entity_id][
+                ATTR_DIR_OF_TRAVEL
+            ] = self._calc_direction_of_travel(
+                zone_state,
+                new_state,
+                old_state.attributes.get(ATTR_LATITUDE),
+                old_state.attributes.get(ATTR_LONGITUDE),
+                new_state.attributes.get(ATTR_LATITUDE),
+                new_state.attributes.get(ATTR_LONGITUDE),
+            )
 
         # takeover data for legacy proximity entity
         proximity_data: dict[str, str | float] = {

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -19,6 +19,10 @@ from homeassistant.util.location import distance
 from homeassistant.util.unit_conversion import DistanceConverter
 
 from .const import (
+    ATTR_DIR_OF_TRAVEL,
+    ATTR_DIST_TO,
+    ATTR_DIST_TO_CONVERTED,
+    ATTR_NEAREST,
     CONF_IGNORED_ZONES,
     CONF_TOLERANCE,
     DEFAULT_DIR_OF_TRAVEL,
@@ -71,10 +75,10 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         )
 
         self.data = {
-            "dist_to_zone": DEFAULT_DIST_TO_ZONE,
-            "dist_to_zone_converted": DEFAULT_DIST_TO_ZONE,
-            "dir_of_travel": DEFAULT_DIR_OF_TRAVEL,
-            "nearest": DEFAULT_NEAREST,
+            ATTR_DIST_TO: DEFAULT_DIST_TO_ZONE,
+            ATTR_DIST_TO_CONVERTED: DEFAULT_DIST_TO_ZONE,
+            ATTR_DIR_OF_TRAVEL: DEFAULT_DIR_OF_TRAVEL,
+            ATTR_NEAREST: DEFAULT_NEAREST,
         }
 
         self.state_change_data: StateChangedData | None = None
@@ -137,20 +141,20 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         if not devices_to_calculate:
             _LOGGER.debug("no devices_to_calculate -> abort")
             return {
-                "dist_to_zone": DEFAULT_DIST_TO_ZONE,
-                "dist_to_zone_converted": DEFAULT_DIST_TO_ZONE,
-                "dir_of_travel": DEFAULT_DIR_OF_TRAVEL,
-                "nearest": DEFAULT_NEAREST,
+                ATTR_DIST_TO: DEFAULT_DIST_TO_ZONE,
+                ATTR_DIST_TO_CONVERTED: DEFAULT_DIST_TO_ZONE,
+                ATTR_DIR_OF_TRAVEL: DEFAULT_DIR_OF_TRAVEL,
+                ATTR_NEAREST: DEFAULT_NEAREST,
             }
 
         # At least one device is in the monitored zone so update the entity.
         if devices_in_zone:
             _LOGGER.debug("at least one device is in zone -> arrived")
             return {
-                "dist_to_zone": 0,
-                "dist_to_zone_converted": 0,
-                "dir_of_travel": "arrived",
-                "nearest": ", ".join(devices_in_zone),
+                ATTR_DIST_TO: 0,
+                ATTR_DIST_TO_CONVERTED: 0,
+                ATTR_DIR_OF_TRAVEL: "arrived",
+                ATTR_NEAREST: ", ".join(devices_in_zone),
             }
 
         # We can't check proximity because latitude and longitude don't exist.
@@ -199,12 +203,12 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
             device_state = self.hass.states.get(closest_device)
             assert device_state
             return {
-                "dist_to_zone": round(distances_to_zone[closest_device]),
-                "dist_to_zone_converted": self._convert(
+                ATTR_DIST_TO: round(distances_to_zone[closest_device]),
+                ATTR_DIST_TO_CONVERTED: self._convert(
                     distances_to_zone[closest_device]
                 ),
-                "dir_of_travel": "unknown",
-                "nearest": device_state.name,
+                ATTR_DIR_OF_TRAVEL: "unknown",
+                ATTR_NEAREST: device_state.name,
             }
 
         # Stop if we cannot calculate the direction of travel (i.e. we don't
@@ -215,12 +219,12 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         ):
             _LOGGER.debug("no lat and lon in old_state -> unknown")
             return {
-                "dist_to_zone": round(distances_to_zone[state_change_data.entity_id]),
-                "dist_to_zone_converted": self._convert(
+                ATTR_DIST_TO: round(distances_to_zone[state_change_data.entity_id]),
+                ATTR_DIST_TO_CONVERTED: self._convert(
                     distances_to_zone[state_change_data.entity_id]
                 ),
-                "dir_of_travel": "unknown",
-                "nearest": entity_name,
+                ATTR_DIR_OF_TRAVEL: "unknown",
+                ATTR_NEAREST: entity_name,
             }
 
         # Reset the variables
@@ -268,8 +272,8 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         )
 
         return {
-            "dist_to_zone": dist_to,
-            "dist_to_zone_converted": dist_to_converted,
-            "dir_of_travel": direction_of_travel,
-            "nearest": entity_name,
+            ATTR_DIST_TO: dist_to,
+            ATTR_DIST_TO_CONVERTED: dist_to_converted,
+            ATTR_DIR_OF_TRAVEL: direction_of_travel,
+            ATTR_NEAREST: entity_name,
         }

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -195,7 +195,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         """Calculate Proximity data."""
         if (zone_state := self.hass.states.get(f"zone.{self.proximity_zone}")) is None:
             _LOGGER.debug(
-                "%s: zone %s not exists -> reset",
+                "%s: zone %s does not exist -> reset",
                 self.friendly_name,
                 self.proximity_zone,
             )
@@ -208,7 +208,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
             if (device_state := self.hass.states.get(device)) is None:
                 if entities_data.pop(device, None) is not None:
                     _LOGGER.debug(
-                        "%s: %s not exists -> remove", self.friendly_name, device
+                        "%s: %s does not exist -> remove", self.friendly_name, device
                     )
                 continue
 
@@ -231,7 +231,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
             )
             if entities_data[device][ATTR_DIST_TO] is None:
                 _LOGGER.debug(
-                    "%s: %s distance got unknown -> direction_of_travel=None",
+                    "%s: %s has unknown distance got -> direction_of_travel=None",
                     self.friendly_name,
                     device,
                 )
@@ -296,7 +296,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
                 continue
 
             if float(nearest_distance_to) == float(distance_to):
-                _LOGGER.debug("set same close entity_data: %s", entity_data)
+                _LOGGER.debug("set equally close entity_data: %s", entity_data)
                 proximity_data[
                     ATTR_NEAREST
                 ] = f"{proximity_data[ATTR_NEAREST]}, {str(entity_data[ATTR_NAME])}"

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -6,6 +6,7 @@ import logging
 from homeassistant.const import (
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
+    ATTR_NAME,
     CONF_DEVICES,
     CONF_UNIT_OF_MEASUREMENT,
     CONF_ZONE,
@@ -20,7 +21,6 @@ from homeassistant.util.unit_conversion import DistanceConverter
 from .const import (
     ATTR_DIR_OF_TRAVEL,
     ATTR_DIST_TO,
-    ATTR_DIST_TO_CONVERTED,
     ATTR_NEAREST,
     CONF_IGNORED_ZONES,
     CONF_TOLERANCE,
@@ -41,7 +41,25 @@ class StateChangedData:
     new_state: State | None
 
 
-class ProximityDataUpdateCoordinator(DataUpdateCoordinator[dict[str, str | float]]):
+@dataclass
+class ProximityData:
+    """ProximityCoordinatorData class."""
+
+    proximity: dict[str, str | float]
+    entities: dict[str, dict[str, str | float | None]]
+
+
+DEFAULT_DATA = ProximityData(
+    {
+        ATTR_DIST_TO: DEFAULT_DIST_TO_ZONE,
+        ATTR_DIR_OF_TRAVEL: DEFAULT_DIR_OF_TRAVEL,
+        ATTR_NEAREST: DEFAULT_NEAREST,
+    },
+    {},
+)
+
+
+class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
     """Proximity data update coordinator."""
 
     def __init__(
@@ -64,12 +82,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[dict[str, str | float
             update_interval=None,
         )
 
-        self.data = {
-            ATTR_DIST_TO: DEFAULT_DIST_TO_ZONE,
-            ATTR_DIST_TO_CONVERTED: DEFAULT_DIST_TO_ZONE,
-            ATTR_DIR_OF_TRAVEL: DEFAULT_DIR_OF_TRAVEL,
-            ATTR_NEAREST: DEFAULT_NEAREST,
-        }
+        self.data = DEFAULT_DATA
 
         self.state_change_data: StateChangedData | None = None
 
@@ -77,15 +90,13 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[dict[str, str | float
         self, entity: str, old_state: State | None, new_state: State | None
     ) -> None:
         """Fetch and process state change event."""
-        if new_state is None:
-            _LOGGER.debug("no new_state -> abort")
-            return
-
         self.state_change_data = StateChangedData(entity, old_state, new_state)
         await self.async_refresh()
 
-    def _convert(self, value: int | float) -> float:
+    def _convert(self, value: float | str) -> float | str:
         """Round and convert given distance value."""
+        if isinstance(value, str):
+            return value
         return round(
             DistanceConverter.convert(
                 value,
@@ -94,176 +105,207 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[dict[str, str | float
             )
         )
 
-    async def _async_update_data(self) -> dict[str, str | float]:
-        """Calculate Proximity data."""
-        if (
-            state_change_data := self.state_change_data
-        ) is None or state_change_data.new_state is None:
-            return self.data
-
-        entity_name = state_change_data.new_state.name
-        devices_to_calculate = False
-        devices_in_zone = []
-
-        zone_state = self.hass.states.get(f"zone.{self.proximity_zone}")
-        proximity_latitude = (
-            zone_state.attributes.get(ATTR_LATITUDE) if zone_state else None
-        )
-        proximity_longitude = (
-            zone_state.attributes.get(ATTR_LONGITUDE) if zone_state else None
-        )
-
-        # Check for devices in the monitored zone.
-        for device in self.proximity_devices:
-            if (device_state := self.hass.states.get(device)) is None:
-                devices_to_calculate = True
-                continue
-
-            if device_state.state not in self.ignored_zones:
-                devices_to_calculate = True
-
-            # Check the location of all devices.
-            if (device_state.state).lower() == (self.proximity_zone).lower():
-                device_friendly = device_state.name
-                devices_in_zone.append(device_friendly)
-
-        # No-one to track so reset the entity.
-        if not devices_to_calculate:
-            _LOGGER.debug("no devices_to_calculate -> abort")
-            return {
-                ATTR_DIST_TO: DEFAULT_DIST_TO_ZONE,
-                ATTR_DIST_TO_CONVERTED: DEFAULT_DIST_TO_ZONE,
-                ATTR_DIR_OF_TRAVEL: DEFAULT_DIR_OF_TRAVEL,
-                ATTR_NEAREST: DEFAULT_NEAREST,
-            }
-
-        # At least one device is in the monitored zone so update the entity.
-        if devices_in_zone:
-            _LOGGER.debug("at least one device is in zone -> arrived")
-            return {
-                ATTR_DIST_TO: 0,
-                ATTR_DIST_TO_CONVERTED: 0,
-                ATTR_DIR_OF_TRAVEL: "arrived",
-                ATTR_NEAREST: ", ".join(devices_in_zone),
-            }
-
-        # We can't check proximity because latitude and longitude don't exist.
-        if "latitude" not in state_change_data.new_state.attributes:
-            _LOGGER.debug("no latitude and longitude -> reset")
-            return self.data
-
-        # Collect distances to the zone for all devices.
-        distances_to_zone: dict[str, float] = {}
-        for device in self.proximity_devices:
-            # Ignore devices in an ignored zone.
-            device_state = self.hass.states.get(device)
-            if not device_state or device_state.state in self.ignored_zones:
-                continue
-
-            # Ignore devices if proximity cannot be calculated.
-            if "latitude" not in device_state.attributes:
-                continue
-
-            # Calculate the distance to the proximity zone.
-            proximity = distance(
-                proximity_latitude,
-                proximity_longitude,
-                device_state.attributes[ATTR_LATITUDE],
-                device_state.attributes[ATTR_LONGITUDE],
+    def _calc_distance_to_zone(
+        self,
+        zone: State,
+        device: State,
+        latitude: float | None,
+        longitude: float | None,
+    ) -> float | None:
+        if device.state.lower() == self.proximity_zone.lower():
+            _LOGGER.debug(
+                "%s: %s in zone -> distance=0", self.friendly_name, device.entity_id
             )
+            return 0
 
-            # Add the device and distance to a dictionary.
-            if proximity is None:
-                continue
-            distances_to_zone[device] = proximity
+        if latitude is None or longitude is None:
+            _LOGGER.debug(
+                "%s: %s has no coordinates -> distance=None",
+                self.friendly_name,
+                device.entity_id,
+            )
+            return None
 
-        # Loop through each of the distances collected and work out the
-        # closest.
-        closest_device: str | None = None
-        dist_to_zone: float | None = None
+        if device.state.lower() in self.ignored_zones:
+            _LOGGER.debug(
+                "%s: %s in ignored zone -> distance=None",
+                self.friendly_name,
+                device.entity_id,
+            )
+            return None
 
-        for device, zone in distances_to_zone.items():
-            if not dist_to_zone or zone < dist_to_zone:
-                closest_device = device
-                dist_to_zone = zone
+        distance_to_zone = distance(
+            zone.attributes[ATTR_LATITUDE],
+            zone.attributes[ATTR_LONGITUDE],
+            latitude,
+            longitude,
+        )
 
-        # If the closest device is one of the other devices.
-        if closest_device is not None and closest_device != state_change_data.entity_id:
-            _LOGGER.debug("closest device is one of the other devices -> unknown")
-            device_state = self.hass.states.get(closest_device)
-            assert device_state
-            return {
-                ATTR_DIST_TO: round(distances_to_zone[closest_device]),
-                ATTR_DIST_TO_CONVERTED: self._convert(
-                    distances_to_zone[closest_device]
-                ),
-                ATTR_DIR_OF_TRAVEL: "unknown",
-                ATTR_NEAREST: device_state.name,
-            }
+        # it is ensured, that distance can't be None, since zones must have lat/lon coordinates
+        assert distance_to_zone is not None
+        return round(distance_to_zone)
 
-        # Stop if we cannot calculate the direction of travel (i.e. we don't
-        # have a previous state and a current LAT and LONG).
+    def _calc_direction_of_travel(
+        self,
+        zone: State,
+        device: State,
+        old_latitude: float | None,
+        old_longitude: float | None,
+        new_latitude: float | None,
+        new_longitude: float | None,
+    ) -> str | None:
+        if device.state.lower() in self.ignored_zones:
+            _LOGGER.debug(
+                "%s: %s in ignored zone -> direction_of_travel=None",
+                self.friendly_name,
+                device.entity_id,
+            )
+            return None
+
         if (
-            state_change_data.old_state is None
-            or "latitude" not in state_change_data.old_state.attributes
+            old_latitude is None
+            or old_longitude is None
+            or new_latitude is None
+            or new_longitude is None
         ):
-            _LOGGER.debug("no lat and lon in old_state -> unknown")
-            return {
-                ATTR_DIST_TO: round(distances_to_zone[state_change_data.entity_id]),
-                ATTR_DIST_TO_CONVERTED: self._convert(
-                    distances_to_zone[state_change_data.entity_id]
-                ),
-                ATTR_DIR_OF_TRAVEL: "unknown",
-                ATTR_NEAREST: entity_name,
-            }
+            return None
 
-        # Reset the variables
-        distance_travelled: float = 0
-
-        # Calculate the distance travelled.
         old_distance = distance(
-            proximity_latitude,
-            proximity_longitude,
-            state_change_data.old_state.attributes[ATTR_LATITUDE],
-            state_change_data.old_state.attributes[ATTR_LONGITUDE],
+            zone.attributes[ATTR_LATITUDE],
+            zone.attributes[ATTR_LONGITUDE],
+            old_latitude,
+            old_longitude,
         )
         new_distance = distance(
-            proximity_latitude,
-            proximity_longitude,
-            state_change_data.new_state.attributes[ATTR_LATITUDE],
-            state_change_data.new_state.attributes[ATTR_LONGITUDE],
+            zone.attributes[ATTR_LATITUDE],
+            zone.attributes[ATTR_LONGITUDE],
+            new_latitude,
+            new_longitude,
         )
-        assert new_distance is not None and old_distance is not None
+
+        # it is ensured, that distance can't be None, since zones must have lat/lon coordinates
+        assert old_distance is not None
+        assert new_distance is not None
         distance_travelled = round(new_distance - old_distance, 1)
 
-        # Check for tolerance
         if distance_travelled < self.tolerance * -1:
-            direction_of_travel = "towards"
-        elif distance_travelled > self.tolerance:
-            direction_of_travel = "away_from"
-        else:
-            direction_of_travel = "stationary"
+            return "towards"
 
-        # Update the proximity entity
-        dist_to: float | str
-        dist_to_converted: float | str
-        if dist_to_zone is not None:
-            dist_to = round(dist_to_zone)
-            dist_to_converted = self._convert(dist_to_zone)
-        else:
-            dist_to = dist_to_converted = DEFAULT_DIST_TO_ZONE
+        if distance_travelled > self.tolerance:
+            return "away_from"
 
-        _LOGGER.debug(
-            "%s updated: distance=%s: direction=%s: device=%s",
-            self.friendly_name,
-            dist_to,
-            direction_of_travel,
-            entity_name,
-        )
+        return "stationary"
 
-        return {
-            ATTR_DIST_TO: dist_to,
-            ATTR_DIST_TO_CONVERTED: dist_to_converted,
-            ATTR_DIR_OF_TRAVEL: direction_of_travel,
-            ATTR_NEAREST: entity_name,
+    async def _async_update_data(self) -> ProximityData:
+        """Calculate Proximity data."""
+        if (zone_state := self.hass.states.get(f"zone.{self.proximity_zone}")) is None:
+            _LOGGER.debug(
+                "%s: zone %s not exists -> reset",
+                self.friendly_name,
+                self.proximity_zone,
+            )
+            return DEFAULT_DATA
+
+        entities_data: dict[str, dict[str, str | float | None]] = self.data.entities
+
+        # calculate distance for all tracked entities
+        for device in self.proximity_devices:
+            if (device_state := self.hass.states.get(device)) is None:
+                if entities_data.pop(device, None) is not None:
+                    _LOGGER.debug(
+                        "%s: %s not exists -> remove", self.friendly_name, device
+                    )
+                continue
+
+            if device not in entities_data:
+                _LOGGER.debug("%s: %s is new -> add", self.friendly_name, device)
+                entities_data[device] = {
+                    ATTR_DIST_TO: None,
+                    ATTR_DIR_OF_TRAVEL: None,
+                    ATTR_NAME: device_state.name,
+                }
+            entities_data[device][ATTR_DIST_TO] = self._calc_distance_to_zone(
+                zone_state,
+                device_state,
+                device_state.attributes.get(ATTR_LATITUDE),
+                device_state.attributes.get(ATTR_LONGITUDE),
+            )
+            if entities_data[device][ATTR_DIST_TO] is None:
+                _LOGGER.debug(
+                    "%s: %s distance got unknown -> direction_of_travel=None",
+                    self.friendly_name,
+                    device,
+                )
+                entities_data[device][ATTR_DIR_OF_TRAVEL] = None
+
+            # calculate drection of travel only for last updated tracked entity
+            if (
+                (state_change_data := self.state_change_data) is not None
+                and device == state_change_data.entity_id
+                and device_state.state.lower() == self.proximity_zone.lower()
+            ):
+                _LOGGER.debug(
+                    "%s: %s in zone -> direction_of_travel=arrived",
+                    self.friendly_name,
+                    device_state.entity_id,
+                )
+                entities_data[device][ATTR_DIR_OF_TRAVEL] = "arrived"
+            elif (
+                state_change_data is not None
+                and device == state_change_data.entity_id
+                and (old_state := state_change_data.old_state) is not None
+                and (new_state := state_change_data.new_state) is not None
+            ):
+                _LOGGER.debug(
+                    "%s: calculate direction of travel for %s",
+                    self.friendly_name,
+                    device,
+                )
+                entities_data[device][
+                    ATTR_DIR_OF_TRAVEL
+                ] = self._calc_direction_of_travel(
+                    zone_state,
+                    device_state,
+                    old_state.attributes.get(ATTR_LATITUDE),
+                    old_state.attributes.get(ATTR_LONGITUDE),
+                    new_state.attributes.get(ATTR_LATITUDE),
+                    new_state.attributes.get(ATTR_LONGITUDE),
+                )
+
+        # takeover data for legacy proximity entity
+        proximity_data: dict[str, str | float] = {
+            ATTR_DIST_TO: DEFAULT_DIST_TO_ZONE,
+            ATTR_DIR_OF_TRAVEL: DEFAULT_DIR_OF_TRAVEL,
+            ATTR_NEAREST: DEFAULT_NEAREST,
         }
+        for entity_data in entities_data.values():
+            if (distance_to := entity_data[ATTR_DIST_TO]) is None:
+                continue
+
+            if isinstance((nearest_distance_to := proximity_data[ATTR_DIST_TO]), str):
+                _LOGGER.debug("set first entity_data: %s", entity_data)
+                proximity_data = {
+                    ATTR_DIST_TO: distance_to,
+                    ATTR_DIR_OF_TRAVEL: entity_data[ATTR_DIR_OF_TRAVEL] or "unknown",
+                    ATTR_NEAREST: str(entity_data[ATTR_NAME]),
+                }
+                continue
+
+            if float(nearest_distance_to) > float(distance_to):
+                _LOGGER.debug("set closer entity_data: %s", entity_data)
+                proximity_data = {
+                    ATTR_DIST_TO: distance_to,
+                    ATTR_DIR_OF_TRAVEL: entity_data[ATTR_DIR_OF_TRAVEL] or "unknown",
+                    ATTR_NEAREST: str(entity_data[ATTR_NAME]),
+                }
+                continue
+
+            if float(nearest_distance_to) == float(distance_to):
+                _LOGGER.debug("set same close entity_data: %s", entity_data)
+                proximity_data[
+                    ATTR_NEAREST
+                ] = f"{proximity_data[ATTR_NEAREST]}, {str(entity_data[ATTR_NAME])}"
+
+        proximity_data[ATTR_DIST_TO] = self._convert(proximity_data[ATTR_DIST_TO])
+
+        return ProximityData(proximity_data, entities_data)

--- a/homeassistant/components/proximity/sensor.py
+++ b/homeassistant/components/proximity/sensor.py
@@ -76,7 +76,7 @@ async def async_setup_platform(
     async_add_entities(entities)
 
 
-class ProximitySensor(SensorEntity, CoordinatorEntity[ProximityDataUpdateCoordinator]):
+class ProximitySensor(CoordinatorEntity[ProximityDataUpdateCoordinator], SensorEntity):
     """Represents a Proximity sensor."""
 
     _attr_has_entity_name = True
@@ -106,7 +106,7 @@ class ProximitySensor(SensorEntity, CoordinatorEntity[ProximityDataUpdateCoordin
 
 
 class ProximityTrackedEntitySensor(
-    SensorEntity, CoordinatorEntity[ProximityDataUpdateCoordinator]
+    CoordinatorEntity[ProximityDataUpdateCoordinator], SensorEntity
 ):
     """Represents a Proximity tracked entity sensor."""
 

--- a/homeassistant/components/proximity/sensor.py
+++ b/homeassistant/components/proximity/sensor.py
@@ -27,6 +27,14 @@ SENSORS_PER_ENTITY: list[SensorEntityDescription] = [
         key=ATTR_DIR_OF_TRAVEL,
         translation_key=ATTR_DIR_OF_TRAVEL,
         icon="mdi:compass-outline",
+        device_class=SensorDeviceClass.ENUM,
+        options=[
+            "arrived",
+            "away_from",
+            "stationary",
+            "towards",
+            "unknown",
+        ],
     ),
 ]
 

--- a/homeassistant/components/proximity/sensor.py
+++ b/homeassistant/components/proximity/sensor.py
@@ -70,7 +70,7 @@ async def async_setup_platform(
     entities += [
         ProximityTrackedEntitySensor(description, coordinator, tracked_entity_id)
         for description in SENSORS_PER_ENTITY
-        for tracked_entity_id in coordinator.proximity_devices
+        for tracked_entity_id in coordinator.tracked_entities
     ]
 
     async_add_entities(entities)

--- a/homeassistant/components/proximity/sensor.py
+++ b/homeassistant/components/proximity/sensor.py
@@ -40,7 +40,6 @@ _LOGGER = logging.getLogger(__name__)
 SENSORS: list[SensorEntityDescription] = [
     SensorEntityDescription(
         key=ATTR_DIST_FROM,
-        translation_key=ATTR_DIST_FROM,
         device_class=SensorDeviceClass.DISTANCE,
         native_unit_of_measurement=UnitOfLength.METERS,
     ),

--- a/homeassistant/components/proximity/sensor.py
+++ b/homeassistant/components/proximity/sensor.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-import logging
-
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntityDescription
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+)
 from homeassistant.const import CONF_NAME, UnitOfLength
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -14,8 +16,6 @@ from homeassistant.util import slugify
 
 from .const import ATTR_DIR_OF_TRAVEL, ATTR_DIST_TO, ATTR_NEAREST, DOMAIN
 from .coordinator import ProximityDataUpdateCoordinator
-
-_LOGGER = logging.getLogger(__name__)
 
 SENSORS: list[SensorEntityDescription] = [
     SensorEntityDescription(
@@ -49,11 +49,8 @@ async def async_setup_platform(
     async_add_entities(ProximitySensor(sensor, coordinator) for sensor in SENSORS)
 
 
-class ProximitySensor(CoordinatorEntity[ProximityDataUpdateCoordinator]):
+class ProximitySensor(SensorEntity, CoordinatorEntity[ProximityDataUpdateCoordinator]):
     """Represents a Proximity sensor."""
-
-    _attr_should_poll = False
-    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -66,7 +63,7 @@ class ProximitySensor(CoordinatorEntity[ProximityDataUpdateCoordinator]):
         self.entity_description = description
 
         self._attr_unique_id = slugify(
-            f"{DOMAIN}_{slugify(coordinator.friendly_name)}_{description.key}"
+            f"{slugify(coordinator.friendly_name)}_{description.key}"
         )
 
     @property

--- a/homeassistant/components/proximity/sensor.py
+++ b/homeassistant/components/proximity/sensor.py
@@ -32,7 +32,6 @@ SENSORS_PER_ENTITY: list[SensorEntityDescription] = [
             "away_from",
             "stationary",
             "towards",
-            "unknown",
         ],
     ),
 ]

--- a/homeassistant/components/proximity/sensor.py
+++ b/homeassistant/components/proximity/sensor.py
@@ -86,7 +86,7 @@ class ProximitySensor(SensorEntity):
 
         self.data: dict[str, int | str | None] = {
             ATTR_DIST_FROM: None,
-            ATTR_DIR_OF_TRAVEL: DEFAULT_DIR_OF_TRAVEL,
+            ATTR_DIR_OF_TRAVEL: slugify(DEFAULT_DIR_OF_TRAVEL),
             ATTR_NEAREST: DEFAULT_NEAREST,
         }
 
@@ -148,7 +148,7 @@ class ProximitySensor(SensorEntity):
         # No-one to track so reset the entity.
         if not devices_to_calculate:
             self.data[ATTR_DIST_FROM] = None
-            self.data[ATTR_DIR_OF_TRAVEL] = DEFAULT_DIR_OF_TRAVEL
+            self.data[ATTR_DIR_OF_TRAVEL] = slugify(DEFAULT_DIR_OF_TRAVEL)
             self.data[ATTR_NEAREST] = DEFAULT_NEAREST
             self.async_write_ha_state()
             return

--- a/homeassistant/components/proximity/sensor.py
+++ b/homeassistant/components/proximity/sensor.py
@@ -67,7 +67,7 @@ class ProximitySensor(SensorEntity, CoordinatorEntity[ProximityDataUpdateCoordin
         )
 
     @property
-    def native_value(self) -> str | int | float | None:
+    def native_value(self) -> str | float | None:
         """Return native sensor value."""
         if (value := self.coordinator.data[self.entity_description.key]) == "not set":
             return None

--- a/homeassistant/components/proximity/sensor.py
+++ b/homeassistant/components/proximity/sensor.py
@@ -12,7 +12,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import slugify
 
 from .const import ATTR_DIR_OF_TRAVEL, ATTR_DIST_TO, ATTR_NEAREST, DOMAIN
 from .coordinator import ProximityDataUpdateCoordinator
@@ -76,6 +75,8 @@ async def async_setup_platform(
 class ProximitySensor(SensorEntity, CoordinatorEntity[ProximityDataUpdateCoordinator]):
     """Represents a Proximity sensor."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         description: SensorEntityDescription,
@@ -86,7 +87,7 @@ class ProximitySensor(SensorEntity, CoordinatorEntity[ProximityDataUpdateCoordin
 
         self.entity_description = description
 
-        self._attr_unique_id = slugify(f"{coordinator.friendly_name}_{description.key}")
+        self._attr_name = f"{coordinator.friendly_name} {description.key}"
 
     @property
     def native_value(self) -> str | float | None:
@@ -103,6 +104,8 @@ class ProximityTrackedEntitySensor(
 ):
     """Represents a Proximity tracked entity sensor."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         description: SensorEntityDescription,
@@ -115,8 +118,8 @@ class ProximityTrackedEntitySensor(
         self.entity_description = description
         self.tracked_entity_id = tracked_entity_id
 
-        self._attr_unique_id = slugify(
-            f"{coordinator.friendly_name}_{tracked_entity_id}_{description.key}"
+        self._attr_name = (
+            f"{coordinator.friendly_name} {tracked_entity_id} {description.key}"
         )
 
     @property

--- a/homeassistant/components/proximity/sensor.py
+++ b/homeassistant/components/proximity/sensor.py
@@ -19,11 +19,13 @@ from .coordinator import ProximityDataUpdateCoordinator
 SENSORS_PER_ENTITY: list[SensorEntityDescription] = [
     SensorEntityDescription(
         key=ATTR_DIST_TO,
+        name="Distance",
         device_class=SensorDeviceClass.DISTANCE,
         native_unit_of_measurement=UnitOfLength.METERS,
     ),
     SensorEntityDescription(
         key=ATTR_DIR_OF_TRAVEL,
+        name="Direction of travel",
         translation_key=ATTR_DIR_OF_TRAVEL,
         icon="mdi:compass-outline",
         device_class=SensorDeviceClass.ENUM,
@@ -38,7 +40,10 @@ SENSORS_PER_ENTITY: list[SensorEntityDescription] = [
 
 SENSORS_PER_PROXIMITY: list[SensorEntityDescription] = [
     SensorEntityDescription(
-        key=ATTR_NEAREST, translation_key=ATTR_NEAREST, icon="mdi:near-me"
+        key=ATTR_NEAREST,
+        name="Nearest",
+        translation_key=ATTR_NEAREST,
+        icon="mdi:near-me",
     ),
 ]
 
@@ -86,7 +91,9 @@ class ProximitySensor(SensorEntity, CoordinatorEntity[ProximityDataUpdateCoordin
 
         self.entity_description = description
 
-        self._attr_name = f"{coordinator.friendly_name} {description.key}"
+        # entity name will be removed as soon as we have a config entry
+        # and can follow the entity naming guidelines
+        self._attr_name = f"{coordinator.friendly_name} {description.name}"
 
     @property
     def native_value(self) -> str | float | None:
@@ -117,8 +124,10 @@ class ProximityTrackedEntitySensor(
         self.entity_description = description
         self.tracked_entity_id = tracked_entity_id
 
+        # entity name will be removed as soon as we have a config entry
+        # and can follow the entity naming guidelines
         self._attr_name = (
-            f"{coordinator.friendly_name} {tracked_entity_id} {description.key}"
+            f"{coordinator.friendly_name} {tracked_entity_id} {description.name}"
         )
 
     @property

--- a/homeassistant/components/proximity/sensor.py
+++ b/homeassistant/components/proximity/sensor.py
@@ -1,0 +1,262 @@
+"""Support for Proximity sensors."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+)
+from homeassistant.const import (
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
+    CONF_DEVICES,
+    CONF_NAME,
+    CONF_ZONE,
+    UnitOfLength,
+)
+from homeassistant.core import HomeAssistant, State, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.util import slugify
+from homeassistant.util.location import distance
+
+from .const import (
+    ATTR_DIR_OF_TRAVEL,
+    ATTR_DIST_FROM,
+    ATTR_NEAREST,
+    CONF_IGNORED_ZONES,
+    CONF_TOLERANCE,
+    DEFAULT_DIR_OF_TRAVEL,
+    DEFAULT_NEAREST,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+SENSORS: list[SensorEntityDescription] = [
+    SensorEntityDescription(
+        key=ATTR_DIST_FROM,
+        translation_key=ATTR_DIST_FROM,
+        device_class=SensorDeviceClass.DISTANCE,
+        native_unit_of_measurement=UnitOfLength.METERS,
+    ),
+    SensorEntityDescription(
+        key=ATTR_DIR_OF_TRAVEL,
+        translation_key=ATTR_DIR_OF_TRAVEL,
+        icon="mdi:compass-outline",
+    ),
+    SensorEntityDescription(
+        key=ATTR_NEAREST, translation_key=ATTR_NEAREST, icon="mdi:near-me"
+    ),
+]
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up the Proximity sensor platform."""
+    if discovery_info is None:
+        return
+
+    async_add_entities(
+        ProximitySensor(sensor, dict(discovery_info)) for sensor in SENSORS
+    )
+
+
+class ProximitySensor(SensorEntity):
+    """Represents a Proximity sensor."""
+
+    _attr_should_poll = False
+    _attr_has_entity_name = True
+
+    def __init__(self, description: SensorEntityDescription, config: dict) -> None:
+        """Initialize the proximity."""
+        self.ignored_zones = config[CONF_IGNORED_ZONES]
+        self.proximity_devices = config[CONF_DEVICES]
+        self.tolerance = config[CONF_TOLERANCE]
+        self.proximity_zone = f"zone.{config[CONF_ZONE]}"
+        self.config_name = slugify(config[CONF_NAME])
+
+        self.data: dict[str, int | str | None] = {
+            ATTR_DIST_FROM: None,
+            ATTR_DIR_OF_TRAVEL: DEFAULT_DIR_OF_TRAVEL,
+            ATTR_NEAREST: DEFAULT_NEAREST,
+        }
+
+        self.entity_description = description
+
+        self._attr_unique_id = slugify(f"{DOMAIN}_{self.config_name}_{description.key}")
+
+    @property
+    def native_value(self) -> int | str | None:
+        """Return native sensor value."""
+        return self.data[self.entity_description.key]
+
+    async def async_added_to_hass(self) -> None:
+        """Start listening for state changes."""
+        self.async_on_remove(
+            async_track_state_change(
+                self.hass,
+                self.proximity_devices,
+                self.async_check_proximity_state_change,
+            )
+        )
+
+    @callback
+    def async_check_proximity_state_change(
+        self, entity: str, old_state: State | None, new_state: State | None
+    ) -> None:
+        """Perform the proximity checking."""
+        if new_state is None:
+            return
+
+        entity_name = new_state.name
+        devices_to_calculate = False
+        devices_in_zone = ""
+
+        zone_state = self.hass.states.get(self.proximity_zone)
+        proximity_latitude = (
+            zone_state.attributes.get(ATTR_LATITUDE) if zone_state else None
+        )
+        proximity_longitude = (
+            zone_state.attributes.get(ATTR_LONGITUDE) if zone_state else None
+        )
+
+        # Check for devices in the monitored zone.
+        for device in self.proximity_devices:
+            if (device_state := self.hass.states.get(device)) is None:
+                devices_to_calculate = True
+                continue
+
+            if device_state.state not in self.ignored_zones:
+                devices_to_calculate = True
+
+            # Check the location of all devices.
+            if (device_state.state).lower() == (self.config_name).lower():
+                device_friendly = device_state.name
+                if devices_in_zone != "":
+                    devices_in_zone = f"{devices_in_zone}, "
+                devices_in_zone = devices_in_zone + device_friendly
+
+        # No-one to track so reset the entity.
+        if not devices_to_calculate:
+            self.data[ATTR_DIST_FROM] = None
+            self.data[ATTR_DIR_OF_TRAVEL] = DEFAULT_DIR_OF_TRAVEL
+            self.data[ATTR_NEAREST] = DEFAULT_NEAREST
+            self.async_write_ha_state()
+            return
+
+        # At least one device is in the monitored zone so update the entity.
+        if devices_in_zone != "":
+            self.data[ATTR_DIST_FROM] = 0
+            self.data[ATTR_DIR_OF_TRAVEL] = "arrived"
+            self.data[ATTR_NEAREST] = devices_in_zone
+            self.async_write_ha_state()
+            return
+
+        # We can't check proximity because latitude and longitude don't exist.
+        if "latitude" not in new_state.attributes:
+            return
+
+        # Collect distances to the zone for all devices.
+        distances_to_zone: dict[str, int] = {}
+        for device in self.proximity_devices:
+            # Ignore devices in an ignored zone.
+            device_state = self.hass.states.get(device)
+            if not device_state or device_state.state in self.ignored_zones:
+                continue
+
+            # Ignore devices if proximity cannot be calculated.
+            if "latitude" not in device_state.attributes:
+                continue
+
+            # Calculate the distance to the proximity zone.
+            proximity = distance(
+                proximity_latitude,
+                proximity_longitude,
+                device_state.attributes[ATTR_LATITUDE],
+                device_state.attributes[ATTR_LONGITUDE],
+            )
+
+            # Add the device and distance to a dictionary.
+            if not proximity:
+                continue
+            distances_to_zone[device] = round(proximity)
+
+        # Loop through each of the distances collected and work out the
+        # closest.
+        closest_device: str | None = None
+        dist_to_zone: int | None = None
+
+        for device, zone in distances_to_zone.items():
+            if not dist_to_zone or zone < dist_to_zone:
+                closest_device = device
+                dist_to_zone = zone
+
+        # If the closest device is one of the other devices.
+        if closest_device is not None and closest_device != entity:
+            self.data[ATTR_DIST_FROM] = round(distances_to_zone[closest_device])
+            self.data[ATTR_DIR_OF_TRAVEL] = "unknown"
+            device_state = self.hass.states.get(closest_device)
+            assert device_state
+            self.data[ATTR_NEAREST] = device_state.name
+            self.async_write_ha_state()
+            return
+
+        # Stop if we cannot calculate the direction of travel (i.e. we don't
+        # have a previous state and a current LAT and LONG).
+        if old_state is None or "latitude" not in old_state.attributes:
+            self.data[ATTR_DIST_FROM] = round(distances_to_zone[entity])
+            self.data[ATTR_DIR_OF_TRAVEL] = "unknown"
+            self.data[ATTR_NEAREST] = entity_name
+            self.async_write_ha_state()
+            return
+
+        # Reset the variables
+        distance_travelled: float = 0
+
+        # Calculate the distance travelled.
+        old_distance = distance(
+            proximity_latitude,
+            proximity_longitude,
+            old_state.attributes[ATTR_LATITUDE],
+            old_state.attributes[ATTR_LONGITUDE],
+        )
+        new_distance = distance(
+            proximity_latitude,
+            proximity_longitude,
+            new_state.attributes[ATTR_LATITUDE],
+            new_state.attributes[ATTR_LONGITUDE],
+        )
+        assert new_distance is not None and old_distance is not None
+        distance_travelled = round(new_distance - old_distance, 1)
+
+        # Check for tolerance
+        if distance_travelled < self.tolerance * -1:
+            direction_of_travel = "towards"
+        elif distance_travelled > self.tolerance:
+            direction_of_travel = "away_from"
+        else:
+            direction_of_travel = "stationary"
+
+        # Update the proximity entity
+        self.data[ATTR_DIST_FROM] = dist_to_zone
+        self.data[ATTR_DIR_OF_TRAVEL] = direction_of_travel
+        self.data[ATTR_NEAREST] = entity_name
+        self.async_write_ha_state()
+        _LOGGER.debug(
+            "proximity.%s update entity: distance=%s: direction=%s: device=%s",
+            self.name,
+            dist_to_zone,
+            direction_of_travel,
+            entity_name,
+        )
+
+        _LOGGER.info("%s: proximity calculation complete", entity_name)

--- a/homeassistant/components/proximity/sensor.py
+++ b/homeassistant/components/proximity/sensor.py
@@ -52,13 +52,14 @@ async def async_setup_platform(
     ]
 
     entities: list[ProximitySensor | ProximityTrackedEntitySensor] = [
-        ProximitySensor(sensor, coordinator) for sensor in SENSORS_PER_PROXIMITY
+        ProximitySensor(description, coordinator)
+        for description in SENSORS_PER_PROXIMITY
     ]
 
     entities += [
-        ProximityTrackedEntitySensor(sensor, coordinator, tracked_entity)
-        for sensor in SENSORS_PER_ENTITY
-        for tracked_entity in coordinator.proximity_devices
+        ProximityTrackedEntitySensor(description, coordinator, tracked_entity_id)
+        for description in SENSORS_PER_ENTITY
+        for tracked_entity_id in coordinator.proximity_devices
     ]
 
     async_add_entities(entities)
@@ -77,9 +78,7 @@ class ProximitySensor(SensorEntity, CoordinatorEntity[ProximityDataUpdateCoordin
 
         self.entity_description = description
 
-        self._attr_unique_id = slugify(
-            f"{slugify(coordinator.friendly_name)}_{description.key}"
-        )
+        self._attr_unique_id = slugify(f"{coordinator.friendly_name}_{description.key}")
 
     @property
     def native_value(self) -> str | float | None:
@@ -100,21 +99,21 @@ class ProximityTrackedEntitySensor(
         self,
         description: SensorEntityDescription,
         coordinator: ProximityDataUpdateCoordinator,
-        tracked_entity: str,
+        tracked_entity_id: str,
     ) -> None:
         """Initialize the proximity."""
         super().__init__(coordinator)
 
         self.entity_description = description
-        self.tracked_entity = tracked_entity
+        self.tracked_entity_id = tracked_entity_id
 
         self._attr_unique_id = slugify(
-            f"{slugify(coordinator.friendly_name)}_{tracked_entity}_{description.key}"
+            f"{coordinator.friendly_name}_{tracked_entity_id}_{description.key}"
         )
 
     @property
     def native_value(self) -> str | float | None:
         """Return native sensor value."""
-        if (data := self.coordinator.data.entities.get(self.tracked_entity)) is None:
+        if (data := self.coordinator.data.entities.get(self.tracked_entity_id)) is None:
             return None
         return data.get(self.entity_description.key)

--- a/homeassistant/components/proximity/sensor.py
+++ b/homeassistant/components/proximity/sensor.py
@@ -4,42 +4,22 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.sensor import (
-    SensorDeviceClass,
-    SensorEntity,
-    SensorEntityDescription,
-)
-from homeassistant.const import (
-    ATTR_LATITUDE,
-    ATTR_LONGITUDE,
-    CONF_DEVICES,
-    CONF_NAME,
-    CONF_ZONE,
-    UnitOfLength,
-)
-from homeassistant.core import HomeAssistant, State, callback
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntityDescription
+from homeassistant.const import CONF_NAME, UnitOfLength
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
-from homeassistant.util.location import distance
 
-from .const import (
-    ATTR_DIR_OF_TRAVEL,
-    ATTR_DIST_FROM,
-    ATTR_NEAREST,
-    CONF_IGNORED_ZONES,
-    CONF_TOLERANCE,
-    DEFAULT_DIR_OF_TRAVEL,
-    DEFAULT_NEAREST,
-    DOMAIN,
-)
+from .const import ATTR_DIR_OF_TRAVEL, ATTR_DIST_TO, ATTR_NEAREST, DOMAIN
+from .coordinator import ProximityDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
 SENSORS: list[SensorEntityDescription] = [
     SensorEntityDescription(
-        key=ATTR_DIST_FROM,
+        key=ATTR_DIST_TO,
         device_class=SensorDeviceClass.DISTANCE,
         native_unit_of_measurement=UnitOfLength.METERS,
     ),
@@ -64,198 +44,34 @@ async def async_setup_platform(
     if discovery_info is None:
         return
 
-    async_add_entities(
-        ProximitySensor(sensor, dict(discovery_info)) for sensor in SENSORS
-    )
+    coordinator = hass.data[DOMAIN][discovery_info[CONF_NAME]]
+
+    async_add_entities(ProximitySensor(sensor, coordinator) for sensor in SENSORS)
 
 
-class ProximitySensor(SensorEntity):
+class ProximitySensor(CoordinatorEntity[ProximityDataUpdateCoordinator]):
     """Represents a Proximity sensor."""
 
     _attr_should_poll = False
     _attr_has_entity_name = True
 
-    def __init__(self, description: SensorEntityDescription, config: dict) -> None:
+    def __init__(
+        self,
+        description: SensorEntityDescription,
+        coordinator: ProximityDataUpdateCoordinator,
+    ) -> None:
         """Initialize the proximity."""
-        self.ignored_zones = config[CONF_IGNORED_ZONES]
-        self.proximity_devices = config[CONF_DEVICES]
-        self.tolerance = config[CONF_TOLERANCE]
-        self.proximity_zone = f"zone.{config[CONF_ZONE]}"
-        self.config_name = slugify(config[CONF_NAME])
-
-        self.data: dict[str, int | str | None] = {
-            ATTR_DIST_FROM: None,
-            ATTR_DIR_OF_TRAVEL: slugify(DEFAULT_DIR_OF_TRAVEL),
-            ATTR_NEAREST: DEFAULT_NEAREST,
-        }
+        super().__init__(coordinator)
 
         self.entity_description = description
 
-        self._attr_unique_id = slugify(f"{DOMAIN}_{self.config_name}_{description.key}")
+        self._attr_unique_id = slugify(
+            f"{DOMAIN}_{slugify(coordinator.friendly_name)}_{description.key}"
+        )
 
     @property
-    def native_value(self) -> int | str | None:
+    def native_value(self) -> str | int | float | None:
         """Return native sensor value."""
-        return self.data[self.entity_description.key]
-
-    async def async_added_to_hass(self) -> None:
-        """Start listening for state changes."""
-        self.async_on_remove(
-            async_track_state_change(
-                self.hass,
-                self.proximity_devices,
-                self.async_check_proximity_state_change,
-            )
-        )
-
-    @callback
-    def async_check_proximity_state_change(
-        self, entity: str, old_state: State | None, new_state: State | None
-    ) -> None:
-        """Perform the proximity checking."""
-        if new_state is None:
-            return
-
-        entity_name = new_state.name
-        devices_to_calculate = False
-        devices_in_zone = ""
-
-        zone_state = self.hass.states.get(self.proximity_zone)
-        proximity_latitude = (
-            zone_state.attributes.get(ATTR_LATITUDE) if zone_state else None
-        )
-        proximity_longitude = (
-            zone_state.attributes.get(ATTR_LONGITUDE) if zone_state else None
-        )
-
-        # Check for devices in the monitored zone.
-        for device in self.proximity_devices:
-            if (device_state := self.hass.states.get(device)) is None:
-                devices_to_calculate = True
-                continue
-
-            if device_state.state not in self.ignored_zones:
-                devices_to_calculate = True
-
-            # Check the location of all devices.
-            if (device_state.state).lower() == (self.config_name).lower():
-                device_friendly = device_state.name
-                if devices_in_zone != "":
-                    devices_in_zone = f"{devices_in_zone}, "
-                devices_in_zone = devices_in_zone + device_friendly
-
-        # No-one to track so reset the entity.
-        if not devices_to_calculate:
-            self.data[ATTR_DIST_FROM] = None
-            self.data[ATTR_DIR_OF_TRAVEL] = slugify(DEFAULT_DIR_OF_TRAVEL)
-            self.data[ATTR_NEAREST] = DEFAULT_NEAREST
-            self.async_write_ha_state()
-            return
-
-        # At least one device is in the monitored zone so update the entity.
-        if devices_in_zone != "":
-            self.data[ATTR_DIST_FROM] = 0
-            self.data[ATTR_DIR_OF_TRAVEL] = "arrived"
-            self.data[ATTR_NEAREST] = devices_in_zone
-            self.async_write_ha_state()
-            return
-
-        # We can't check proximity because latitude and longitude don't exist.
-        if "latitude" not in new_state.attributes:
-            return
-
-        # Collect distances to the zone for all devices.
-        distances_to_zone: dict[str, int] = {}
-        for device in self.proximity_devices:
-            # Ignore devices in an ignored zone.
-            device_state = self.hass.states.get(device)
-            if not device_state or device_state.state in self.ignored_zones:
-                continue
-
-            # Ignore devices if proximity cannot be calculated.
-            if "latitude" not in device_state.attributes:
-                continue
-
-            # Calculate the distance to the proximity zone.
-            proximity = distance(
-                proximity_latitude,
-                proximity_longitude,
-                device_state.attributes[ATTR_LATITUDE],
-                device_state.attributes[ATTR_LONGITUDE],
-            )
-
-            # Add the device and distance to a dictionary.
-            if not proximity:
-                continue
-            distances_to_zone[device] = round(proximity)
-
-        # Loop through each of the distances collected and work out the
-        # closest.
-        closest_device: str | None = None
-        dist_to_zone: int | None = None
-
-        for device, zone in distances_to_zone.items():
-            if not dist_to_zone or zone < dist_to_zone:
-                closest_device = device
-                dist_to_zone = zone
-
-        # If the closest device is one of the other devices.
-        if closest_device is not None and closest_device != entity:
-            self.data[ATTR_DIST_FROM] = round(distances_to_zone[closest_device])
-            self.data[ATTR_DIR_OF_TRAVEL] = "unknown"
-            device_state = self.hass.states.get(closest_device)
-            assert device_state
-            self.data[ATTR_NEAREST] = device_state.name
-            self.async_write_ha_state()
-            return
-
-        # Stop if we cannot calculate the direction of travel (i.e. we don't
-        # have a previous state and a current LAT and LONG).
-        if old_state is None or "latitude" not in old_state.attributes:
-            self.data[ATTR_DIST_FROM] = round(distances_to_zone[entity])
-            self.data[ATTR_DIR_OF_TRAVEL] = "unknown"
-            self.data[ATTR_NEAREST] = entity_name
-            self.async_write_ha_state()
-            return
-
-        # Reset the variables
-        distance_travelled: float = 0
-
-        # Calculate the distance travelled.
-        old_distance = distance(
-            proximity_latitude,
-            proximity_longitude,
-            old_state.attributes[ATTR_LATITUDE],
-            old_state.attributes[ATTR_LONGITUDE],
-        )
-        new_distance = distance(
-            proximity_latitude,
-            proximity_longitude,
-            new_state.attributes[ATTR_LATITUDE],
-            new_state.attributes[ATTR_LONGITUDE],
-        )
-        assert new_distance is not None and old_distance is not None
-        distance_travelled = round(new_distance - old_distance, 1)
-
-        # Check for tolerance
-        if distance_travelled < self.tolerance * -1:
-            direction_of_travel = "towards"
-        elif distance_travelled > self.tolerance:
-            direction_of_travel = "away_from"
-        else:
-            direction_of_travel = "stationary"
-
-        # Update the proximity entity
-        self.data[ATTR_DIST_FROM] = dist_to_zone
-        self.data[ATTR_DIR_OF_TRAVEL] = direction_of_travel
-        self.data[ATTR_NEAREST] = entity_name
-        self.async_write_ha_state()
-        _LOGGER.debug(
-            "proximity.%s update entity: distance=%s: direction=%s: device=%s",
-            self.name,
-            dist_to_zone,
-            direction_of_travel,
-            entity_name,
-        )
-
-        _LOGGER.info("%s: proximity calculation complete", entity_name)
+        if (value := self.coordinator.data[self.entity_description.key]) == "not set":
+            return None
+        return value

--- a/homeassistant/components/proximity/strings.json
+++ b/homeassistant/components/proximity/strings.json
@@ -1,3 +1,18 @@
 {
-  "title": "Proximity"
+  "title": "Proximity",
+  "entity": {
+    "sensor": {
+      "distance_to_zone": { "name": "Distance to zone" },
+      "dir_of_travel": {
+        "name": "Direction of travel",
+        "state": {
+          "arrived": "Arrived",
+          "away_from": "Away from",
+          "stationary": "Stationary",
+          "towards": "Towards"
+        }
+      },
+      "nearest": { "name": "Nearest device" }
+    }
+  }
 }

--- a/homeassistant/components/proximity/strings.json
+++ b/homeassistant/components/proximity/strings.json
@@ -2,7 +2,6 @@
   "title": "Proximity",
   "entity": {
     "sensor": {
-      "distance_to_zone": { "name": "Distance to zone" },
       "dir_of_travel": {
         "name": "Direction of travel",
         "state": {

--- a/homeassistant/components/proximity/strings.json
+++ b/homeassistant/components/proximity/strings.json
@@ -8,8 +8,7 @@
           "arrived": "Arrived",
           "away_from": "Away from",
           "stationary": "Stationary",
-          "towards": "Towards",
-          "unknown": "Unknown"
+          "towards": "Towards"
         }
       },
       "nearest": { "name": "Nearest device" }

--- a/homeassistant/components/proximity/strings.json
+++ b/homeassistant/components/proximity/strings.json
@@ -7,7 +7,6 @@
         "state": {
           "arrived": "Arrived",
           "away_from": "Away from",
-          "not_set": "Not set",
           "stationary": "Stationary",
           "towards": "Towards",
           "unknown": "Unknown"

--- a/homeassistant/components/proximity/strings.json
+++ b/homeassistant/components/proximity/strings.json
@@ -7,8 +7,10 @@
         "state": {
           "arrived": "Arrived",
           "away_from": "Away from",
+          "not_set": "Not set",
           "stationary": "Stationary",
-          "towards": "Towards"
+          "towards": "Towards",
+          "unknown": "Unknown"
         }
       },
       "nearest": { "name": "Nearest device" }

--- a/tests/components/proximity/test_init.py
+++ b/tests/components/proximity/test_init.py
@@ -46,11 +46,11 @@ async def test_proximities(hass: HomeAssistant, friendly_name: str) -> None:
     assert state.state == "0"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{DOMAIN}_{friendly_name}_nearest")
+    state = hass.states.get(f"sensor.{friendly_name}_nearest")
     assert state.state == STATE_UNKNOWN
 
     for device in config["proximity"][friendly_name]["devices"]:
-        entity_base_name = f"sensor.{DOMAIN}_{friendly_name}_{slugify(device)}"
+        entity_base_name = f"sensor.{friendly_name}_{slugify(device)}"
         state = hass.states.get(f"{entity_base_name}_dist_to_zone")
         assert state.state == STATE_UNKNOWN
         state = hass.states.get(f"{entity_base_name}_dir_of_travel")
@@ -96,17 +96,17 @@ async def test_device_tracker_test1_in_zone(hass: HomeAssistant) -> None:
 
     # proximity entity
     state = hass.states.get("proximity.home")
-    assert state.state == "0"
+    assert state.state == "12491"
     assert state.attributes.get("nearest") == "test1"
     assert state.attributes.get("dir_of_travel") == "arrived"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{DOMAIN}_home_nearest")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test1')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
-    assert state.state == "0"
+    assert state.state == "12491361"
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
     assert state.state == "arrived"
 
@@ -139,10 +139,10 @@ async def test_device_tracker_test1_away(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{DOMAIN}_home_nearest")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test1')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == "11912010"
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
@@ -180,10 +180,10 @@ async def test_device_tracker_test1_awayfurther(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{DOMAIN}_home_nearest")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test1')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == "2218752"
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
@@ -202,10 +202,10 @@ async def test_device_tracker_test1_awayfurther(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "away_from"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{DOMAIN}_home_nearest")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test1')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == "4625264"
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
@@ -242,10 +242,10 @@ async def test_device_tracker_test1_awaycloser(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{DOMAIN}_home_nearest")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test1')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == "4625264"
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
@@ -264,10 +264,10 @@ async def test_device_tracker_test1_awaycloser(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "towards"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{DOMAIN}_home_nearest")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test1')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == "2218752"
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
@@ -298,10 +298,10 @@ async def test_all_device_trackers_in_ignored_zone(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "not set"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{DOMAIN}_home_nearest")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == STATE_UNKNOWN
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test1')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == STATE_UNKNOWN
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
@@ -333,10 +333,10 @@ async def test_device_tracker_test1_no_coordinates(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "not set"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{DOMAIN}_home_nearest")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == STATE_UNKNOWN
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test1')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == STATE_UNKNOWN
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
@@ -373,10 +373,10 @@ async def test_device_tracker_test1_awayfurther_a_bit(hass: HomeAssistant) -> No
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{DOMAIN}_home_nearest")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test1')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == "11912010"
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
@@ -395,10 +395,10 @@ async def test_device_tracker_test1_awayfurther_a_bit(hass: HomeAssistant) -> No
     assert state.attributes.get("dir_of_travel") == "stationary"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{DOMAIN}_home_nearest")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test1')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == "11912010"
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
@@ -434,20 +434,20 @@ async def test_device_trackers_in_zone(hass: HomeAssistant) -> None:
 
     # proximity entity
     state = hass.states.get("proximity.home")
-    assert state.state == "0"
+    assert state.state == "12491"
     assert (state.attributes.get("nearest") == "test1, test2") or (
         state.attributes.get("nearest") == "test2, test1"
     )
     assert state.attributes.get("dir_of_travel") == "arrived"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{DOMAIN}_home_nearest")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1, test2"
 
     for device in ["device_tracker.test1", "device_tracker.test2"]:
-        entity_base_name = f"sensor.{DOMAIN}_home_{slugify(device)}"
+        entity_base_name = f"sensor.home_{slugify(device)}"
         state = hass.states.get(f"{entity_base_name}_dist_to_zone")
-        assert state.state == "0"
+        assert state.state == "12491361"
         state = hass.states.get(f"{entity_base_name}_dir_of_travel")
         assert state.state == "arrived"
 
@@ -496,16 +496,16 @@ async def test_device_tracker_test1_awayfurther_than_test2_first_test1(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{DOMAIN}_home_nearest")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test1')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == "2218752"
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
     assert state.state == STATE_UNKNOWN
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test2')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == STATE_UNKNOWN
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
@@ -524,16 +524,16 @@ async def test_device_tracker_test1_awayfurther_than_test2_first_test1(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{DOMAIN}_home_nearest")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test1')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == "2218752"
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
     assert state.state == STATE_UNKNOWN
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test2')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == "4625264"
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
@@ -582,16 +582,16 @@ async def test_device_tracker_test1_awayfurther_than_test2_first_test2(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{DOMAIN}_home_nearest")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test2"
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test1')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == STATE_UNKNOWN
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
     assert state.state == STATE_UNKNOWN
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test2')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == "4625264"
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
@@ -610,16 +610,16 @@ async def test_device_tracker_test1_awayfurther_than_test2_first_test2(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{DOMAIN}_home_nearest")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test1')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == "2218752"
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
     assert state.state == STATE_UNKNOWN
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test2')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == "4625264"
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
@@ -663,16 +663,16 @@ async def test_device_tracker_test1_awayfurther_test2_in_ignored_zone(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{DOMAIN}_home_nearest")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test1')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == "11912010"
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
     assert state.state == STATE_UNKNOWN
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test2')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == STATE_UNKNOWN
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
@@ -746,16 +746,16 @@ async def test_device_tracker_test1_awayfurther_test2_first(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{DOMAIN}_home_nearest")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test2"
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test1')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == STATE_UNKNOWN
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
     assert state.state == STATE_UNKNOWN
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test2')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == "2218752"
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
@@ -805,16 +805,16 @@ async def test_device_tracker_test1_nearest_after_test2_in_ignored_zone(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{DOMAIN}_home_nearest")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test1')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == "2218752"
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
     assert state.state == STATE_UNKNOWN
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test2')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == STATE_UNKNOWN
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
@@ -833,16 +833,16 @@ async def test_device_tracker_test1_nearest_after_test2_in_ignored_zone(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{DOMAIN}_home_nearest")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test2"
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test1')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == "2218752"
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
     assert state.state == STATE_UNKNOWN
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test2')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == "989156"
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
@@ -861,16 +861,16 @@ async def test_device_tracker_test1_nearest_after_test2_in_ignored_zone(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{DOMAIN}_home_nearest")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test1')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == "2218752"
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
     assert state.state == STATE_UNKNOWN
 
-    entity_base_name = f"sensor.{DOMAIN}_home_{slugify('device_tracker.test2')}"
+    entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
     assert state.state == STATE_UNKNOWN
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")

--- a/tests/components/proximity/test_init.py
+++ b/tests/components/proximity/test_init.py
@@ -872,9 +872,9 @@ async def test_device_tracker_test1_nearest_after_test2_in_ignored_zone(
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
-    assert state.state == STATE_UNKNOWN
+    assert state.state == "1364567"
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
-    assert state.state == STATE_UNKNOWN
+    assert state.state == "away_from"
 
 
 def config_zones(hass):

--- a/tests/components/proximity/test_init.py
+++ b/tests/components/proximity/test_init.py
@@ -51,9 +51,9 @@ async def test_proximities(hass: HomeAssistant, friendly_name: str) -> None:
 
     for device in config["proximity"][friendly_name]["devices"]:
         entity_base_name = f"sensor.{friendly_name}_{slugify(device)}"
-        state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+        state = hass.states.get(f"{entity_base_name}_distance")
         assert state.state == STATE_UNKNOWN
-        state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+        state = hass.states.get(f"{entity_base_name}_direction_of_travel")
         assert state.state == STATE_UNKNOWN
 
 
@@ -105,9 +105,9 @@ async def test_device_tracker_test1_in_zone(hass: HomeAssistant) -> None:
     assert state.state == "test1"
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "0"
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == "arrived"
 
 
@@ -143,9 +143,9 @@ async def test_device_tracker_test1_away(hass: HomeAssistant) -> None:
     assert state.state == "test1"
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "11912010"
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
 
@@ -184,9 +184,9 @@ async def test_device_tracker_test1_awayfurther(hass: HomeAssistant) -> None:
     assert state.state == "test1"
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "2218752"
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
     hass.states.async_set(
@@ -206,9 +206,9 @@ async def test_device_tracker_test1_awayfurther(hass: HomeAssistant) -> None:
     assert state.state == "test1"
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "4625264"
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == "away_from"
 
 
@@ -246,9 +246,9 @@ async def test_device_tracker_test1_awaycloser(hass: HomeAssistant) -> None:
     assert state.state == "test1"
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "4625264"
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
     hass.states.async_set(
@@ -268,9 +268,9 @@ async def test_device_tracker_test1_awaycloser(hass: HomeAssistant) -> None:
     assert state.state == "test1"
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "2218752"
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == "towards"
 
 
@@ -302,9 +302,9 @@ async def test_all_device_trackers_in_ignored_zone(hass: HomeAssistant) -> None:
     assert state.state == STATE_UNKNOWN
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == STATE_UNKNOWN
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
 
@@ -337,9 +337,9 @@ async def test_device_tracker_test1_no_coordinates(hass: HomeAssistant) -> None:
     assert state.state == STATE_UNKNOWN
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == STATE_UNKNOWN
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
 
@@ -377,9 +377,9 @@ async def test_device_tracker_test1_awayfurther_a_bit(hass: HomeAssistant) -> No
     assert state.state == "test1"
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "11912010"
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
     hass.states.async_set(
@@ -399,9 +399,9 @@ async def test_device_tracker_test1_awayfurther_a_bit(hass: HomeAssistant) -> No
     assert state.state == "test1"
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "11912010"
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == "stationary"
 
 
@@ -446,9 +446,9 @@ async def test_device_trackers_in_zone(hass: HomeAssistant) -> None:
 
     for device in ["device_tracker.test1", "device_tracker.test2"]:
         entity_base_name = f"sensor.home_{slugify(device)}"
-        state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+        state = hass.states.get(f"{entity_base_name}_distance")
         assert state.state == "0"
-        state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+        state = hass.states.get(f"{entity_base_name}_direction_of_travel")
         assert state.state == "arrived"
 
 
@@ -500,15 +500,15 @@ async def test_device_tracker_test1_awayfurther_than_test2_first_test1(
     assert state.state == "test1"
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "2218752"
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == STATE_UNKNOWN
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
     hass.states.async_set(
@@ -528,15 +528,15 @@ async def test_device_tracker_test1_awayfurther_than_test2_first_test1(
     assert state.state == "test1"
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "2218752"
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "4625264"
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
 
@@ -586,15 +586,15 @@ async def test_device_tracker_test1_awayfurther_than_test2_first_test2(
     assert state.state == "test2"
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == STATE_UNKNOWN
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "4625264"
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
     hass.states.async_set(
@@ -614,15 +614,15 @@ async def test_device_tracker_test1_awayfurther_than_test2_first_test2(
     assert state.state == "test1"
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "2218752"
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "4625264"
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
 
@@ -667,15 +667,15 @@ async def test_device_tracker_test1_awayfurther_test2_in_ignored_zone(
     assert state.state == "test1"
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "11912010"
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == STATE_UNKNOWN
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
 
@@ -750,15 +750,15 @@ async def test_device_tracker_test1_awayfurther_test2_first(
     assert state.state == "test2"
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == STATE_UNKNOWN
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "2218752"
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
 
@@ -809,15 +809,15 @@ async def test_device_tracker_test1_nearest_after_test2_in_ignored_zone(
     assert state.state == "test1"
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "2218752"
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == STATE_UNKNOWN
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
     hass.states.async_set(
@@ -837,15 +837,15 @@ async def test_device_tracker_test1_nearest_after_test2_in_ignored_zone(
     assert state.state == "test2"
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "2218752"
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "989156"
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
     hass.states.async_set(
@@ -865,15 +865,15 @@ async def test_device_tracker_test1_nearest_after_test2_in_ignored_zone(
     assert state.state == "test1"
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "2218752"
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
-    state = hass.states.get(f"{entity_base_name}_dist_to_zone")
+    state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "1364567"
-    state = hass.states.get(f"{entity_base_name}_dir_of_travel")
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == "away_from"
 
 

--- a/tests/components/proximity/test_init.py
+++ b/tests/components/proximity/test_init.py
@@ -96,7 +96,7 @@ async def test_device_tracker_test1_in_zone(hass: HomeAssistant) -> None:
 
     # proximity entity
     state = hass.states.get("proximity.home")
-    assert state.state == "12491"
+    assert state.state == "0"
     assert state.attributes.get("nearest") == "test1"
     assert state.attributes.get("dir_of_travel") == "arrived"
 
@@ -434,7 +434,7 @@ async def test_device_trackers_in_zone(hass: HomeAssistant) -> None:
 
     # proximity entity
     state = hass.states.get("proximity.home")
-    assert state.state == "12491"
+    assert state.state == "0"
     assert (state.attributes.get("nearest") == "test1, test2") or (
         state.attributes.get("nearest") == "test2, test1"
     )

--- a/tests/components/proximity/test_init.py
+++ b/tests/components/proximity/test_init.py
@@ -106,7 +106,7 @@ async def test_device_tracker_test1_in_zone(hass: HomeAssistant) -> None:
 
     entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
     state = hass.states.get(f"{entity_base_name}_dist_to_zone")
-    assert state.state == "12491361"
+    assert state.state == "0"
     state = hass.states.get(f"{entity_base_name}_dir_of_travel")
     assert state.state == "arrived"
 
@@ -447,7 +447,7 @@ async def test_device_trackers_in_zone(hass: HomeAssistant) -> None:
     for device in ["device_tracker.test1", "device_tracker.test2"]:
         entity_base_name = f"sensor.home_{slugify(device)}"
         state = hass.states.get(f"{entity_base_name}_dist_to_zone")
-        assert state.state == "12491361"
+        assert state.state == "0"
         state = hass.states.get(f"{entity_base_name}_dir_of_travel")
         assert state.state == "arrived"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds the sensor platform in preparation of removing the proximity entity at all.
Per each proximity configuration, each tracked device/person get's one "distance" and one "direction of travel" sensor, and one central sensor which shows the nearest device/person to the monitored zone.
With this new approach (_sensors per tracked device/person_) some issues in the current implementation of the proximity entity get resolved - eq. when tracking more than one device per zone, the proximity entities tries to figure out the nearest device which often end up in "unknown" direction of travel, especial when the tracked devices/persons move in different directions.

upcoming PRs
- add config flow (#103894)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29223

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
