### PR TITLE
supla: Change casing of integration name to upstream SUPLA

### DIFF
--- a/homeassistant/components/supla/cover.py
+++ b/homeassistant/components/supla/cover.py
@@ -1,4 +1,4 @@
-"""Support for Supla cover - curtains, rollershutters, entry gate etc."""
+"""Support for SUPLA covers - curtains, rollershutters, entry gate etc."""
 from __future__ import annotations
 
 import logging
@@ -26,7 +26,7 @@ async def async_setup_platform(
     async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
-    """Set up the Supla covers."""
+    """Set up the SUPLA covers."""
     if discovery_info is None:
         return
 
@@ -59,7 +59,7 @@ async def async_setup_platform(
 
 
 class SuplaCoverEntity(SuplaEntity, CoverEntity):
-    """Representation of a Supla Cover."""
+    """Representation of a SUPLA Cover."""
 
     @property
     def current_cover_position(self) -> int | None:
@@ -93,7 +93,7 @@ class SuplaCoverEntity(SuplaEntity, CoverEntity):
 
 
 class SuplaDoorEntity(SuplaEntity, CoverEntity):
-    """Representation of a Supla door."""
+    """Representation of a SUPLA door."""
 
     _attr_device_class = CoverDeviceClass.GARAGE
 

--- a/homeassistant/components/supla/entity.py
+++ b/homeassistant/components/supla/entity.py
@@ -1,4 +1,4 @@
-"""Base class for Supla channels."""
+"""Base class for SUPLA channels."""
 from __future__ import annotations
 
 import logging
@@ -9,7 +9,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class SuplaEntity(CoordinatorEntity):
-    """Base class of a Supla Channel (an equivalent of HA's Entity)."""
+    """Base class of a SUPLA Channel (an equivalent of HA's Entity)."""
 
     def __init__(self, config, server, coordinator):
         """Init from config, hookup[ server and coordinator."""
@@ -49,7 +49,7 @@ class SuplaEntity(CoordinatorEntity):
         """Run server action.
 
         Actions are currently hardcoded in components.
-        Supla's API enables autodiscovery
+        SUPLA's API enables autodiscovery
         """
         _LOGGER.debug(
             "Executing action %s on channel %d, params: %s",

--- a/homeassistant/components/supla/manifest.json
+++ b/homeassistant/components/supla/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "supla",
-  "name": "Supla",
+  "name": "SUPLA",
   "codeowners": ["@mwegrzynek"],
   "documentation": "https://www.home-assistant.io/integrations/supla",
   "iot_class": "cloud_polling",

--- a/homeassistant/components/supla/switch.py
+++ b/homeassistant/components/supla/switch.py
@@ -1,4 +1,4 @@
-"""Support for Supla switch."""
+"""Support for SUPLA switch."""
 from __future__ import annotations
 
 import logging
@@ -22,7 +22,7 @@ async def async_setup_platform(
     async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
-    """Set up the Supla switches."""
+    """Set up the SUPLA switches."""
     if discovery_info is None:
         return
 
@@ -44,7 +44,7 @@ async def async_setup_platform(
 
 
 class SuplaSwitchEntity(SuplaEntity, SwitchEntity):
-    """Representation of a Supla Switch."""
+    """Representation of a SUPLA Switch."""
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -5503,7 +5503,7 @@
       "iot_class": "local_polling"
     },
     "supla": {
-      "name": "Supla",
+      "name": "SUPLA",
       "integration_type": "hub",
       "config_flow": false,
       "iot_class": "cloud_polling"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Per the upstream documentation/usages at https://www.supla.org/en/, **SUPLA** is the correct capitalisation, not **Supla**.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29263

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
