### PR TITLE
Auto-fix common key entry issues during WeatherKit config flow

### DIFF
--- a/homeassistant/components/weatherkit/config_flow.py
+++ b/homeassistant/components/weatherkit/config_flow.py
@@ -116,11 +116,11 @@ class WeatherKitFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         # Make sure header and footer are present
         header = "-----BEGIN PRIVATE KEY-----"
         if not key_input.startswith(header):
-            key_input = header + "\n" + key_input
+            key_input = f"{header}\n{key_input}"
 
         footer = "-----END PRIVATE KEY-----"
         if not key_input.endswith(footer):
-            key_input += "\n" + footer
+            key_input += f"\n{footer}"
 
         return key_input
 

--- a/homeassistant/components/weatherkit/config_flow.py
+++ b/homeassistant/components/weatherkit/config_flow.py
@@ -66,6 +66,7 @@ class WeatherKitFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
         if user_input is not None:
             try:
+                user_input[CONF_KEY_PEM] = self._fix_key_input(user_input[CONF_KEY_PEM])
                 await self._test_config(user_input)
             except WeatherKitUnsupportedLocationError as exception:
                 LOGGER.error(exception)
@@ -103,6 +104,25 @@ class WeatherKitFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=data_schema,
             errors=errors,
         )
+
+    def _fix_key_input(self, key_input: str) -> str:
+        """Fix common user errors with the key input."""
+        # OSes may sometimes turn two hyphens (--) into an em dash (—)
+        key_input = key_input.replace("—", "--")
+
+        # Trim whitespace and line breaks
+        key_input = key_input.strip()
+
+        # Make sure header and footer are present
+        header = "-----BEGIN PRIVATE KEY-----"
+        if not key_input.startswith(header):
+            key_input = header + "\n" + key_input
+
+        footer = "-----END PRIVATE KEY-----"
+        if not key_input.endswith(footer):
+            key_input += "\n" + footer
+
+        return key_input
 
     async def _test_config(self, user_input: dict[str, Any]) -> None:
         """Validate credentials."""

--- a/tests/components/weatherkit/test_config_flow.py
+++ b/tests/components/weatherkit/test_config_flow.py
@@ -166,7 +166,7 @@ async def test_auto_fix_key_input(
         return_value=[DataSetType.CURRENT_WEATHER],
     ):
         user_input = EXAMPLE_USER_INPUT.copy()
-        user_input[CONF_KEY_PEM] = input_header + "whateverkey" + input_footer
+        user_input[CONF_KEY_PEM] = f"{input_header}whateverkey{input_footer}"
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input,

--- a/tests/components/weatherkit/test_config_flow.py
+++ b/tests/components/weatherkit/test_config_flow.py
@@ -126,3 +126,54 @@ async def test_form_unsupported_location(hass: HomeAssistant) -> None:
         )
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
+
+
+@pytest.mark.parametrize(
+    ("input_header"),
+    [
+        "-----BEGIN PRIVATE KEY-----\n",
+        "",
+        "  \n\n-----BEGIN PRIVATE KEY-----\n",
+        "—---BEGIN PRIVATE KEY-----\n",
+    ],
+    ids=["Correct header", "No header", "Leading characters", "Em dash in header"],
+)
+@pytest.mark.parametrize(
+    ("input_footer"),
+    [
+        "\n-----END PRIVATE KEY-----",
+        "",
+        "\n-----END PRIVATE KEY-----\n\n  ",
+        "\n—---END PRIVATE KEY-----",
+    ],
+    ids=["Correct footer", "No footer", "Trailing characters", "Em dash in footer"],
+)
+async def test_auto_fix_key_input(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    input_header: str,
+    input_footer: str,
+) -> None:
+    """Test that we fix common user errors in key input."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.weatherkit.WeatherKitApiClient.get_availability",
+        return_value=[DataSetType.CURRENT_WEATHER],
+    ):
+        user_input = EXAMPLE_USER_INPUT.copy()
+        user_input[CONF_KEY_PEM] = input_header + "whateverkey" + input_footer
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input,
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+
+    assert result["data"][CONF_KEY_PEM] == EXAMPLE_CONFIG_DATA[CONF_KEY_PEM]
+    assert len(mock_setup_entry.mock_calls) == 1


### PR DESCRIPTION
## Proposed change

Some users have been having issues configuring the WeatherKit integration, mostly due to simple user error with entering the key. This change attempts to automatically fix the most common errors with key entry so that they can continue, even if the input is slightly incorrect.

For cases that are not covered by this change, I am making a separate documentation PR to help with troubleshooting.

Hoping this can be cherry-picked into a 2023.10 point release.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #101434
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29201

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
