### PR TITLE
Let the statistics component calculate changes in fossil energy consumption calculation

### DIFF
--- a/homeassistant/components/energy/websocket_api.py
+++ b/homeassistant/components/energy/websocket_api.py
@@ -277,7 +277,7 @@ async def ws_get_fossil_energy_consumption(
         {"mean", "change"},
     )
 
-    def _combine_sum_statistics(
+    def _combine_change_statistics(
         stats: dict[str, list[StatisticsRow]], statistic_ids: list[str]
     ) -> dict[float, float]:
         """Combine multiple statistics, returns a dict indexed by start time."""
@@ -325,7 +325,7 @@ async def ws_get_fossil_energy_consumption(
 
         return result
 
-    merged_energy_statistics = _combine_sum_statistics(
+    merged_energy_statistics = _combine_change_statistics(
         statistics, msg["energy_statistic_ids"]
     )
     indexed_co2_statistics = cast(

--- a/homeassistant/components/energy/websocket_api.py
+++ b/homeassistant/components/energy/websocket_api.py
@@ -274,7 +274,7 @@ async def ws_get_fossil_energy_consumption(
         statistic_ids,
         "hour",
         {"energy": UnitOfEnergy.KILO_WATT_HOUR},
-        {"mean", "sum"},
+        {"mean", "change"},
     )
 
     def _combine_sum_statistics(
@@ -287,20 +287,11 @@ async def ws_get_fossil_energy_consumption(
             if statistics_id not in statistic_ids:
                 continue
             for period in stat:
-                if period["sum"] is None:
+                if period["change"] is None:
                     continue
-                result[period["start"]] += period["sum"]
+                result[period["start"]] += period["change"]
 
         return {key: result[key] for key in sorted(result)}
-
-    def _calculate_deltas(sums: dict[float, float]) -> dict[float, float]:
-        prev: float | None = None
-        result: dict[float, float] = {}
-        for period, sum_ in sums.items():
-            if prev is not None:
-                result[period] = sum_ - prev
-            prev = sum_
-        return result
 
     def _reduce_deltas(
         stat_list: list[dict[str, Any]],
@@ -337,7 +328,6 @@ async def ws_get_fossil_energy_consumption(
     merged_energy_statistics = _combine_sum_statistics(
         statistics, msg["energy_statistic_ids"]
     )
-    energy_deltas = _calculate_deltas(merged_energy_statistics)
     indexed_co2_statistics = cast(
         dict[float, float],
         {
@@ -349,7 +339,7 @@ async def ws_get_fossil_energy_consumption(
     # Calculate amount of fossil based energy, assume 100% fossil if missing
     fossil_energy = [
         {"start": start, "delta": delta * indexed_co2_statistics.get(start, 100) / 100}
-        for start, delta in energy_deltas.items()
+        for start, delta in merged_energy_statistics.items()
     ]
 
     if msg["period"] == "hour":

--- a/tests/components/energy/test_websocket_api.py
+++ b/tests/components/energy/test_websocket_api.py
@@ -1038,3 +1038,120 @@ async def test_fossil_energy_consumption_checks(
     assert msg["id"] == 2
     assert not msg["success"]
     assert msg["error"] == {"code": "invalid_end_time", "message": "Invalid end_time"}
+
+
+@pytest.mark.freeze_time("2021-08-01 01:00:00+00:00")
+async def test_fossil_energy_consumption_check_missing_hour(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Test explicitly if the API omits the first hour of data for the requested time frame."""
+
+    now = dt_util.utcnow()
+    later = dt_util.as_utc(dt_util.parse_datetime("2021-08-01 05:00:00"))
+
+    await async_setup_component(hass, "history", {})
+    await async_setup_component(hass, "sensor", {})
+    await async_recorder_block_till_done(hass)
+
+    hour1 = dt_util.as_utc(dt_util.parse_datetime("2021-08-01 01:00:00"))
+    hour2 = dt_util.as_utc(dt_util.parse_datetime("2021-08-01 02:00:00"))
+    hour3 = dt_util.as_utc(dt_util.parse_datetime("2021-08-01 03:00:00"))
+    hour4 = dt_util.as_utc(dt_util.parse_datetime("2021-08-01 04:00:00"))
+
+    # add energy statistics for 4 hours
+    energy_statistics_1 = (
+        {
+            "start": hour1,
+            "last_reset": None,
+            "state": 0,
+            "sum": 1,
+        },
+        {
+            "start": hour2,
+            "last_reset": None,
+            "state": 1,
+            "sum": 3,
+        },
+        {
+            "start": hour3,
+            "last_reset": None,
+            "state": 2,
+            "sum": 5,
+        },
+        {
+            "start": hour4,
+            "last_reset": None,
+            "state": 3,
+            "sum": 8,
+        },
+    )
+    energy_metadata_1 = {
+        "has_mean": False,
+        "has_sum": True,
+        "name": "Total imported energy",
+        "source": "test",
+        "statistic_id": "test:total_energy_import",
+        "unit_of_measurement": "kWh",
+    }
+
+    async_add_external_statistics(hass, energy_metadata_1, energy_statistics_1)
+
+    # add co2 statistics for 4 hours
+    co2_statistics = (
+        {
+            "start": hour1,
+            "last_reset": None,
+            "mean": 10,
+        },
+        {
+            "start": hour2,
+            "last_reset": None,
+            "mean": 30,
+        },
+        {
+            "start": hour3,
+            "last_reset": None,
+            "mean": 60,
+        },
+        {
+            "start": hour4,
+            "last_reset": None,
+            "mean": 90,
+        },
+    )
+    co2_metadata = {
+        "has_mean": True,
+        "has_sum": False,
+        "name": "Fossil percentage",
+        "source": "test",
+        "statistic_id": "test:fossil_percentage",
+        "unit_of_measurement": "%",
+    }
+
+    async_add_external_statistics(hass, co2_metadata, co2_statistics)
+    await async_wait_recording_done(hass)
+
+    client = await hass_ws_client()
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "energy/fossil_energy_consumption",
+            "start_time": now.isoformat(),
+            "end_time": later.isoformat(),
+            "energy_statistic_ids": [
+                "test:total_energy_import",
+            ],
+            "co2_statistic_id": "test:fossil_percentage",
+            "period": "hour",
+        }
+    )
+
+    # check if we received deltas for the requested time frame
+    response = await client.receive_json()
+    assert response["success"]
+    assert list(response["result"].keys()) == [
+        hour1.isoformat(),
+        hour2.isoformat(),
+        hour3.isoformat(),
+        hour4.isoformat(),
+    ]

--- a/tests/components/energy/test_websocket_api.py
+++ b/tests/components/energy/test_websocket_api.py
@@ -1044,7 +1044,7 @@ async def test_fossil_energy_consumption_checks(
 async def test_fossil_energy_consumption_check_missing_hour(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
-    """Test explicitly if the API omits the first hour of data for the requested time frame."""
+    """Test explicitly if the API keeps the first hour of data for the requested time frame."""
 
     now = dt_util.utcnow()
     later = dt_util.as_utc(dt_util.parse_datetime("2021-08-01 05:00:00"))

--- a/tests/components/energy/test_websocket_api.py
+++ b/tests/components/energy/test_websocket_api.py
@@ -423,6 +423,7 @@ async def test_fossil_energy_consumption_no_co2(
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == {
+        period1.isoformat(): pytest.approx(22.0),
         period2.isoformat(): pytest.approx(33.0 - 22.0),
         period3.isoformat(): pytest.approx(55.0 - 33.0),
         period4.isoformat(): pytest.approx(88.0 - 55.0),
@@ -445,6 +446,7 @@ async def test_fossil_energy_consumption_no_co2(
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == {
+        period1.isoformat(): pytest.approx(22.0),
         period2_day_start.isoformat(): pytest.approx(33.0 - 22.0),
         period3.isoformat(): pytest.approx(55.0 - 33.0),
         period4_day_start.isoformat(): pytest.approx(88.0 - 55.0),
@@ -467,7 +469,7 @@ async def test_fossil_energy_consumption_no_co2(
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == {
-        period1.isoformat(): pytest.approx(33.0 - 22.0),
+        period1.isoformat(): pytest.approx(33.0),
         period3.isoformat(): pytest.approx((55.0 - 33.0) + (88.0 - 55.0)),
     }
 
@@ -586,8 +588,9 @@ async def test_fossil_energy_consumption_hole(
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == {
-        period2.isoformat(): pytest.approx(3.0 - 20.0),
-        period3.isoformat(): pytest.approx(55.0 - 3.0),
+        period1.isoformat(): pytest.approx(20.0),
+        period2.isoformat(): pytest.approx(3.0),
+        period3.isoformat(): pytest.approx(32.0),
         period4.isoformat(): pytest.approx(88.0 - 55.0),
     }
 
@@ -608,8 +611,9 @@ async def test_fossil_energy_consumption_hole(
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == {
-        period2_day_start.isoformat(): pytest.approx(3.0 - 20.0),
-        period3.isoformat(): pytest.approx(55.0 - 3.0),
+        period1.isoformat(): pytest.approx(20.0),
+        period2_day_start.isoformat(): pytest.approx(3.0),
+        period3.isoformat(): pytest.approx(32.0),
         period4_day_start.isoformat(): pytest.approx(88.0 - 55.0),
     }
 
@@ -630,8 +634,8 @@ async def test_fossil_energy_consumption_hole(
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == {
-        period1.isoformat(): pytest.approx(3.0 - 20.0),
-        period3.isoformat(): pytest.approx((55.0 - 3.0) + (88.0 - 55.0)),
+        period1.isoformat(): pytest.approx(23.0),
+        period3.isoformat(): pytest.approx((55.0 - 3.0) + (88.0 - 55.0) - 20.0),
     }
 
 
@@ -930,6 +934,7 @@ async def test_fossil_energy_consumption(
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == {
+        period1.isoformat(): pytest.approx(11.0 * 0.2),
         period2.isoformat(): pytest.approx((33.0 - 22.0) * 0.3),
         period3.isoformat(): pytest.approx((44.0 - 33.0) * 0.6),
         period4.isoformat(): pytest.approx((55.0 - 44.0) * 0.9),
@@ -952,6 +957,7 @@ async def test_fossil_energy_consumption(
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == {
+        period1.isoformat(): pytest.approx(11.0 * 0.2),
         period2_day_start.isoformat(): pytest.approx((33.0 - 22.0) * 0.3),
         period3.isoformat(): pytest.approx((44.0 - 33.0) * 0.6),
         period4_day_start.isoformat(): pytest.approx((55.0 - 44.0) * 0.9),
@@ -974,7 +980,7 @@ async def test_fossil_energy_consumption(
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == {
-        period1.isoformat(): pytest.approx((33.0 - 22.0) * 0.3),
+        period1.isoformat(): pytest.approx(11.0 * 0.5),
         period3.isoformat(): pytest.approx(
             ((44.0 - 33.0) * 0.6) + ((55.0 - 44.0) * 0.9)
         ),


### PR DESCRIPTION
## Proposed change
As described in #93771 and #79774, the calculation of fossil energy consumed is sometimes wrong, especially in the case of missing data.

The reason seems to be that `_calculate_deltas` omits the first hour of the requested period, since the initial value of prev is "None", which is then checked in the loop, which then skips that hour.
For example, if there is only one hour of data, `_calculate_deltas` will skip that hour, resulting in 100% low carbon energy.

Therefore, this PR suggests using the statistics module function to calculate the change instead of doing it on our own.

I'm currently running on my prod. instance and seeing good results.

Edit: This is a second approach, the first one (https://github.com/home-assistant/core/pull/101328) didn't work very well in the long run.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #79774 #93771
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
