### PR TITLE
Add Entity.async_update_capabilities

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -1261,6 +1261,25 @@ class Entity(ABC):
             self.hass, integration_domain=platform_name, module=type(self).__module__
         )
 
+    @final
+    @callback
+    def async_update_capabilities(self) -> None:
+        """Update capabilities and supported features stored in the entity registry.
+
+        Integrations should call this method when capability attributes or supported
+        features have changed.
+
+        The method does nothing if the entity is not in the entity registry.
+        """
+        if not self.registry_entry:
+            return
+        entity_registry = er.async_get(self.hass)
+        entity_registry.async_update_entity(
+            self.entity_id,
+            capabilities=self.capability_attributes,
+            supported_features=self.supported_features,
+        )
+
 
 @dataclass(slots=True)
 class ToggleEntityDescription(EntityDescription):

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -936,11 +936,13 @@ class EntityRegistry:
         original_device_class: str | None | UndefinedType = UNDEFINED,
         original_icon: str | None | UndefinedType = UNDEFINED,
         original_name: str | None | UndefinedType = UNDEFINED,
-        supported_features: int | UndefinedType = UNDEFINED,
+        supported_features: int | None | UndefinedType = UNDEFINED,
         translation_key: str | None | UndefinedType = UNDEFINED,
         unit_of_measurement: str | None | UndefinedType = UNDEFINED,
     ) -> RegistryEntry:
         """Update properties of an entity."""
+        supported_features = supported_features or 0
+
         return self._async_update_entity(
             entity_id,
             aliases=aliases,

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1560,3 +1560,49 @@ async def test_suggest_report_issue_custom_component(
 
     suggestion = mock_entity._suggest_report_issue()
     assert suggestion == "create a bug report at https://some_url"
+
+
+async def test_update_capabilities(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test calling async_update_capabilities."""
+    platform = MockEntityPlatform(hass)
+
+    entity = MockEntity(unique_id="qwer")
+    await platform.async_add_entities([entity])
+
+    entry = entity_registry.async_get(entity.entity_id)
+    assert entry.capabilities is None
+    assert entry.supported_features == 0
+
+    entity._values["capability_attributes"] = {"bla": "blu"}
+    entity._values["supported_features"] = 127
+    entity.async_write_ha_state()
+    entry = entity_registry.async_get(entity.entity_id)
+    assert entry.capabilities is None
+    assert entry.supported_features == 0
+
+    entity.async_update_capabilities()
+    entry = entity_registry.async_get(entity.entity_id)
+    assert entry.capabilities == {"bla": "blu"}
+    assert entry.supported_features == 127
+
+
+async def test_update_capabilities_no_unique_id(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test calling async_update_capabilities."""
+    platform = MockEntityPlatform(hass)
+
+    entity = MockEntity()
+    await platform.async_add_entities([entity])
+
+    assert entity_registry.async_get(entity.entity_id) is None
+
+    entity._values["capability_attributes"] = {"bla": "blu"}
+    entity._values["supported_features"] = 127
+    entity.async_write_ha_state()
+    entity.async_update_capabilities()
+    assert entity_registry.async_get(entity.entity_id) is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `Entity.async_update_capabilities`, to be called by integrations when either `supported_features` or a capability attribute has changed.

### Rationale

Some integrations change capability attributes and supported features, causing state and entity registry to be out of sync. This adds a method to make it easier for integrations to update the entity registry when this happens.

### Alternative

An alternative would be to let the `Entity` class check the entity registry entry when updating state and automatically update the entity registry if a change is detected. This would not be expensive because an `Entity` object already has a reference to its entity registry object, and `supported_features` + `capability_attributes` are already generated in each state write.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
