### PR TITLE
Suggest an ISO 8601 sample in datetime.set_value

### DIFF
--- a/homeassistant/components/datetime/services.yaml
+++ b/homeassistant/components/datetime/services.yaml
@@ -5,6 +5,6 @@ set_value:
   fields:
     datetime:
       required: true
-      example: "2022/11/01 22:15"
+      example: "2023-10-07T21:35:22.586205"
       selector:
         datetime:

--- a/homeassistant/components/datetime/services.yaml
+++ b/homeassistant/components/datetime/services.yaml
@@ -5,6 +5,6 @@ set_value:
   fields:
     datetime:
       required: true
-      example: "2023-10-07T21:35:22.586205"
+      example: "2023-10-07T21:35:22"
       selector:
         datetime:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The example datetime value proposed in the developer tools for the datetime.set_value is currently not correct. It does not comply with any of the formats supported by [`parse_datetime()`](https://github.com/home-assistant/core/blob/55bf309d2f9b5bde2025fbae9f0d101b8755893b/homeassistant/util/dt.py#L183) in `homeassistant/util/dt.py`

![image](https://github.com/home-assistant/core/assets/7327649/3c0ff05e-d8ba-4087-a460-62ff9d3ca001)

The obvious problem is the slashes in the date which must be replaced by hyphens. So we could just use `2022-11-01 22:15` and that would work.

But `parse_datetime()` does its first parsing attempt against the ISO 8601 format and the regex looks like a fallback approach to me. Because of that, I figured proposing a value complying with the ISO standard is the best we can do to educate users as to how to use the datetime.set_value service.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: No issue submitted yet. I'm happy to file one if needed!
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
