### PR TITLE
Bump aiocomelit to 0.2.0

### DIFF
--- a/homeassistant/components/comelit/__init__.py
+++ b/homeassistant/components/comelit/__init__.py
@@ -5,7 +5,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PIN, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .const import DEFAULT_PORT, DOMAIN
 from .coordinator import ComelitSerialBridge
 
 PLATFORMS = [Platform.COVER, Platform.LIGHT]
@@ -14,7 +14,10 @@ PLATFORMS = [Platform.COVER, Platform.LIGHT]
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Comelit platform."""
     coordinator = ComelitSerialBridge(
-        hass, entry.data[CONF_HOST], entry.data[CONF_PORT], entry.data[CONF_PIN]
+        hass,
+        entry.data[CONF_HOST],
+        entry.data.get(CONF_PORT, DEFAULT_PORT),
+        entry.data[CONF_PIN],
     )
 
     await coordinator.async_config_entry_first_refresh()

--- a/homeassistant/components/comelit/__init__.py
+++ b/homeassistant/components/comelit/__init__.py
@@ -1,10 +1,12 @@
 """Comelit integration."""
 
+from aiocomelit.const import BRIDGE
+
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_PIN, Platform
+from homeassistant.const import CONF_DEVICE, CONF_HOST, CONF_PIN, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .const import _LOGGER, DEFAULT_PORT, DOMAIN
 from .coordinator import ComelitSerialBridge
 
 PLATFORMS = [Platform.COVER, Platform.LIGHT]
@@ -12,13 +14,31 @@ PLATFORMS = [Platform.COVER, Platform.LIGHT]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Comelit platform."""
-    coordinator = ComelitSerialBridge(hass, entry.data[CONF_HOST], entry.data[CONF_PIN])
+    coordinator = ComelitSerialBridge(
+        hass, entry.data[CONF_HOST], entry.data[CONF_PORT], entry.data[CONF_PIN]
+    )
 
     await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate old entry."""
+    _LOGGER.debug("Migrating from version %s", entry.version)
+
+    if entry.version == 1:
+        new_data = entry.data.copy()
+        new_data.update({CONF_PORT: DEFAULT_PORT, CONF_DEVICE: BRIDGE})
+
+        entry.version = 2
+        hass.config_entries.async_update_entry(entry, data=new_data)
+
+    _LOGGER.info("Migration to version %s successful", entry.version)
 
     return True
 

--- a/homeassistant/components/comelit/__init__.py
+++ b/homeassistant/components/comelit/__init__.py
@@ -1,12 +1,11 @@
 """Comelit integration."""
 
-from aiocomelit.const import BRIDGE
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_DEVICE, CONF_HOST, CONF_PIN, CONF_PORT, Platform
+from homeassistant.const import CONF_HOST, CONF_PIN, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
 
-from .const import _LOGGER, DEFAULT_PORT, DOMAIN
+from .const import DOMAIN
 from .coordinator import ComelitSerialBridge
 
 PLATFORMS = [Platform.COVER, Platform.LIGHT]
@@ -23,22 +22,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-    return True
-
-
-async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Migrate old entry."""
-    _LOGGER.debug("Migrating from version %s", entry.version)
-
-    if entry.version == 1:
-        new_data = entry.data.copy()
-        new_data.update({CONF_PORT: DEFAULT_PORT, CONF_DEVICE: BRIDGE})
-
-        entry.version = 2
-        hass.config_entries.async_update_entry(entry, data=new_data)
-
-    _LOGGER.info("Migration to version %s successful", entry.version)
 
     return True
 

--- a/homeassistant/components/comelit/config_flow.py
+++ b/homeassistant/components/comelit/config_flow.py
@@ -5,14 +5,16 @@ from collections.abc import Mapping
 from typing import Any
 
 from aiocomelit import ComeliteSerialBridgeApi, exceptions as aiocomelit_exceptions
+from aiocomelit.const import BRIDGE
 import voluptuous as vol
 
 from homeassistant import core, exceptions
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
-from homeassistant.const import CONF_HOST, CONF_PIN
+from homeassistant.const import CONF_DEVICE, CONF_HOST, CONF_PIN, CONF_PORT
 from homeassistant.data_entry_flow import FlowResult
+import homeassistant.helpers.config_validation as cv
 
-from .const import _LOGGER, DOMAIN
+from .const import _LOGGER, DEFAULT_PORT, DOMAIN
 
 DEFAULT_HOST = "192.168.1.252"
 DEFAULT_PIN = "111111"
