### PR TITLE
 Add service set_preset_mode_with_end_datetime in Netatmo integration

### DIFF
--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -46,7 +46,7 @@ from .const import (
     EVENT_TYPE_SET_POINT,
     EVENT_TYPE_THERM_MODE,
     NETATMO_CREATE_CLIMATE,
-    SERVICE_SET_PRESET_MODE_WITH_OPTIONAL_END_DATETIME,
+    SERVICE_SET_PRESET_MODE_WITH_END_DATETIME,
     SERVICE_SET_SCHEDULE,
 )
 from .data_handler import HOME, SIGNAL_NAME, NetatmoRoom
@@ -131,12 +131,12 @@ async def async_setup_entry(
         "_async_service_set_schedule",
     )
     platform.async_register_entity_service(
-        SERVICE_SET_PRESET_MODE_WITH_OPTIONAL_END_DATETIME,
+        SERVICE_SET_PRESET_MODE_WITH_END_DATETIME,
         {
             vol.Required(ATTR_PRESET_MODE): vol.In(THERM_MODES),
-            vol.Optional(ATTR_END_DATETIME): cv.datetime,
+            vol.Required(ATTR_END_DATETIME): cv.datetime,
         },
-        "_async_service_set_preset_mode_with_optional_end_datetime",
+        "_async_service_set_preset_mode_with_end_datetime",
     )
 
 
@@ -424,15 +424,12 @@ class NetatmoThermostat(NetatmoBase, ClimateEntity):
             schedule_id,
         )
 
