### PR TITLE
Make Hydrawise initialize data immediately

### DIFF
--- a/homeassistant/components/hydrawise/binary_sensor.py
+++ b/homeassistant/components/hydrawise/binary_sensor.py
@@ -12,12 +12,12 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_MONITORED_CONDITIONS
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from .const import DOMAIN, LOGGER
+from .const import DOMAIN
 from .coordinator import HydrawiseDataUpdateCoordinator
 from .entity import HydrawiseEntity
 
@@ -95,13 +95,10 @@ async def async_setup_entry(
 class HydrawiseBinarySensor(HydrawiseEntity, BinarySensorEntity):
     """A sensor implementation for Hydrawise device."""
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Get the latest data and updates the state."""
-        LOGGER.debug("Updating Hydrawise binary sensor: %s", self.name)
+    def _update_attrs(self) -> None:
+        """Update state attributes."""
         if self.entity_description.key == "status":
             self._attr_is_on = self.coordinator.last_update_success
         elif self.entity_description.key == "is_watering":
             relay_data = self.coordinator.api.relays_by_zone_number[self.data["relay"]]
             self._attr_is_on = relay_data["timestr"] == "Now"
-        super()._handle_coordinator_update()

--- a/homeassistant/components/hydrawise/entity.py
+++ b/homeassistant/components/hydrawise/entity.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -36,3 +37,14 @@ class HydrawiseEntity(CoordinatorEntity[HydrawiseDataUpdateCoordinator]):
             name=data["name"],
             manufacturer=MANUFACTURER,
         )
+        self._update_attrs()
+
+    def _update_attrs(self) -> None:
+        """Update state attributes."""
+        return
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Get the latest data and updates the state."""
+        self._update_attrs()
+        super()._handle_coordinator_update()

--- a/homeassistant/components/hydrawise/entity.py
+++ b/homeassistant/components/hydrawise/entity.py
@@ -41,7 +41,7 @@ class HydrawiseEntity(CoordinatorEntity[HydrawiseDataUpdateCoordinator]):
 
     def _update_attrs(self) -> None:
         """Update state attributes."""
-        return
+        return  # pragma: no cover
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/homeassistant/components/hydrawise/sensor.py
+++ b/homeassistant/components/hydrawise/sensor.py
@@ -11,13 +11,13 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_MONITORED_CONDITIONS, UnitOfTime
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN, LOGGER
+from .const import DOMAIN
 from .coordinator import HydrawiseDataUpdateCoordinator
 from .entity import HydrawiseEntity
 
@@ -82,10 +82,8 @@ async def async_setup_entry(
 class HydrawiseSensor(HydrawiseEntity, SensorEntity):
     """A sensor implementation for Hydrawise device."""
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Get the latest data and updates the states."""
-        LOGGER.debug("Updating Hydrawise sensor: %s", self.name)
+    def _update_attrs(self) -> None:
+        """Update state attributes."""
         relay_data = self.coordinator.api.relays_by_zone_number[self.data["relay"]]
         if self.entity_description.key == "watering_time":
             if relay_data["timestr"] == "Now":
@@ -94,8 +92,6 @@ class HydrawiseSensor(HydrawiseEntity, SensorEntity):
                 self._attr_native_value = 0
         else:  # _sensor_type == 'next_cycle'
             next_cycle = min(relay_data["time"], TWO_YEAR_SECONDS)
-            LOGGER.debug("New cycle time: %s", next_cycle)
             self._attr_native_value = dt_util.utc_from_timestamp(
                 dt_util.as_timestamp(dt_util.now()) + next_cycle
             )
-        super()._handle_coordinator_update()

--- a/homeassistant/components/hydrawise/switch.py
+++ b/homeassistant/components/hydrawise/switch.py
@@ -13,7 +13,7 @@ from homeassistant.components.switch import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_MONITORED_CONDITIONS
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -23,7 +23,6 @@ from .const import (
     CONF_WATERING_TIME,
     DEFAULT_WATERING_TIME,
     DOMAIN,
-    LOGGER,
 )
 from .coordinator import HydrawiseDataUpdateCoordinator
 from .entity import HydrawiseEntity
@@ -124,14 +123,11 @@ class HydrawiseSwitch(HydrawiseEntity, SwitchEntity):
         elif self.entity_description.key == "auto_watering":
             self.coordinator.api.suspend_zone(365, zone_number)
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Update device state."""
+    def _update_attrs(self) -> None:
+        """Update state attributes."""
         zone_number = self.data["relay"]
-        LOGGER.debug("Updating Hydrawise switch: %s", self.name)
         timestr = self.coordinator.api.relays_by_zone_number[zone_number]["timestr"]
         if self.entity_description.key == "manual_watering":
             self._attr_is_on = timestr == "Now"
         elif self.entity_description.key == "auto_watering":
             self._attr_is_on = timestr not in {"", "Now"}
-        super()._handle_coordinator_update()

--- a/tests/components/hydrawise/test_binary_sensor.py
+++ b/tests/components/hydrawise/test_binary_sensor.py
@@ -14,14 +14,8 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 async def test_states(
     hass: HomeAssistant,
     mock_added_config_entry: MockConfigEntry,
-    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test binary_sensor states."""
-    # Make the coordinator refresh data.
-    freezer.tick(SCAN_INTERVAL + timedelta(seconds=30))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-
     connectivity = hass.states.get("binary_sensor.home_controller_connectivity")
     assert connectivity is not None
     assert connectivity.state == "on"

--- a/tests/components/hydrawise/test_sensor.py
+++ b/tests/components/hydrawise/test_sensor.py
@@ -1,28 +1,18 @@
 """Test Hydrawise sensor."""
 
-from datetime import timedelta
-
-from freezegun.api import FrozenDateTimeFactory
 import pytest
 
-from homeassistant.components.hydrawise.const import SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import MockConfigEntry
 
 
 @pytest.mark.freeze_time("2023-10-01 00:00:00+00:00")
 async def test_states(
     hass: HomeAssistant,
     mock_added_config_entry: MockConfigEntry,
-    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test sensor states."""
-    # Make the coordinator refresh data.
-    freezer.tick(SCAN_INTERVAL + timedelta(seconds=30))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-
     watering_time1 = hass.states.get("sensor.zone_one_watering_time")
     assert watering_time1 is not None
     assert watering_time1.state == "0"
@@ -33,4 +23,4 @@ async def test_states(
 
     next_cycle = hass.states.get("sensor.zone_one_next_cycle")
     assert next_cycle is not None
-    assert next_cycle.state == "2023-10-04T19:52:27+00:00"
+    assert next_cycle.state == "2023-10-04T19:49:57+00:00"

--- a/tests/components/hydrawise/test_switch.py
+++ b/tests/components/hydrawise/test_switch.py
@@ -1,29 +1,19 @@
 """Test Hydrawise switch."""
 
-from datetime import timedelta
 from unittest.mock import Mock
 
-from freezegun.api import FrozenDateTimeFactory
-
-from homeassistant.components.hydrawise.const import SCAN_INTERVAL
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import MockConfigEntry
 
 
 async def test_states(
     hass: HomeAssistant,
     mock_added_config_entry: MockConfigEntry,
-    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test switch states."""
-    # Make the coordinator refresh data.
-    freezer.tick(SCAN_INTERVAL + timedelta(seconds=30))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-
     watering1 = hass.states.get("switch.zone_one_manual_watering")
     assert watering1 is not None
     assert watering1.state == "off"


### PR DESCRIPTION
## Proposed change
Fix the Hydrawise integration to load data immediately on initialization instead of waiting for the first coordinator data refresh.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