@@ -23,8 +25,10 @@ def user_form_schema(user_input: dict[str, Any] | None) -> vol.Schema:
     user_input = user_input or {}
     return vol.Schema(
         {
-            vol.Optional(CONF_HOST, default=DEFAULT_HOST): str,
-            vol.Optional(CONF_PIN, default=DEFAULT_PIN): str,
+            vol.Required(CONF_HOST, default=DEFAULT_HOST): cv.string,
+            vol.Required(CONF_PORT, default=DEFAULT_PORT): cv.port,
+            vol.Optional(CONF_PIN, default=DEFAULT_PIN): cv.positive_int,
+            vol.Required(CONF_DEVICE, default=BRIDGE): vol.All(BRIDGE),
         }
     )
 
@@ -37,7 +41,7 @@ async def validate_input(
 ) -> dict[str, str]:
     """Validate the user input allows us to connect."""
 
-    api = ComeliteSerialBridgeApi(data[CONF_HOST], data[CONF_PIN])
+    api = ComeliteSerialBridgeApi(data[CONF_HOST], data[CONF_PORT], data[CONF_PIN])
 
     try:
         await api.login()
@@ -58,6 +62,8 @@ class ComelitConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
     _reauth_entry: ConfigEntry | None
     _reauth_host: str
+    _reauth_port: int
+    _reauth_device: str
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -94,6 +100,9 @@ class ComelitConfigFlow(ConfigFlow, domain=DOMAIN):
             self.context["entry_id"]
         )
         self._reauth_host = entry_data[CONF_HOST]
+        self._reauth_port = entry_data[CONF_PORT]
+        self._reauth_device = entry_data[CONF_DEVICE]
+
         self.context["title_placeholders"] = {"host": self._reauth_host}
         return await self.async_step_reauth_confirm()
 
@@ -120,7 +129,9 @@ class ComelitConfigFlow(ConfigFlow, domain=DOMAIN):
                 self.hass.config_entries.async_update_entry(
                     self._reauth_entry,
                     data={
+                        CONF_DEVICE: self._reauth_device,
                         CONF_HOST: self._reauth_host,
+                        CONF_PORT: self._reauth_port,
                         CONF_PIN: user_input[CONF_PIN],
                     },
                 )

--- a/homeassistant/components/comelit/config_flow.py
+++ b/homeassistant/components/comelit/config_flow.py
@@ -116,7 +116,13 @@ class ComelitConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 await validate_input(
-                    self.hass, {CONF_HOST: self._reauth_host} | user_input
+                    self.hass,
+                    {
+                        CONF_HOST: self._reauth_host,
+                        CONF_PORT: self._reauth_port,
+                        CONF_DEVICE: self._reauth_device,
+                    }
+                    | user_input,
                 )
             except CannotConnect:
                 errors["base"] = "cannot_connect"

--- a/homeassistant/components/comelit/const.py
+++ b/homeassistant/components/comelit/const.py
@@ -4,3 +4,8 @@ import logging
 _LOGGER = logging.getLogger(__package__)
 
 DOMAIN = "comelit"
+DEFAULT_PORT = 80
+
+# Entity states
+STATE_OFF = 0
+STATE_ON = 1

--- a/homeassistant/components/comelit/coordinator.py
+++ b/homeassistant/components/comelit/coordinator.py
@@ -21,13 +21,14 @@ class ComelitSerialBridge(DataUpdateCoordinator):
 
     config_entry: ConfigEntry
 
-    def __init__(self, hass: HomeAssistant, host: str, pin: int) -> None:
+    def __init__(self, hass: HomeAssistant, host: str, port: int, pin: int) -> None:
         """Initialize the scanner."""
 
         self._host = host
+        self._port = port
         self._pin = pin
 
-        self.api = ComeliteSerialBridgeApi(host, pin)
+        self.api = ComeliteSerialBridgeApi(host, port, pin)
 
         super().__init__(
             hass=hass,
@@ -53,18 +54,16 @@ class ComelitSerialBridge(DataUpdateCoordinator):
             "hw_version": "20003101",
         }
 
-    def platform_device_info(
-        self, device: ComelitSerialBridgeObject, platform: str
-    ) -> dr.DeviceInfo:
+    def platform_device_info(self, device: ComelitSerialBridgeObject) -> dr.DeviceInfo:
         """Set platform device info."""
 
         return dr.DeviceInfo(
             identifiers={
-                (DOMAIN, f"{self.config_entry.entry_id}-{platform}-{device.index}")
+                (DOMAIN, f"{self.config_entry.entry_id}-{device.type}-{device.index}")
             },
             via_device=(DOMAIN, self.config_entry.entry_id),
             name=device.name,
-            model=f"{BRIDGE} {platform}",
+            model=f"{BRIDGE} {device.type}",
             **self.basic_device_info,
         )
 