-    async def _async_service_set_preset_mode_with_optional_end_datetime(
+    async def _async_service_set_preset_mode_with_end_datetime(
         self, **kwargs: Any
     ) -> None:
         preset_mode = kwargs[ATTR_PRESET_MODE]
-        end_datetime = kwargs.get(ATTR_END_DATETIME)
-        end_timestamp = None
-
-        if end_datetime:
-            end_timestamp = int(dt_util.as_timestamp(end_datetime))
+        end_datetime = kwargs[ATTR_END_DATETIME]
+        end_timestamp = int(dt_util.as_timestamp(end_datetime))
 
         await self._room.home.async_set_thermmode(
             mode=PRESET_MAP_NETATMO[preset_mode], end_time=end_timestamp

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -133,7 +133,7 @@ async def async_setup_entry(
     platform.async_register_entity_service(
         SERVICE_SET_PRESET_MODE_WITH_OPTIONAL_END_DATETIME,
         {
-            vol.Required(ATTR_PRESET_MODE): cv.string,
+            vol.Required(ATTR_PRESET_MODE): vol.In(THERM_MODES),
             vol.Optional(ATTR_END_DATETIME): cv.datetime,
         },
         "_async_service_set_preset_mode_with_optional_end_datetime",
@@ -427,16 +427,9 @@ class NetatmoThermostat(NetatmoBase, ClimateEntity):
     async def _async_service_set_preset_mode_with_optional_end_datetime(
         self, **kwargs: Any
     ) -> None:
-        preset_mode = kwargs.get(ATTR_PRESET_MODE)
+        preset_mode = kwargs[ATTR_PRESET_MODE]
         end_datetime = kwargs.get(ATTR_END_DATETIME)
         end_timestamp = None
-
-        if preset_mode not in THERM_MODES:
-            msg = (
-                f"{preset_mode} does not support end datetime. "
-                "Only 'away' and 'Frost Guard' are supported"
-            )
-            raise ValueError(msg)
 
         if end_datetime:
             end_timestamp = int(dt_util.as_timestamp(end_datetime))
@@ -445,11 +438,9 @@ class NetatmoThermostat(NetatmoBase, ClimateEntity):
             mode=PRESET_MAP_NETATMO[preset_mode], end_time=end_timestamp
         )
         _LOGGER.debug(
-            "Setting %s preset to %s (%s) with optional end datetime to %s (%s)",
+            "Setting %s preset to %s with optional end datetime to %s",
             self._room.home.entity_id,
-            kwargs.get(ATTR_PRESET_MODE),
             preset_mode,
-            kwargs.get(ATTR_END_DATETIME),
             end_timestamp,
         )
 

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -8,6 +8,7 @@ from pyatmo.modules import NATherm1
 import voluptuous as vol
 
 from homeassistant.components.climate import (
+    ATTR_PRESET_MODE,
     DEFAULT_MIN_TEMP,
     PRESET_AWAY,
     PRESET_BOOST,
@@ -30,8 +31,10 @@ from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import dt as dt_util
 
 from .const import (
+    ATTR_END_DATETIME,
     ATTR_HEATING_POWER_REQUEST,
     ATTR_SCHEDULE_NAME,
     ATTR_SELECTED_SCHEDULE,
@@ -43,6 +46,7 @@ from .const import (
     EVENT_TYPE_SET_POINT,
     EVENT_TYPE_THERM_MODE,
     NETATMO_CREATE_CLIMATE,
+    SERVICE_SET_PRESET_MODE_WITH_END_DATETIME,
     SERVICE_SET_SCHEDULE,
 )
 from .data_handler import HOME, SIGNAL_NAME, NetatmoRoom
@@ -58,6 +62,8 @@ SUPPORT_FLAGS = (
     ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
 )
 SUPPORT_PRESET = [PRESET_AWAY, PRESET_BOOST, PRESET_FROST_GUARD, PRESET_SCHEDULE]
+
+THERM_MODES = (PRESET_SCHEDULE, PRESET_FROST_GUARD, PRESET_AWAY)
 
 STATE_NETATMO_SCHEDULE = "schedule"
 STATE_NETATMO_HG = "hg"
@@ -123,6 +129,14 @@ async def async_setup_entry(
         SERVICE_SET_SCHEDULE,
         {vol.Required(ATTR_SCHEDULE_NAME): cv.string},
         "_async_service_set_schedule",
+    )
+    platform.async_register_entity_service(
+        SERVICE_SET_PRESET_MODE_WITH_END_DATETIME,
+        {
+            vol.Required(ATTR_PRESET_MODE): cv.string,
+            vol.Required(ATTR_END_DATETIME): cv.datetime,
+        },
+        "_async_service_set_preset_mode_with_end_datetime",
     )
 
 
@@ -314,7 +328,7 @@ class NetatmoThermostat(NetatmoBase, ClimateEntity):
             await self._room.async_therm_set(STATE_NETATMO_HOME)
         elif preset_mode in (PRESET_BOOST, STATE_NETATMO_MAX):
             await self._room.async_therm_set(PRESET_MAP_NETATMO[preset_mode])
-        elif preset_mode in (PRESET_SCHEDULE, PRESET_FROST_GUARD, PRESET_AWAY):
+        elif preset_mode in THERM_MODES:
             await self._room.home.async_set_thermmode(PRESET_MAP_NETATMO[preset_mode])
         else:
             _LOGGER.error("Preset mode '%s' not available", preset_mode)
@@ -408,6 +422,36 @@ class NetatmoThermostat(NetatmoBase, ClimateEntity):
             self._room.home.entity_id,
             kwargs.get(ATTR_SCHEDULE_NAME),
             schedule_id,
+        )
+
+    async def _async_service_set_preset_mode_with_end_datetime(
+        self, **kwargs: Any
+    ) -> None:
+        preset_mode = kwargs.get(ATTR_PRESET_MODE)
+        end_datetime = kwargs.get(ATTR_END_DATETIME)
+        end_timestamp = None
+
+        if preset_mode not in THERM_MODES:
+            _LOGGER.error(
+                "%s does not support end datetime. Only %s are supported",
+                preset_mode,
+                ", ".join(THERM_MODES),
+            )
+            return
+
+        if end_datetime:
+            end_timestamp = int(dt_util.as_timestamp(end_datetime))
+
+        await self._room.home.async_set_thermmode(
+            mode=PRESET_MAP_NETATMO[preset_mode], end_time=end_timestamp
+        )
+        _LOGGER.debug(
+            "Setting %s preset to %s (%s) with optional end datetime to %s (%s)",
+            self._room.home.entity_id,
+            kwargs.get(ATTR_PRESET_MODE),
+            preset_mode,
+            kwargs.get(ATTR_END_DATETIME),
+            end_timestamp,
         )
 
     @property

--- a/homeassistant/components/netatmo/const.py
+++ b/homeassistant/components/netatmo/const.py
@@ -69,6 +69,7 @@ DEFAULT_PERSON = "unknown"
 DEFAULT_WEBHOOKS = False
 
 ATTR_CAMERA_LIGHT_MODE = "camera_light_mode"
+ATTR_END_DATETIME = "end_datetime"
 ATTR_EVENT_TYPE = "event_type"
 ATTR_FACE_URL = "face_url"
 ATTR_HEATING_POWER_REQUEST = "heating_power_request"
@@ -86,6 +87,7 @@ SERVICE_SET_CAMERA_LIGHT = "set_camera_light"
 SERVICE_SET_PERSON_AWAY = "set_person_away"
 SERVICE_SET_PERSONS_HOME = "set_persons_home"
 SERVICE_SET_SCHEDULE = "set_schedule"
+SERVICE_SET_PRESET_MODE_WITH_END_DATETIME = "set_preset_mode_with_end_datetime"
 
 # Climate events
 EVENT_TYPE_CANCEL_SET_POINT = "cancel_set_point"

--- a/homeassistant/components/netatmo/const.py
+++ b/homeassistant/components/netatmo/const.py
@@ -87,7 +87,9 @@ SERVICE_SET_CAMERA_LIGHT = "set_camera_light"
 SERVICE_SET_PERSON_AWAY = "set_person_away"
 SERVICE_SET_PERSONS_HOME = "set_persons_home"
 SERVICE_SET_SCHEDULE = "set_schedule"
-SERVICE_SET_PRESET_MODE_WITH_END_DATETIME = "set_preset_mode_with_end_datetime"
+SERVICE_SET_PRESET_MODE_WITH_OPTIONAL_END_DATETIME = (
+    "set_preset_mode_with_optional_end_datetime"
+)
 
 # Climate events
 EVENT_TYPE_CANCEL_SET_POINT = "cancel_set_point"

--- a/homeassistant/components/netatmo/const.py
+++ b/homeassistant/components/netatmo/const.py
@@ -87,9 +87,7 @@ SERVICE_SET_CAMERA_LIGHT = "set_camera_light"
 SERVICE_SET_PERSON_AWAY = "set_person_away"
 SERVICE_SET_PERSONS_HOME = "set_persons_home"
 SERVICE_SET_SCHEDULE = "set_schedule"
-SERVICE_SET_PRESET_MODE_WITH_END_DATETIME = (
-    "set_preset_mode_with_end_datetime"
-)
+SERVICE_SET_PRESET_MODE_WITH_END_DATETIME = "set_preset_mode_with_end_datetime"
 
 # Climate events
 EVENT_TYPE_CANCEL_SET_POINT = "cancel_set_point"

--- a/homeassistant/components/netatmo/const.py
+++ b/homeassistant/components/netatmo/const.py
@@ -87,8 +87,8 @@ SERVICE_SET_CAMERA_LIGHT = "set_camera_light"
 SERVICE_SET_PERSON_AWAY = "set_person_away"
 SERVICE_SET_PERSONS_HOME = "set_persons_home"
 SERVICE_SET_SCHEDULE = "set_schedule"
-SERVICE_SET_PRESET_MODE_WITH_OPTIONAL_END_DATETIME = (
-    "set_preset_mode_with_optional_end_datetime"
+SERVICE_SET_PRESET_MODE_WITH_END_DATETIME = (
+    "set_preset_mode_with_end_datetime"
 )
 
 # Climate events

--- a/homeassistant/components/netatmo/services.yaml
+++ b/homeassistant/components/netatmo/services.yaml
@@ -26,6 +26,29 @@ set_schedule:
       selector:
         text:
 
+set_preset_mode_with_end_datetime:
+  name: Set preset mode with an end datetime
+  description: Set preset mode for Netatmo climate device with end datetime.
+  target:
+    entity:
+      integration: netatmo
+      domain: climate
+  fields:
+    preset_mode:
+      name: Preset mode
+      description: New value of preset mode.
+      required: true
+      example: "away"
+      selector:
+        text:
+    end_datetime:
+      name: End date & time
+      description: The end date & time of the preset mode.
+      required: true
+      example: '"2019-04-20 05:04:20"'
+      selector:
+        text:
+
 set_persons_home:
   target:
     entity:

--- a/homeassistant/components/netatmo/services.yaml
+++ b/homeassistant/components/netatmo/services.yaml
@@ -26,7 +26,7 @@ set_schedule:
       selector:
         text:
 
-set_preset_mode_with_optional_end_datetime:
+set_preset_mode_with_end_datetime:
   target:
     entity:
       integration: netatmo
@@ -41,7 +41,7 @@ set_preset_mode_with_optional_end_datetime:
             - "away"
             - "Frost Guard"
     end_datetime:
-      required: false
+      required: true
       example: '"2019-04-20 05:04:20"'
       selector:
         datetime:

--- a/homeassistant/components/netatmo/services.yaml
+++ b/homeassistant/components/netatmo/services.yaml
@@ -26,28 +26,25 @@ set_schedule:
       selector:
         text:
 
-set_preset_mode_with_end_datetime:
-  name: Set preset mode with an end datetime
-  description: Set preset mode for Netatmo climate device with end datetime.
+set_preset_mode_with_optional_end_datetime:
   target:
     entity:
       integration: netatmo
       domain: climate
   fields:
     preset_mode:
-      name: Preset mode
-      description: New value of preset mode.
       required: true
       example: "away"
       selector:
-        text:
+        select:
+          options:
+            - "away"
+            - "Frost Guard"
     end_datetime:
-      name: End date & time
-      description: The end date & time of the preset mode.
-      required: true
+      required: false
       example: '"2019-04-20 05:04:20"'
       selector:
-        text:
+        datetime:
 
 set_persons_home:
   target:

--- a/homeassistant/components/netatmo/strings.json
+++ b/homeassistant/components/netatmo/strings.json
@@ -126,7 +126,7 @@
         },
         "end_datetime": {
           "name": "End datetime",
-          "description": "Datetime for the how long the preset will be active."
+          "description": "Datetime for until when the preset will be active."
         }
       }
     }

--- a/homeassistant/components/netatmo/strings.json
+++ b/homeassistant/components/netatmo/strings.json
@@ -115,6 +115,20 @@
     "unregister_webhook": {
       "name": "Unregister webhook",
       "description": "Unregisters the webhook from the Netatmo backend."
+    },
+    "set_preset_mode_with_optional_end_datetime": {
+      "name": "Set preset mode with optional end datetime",
+      "description": "Sets the preset mode for a Netatmo climate device. The preset mode must match a preset mode configured at Netatmo.",
+      "fields": {
+        "preset_mode": {
+          "name": "Preset mode",
+          "description": "Preset mode."
+        },
+        "end_datetime": {
+          "name": "End datetime",
+          "description": "End datetime."
+        }
+      }
     }
   }
 }

