### PR TITLE
Fix for rainbird unique id

### DIFF
--- a/homeassistant/components/rainbird/calendar.py
+++ b/homeassistant/components/rainbird/calendar.py
@@ -61,7 +61,7 @@ class RainBirdCalendarEntity(
         """Create the Calendar event device."""
         super().__init__(coordinator)
         self._event: CalendarEvent | None = None
-        if unique_id:
+        if unique_id is not None:
             self._attr_unique_id = unique_id
             self._attr_device_info = device_info
         else:

--- a/homeassistant/components/rainbird/number.py
+++ b/homeassistant/components/rainbird/number.py
@@ -51,7 +51,7 @@ class RainDelayNumber(CoordinatorEntity[RainbirdUpdateCoordinator], NumberEntity
     ) -> None:
         """Initialize the Rain Bird sensor."""
         super().__init__(coordinator)
-        if coordinator.unique_id:
+        if coordinator.unique_id is not None:
             self._attr_unique_id = f"{coordinator.unique_id}-rain-delay"
             self._attr_device_info = coordinator.device_info
         else:

--- a/homeassistant/components/rainbird/sensor.py
+++ b/homeassistant/components/rainbird/sensor.py
@@ -52,7 +52,7 @@ class RainBirdSensor(CoordinatorEntity[RainbirdUpdateCoordinator], SensorEntity)
         """Initialize the Rain Bird sensor."""
         super().__init__(coordinator)
         self.entity_description = description
-        if coordinator.unique_id:
+        if coordinator.unique_id is not None:
             self._attr_unique_id = f"{coordinator.unique_id}-{description.key}"
             self._attr_device_info = coordinator.device_info
         else:

--- a/homeassistant/components/rainbird/switch.py
+++ b/homeassistant/components/rainbird/switch.py
@@ -65,17 +65,18 @@ class RainBirdSwitch(CoordinatorEntity[RainbirdUpdateCoordinator], SwitchEntity)
         """Initialize a Rain Bird Switch Device."""
         super().__init__(coordinator)
         self._zone = zone
-        if coordinator.unique_id:
+        _LOGGER.debug("coordinator.unique_id=%s", coordinator.unique_id)
+        if coordinator.unique_id is not None:
             self._attr_unique_id = f"{coordinator.unique_id}-{zone}"
         device_name = f"{MANUFACTURER} Sprinkler {zone}"
         if imported_name:
             self._attr_name = imported_name
             self._attr_has_entity_name = False
         else:
-            self._attr_name = None if coordinator.unique_id else device_name
+            self._attr_name = None if coordinator.unique_id is not None else device_name
             self._attr_has_entity_name = True
         self._duration_minutes = duration_minutes
-        if coordinator.unique_id and self._attr_unique_id:
+        if coordinator.unique_id is not None and self._attr_unique_id is not None:
             self._attr_device_info = DeviceInfo(
                 name=device_name,
                 identifiers={(DOMAIN, self._attr_unique_id)},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix for rainbird unique id for devices with no serial number. This allows existing config entries with id zero to continue to set a unique id, preserving existing behavior.

New config entries with a serial of `0` have a unique id of `None` and will not have entities with unique ids.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #101470
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