--- a/homeassistant/components/comelit/cover.py
+++ b/homeassistant/components/comelit/cover.py
@@ -53,7 +53,7 @@ class ComelitCoverEntity(
         self._device = device
         super().__init__(coordinator)
         self._attr_unique_id = f"{config_entry_entry_id}-{device.index}"
-        self._attr_device_info = coordinator.platform_device_info(device, COVER)
+        self._attr_device_info = coordinator.platform_device_info(device)
         # Device doesn't provide a status so we assume UNKNOWN at first startup
         self._last_action: int | None = None
         self._last_state: str | None = None
@@ -97,11 +97,11 @@ class ComelitCoverEntity(
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
-        await self._api.cover_move(self._device.index, COVER_CLOSE)
+        await self._api.set_device_status(COVER, self._device.index, COVER_CLOSE)
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open cover."""
-        await self._api.cover_move(self._device.index, COVER_OPEN)
+        await self._api.set_device_status(COVER, self._device.index, COVER_OPEN)
 
     async def async_stop_cover(self, **_kwargs: Any) -> None:
         """Stop the cover."""
@@ -109,7 +109,7 @@ class ComelitCoverEntity(
             return
 
         action = COVER_OPEN if self.is_closing else COVER_CLOSE
-        await self._api.cover_move(self._device.index, action)
+        await self._api.set_device_status(COVER, self._device.index, action)
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/homeassistant/components/comelit/light.py
+++ b/homeassistant/components/comelit/light.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Any
 
 from aiocomelit import ComelitSerialBridgeObject
-from aiocomelit.const import LIGHT, LIGHT_OFF, LIGHT_ON
+from aiocomelit.const import LIGHT
 
 from homeassistant.components.light import LightEntity
 from homeassistant.config_entries import ConfigEntry
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, STATE_OFF, STATE_ON
 from .coordinator import ComelitSerialBridge
 
 
@@ -49,22 +49,22 @@ class ComelitLightEntity(CoordinatorEntity[ComelitSerialBridge], LightEntity):
         self._device = device
         super().__init__(coordinator)
         self._attr_unique_id = f"{config_entry_entry_id}-{device.index}"
-        self._attr_device_info = self.coordinator.platform_device_info(device, LIGHT)
+        self._attr_device_info = self.coordinator.platform_device_info(device)
 
     async def _light_set_state(self, state: int) -> None:
         """Set desired light state."""
-        await self.coordinator.api.light_switch(self._device.index, state)
+        await self.coordinator.api.set_device_status(LIGHT, self._device.index, state)
         await self.coordinator.async_request_refresh()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
-        await self._light_set_state(LIGHT_ON)
+        await self._light_set_state(STATE_ON)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
-        await self._light_set_state(LIGHT_OFF)
+        await self._light_set_state(STATE_OFF)
 
     @property
     def is_on(self) -> bool:
         """Return True if entity is on."""
-        return self.coordinator.data[LIGHT][self._device.index].status == LIGHT_ON
+        return self.coordinator.data[LIGHT][self._device.index].status == STATE_ON

--- a/homeassistant/components/comelit/manifest.json
+++ b/homeassistant/components/comelit/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/comelit",
   "iot_class": "local_polling",
   "loggers": ["aiocomelit"],
-  "requirements": ["aiocomelit==0.0.9"]
+  "requirements": ["aiocomelit==0.2.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -210,7 +210,7 @@ aiobafi6==0.9.0
 aiobotocore==2.6.0
 
 # homeassistant.components.comelit
-aiocomelit==0.0.9
+aiocomelit==0.2.0
 
 # homeassistant.components.dhcp
 aiodiscover==1.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -191,7 +191,7 @@ aiobafi6==0.9.0
 aiobotocore==2.6.0
 
 # homeassistant.components.comelit
-aiocomelit==0.0.9
+aiocomelit==0.2.0
 
 # homeassistant.components.dhcp
 aiodiscover==1.5.1

--- a/tests/components/comelit/const.py
+++ b/tests/components/comelit/const.py
@@ -1,14 +1,7 @@
 """Common stuff for Comelit SimpleHome tests."""
-from aiocomelit.const import BRIDGE
 
 from homeassistant.components.comelit.const import DOMAIN
-from homeassistant.const import (
-    CONF_DEVICE,
-    CONF_DEVICES,
-    CONF_HOST,
-    CONF_PIN,
-    CONF_PORT,
-)
+from homeassistant.const import CONF_DEVICES, CONF_HOST, CONF_PIN, CONF_PORT
 
 MOCK_CONFIG = {
     DOMAIN: {
@@ -17,7 +10,6 @@ MOCK_CONFIG = {
                 CONF_HOST: "fake_host",
                 CONF_PORT: 80,
                 CONF_PIN: 1234,
-                CONF_DEVICE: BRIDGE,
             }
         ]
     }

--- a/tests/components/comelit/const.py
+++ b/tests/components/comelit/const.py
@@ -1,13 +1,23 @@
 """Common stuff for Comelit SimpleHome tests."""
+from aiocomelit.const import BRIDGE
+
 from homeassistant.components.comelit.const import DOMAIN
-from homeassistant.const import CONF_DEVICES, CONF_HOST, CONF_PIN
+from homeassistant.const import (
+    CONF_DEVICE,
+    CONF_DEVICES,
+    CONF_HOST,
+    CONF_PIN,
+    CONF_PORT,
+)
 
 MOCK_CONFIG = {
     DOMAIN: {
         CONF_DEVICES: [
             {
                 CONF_HOST: "fake_host",
-                CONF_PIN: "1234",
+                CONF_PORT: 80,
+                CONF_PIN: 1234,
+                CONF_DEVICE: BRIDGE,
             }
         ]
     }

--- a/tests/components/comelit/test_config_flow.py
+++ b/tests/components/comelit/test_config_flow.py
@@ -69,6 +69,10 @@ async def test_exception_connection(hass: HomeAssistant, side_effect, error) -> 
     with patch(
         "aiocomelit.api.ComeliteSerialBridgeApi.login",
         side_effect=side_effect,
+    ), patch(
+        "aiocomelit.api.ComeliteSerialBridgeApi.logout",
+    ), patch(
+        "homeassistant.components.comelit.async_setup_entry"
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=MOCK_USER_DATA

--- a/tests/components/comelit/test_config_flow.py
+++ b/tests/components/comelit/test_config_flow.py
@@ -2,11 +2,12 @@
 from unittest.mock import patch
 
 from aiocomelit import CannotAuthenticate, CannotConnect
+from aiocomelit.const import BRIDGE
 import pytest
 
 from homeassistant.components.comelit.const import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
-from homeassistant.const import CONF_HOST, CONF_PIN
+from homeassistant.const import CONF_DEVICE, CONF_HOST, CONF_PIN, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -39,7 +40,9 @@ async def test_user(hass: HomeAssistant) -> None:
         )
         assert result["type"] == FlowResultType.CREATE_ENTRY
         assert result["data"][CONF_HOST] == "fake_host"
-        assert result["data"][CONF_PIN] == "1234"
+        assert result["data"][CONF_PORT] == 80
+        assert result["data"][CONF_PIN] == 1234
+        assert result["data"][CONF_DEVICE] == BRIDGE
         assert not result["result"].unique_id
         await hass.async_block_till_done()
 

--- a/tests/components/comelit/test_config_flow.py
+++ b/tests/components/comelit/test_config_flow.py
@@ -2,12 +2,11 @@
 from unittest.mock import patch
 
 from aiocomelit import CannotAuthenticate, CannotConnect
-from aiocomelit.const import BRIDGE
 import pytest
 
 from homeassistant.components.comelit.const import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
-from homeassistant.const import CONF_DEVICE, CONF_HOST, CONF_PIN, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_PIN, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -42,7 +41,6 @@ async def test_user(hass: HomeAssistant) -> None:
         assert result["data"][CONF_HOST] == "fake_host"
         assert result["data"][CONF_PORT] == 80
         assert result["data"][CONF_PIN] == 1234
-        assert result["data"][CONF_DEVICE] == BRIDGE
         assert not result["result"].unique_id
         await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump aiocomelit to 0.2.0:

changelog: https://github.com/chemelli74/aiocomelit/releases/tag/v0.2.0
diff: https://github.com/chemelli74/aiocomelit/compare/v0.0.9...v0.2.0

Changes in HomeAssistant integration:

- Allow different http port
- Migrate entity to add port and device type (preparation for the future introduction of alarm platform)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