--- a/homeassistant/components/netatmo/strings.json
+++ b/homeassistant/components/netatmo/strings.json
@@ -116,17 +116,17 @@
       "name": "Unregister webhook",
       "description": "Unregisters the webhook from the Netatmo backend."
     },
-    "set_preset_mode_with_optional_end_datetime": {
-      "name": "Set preset mode with optional end datetime",
+    "set_preset_mode_with_end_datetime": {
+      "name": "Set preset mode with end datetime",
       "description": "Sets the preset mode for a Netatmo climate device. The preset mode must match a preset mode configured at Netatmo.",
       "fields": {
         "preset_mode": {
           "name": "Preset mode",
-          "description": "Preset mode."
+          "description": "Climate preset mode such as Schedule, Away or Frost Guard."
         },
         "end_datetime": {
           "name": "End datetime",
-          "description": "End datetime."
+          "description": "Datetime for the how long the preset will be active."
         }
       }
     }

--- a/tests/components/netatmo/test_climate.py
+++ b/tests/components/netatmo/test_climate.py
@@ -1,4 +1,5 @@
 """The tests for the Netatmo climate platform."""
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
@@ -18,11 +19,14 @@ from homeassistant.components.climate import (
 )
 from homeassistant.components.netatmo.climate import PRESET_FROST_GUARD, PRESET_SCHEDULE
 from homeassistant.components.netatmo.const import (
+    ATTR_END_DATETIME,
     ATTR_SCHEDULE_NAME,
+    SERVICE_SET_PRESET_MODE_WITH_END_DATETIME,
     SERVICE_SET_SCHEDULE,
 )
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE, CONF_WEBHOOK_ID
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt
 
 from .common import selected_platforms, simulate_webhook
 
@@ -456,6 +460,68 @@ async def test_service_schedule_thermostats(
         mock_switch_home_schedule.assert_not_called()
 
     assert "summer is not a valid schedule" in caplog.text
+
+
+async def test_service_preset_mode_with_end_time_thermostats(
+    hass: HomeAssistant, config_entry, caplog: pytest.LogCaptureFixture, netatmo_auth
+) -> None:
+    """Test service for set preset mode with end datetime for Netatmo thermostats."""
+    with selected_platforms(["climate"]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+        await hass.async_block_till_done()
+
+    webhook_id = config_entry.data[CONF_WEBHOOK_ID]
+    climate_entity_livingroom = "climate.livingroom"
+
+    # Test setting a valid preset mode (that allow an end datetime in Netatmo == THERM_MODES) and a valid end datetime
+    await hass.services.async_call(
+        "netatmo",
+        SERVICE_SET_PRESET_MODE_WITH_END_DATETIME,
+        {
+            ATTR_ENTITY_ID: climate_entity_livingroom,
+            ATTR_PRESET_MODE: PRESET_AWAY,
+            ATTR_END_DATETIME: (dt.now() + timedelta(days=10)).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            ),
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    # Fake webhook thermostat mode change to "Away"
+    response = {
+        "event_type": "therm_mode",
+        "home": {"id": "91763b24c43d3e344f424e8b", "therm_mode": "away"},
+        "mode": "away",
+        "previous_mode": "schedule",
+        "push_type": "home_event_changed",
+    }
+    await simulate_webhook(hass, webhook_id, response)
+
+    assert hass.states.get(climate_entity_livingroom).state == "auto"
+    assert (
+        hass.states.get(climate_entity_livingroom).attributes["preset_mode"] == "away"
+    )
+
+    # Test setting an in valid preset mode (not in THERM_MODES) and a valid end datetime
+    with patch("pyatmo.home.Home.async_set_thermmode") as mock_set_home_thermmode:
+        await hass.services.async_call(
+            "netatmo",
+            SERVICE_SET_PRESET_MODE_WITH_END_DATETIME,
+            {
+                ATTR_ENTITY_ID: climate_entity_livingroom,
+                ATTR_PRESET_MODE: PRESET_BOOST,
+                ATTR_END_DATETIME: (dt.now() + timedelta(days=10)).strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                ),
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        mock_set_home_thermmode.assert_not_called()
+
+    assert "boost does not support end datetime" in caplog.text
 
 
 async def test_service_preset_mode_already_boost_valves(

--- a/tests/components/netatmo/test_climate.py
+++ b/tests/components/netatmo/test_climate.py
@@ -22,7 +22,7 @@ from homeassistant.components.netatmo.climate import PRESET_FROST_GUARD, PRESET_
 from homeassistant.components.netatmo.const import (
     ATTR_END_DATETIME,
     ATTR_SCHEDULE_NAME,
-    SERVICE_SET_PRESET_MODE_WITH_OPTIONAL_END_DATETIME,
+    SERVICE_SET_PRESET_MODE_WITH_END_DATETIME,
     SERVICE_SET_SCHEDULE,
 )
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE, CONF_WEBHOOK_ID
@@ -478,7 +478,7 @@ async def test_service_preset_mode_with_end_time_thermostats(
     # Test setting a valid preset mode (that allow an end datetime in Netatmo == THERM_MODES) and a valid end datetime
     await hass.services.async_call(
         "netatmo",
-        SERVICE_SET_PRESET_MODE_WITH_OPTIONAL_END_DATETIME,
+        SERVICE_SET_PRESET_MODE_WITH_END_DATETIME,
         {
             ATTR_ENTITY_ID: climate_entity_livingroom,
             ATTR_PRESET_MODE: PRESET_AWAY,
@@ -505,11 +505,11 @@ async def test_service_preset_mode_with_end_time_thermostats(
         hass.states.get(climate_entity_livingroom).attributes["preset_mode"] == "away"
     )
 
-    # Test setting an in valid preset mode (not in THERM_MODES) and a valid end datetime
+    # Test setting an invalid preset mode (not in THERM_MODES) and a valid end datetime
     with pytest.raises(MultipleInvalid):
         await hass.services.async_call(
             "netatmo",
-            SERVICE_SET_PRESET_MODE_WITH_OPTIONAL_END_DATETIME,
+            SERVICE_SET_PRESET_MODE_WITH_END_DATETIME,
             {
                 ATTR_ENTITY_ID: climate_entity_livingroom,
                 ATTR_PRESET_MODE: PRESET_BOOST,
@@ -522,31 +522,17 @@ async def test_service_preset_mode_with_end_time_thermostats(
         await hass.async_block_till_done()
 
     # Test setting a valid preset mode (that allow an end datetime in Netatmo == THERM_MODES) without an end datetime
-    await hass.services.async_call(
-        "netatmo",
-        SERVICE_SET_PRESET_MODE_WITH_OPTIONAL_END_DATETIME,
-        {
-            ATTR_ENTITY_ID: climate_entity_livingroom,
-            ATTR_PRESET_MODE: PRESET_AWAY,
-        },
-        blocking=True,
-    )
-    await hass.async_block_till_done()
-
-    # Fake webhook thermostat mode change to "Away"
-    response = {
-        "event_type": "therm_mode",
-        "home": {"id": "91763b24c43d3e344f424e8b", "therm_mode": "away"},
-        "mode": "away",
-        "previous_mode": "schedule",
-        "push_type": "home_event_changed",
-    }
-    await simulate_webhook(hass, webhook_id, response)
-
-    assert hass.states.get(climate_entity_livingroom).state == "auto"
-    assert (
-        hass.states.get(climate_entity_livingroom).attributes["preset_mode"] == "away"
-    )
+    with pytest.raises(MultipleInvalid):
+        await hass.services.async_call(
+            "netatmo",
+            SERVICE_SET_PRESET_MODE_WITH_END_DATETIME,
+            {
+                ATTR_ENTITY_ID: climate_entity_livingroom,
+                ATTR_PRESET_MODE: PRESET_AWAY,
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
 
 
 async def test_service_preset_mode_already_boost_valves(

--- a/tests/components/netatmo/test_climate.py
+++ b/tests/components/netatmo/test_climate.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
+from voluptuous.error import MultipleInvalid
 
 from homeassistant.components.climate import (
     ATTR_HVAC_MODE,
@@ -505,7 +506,7 @@ async def test_service_preset_mode_with_end_time_thermostats(
     )
 
     # Test setting an in valid preset mode (not in THERM_MODES) and a valid end datetime
-    with pytest.raises(ValueError):
+    with pytest.raises(MultipleInvalid):
         await hass.services.async_call(
             "netatmo",
             SERVICE_SET_PRESET_MODE_WITH_OPTIONAL_END_DATETIME,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Picking up https://github.com/home-assistant/core/pull/91571 where @adrienvsj left off. I've made the end date optional for the case when automations may not provide those dates.  


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29245

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
