### PR TITLE
Fix Rainbird unique to use a more reliable source (mac address)

### DIFF
--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -45,7 +45,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
     )
 
-    await _async_fix_unique_id(hass, controller, entry)
+    if not (await _async_fix_unique_id(hass, controller, entry)):
+        return False
     if mac_address := entry.data.get(CONF_MAC):
         _async_fix_entity_unique_id(
             hass,
@@ -72,7 +73,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def _async_fix_unique_id(
     hass: HomeAssistant, controller: AsyncRainbirdController, entry: ConfigEntry
-):
+) -> bool:
     """Update the config entry with a unique id based on the mac address."""
     _LOGGER.debug("Checking for migration of config entry (%s)", entry.unique_id)
     if not (mac_address := entry.data.get(CONF_MAC)):
@@ -80,22 +81,28 @@ async def _async_fix_unique_id(
             wifi_params = await controller.get_wifi_params()
         except RainbirdApiException as err:
             _LOGGER.warning("Unable to fix missing unique id: %s", err)
-            return
+            return True
 
         if (mac_address := wifi_params.mac_address) is None:
             _LOGGER.warning("Unable to fix missing unique id (mac address was None)")
-            return
+            return True
 
     new_unique_id = format_mac(mac_address)
     if entry.unique_id == new_unique_id and CONF_MAC in entry.data:
         _LOGGER.debug("Config entry already in correct state")
-        return
+        return True
 
     entries = hass.config_entries.async_entries(DOMAIN)
     for existing_entry in entries:
         if existing_entry.unique_id == new_unique_id:
-            _LOGGER.warning("Unable to fix missing unique id (already exists)")
-            return
+            _LOGGER.warning(
+                "Unable to fix missing unique id (already exists); Removing duplicate entry"
+            )
+            hass.async_create_background_task(
+                hass.config_entries.async_remove(entry.entry_id),
+                "Remove rainbird config entry",
+            )
+            return False
 
     _LOGGER.debug("Updating unique id to %s", new_unique_id)
     hass.config_entries.async_update_entry(
@@ -106,6 +113,7 @@ async def _async_fix_unique_id(
             CONF_MAC: mac_address,
         },
     )
+    return True
 
 
 def _async_fix_entity_unique_id(

--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -124,20 +124,9 @@ def _async_fix_entity_unique_id(
         if (suffix := unique_id.removeprefix(str(serial_number))) != unique_id:
             new_unique_id = f"{mac_address}{suffix}"
             _LOGGER.debug("Updating unique id from %s to %s", unique_id, new_unique_id)
-            entity_id = entity_entry.entity_id
-            try:
-                entity_registry.async_update_entity(
-                    entity_id, new_unique_id=new_unique_id
-                )
-            except ValueError:
-                _LOGGER.debug(
-                    (
-                        "Entity %s can't be migrated because the unique ID is taken; "
-                        "Cleaning it up since it is likely no longer valid"
-                    ),
-                    entity_id,
-                )
-                entity_registry.async_remove(entity_id)
+            entity_registry.async_update_entity(
+                entity_entry.entity_id, new_unique_id=new_unique_id
+            )
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -70,10 +70,10 @@ async def _fix_unique_id(
         _LOGGER.warning("Unable to fix missing unique id: %s", err)
         return
 
-    if (new_unique_id := wifi_params.mac_address) is None:
-        _LOGGER.warning("Unable to fix missing unique id (was None)")
+    if (mac_address := wifi_params.mac_address) is None:
+        _LOGGER.warning("Unable to fix missing unique id (mac address was None)")
         return
-    new_unique_id = format_mac(new_unique_id)
+    new_unique_id = format_mac(mac_address)
     entries = hass.config_entries.async_entries(DOMAIN)
     for existing_entry in entries:
         if existing_entry.unique_id == new_unique_id:
@@ -86,7 +86,7 @@ async def _fix_unique_id(
         unique_id=new_unique_id,
         data={
             **entry.data,
-            CONF_MAC: wifi_params.mac_address,
+            CONF_MAC: mac_address,
         },
     )
 

--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -95,7 +95,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
 
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        if entry.entry_id in hass.data[DOMAIN]:
-            hass.data[DOMAIN].pop(entry.entry_id)
+        hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok

--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -121,13 +121,13 @@ def _async_fix_entity_unique_id(
         unique_id = str(entity_entry.unique_id)
         if unique_id.startswith(mac_address):
             continue
-        if unique_id.startswith(str(serial_number)):
-            suffix = unique_id[len(serial_number) :]
+        if (suffix := unique_id.removeprefix(str(serial_number))) != unique_id:
             new_unique_id = f"{mac_address}{suffix}"
             _LOGGER.debug("Updating unique id from %s to %s", unique_id, new_unique_id)
+            entity_id = entity_entry.entity_id
             try:
                 entity_registry.async_update_entity(
-                    entity_entry.entity_id, new_unique_id=new_unique_id
+                    entity_id, new_unique_id=new_unique_id
                 )
             except ValueError:
                 _LOGGER.debug(
@@ -135,9 +135,9 @@ def _async_fix_entity_unique_id(
                         "Entity %s can't be migrated because the unique ID is taken; "
                         "Cleaning it up since it is likely no longer valid"
                     ),
-                    entity_entry.entity_id,
+                    entity_id,
                 )
-                entity_registry.async_remove(entity_entry.entity_id)
+                entity_registry.async_remove(entity_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -42,8 +42,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
     )
 
-    if entry.unique_id is None:
-        await _fix_unique_id(hass, controller, entry)
+    await _fix_unique_id(hass, controller, entry)
 
     try:
         model_info = await controller.get_model_and_version()
@@ -64,6 +63,7 @@ async def _fix_unique_id(
     hass: HomeAssistant, controller: AsyncRainbirdController, entry: ConfigEntry
 ):
     """Update the config entry with a unique id based on the mac address."""
+    _LOGGER.debug("Checking for migration of config entry (%s)", entry.unique_id)
     if not (mac_address := entry.data.get(CONF_MAC)):
         try:
             wifi_params = await controller.get_wifi_params()
@@ -77,6 +77,7 @@ async def _fix_unique_id(
 
     new_unique_id = format_mac(mac_address)
     if entry.unique_id == new_unique_id and CONF_MAC in entry.data:
+        _LOGGER.debug("Config entry already in correct state")
         return
 
     entries = hass.config_entries.async_entries(DOMAIN)

--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PASSWORD, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import format_mac
 
 from .coordinator import RainbirdData
 
@@ -72,7 +73,7 @@ async def _fix_unique_id(
     if (new_unique_id := wifi_params.mac_address) is None:
         _LOGGER.warning("Unable to fix missing unique id (was None)")
         return
-
+    new_unique_id = format_mac(new_unique_id)
     entries = hass.config_entries.async_entries(DOMAIN)
     for existing_entry in entries:
         if existing_entry.unique_id == new_unique_id:

--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -1,16 +1,20 @@
 """Support for Rain Bird Irrigation system LNK WiFi Module."""
 from __future__ import annotations
 
+import logging
+
 from pyrainbird.async_client import AsyncRainbirdClient, AsyncRainbirdController
 from pyrainbird.exceptions import RainbirdApiException
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, Platform
+from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PASSWORD, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .coordinator import RainbirdData
+
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [
     Platform.SWITCH,
@@ -36,6 +40,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry.data[CONF_PASSWORD],
         )
     )
+
+    if entry.unique_id is None:
+        await _fix_unique_id(hass, controller, entry)
+
     try:
         model_info = await controller.get_model_and_version()
     except RainbirdApiException as err:
@@ -51,10 +59,42 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
+async def _fix_unique_id(
+    hass: HomeAssistant, controller: AsyncRainbirdController, entry: ConfigEntry
+):
+    """Update the config entry with a unique id based on the mac address."""
+    try:
+        wifi_params = await controller.get_wifi_params()
+    except RainbirdApiException as err:
+        _LOGGER.warning("Unable to fix missing unique id: %s", err)
+        return
+
+    if (new_unique_id := wifi_params.mac_address) is None:
+        _LOGGER.warning("Unable to fix missing unique id (was None)")
+        return
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    for existing_entry in entries:
+        if existing_entry.unique_id == new_unique_id:
+            _LOGGER.warning("Unable to fix missing unique id (already exists)")
+            return
+
+    _LOGGER.debug("Updating unique id to %s", new_unique_id)
+    hass.config_entries.async_update_entry(
+        entry,
+        unique_id=new_unique_id,
+        data={
+            **entry.data,
+            CONF_MAC: wifi_params.mac_address,
+        },
+    )
+
+
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
 
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
+        if entry.entry_id in hass.data[DOMAIN]:
+            hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok

--- a/homeassistant/components/rainbird/config_flow.py
+++ b/homeassistant/components/rainbird/config_flow.py
@@ -137,7 +137,12 @@ class RainbirdConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         # in the future.
         # Either way, also prevent configuring the same host twice.
         await self.async_set_unique_id(format_mac(data[CONF_MAC]))
-        self._abort_if_unique_id_configured()
+        self._abort_if_unique_id_configured(
+            updates={
+                CONF_HOST: data[CONF_HOST],
+                CONF_PASSWORD: data[CONF_PASSWORD],
+            }
+        )
         self._async_abort_entries_match(
             {
                 CONF_HOST: data[CONF_HOST],

--- a/homeassistant/components/rainbird/config_flow.py
+++ b/homeassistant/components/rainbird/config_flow.py
@@ -11,11 +11,12 @@ from pyrainbird.async_client import (
     AsyncRainbirdController,
     RainbirdApiException,
 )
+from pyrainbird.data import WifiParams
 import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_PASSWORD
+from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PASSWORD
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv, selector
@@ -69,7 +70,7 @@ class RainbirdConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         error_code: str | None = None
         if user_input:
             try:
-                serial_number = await self._test_connection(
+                serial_number, wifi_params = await self._test_connection(
                     user_input[CONF_HOST], user_input[CONF_PASSWORD]
                 )
             except ConfigFlowError as err:
@@ -77,11 +78,11 @@ class RainbirdConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 error_code = err.error_code
             else:
                 return await self.async_finish(
-                    serial_number,
                     data={
                         CONF_HOST: user_input[CONF_HOST],
                         CONF_PASSWORD: user_input[CONF_PASSWORD],
                         CONF_SERIAL_NUMBER: serial_number,
+                        CONF_MAC: wifi_params.mac_address,
                     },
                     options={ATTR_DURATION: DEFAULT_TRIGGER_TIME_MINUTES},
                 )
@@ -92,8 +93,10 @@ class RainbirdConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors={"base": error_code} if error_code else None,
         )
 
-    async def _test_connection(self, host: str, password: str) -> str:
-        """Test the connection and return the device serial number.
+    async def _test_connection(
+        self, host: str, password: str
+    ) -> tuple[str, WifiParams]:
+        """Test the connection and return the device identifiers.
 
         Raises a ConfigFlowError on failure.
         """
@@ -106,7 +109,10 @@ class RainbirdConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         )
         try:
             async with asyncio.timeout(TIMEOUT_SECONDS):
-                return await controller.get_serial_number()
+                return await asyncio.gather(
+                    controller.get_serial_number(),
+                    controller.get_wifi_params(),
+                )
         except asyncio.TimeoutError as err:
             raise ConfigFlowError(
                 f"Timeout connecting to Rain Bird controller: {str(err)}",
@@ -120,18 +126,23 @@ class RainbirdConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_finish(
         self,
-        serial_number: str,
         data: dict[str, Any],
         options: dict[str, Any],
     ) -> FlowResult:
         """Create the config entry."""
-        # Prevent devices with the same serial number. If the device does not have a serial number
-        # then we can at least prevent configuring the same host twice.
-        if serial_number:
-            await self.async_set_unique_id(serial_number)
-            self._abort_if_unique_id_configured()
-        else:
-            self._async_abort_entries_match(data)
+        # The integration has historically used a serial number, but not all devices
+        # historically had a valid one. Now the mac address is used as a unique id
+        # and serial is still persisted in config entry data in case it is needed
+        # in the future.
+        # Either way, also prevent configuring the same host twice.
+        await self.async_set_unique_id(data[CONF_MAC])
+        self._abort_if_unique_id_configured()
+        self._async_abort_entries_match(
+            {
+                CONF_HOST: data[CONF_HOST],
+                CONF_PASSWORD: data[CONF_PASSWORD],
+            }
+        )
         return self.async_create_entry(
             title=data[CONF_HOST],
             data=data,

--- a/homeassistant/components/rainbird/config_flow.py
+++ b/homeassistant/components/rainbird/config_flow.py
@@ -21,6 +21,7 @@ from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv, selector
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import format_mac
 
 from .const import (
     ATTR_DURATION,
@@ -135,7 +136,7 @@ class RainbirdConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         # and serial is still persisted in config entry data in case it is needed
         # in the future.
         # Either way, also prevent configuring the same host twice.
-        await self.async_set_unique_id(data[CONF_MAC])
+        await self.async_set_unique_id(format_mac(data[CONF_MAC]))
         self._abort_if_unique_id_configured()
         self._async_abort_entries_match(
             {

--- a/tests/components/rainbird/conftest.py
+++ b/tests/components/rainbird/conftest.py
@@ -26,6 +26,7 @@ URL = "http://example.com/stick"
 PASSWORD = "password"
 SERIAL_NUMBER = 0x12635436566
 MAC_ADDRESS = "4C:A1:61:00:11:22"
+MAC_ADDRESS_UNIQUE_ID = "4c:a1:61:00:11:22"
 
 #
 # Response payloads below come from pyrainbird test cases.

--- a/tests/components/rainbird/conftest.py
+++ b/tests/components/rainbird/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from http import HTTPStatus
+import json
 from typing import Any
 from unittest.mock import patch
 
@@ -24,6 +25,7 @@ HOST = "example.com"
 URL = "http://example.com/stick"
 PASSWORD = "password"
 SERIAL_NUMBER = 0x12635436566
+MAC_ADDRESS = "4C:A1:61:00:11:22"
 
 #
 # Response payloads below come from pyrainbird test cases.
@@ -50,6 +52,20 @@ RAIN_DELAY = "B60010"  # 0x10 is 16
 RAIN_DELAY_OFF = "B60000"
 # ACK command 0x10, Echo 0x06
 ACK_ECHO = "0106"
+WIFI_PARAMS_RESPONSE = {
+    "macAddress": MAC_ADDRESS,
+    "localIpAddress": "1.1.1.38",
+    "localNetmask": "255.255.255.0",
+    "localGateway": "1.1.1.1",
+    "rssi": -61,
+    "wifiSsid": "wifi-ssid-name",
+    "wifiPassword": "wifi-password-name",
+    "wifiSecurity": "wpa2-aes",
+    "apTimeoutNoLan": 20,
+    "apTimeoutIdle": 20,
+    "apSecurity": "unknown",
+    "stickVersion": "Rain Bird Stick Rev C/1.63",
+}
 
 
 CONFIG = {
@@ -66,6 +82,7 @@ CONFIG_ENTRY_DATA = {
     "host": HOST,
     "password": PASSWORD,
     "serial_number": SERIAL_NUMBER,
+    "mac": MAC_ADDRESS,
 }
 
 
@@ -123,17 +140,24 @@ def setup_platforms(
         yield
 
 
-def rainbird_response(data: str) -> bytes:
+def rainbird_json_response(result: dict[str, str]) -> bytes:
     """Create a fake API response."""
     return encryption.encrypt(
-        '{"jsonrpc": "2.0", "result": {"data":"%s"}, "id": 1} ' % data,
+        '{"jsonrpc": "2.0", "result": %s, "id": 1} ' % json.dumps(result),
         PASSWORD,
+    )
+
+
+def mock_json_response(result: dict[str, str]) -> AiohttpClientMockResponse:
+    """Create a fake AiohttpClientMockResponse."""
+    return AiohttpClientMockResponse(
+        "POST", URL, response=rainbird_json_response(result)
     )
 
 
 def mock_response(data: str) -> AiohttpClientMockResponse:
     """Create a fake AiohttpClientMockResponse."""
-    return AiohttpClientMockResponse("POST", URL, response=rainbird_response(data))
+    return mock_json_response({"data": data})
 
 
 def mock_response_error(

--- a/tests/components/rainbird/conftest.py
+++ b/tests/components/rainbird/conftest.py
@@ -79,6 +79,11 @@ CONFIG = {
     }
 }
 
+CONFIG_ENTRY_DATA_OLD_FORMAT = {
+    "host": HOST,
+    "password": PASSWORD,
+    "serial_number": SERIAL_NUMBER,
+}
 CONFIG_ENTRY_DATA = {
     "host": HOST,
     "password": PASSWORD,

--- a/tests/components/rainbird/conftest.py
+++ b/tests/components/rainbird/conftest.py
@@ -100,14 +100,23 @@ def platforms() -> list[Platform]:
 
 @pytest.fixture
 async def config_entry_unique_id() -> str:
-    """Fixture for serial number used in the config entry."""
+    """Fixture for config entry unique id."""
+    return MAC_ADDRESS_UNIQUE_ID
+
+
+@pytest.fixture
+async def serial_number() -> int:
+    """Fixture for serial number used in the config entry data."""
     return SERIAL_NUMBER
 
 
 @pytest.fixture
-async def config_entry_data() -> dict[str, Any]:
+async def config_entry_data(serial_number: int) -> dict[str, Any]:
     """Fixture for MockConfigEntry data."""
-    return CONFIG_ENTRY_DATA
+    return {
+        **CONFIG_ENTRY_DATA,
+        "serial_number": serial_number,
+    }
 
 
 @pytest.fixture

--- a/tests/components/rainbird/test_binary_sensor.py
+++ b/tests/components/rainbird/test_binary_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .conftest import (
+    CONFIG_ENTRY_DATA_OLD_FORMAT,
     RAIN_SENSOR_OFF,
     RAIN_SENSOR_ON,
     SERIAL_NUMBER,
@@ -87,9 +88,9 @@ async def test_unique_id(
 
 
 @pytest.mark.parametrize(
-    ("config_entry_unique_id"),
+    ("config_entry_data", "config_entry_unique_id"),
     [
-        (None),
+        (CONFIG_ENTRY_DATA_OLD_FORMAT, None),
     ],
 )
 async def test_no_unique_id(

--- a/tests/components/rainbird/test_binary_sensor.py
+++ b/tests/components/rainbird/test_binary_sensor.py
@@ -99,7 +99,7 @@ async def test_no_unique_id(
 ) -> None:
     """Test rainsensor binary sensor with no unique id."""
 
-    # Failure to migrate config entry o a unique id
+    # Failure to migrate config entry to a unique id
     responses.insert(0, mock_response_error(HTTPStatus.SERVICE_UNAVAILABLE))
 
     rainsensor = hass.states.get("binary_sensor.rain_bird_controller_rainsensor")

--- a/tests/components/rainbird/test_binary_sensor.py
+++ b/tests/components/rainbird/test_binary_sensor.py
@@ -1,6 +1,8 @@
 """Tests for rainbird sensor platform."""
 
 
+from http import HTTPStatus
+
 import pytest
 
 from homeassistant.config_entries import ConfigEntryState
@@ -8,7 +10,12 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import RAIN_SENSOR_OFF, RAIN_SENSOR_ON, SERIAL_NUMBER
+from .conftest import (
+    RAIN_SENSOR_OFF,
+    RAIN_SENSOR_ON,
+    SERIAL_NUMBER,
+    mock_response_error,
+)
 
 from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMockResponse
@@ -91,6 +98,9 @@ async def test_no_unique_id(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test rainsensor binary sensor with no unique id."""
+
+    # Failure to migrate config entry o a unique id
+    responses.insert(0, mock_response_error(HTTPStatus.SERVICE_UNAVAILABLE))
 
     rainsensor = hass.states.get("binary_sensor.rain_bird_controller_rainsensor")
     assert rainsensor is not None

--- a/tests/components/rainbird/test_binary_sensor.py
+++ b/tests/components/rainbird/test_binary_sensor.py
@@ -14,7 +14,6 @@ from .conftest import (
     CONFIG_ENTRY_DATA_OLD_FORMAT,
     RAIN_SENSOR_OFF,
     RAIN_SENSOR_ON,
-    SERIAL_NUMBER,
     mock_response_error,
 )
 
@@ -59,49 +58,24 @@ async def test_rainsensor(
 
 
 @pytest.mark.parametrize(
-    ("config_entry_unique_id", "entity_unique_id"),
+    ("config_entry_data", "config_entry_unique_id", "setup_config_entry"),
     [
-        (SERIAL_NUMBER, "1263613994342-rainsensor"),
-        # Some existing config entries may have a "0" serial number but preserve
-        # their unique id
-        (0, "0-rainsensor"),
-    ],
-)
-async def test_unique_id(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    entity_unique_id: str,
-) -> None:
-    """Test rainsensor binary sensor."""
-    rainsensor = hass.states.get("binary_sensor.rain_bird_controller_rainsensor")
-    assert rainsensor is not None
-    assert rainsensor.attributes == {
-        "friendly_name": "Rain Bird Controller Rainsensor",
-        "icon": "mdi:water",
-    }
-
-    entity_entry = entity_registry.async_get(
-        "binary_sensor.rain_bird_controller_rainsensor"
-    )
-    assert entity_entry
-    assert entity_entry.unique_id == entity_unique_id
-
-
-@pytest.mark.parametrize(
-    ("config_entry_data", "config_entry_unique_id"),
-    [
-        (CONFIG_ENTRY_DATA_OLD_FORMAT, None),
+        (CONFIG_ENTRY_DATA_OLD_FORMAT, None, None),
     ],
 )
 async def test_no_unique_id(
     hass: HomeAssistant,
     responses: list[AiohttpClientMockResponse],
     entity_registry: er.EntityRegistry,
+    config_entry: MockConfigEntry,
 ) -> None:
     """Test rainsensor binary sensor with no unique id."""
 
     # Failure to migrate config entry to a unique id
     responses.insert(0, mock_response_error(HTTPStatus.SERVICE_UNAVAILABLE))
+
+    await config_entry.async_setup(hass)
+    assert config_entry.state == ConfigEntryState.LOADED
 
     rainsensor = hass.states.get("binary_sensor.rain_bird_controller_rainsensor")
     assert rainsensor is not None

--- a/tests/components/rainbird/test_calendar.py
+++ b/tests/components/rainbird/test_calendar.py
@@ -17,7 +17,11 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import mock_response, mock_response_error
+from .conftest import (
+    CONFIG_ENTRY_DATA_OLD_FORMAT,
+    mock_response,
+    mock_response_error,
+)
 
 from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMockResponse
@@ -280,9 +284,9 @@ async def test_program_schedule_disabled(
 
 
 @pytest.mark.parametrize(
-    ("config_entry_unique_id"),
+    ("config_entry_data", "config_entry_unique_id"),
     [
-        (None),
+        (CONFIG_ENTRY_DATA_OLD_FORMAT, None),
     ],
 )
 async def test_no_unique_id(

--- a/tests/components/rainbird/test_calendar.py
+++ b/tests/components/rainbird/test_calendar.py
@@ -288,9 +288,13 @@ async def test_program_schedule_disabled(
 async def test_no_unique_id(
     hass: HomeAssistant,
     get_events: GetEventsFn,
+    responses: list[AiohttpClientMockResponse],
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test calendar entity with no unique id."""
+
+    # Failure to migrate config entry to a unique id
+    responses.insert(0, mock_response_error(HTTPStatus.SERVICE_UNAVAILABLE))
 
     state = hass.states.get(TEST_ENTITY)
     assert state is not None

--- a/tests/components/rainbird/test_calendar.py
+++ b/tests/components/rainbird/test_calendar.py
@@ -17,11 +17,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import (
-    CONFIG_ENTRY_DATA_OLD_FORMAT,
-    mock_response,
-    mock_response_error,
-)
+from .conftest import CONFIG_ENTRY_DATA_OLD_FORMAT, mock_response, mock_response_error
 
 from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMockResponse
@@ -214,7 +210,7 @@ async def test_event_state(
 
     entity = entity_registry.async_get(TEST_ENTITY)
     assert entity
-    assert entity.unique_id == 1263613994342
+    assert entity.unique_id == "4c:a1:61:00:11:22"
 
 
 @pytest.mark.parametrize(
@@ -284,9 +280,9 @@ async def test_program_schedule_disabled(
 
 
 @pytest.mark.parametrize(
-    ("config_entry_data", "config_entry_unique_id"),
+    ("config_entry_data", "config_entry_unique_id", "setup_config_entry"),
     [
-        (CONFIG_ENTRY_DATA_OLD_FORMAT, None),
+        (CONFIG_ENTRY_DATA_OLD_FORMAT, None, None),
     ],
 )
 async def test_no_unique_id(
@@ -294,11 +290,15 @@ async def test_no_unique_id(
     get_events: GetEventsFn,
     responses: list[AiohttpClientMockResponse],
     entity_registry: er.EntityRegistry,
+    config_entry: MockConfigEntry,
 ) -> None:
     """Test calendar entity with no unique id."""
 
     # Failure to migrate config entry to a unique id
     responses.insert(0, mock_response_error(HTTPStatus.SERVICE_UNAVAILABLE))
+
+    await config_entry.async_setup(hass)
+    assert config_entry.state == ConfigEntryState.LOADED
 
     state = hass.states.get(TEST_ENTITY)
     assert state is not None

--- a/tests/components/rainbird/test_config_flow.py
+++ b/tests/components/rainbird/test_config_flow.py
@@ -20,6 +20,7 @@ from .conftest import (
     CONFIG_ENTRY_DATA,
     HOST,
     MAC_ADDRESS,
+    MAC_ADDRESS_UNIQUE_ID,
     PASSWORD,
     SERIAL_NUMBER,
     SERIAL_RESPONSE,
@@ -82,7 +83,7 @@ async def complete_flow(hass: HomeAssistant) -> FlowResult:
                 mock_json_response(WIFI_PARAMS_RESPONSE),
             ],
             CONFIG_ENTRY_DATA,
-            MAC_ADDRESS,
+            MAC_ADDRESS_UNIQUE_ID,
         ),
         (
             [
@@ -90,7 +91,7 @@ async def complete_flow(hass: HomeAssistant) -> FlowResult:
                 mock_json_response(WIFI_PARAMS_RESPONSE),
             ],
             {**CONFIG_ENTRY_DATA, "serial_number": 0},
-            MAC_ADDRESS,
+            MAC_ADDRESS_UNIQUE_ID,
         ),
     ],
 )

--- a/tests/components/rainbird/test_init.py
+++ b/tests/components/rainbird/test_init.py
@@ -207,11 +207,13 @@ async def test_fix_unique_id_duplicate(
     assert config_entry.unique_id == MAC_ADDRESS_UNIQUE_ID
 
     await other_entry.async_setup(hass)
-    assert other_entry.state == ConfigEntryState.LOADED
     # Config entry unique id could not be updated since it already exists
-    assert other_entry.unique_id is None
+    assert other_entry.state == ConfigEntryState.SETUP_ERROR
 
     assert "Unable to fix missing unique id (already exists)" in caplog.text
+
+    await hass.async_block_till_done()
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/components/rainbird/test_init.py
+++ b/tests/components/rainbird/test_init.py
@@ -12,6 +12,7 @@ from homeassistant.core import HomeAssistant
 
 from .conftest import (
     CONFIG_ENTRY_DATA,
+    CONFIG_ENTRY_DATA_OLD_FORMAT,
     MAC_ADDRESS,
     MAC_ADDRESS_UNIQUE_ID,
     MODEL_AND_VERSION_RESPONSE,
@@ -142,19 +143,19 @@ async def test_fix_unique_id(
     [
         (
             None,
-            CONFIG_ENTRY_DATA,
+            CONFIG_ENTRY_DATA_OLD_FORMAT,
             mock_response_error(HTTPStatus.SERVICE_UNAVAILABLE),
             "Unable to fix missing unique id:",
         ),
         (
             None,
-            CONFIG_ENTRY_DATA,
+            CONFIG_ENTRY_DATA_OLD_FORMAT,
             mock_response_error(HTTPStatus.NOT_FOUND),
             "Unable to fix missing unique id:",
         ),
         (
             None,
-            CONFIG_ENTRY_DATA,
+            CONFIG_ENTRY_DATA_OLD_FORMAT,
             mock_response("bogus"),
             "Unable to fix missing unique id (mac address was None)",
         ),
@@ -207,7 +208,7 @@ async def test_fix_unique_id_duplicate(
     other_entry = MockConfigEntry(
         unique_id=None,
         domain=DOMAIN,
-        data=CONFIG_ENTRY_DATA,
+        data=CONFIG_ENTRY_DATA_OLD_FORMAT,
     )
     other_entry.add_to_hass(hass)
 

--- a/tests/components/rainbird/test_init.py
+++ b/tests/components/rainbird/test_init.py
@@ -277,37 +277,3 @@ async def test_fix_entity_unique_ids(
     entity_entry = entity_registry.async_get(entity_entry.id)
     assert entity_entry
     assert entity_entry.unique_id == expected_unique_id
-
-
-@pytest.mark.parametrize("config_entry_unique_id", [(SERIAL_NUMBER)])
-async def test_cannot_fix_entity_unique_id(
-    hass: HomeAssistant,
-    config_entry: MockConfigEntry,
-) -> None:
-    """Test cleanup of a entity unique id that cannot be repaired."""
-
-    entity_registry = er.async_get(hass)
-    entity_registry.async_get_or_create(
-        DOMAIN,
-        "number",
-        unique_id=f"{SERIAL_NUMBER}-rain-delay",
-        config_entry=config_entry,
-    )
-    entity_entry = entity_registry.async_get_or_create(
-        DOMAIN,
-        "number",
-        unique_id=f"{MAC_ADDRESS_UNIQUE_ID}-rain-delay",
-        config_entry=config_entry,
-    )
-    assert len(entity_registry.entities) == 2
-
-    await config_entry.async_setup(hass)
-    assert config_entry.state == ConfigEntryState.LOADED
-
-    # Cleaned up entry
-    assert len(entity_registry.entities) == 1
-
-    # The existing entity entry that had the mac address as unique id should remain.
-    entity_entry = entity_registry.async_get(entity_entry.id)
-    assert entity_entry
-    assert entity_entry.unique_id == f"{MAC_ADDRESS_UNIQUE_ID}-rain-delay"

--- a/tests/components/rainbird/test_init.py
+++ b/tests/components/rainbird/test_init.py
@@ -292,7 +292,7 @@ async def test_cannot_fix_entity_unique_id(
         unique_id=f"{SERIAL_NUMBER}-rain-delay",
         config_entry=config_entry,
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN,
         "number",
         unique_id=f"{MAC_ADDRESS_UNIQUE_ID}-rain-delay",
@@ -306,5 +306,7 @@ async def test_cannot_fix_entity_unique_id(
     # Cleaned up entry
     assert len(entity_registry.entities) == 1
 
-    entity_unique_id = next(iter(entity_registry.entities.values())).unique_id
-    assert entity_unique_id == f"{MAC_ADDRESS_UNIQUE_ID}-rain-delay"
+    # The existing entity entry that had the mac address as unique id should remain.
+    entity_entry = entity_registry.async_get(entity_entry.id)
+    assert entity_entry
+    assert entity_entry.unique_id == f"{MAC_ADDRESS_UNIQUE_ID}-rain-delay"

--- a/tests/components/rainbird/test_init.py
+++ b/tests/components/rainbird/test_init.py
@@ -13,6 +13,7 @@ from homeassistant.core import HomeAssistant
 from .conftest import (
     CONFIG_ENTRY_DATA,
     MAC_ADDRESS,
+    MAC_ADDRESS_UNIQUE_ID,
     MODEL_AND_VERSION_RESPONSE,
     WIFI_PARAMS_RESPONSE,
     mock_json_response,
@@ -127,7 +128,7 @@ async def test_fix_unique_id(
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
     assert entries[0].state == ConfigEntryState.LOADED
-    assert entries[0].unique_id == MAC_ADDRESS
+    assert entries[0].unique_id == MAC_ADDRESS_UNIQUE_ID
     assert entries[0].data.get(CONF_MAC) == MAC_ADDRESS
 
 
@@ -190,7 +191,7 @@ async def test_fix_unique_id_failure(
 
 @pytest.mark.parametrize(
     ("config_entry_unique_id"),
-    [(MAC_ADDRESS)],
+    [(MAC_ADDRESS_UNIQUE_ID)],
 )
 async def test_fix_unique_id_duplicate(
     hass: HomeAssistant,
@@ -219,7 +220,7 @@ async def test_fix_unique_id_duplicate(
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 2
     assert entries[0].state == ConfigEntryState.NOT_LOADED
-    assert entries[0].unique_id is MAC_ADDRESS
+    assert entries[0].unique_id is MAC_ADDRESS_UNIQUE_ID
     assert entries[1].state == ConfigEntryState.NOT_LOADED
     assert entries[1].unique_id is None
 
@@ -229,7 +230,7 @@ async def test_fix_unique_id_duplicate(
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 2
     assert entries[0].state == ConfigEntryState.LOADED
-    assert entries[0].unique_id is MAC_ADDRESS
+    assert entries[0].unique_id is MAC_ADDRESS_UNIQUE_ID
     assert entries[1].state == ConfigEntryState.LOADED
     assert entries[1].unique_id is None
 

--- a/tests/components/rainbird/test_init.py
+++ b/tests/components/rainbird/test_init.py
@@ -267,15 +267,16 @@ async def test_fix_entity_unique_ids(
     """Test fixing entity unique ids from old unique id formats."""
 
     entity_registry = er.async_get(hass)
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN, "number", unique_id=entity_unique_id, config_entry=config_entry
     )
 
     await config_entry.async_setup(hass)
     assert config_entry.state == ConfigEntryState.LOADED
 
-    entity_unique_id = next(iter(entity_registry.entities.values())).unique_id
-    assert entity_unique_id == expected_unique_id
+    entity_entry = entity_registry.async_get(entity_entry.id)
+    assert entity_entry
+    assert entity_entry.unique_id == expected_unique_id
 
 
 @pytest.mark.parametrize("config_entry_unique_id", [(SERIAL_NUMBER)])

--- a/tests/components/rainbird/test_init.py
+++ b/tests/components/rainbird/test_init.py
@@ -156,7 +156,7 @@ async def test_fix_unique_id(
             None,
             CONFIG_ENTRY_DATA,
             mock_response("bogus"),
-            "Unable to fix missing unique id (was None)",
+            "Unable to fix missing unique id (mac address was None)",
         ),
     ],
     ids=["service_unavailable", "not_found", "unexpected_response_format"],

--- a/tests/components/rainbird/test_number.py
+++ b/tests/components/rainbird/test_number.py
@@ -14,6 +14,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .conftest import (
     ACK_ECHO,
+    CONFIG_ENTRY_DATA_OLD_FORMAT,
     RAIN_DELAY,
     RAIN_DELAY_OFF,
     SERIAL_NUMBER,
@@ -162,9 +163,9 @@ async def test_set_value_error(
 
 
 @pytest.mark.parametrize(
-    ("config_entry_unique_id"),
+    ("config_entry_data", "config_entry_unique_id"),
     [
-        (None),
+        (CONFIG_ENTRY_DATA_OLD_FORMAT, None),
     ],
 )
 async def test_no_unique_id(

--- a/tests/components/rainbird/test_number.py
+++ b/tests/components/rainbird/test_number.py
@@ -6,7 +6,7 @@ import pytest
 
 from homeassistant.components import number
 from homeassistant.components.rainbird import DOMAIN
-from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -15,9 +15,9 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from .conftest import (
     ACK_ECHO,
     CONFIG_ENTRY_DATA_OLD_FORMAT,
+    MAC_ADDRESS,
     RAIN_DELAY,
     RAIN_DELAY_OFF,
-    SERIAL_NUMBER,
     mock_response,
     mock_response_error,
 )
@@ -67,46 +67,23 @@ async def test_number_values(
 
     entity_entry = entity_registry.async_get("number.rain_bird_controller_rain_delay")
     assert entity_entry
-    assert entity_entry.unique_id == "1263613994342-rain-delay"
-
-
-@pytest.mark.parametrize(
-    ("config_entry_unique_id", "entity_unique_id"),
-    [
-        (SERIAL_NUMBER, "1263613994342-rain-delay"),
-        # Some existing config entries may have a "0" serial number but preserve
-        # their unique id
-        (0, "0-rain-delay"),
-    ],
-)
-async def test_unique_id(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    entity_unique_id: str,
-) -> None:
-    """Test number platform."""
-
-    raindelay = hass.states.get("number.rain_bird_controller_rain_delay")
-    assert raindelay is not None
-    assert (
-        raindelay.attributes.get("friendly_name") == "Rain Bird Controller Rain delay"
-    )
-
-    entity_entry = entity_registry.async_get("number.rain_bird_controller_rain_delay")
-    assert entity_entry
-    assert entity_entry.unique_id == entity_unique_id
+    assert entity_entry.unique_id == "4c:a1:61:00:11:22-rain-delay"
 
 
 async def test_set_value(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     responses: list[str],
-    config_entry: ConfigEntry,
 ) -> None:
     """Test setting the rain delay number."""
 
+    raindelay = hass.states.get("number.rain_bird_controller_rain_delay")
+    assert raindelay is not None
+
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device(identifiers={(DOMAIN, SERIAL_NUMBER)})
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, MAC_ADDRESS.lower())}
+    )
     assert device
     assert device.name == "Rain Bird Controller"
     assert device.model == "ESP-TM2"
@@ -139,7 +116,6 @@ async def test_set_value_error(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     responses: list[str],
-    config_entry: ConfigEntry,
     status: HTTPStatus,
     expected_msg: str,
 ) -> None:
@@ -163,20 +139,24 @@ async def test_set_value_error(
 
 
 @pytest.mark.parametrize(
-    ("config_entry_data", "config_entry_unique_id"),
+    ("config_entry_data", "config_entry_unique_id", "setup_config_entry"),
     [
-        (CONFIG_ENTRY_DATA_OLD_FORMAT, None),
+        (CONFIG_ENTRY_DATA_OLD_FORMAT, None, None),
     ],
 )
 async def test_no_unique_id(
     hass: HomeAssistant,
     responses: list[AiohttpClientMockResponse],
     entity_registry: er.EntityRegistry,
+    config_entry: MockConfigEntry,
 ) -> None:
     """Test number platform with no unique id."""
 
     # Failure to migrate config entry to a unique id
     responses.insert(0, mock_response_error(HTTPStatus.SERVICE_UNAVAILABLE))
+
+    await config_entry.async_setup(hass)
+    assert config_entry.state == ConfigEntryState.LOADED
 
     raindelay = hass.states.get("number.rain_bird_controller_rain_delay")
     assert raindelay is not None

--- a/tests/components/rainbird/test_number.py
+++ b/tests/components/rainbird/test_number.py
@@ -22,7 +22,7 @@ from .conftest import (
 )
 
 from tests.common import MockConfigEntry
-from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.test_util.aiohttp import AiohttpClientMocker, AiohttpClientMockResponse
 
 
 @pytest.fixture
@@ -169,9 +169,13 @@ async def test_set_value_error(
 )
 async def test_no_unique_id(
     hass: HomeAssistant,
+    responses: list[AiohttpClientMockResponse],
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test number platform with no unique id."""
+
+    # Failure to migrate config entry to a unique id
+    responses.insert(0, mock_response_error(HTTPStatus.SERVICE_UNAVAILABLE))
 
     raindelay = hass.states.get("number.rain_bird_controller_rain_delay")
     assert raindelay is not None

--- a/tests/components/rainbird/test_sensor.py
+++ b/tests/components/rainbird/test_sensor.py
@@ -15,6 +15,7 @@ from .conftest import (
     RAIN_DELAY_OFF,
     mock_response_error,
 )
+
 from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMockResponse
 
@@ -55,24 +56,15 @@ async def test_sensors(
 
     entity_entry = entity_registry.async_get("sensor.rain_bird_controller_raindelay")
     assert entity_entry
-    assert entity_entry.unique_id == "1263613994342-raindelay"
+    assert entity_entry.unique_id == "4c:a1:61:00:11:22-raindelay"
 
 
 @pytest.mark.parametrize(
-    ("config_entry_unique_id", "config_entry_data", "initial_response"),
+    ("config_entry_unique_id", "config_entry_data", "setup_config_entry"),
     [
         # Config entry setup without a unique id since it had no serial number
         (
             None,
-            {
-                **CONFIG_ENTRY_DATA_OLD_FORMAT,
-                "serial_number": 0,
-            },
-            mock_response_error(HTTPStatus.SERVICE_UNAVAILABLE),
-        ),
-        # Legacy case for old config entries with serial number 0 preserves old behavior
-        (
-            "0",
             {
                 **CONFIG_ENTRY_DATA_OLD_FORMAT,
                 "serial_number": 0,
@@ -86,13 +78,15 @@ async def test_sensor_no_unique_id(
     entity_registry: er.EntityRegistry,
     responses: list[AiohttpClientMockResponse],
     config_entry_unique_id: str | None,
-    initial_response: AiohttpClientMockResponse,
+    config_entry: MockConfigEntry,
 ) -> None:
     """Test sensor platform with no unique id."""
 
     # Failure to migrate config entry to a unique id
-    if initial_response:
-        responses.insert(0, initial_response)
+    responses.insert(0, mock_response_error(HTTPStatus.SERVICE_UNAVAILABLE))
+
+    await config_entry.async_setup(hass)
+    assert config_entry.state == ConfigEntryState.LOADED
 
     raindelay = hass.states.get("sensor.rain_bird_controller_raindelay")
     assert raindelay is not None

--- a/tests/components/rainbird/test_sensor.py
+++ b/tests/components/rainbird/test_sensor.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .conftest import (
-    CONFIG_ENTRY_DATA,
+    CONFIG_ENTRY_DATA_OLD_FORMAT,
     RAIN_DELAY,
     RAIN_DELAY_OFF,
     mock_response_error,
@@ -65,7 +65,7 @@ async def test_sensors(
         (
             None,
             {
-                **CONFIG_ENTRY_DATA,
+                **CONFIG_ENTRY_DATA_OLD_FORMAT,
                 "serial_number": 0,
             },
             mock_response_error(HTTPStatus.SERVICE_UNAVAILABLE),
@@ -74,7 +74,7 @@ async def test_sensors(
         (
             "0",
             {
-                **CONFIG_ENTRY_DATA,
+                **CONFIG_ENTRY_DATA_OLD_FORMAT,
                 "serial_number": 0,
             },
             None,

--- a/tests/components/rainbird/test_switch.py
+++ b/tests/components/rainbird/test_switch.py
@@ -287,6 +287,9 @@ async def test_no_unique_id(
 ) -> None:
     """Test an irrigation switch with no unique id."""
 
+    # Failure to migrate config entry to a unique id
+    responses.insert(0, mock_response_error(HTTPStatus.SERVICE_UNAVAILABLE))
+
     zone = hass.states.get("switch.rain_bird_sprinkler_3")
     assert zone is not None
     assert zone.attributes.get("friendly_name") == "Rain Bird Sprinkler 3"

--- a/tests/components/rainbird/test_switch.py
+++ b/tests/components/rainbird/test_switch.py
@@ -13,6 +13,7 @@ from homeassistant.helpers import entity_registry as er
 
 from .conftest import (
     ACK_ECHO,
+    CONFIG_ENTRY_DATA_OLD_FORMAT,
     EMPTY_STATIONS_RESPONSE,
     HOST,
     PASSWORD,
@@ -274,9 +275,9 @@ async def test_switch_error(
 
 
 @pytest.mark.parametrize(
-    ("config_entry_unique_id"),
+    ("config_entry_data", "config_entry_unique_id"),
     [
-        (None),
+        (CONFIG_ENTRY_DATA_OLD_FORMAT, None),
     ],
 )
 async def test_no_unique_id(

--- a/tests/components/rainbird/test_switch.py
+++ b/tests/components/rainbird/test_switch.py
@@ -16,10 +16,10 @@ from .conftest import (
     CONFIG_ENTRY_DATA_OLD_FORMAT,
     EMPTY_STATIONS_RESPONSE,
     HOST,
+    MAC_ADDRESS,
     PASSWORD,
     RAIN_DELAY_OFF,
     RAIN_SENSOR_OFF,
-    SERIAL_NUMBER,
     ZONE_3_ON_RESPONSE,
     ZONE_5_ON_RESPONSE,
     ZONE_OFF_RESPONSE,
@@ -110,7 +110,7 @@ async def test_zones(
 
     # Verify unique id for one of the switches
     entity_entry = entity_registry.async_get("switch.rain_bird_sprinkler_3")
-    assert entity_entry.unique_id == "1263613994342-3"
+    assert entity_entry.unique_id == "4c:a1:61:00:11:22-3"
 
 
 async def test_switch_on(
@@ -227,6 +227,7 @@ async def test_irrigation_service(
                     "1": "Garden Sprinkler",
                     "2": "Back Yard",
                 },
+                "mac": MAC_ADDRESS,
             }
         )
     ],
@@ -275,9 +276,9 @@ async def test_switch_error(
 
 
 @pytest.mark.parametrize(
-    ("config_entry_data", "config_entry_unique_id"),
+    ("config_entry_data", "config_entry_unique_id", "setup_config_entry"),
     [
-        (CONFIG_ENTRY_DATA_OLD_FORMAT, None),
+        (CONFIG_ENTRY_DATA_OLD_FORMAT, None, None),
     ],
 )
 async def test_no_unique_id(
@@ -285,11 +286,15 @@ async def test_no_unique_id(
     aioclient_mock: AiohttpClientMocker,
     responses: list[AiohttpClientMockResponse],
     entity_registry: er.EntityRegistry,
+    config_entry: MockConfigEntry,
 ) -> None:
-    """Test an irrigation switch with no unique id."""
+    """Test an irrigation switch with no unique id due to migration failure."""
 
     # Failure to migrate config entry to a unique id
     responses.insert(0, mock_response_error(HTTPStatus.SERVICE_UNAVAILABLE))
+
+    await config_entry.async_setup(hass)
+    assert config_entry.state == ConfigEntryState.LOADED
 
     zone = hass.states.get("switch.rain_bird_sprinkler_3")
     assert zone is not None
@@ -298,31 +303,3 @@ async def test_no_unique_id(
 
     entity_entry = entity_registry.async_get("switch.rain_bird_sprinkler_3")
     assert entity_entry is None
-
-
-@pytest.mark.parametrize(
-    ("config_entry_unique_id", "entity_unique_id"),
-    [
-        (SERIAL_NUMBER, "1263613994342-3"),
-        # Some existing config entries may have a "0" serial number but preserve
-        # their unique id
-        (0, "0-3"),
-    ],
-)
-async def test_has_unique_id(
-    hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
-    responses: list[AiohttpClientMockResponse],
-    entity_registry: er.EntityRegistry,
-    entity_unique_id: str,
-) -> None:
-    """Test an irrigation switch with no unique id."""
-
-    zone = hass.states.get("switch.rain_bird_sprinkler_3")
-    assert zone is not None
-    assert zone.attributes.get("friendly_name") == "Rain Bird Sprinkler 3"
-    assert zone.state == "off"
-
-    entity_entry = entity_registry.async_get("switch.rain_bird_sprinkler_3")
-    assert entity_entry
-    assert entity_entry.unique_id == entity_unique_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update rainbird unique id selection to use the mac address rather than the serial number, which is sometimes zero.  This would have been a better fix for #101168 to handle the zero serial number case in hindsight.

The config flow will now exclusively use the rainbird mac address, which seems to be broadly supported according to testing from the community in https://github.com/allenporter/pyrainbird/issues/270  -- but just incase, we still keep the serial number around in the config entry. We still additionally dedup config entries on unique host/pass given the mix of prior types of unique ids.

Existing config entries that have no unique id (created using the logic in 2023.10.X that skips setting unique id for serial "0") are fixed in the setup to use the mac address.  Existing unique ids that use the serial number are left alone. 

This is not scheduled for a patch release, since it is a larger change than the previous unique id fixes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #103461
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
