### PR TITLE
Move wallbox base entity to its own file

### DIFF
--- a/homeassistant/components/wallbox/__init__.py
+++ b/homeassistant/components/wallbox/__init__.py
@@ -13,24 +13,14 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
-from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-    UpdateFailed,
-)
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
     CHARGER_CURRENCY_KEY,
-    CHARGER_CURRENT_VERSION_KEY,
     CHARGER_DATA_KEY,
     CHARGER_ENERGY_PRICE_KEY,
     CHARGER_LOCKED_UNLOCKED_KEY,
     CHARGER_MAX_CHARGING_CURRENT_KEY,
-    CHARGER_NAME_KEY,
-    CHARGER_PART_NUMBER_KEY,
-    CHARGER_SERIAL_NUMBER_KEY,
-    CHARGER_SOFTWARE_KEY,
     CHARGER_STATUS_DESCRIPTION_KEY,
     CHARGER_STATUS_ID_KEY,
     CODE_KEY,
@@ -241,27 +231,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 class InvalidAuth(HomeAssistantError):
     """Error to indicate there is invalid auth."""
-
-
-class WallboxEntity(CoordinatorEntity[WallboxCoordinator]):
-    """Defines a base Wallbox entity."""
-
-    _attr_has_entity_name = True
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information about this Wallbox device."""
-        return DeviceInfo(
-            identifiers={
-                (
-                    DOMAIN,
-                    self.coordinator.data[CHARGER_DATA_KEY][CHARGER_SERIAL_NUMBER_KEY],
-                )
-            },
-            name=f"Wallbox {self.coordinator.data[CHARGER_NAME_KEY]}",
-            manufacturer="Wallbox",
-            model=self.coordinator.data[CHARGER_DATA_KEY][CHARGER_PART_NUMBER_KEY],
-            sw_version=self.coordinator.data[CHARGER_DATA_KEY][CHARGER_SOFTWARE_KEY][
-                CHARGER_CURRENT_VERSION_KEY
-            ],
-        )

--- a/homeassistant/components/wallbox/entity.py
+++ b/homeassistant/components/wallbox/entity.py
@@ -1,0 +1,40 @@
+"""Base entity for the wallbox integration."""
+from __future__ import annotations
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import WallboxCoordinator
+from .const import (
+    CHARGER_CURRENT_VERSION_KEY,
+    CHARGER_DATA_KEY,
+    CHARGER_NAME_KEY,
+    CHARGER_PART_NUMBER_KEY,
+    CHARGER_SERIAL_NUMBER_KEY,
+    CHARGER_SOFTWARE_KEY,
+    DOMAIN,
+)
+
+
+class WallboxEntity(CoordinatorEntity[WallboxCoordinator]):
+    """Defines a base Wallbox entity."""
+
+    _attr_has_entity_name = True
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information about this Wallbox device."""
+        return DeviceInfo(
+            identifiers={
+                (
+                    DOMAIN,
+                    self.coordinator.data[CHARGER_DATA_KEY][CHARGER_SERIAL_NUMBER_KEY],
+                )
+            },
+            name=f"Wallbox {self.coordinator.data[CHARGER_NAME_KEY]}",
+            manufacturer="Wallbox",
+            model=self.coordinator.data[CHARGER_DATA_KEY][CHARGER_PART_NUMBER_KEY],
+            sw_version=self.coordinator.data[CHARGER_DATA_KEY][CHARGER_SOFTWARE_KEY][
+                CHARGER_CURRENT_VERSION_KEY
+            ],
+        )

--- a/homeassistant/components/wallbox/lock.py
+++ b/homeassistant/components/wallbox/lock.py
@@ -9,13 +9,14 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import InvalidAuth, WallboxCoordinator, WallboxEntity
+from . import InvalidAuth, WallboxCoordinator
 from .const import (
     CHARGER_DATA_KEY,
     CHARGER_LOCKED_UNLOCKED_KEY,
     CHARGER_SERIAL_NUMBER_KEY,
     DOMAIN,
 )
+from .entity import WallboxEntity
 
 LOCK_TYPES: dict[str, LockEntityDescription] = {
     CHARGER_LOCKED_UNLOCKED_KEY: LockEntityDescription(

--- a/homeassistant/components/wallbox/number.py
+++ b/homeassistant/components/wallbox/number.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import InvalidAuth, WallboxCoordinator, WallboxEntity
+from . import InvalidAuth, WallboxCoordinator
 from .const import (
     BIDIRECTIONAL_MODEL_PREFIXES,
     CHARGER_DATA_KEY,
@@ -23,6 +23,7 @@ from .const import (
     CHARGER_SERIAL_NUMBER_KEY,
     DOMAIN,
 )
+from .entity import WallboxEntity
 
 
 @dataclass

--- a/homeassistant/components/wallbox/sensor.py
+++ b/homeassistant/components/wallbox/sensor.py
@@ -23,7 +23,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from . import WallboxCoordinator, WallboxEntity
+from . import WallboxCoordinator
 from .const import (
     CHARGER_ADDED_DISCHARGED_ENERGY_KEY,
     CHARGER_ADDED_ENERGY_KEY,
@@ -43,6 +43,7 @@ from .const import (
     CHARGER_STATUS_DESCRIPTION_KEY,
     DOMAIN,
 )
+from .entity import WallboxEntity
 
 CHARGER_STATION = "station"
 UPDATE_INTERVAL = 30

--- a/homeassistant/components/wallbox/switch.py
+++ b/homeassistant/components/wallbox/switch.py
@@ -8,7 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import WallboxCoordinator, WallboxEntity
+from . import WallboxCoordinator
 from .const import (
     CHARGER_DATA_KEY,
     CHARGER_PAUSE_RESUME_KEY,
@@ -17,6 +17,7 @@ from .const import (
     DOMAIN,
     ChargerStatus,
 )
+from .entity import WallboxEntity
 
 SWITCH_TYPES: dict[str, SwitchEntityDescription] = {
     CHARGER_PAUSE_RESUME_KEY: SwitchEntityDescription(


### PR DESCRIPTION
## Proposed change
For better readability move the base entity to its own file. In an followup PR I'm going to move the data update coordinator to its own file to comply with the recommended way.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
