### PR TITLE
ZHA Component: Correct AttributeUpdated signal in Thermostat climate entity, ThermostatClusterHandler and ThermostatHVACAction sensor entity

### DIFF
--- a/homeassistant/components/zha/climate.py
+++ b/homeassistant/components/zha/climate.py
@@ -367,10 +367,10 @@ class Thermostat(ZhaEntity, ClimateEntity):
             self._thrm, SIGNAL_ATTR_UPDATED, self.async_attribute_updated
         )
 
-    async def async_attribute_updated(self, record):
+    async def async_attribute_updated(self, attr_id, attr_name, value):
         """Handle attribute update from device."""
         if (
-            record.attr_name in (ATTR_OCCP_COOL_SETPT, ATTR_OCCP_HEAT_SETPT)
+            attr_name in (ATTR_OCCP_COOL_SETPT, ATTR_OCCP_HEAT_SETPT)
             and self.preset_mode == PRESET_AWAY
         ):
             # occupancy attribute is an unreportable attribute, but if we get
@@ -379,7 +379,7 @@ class Thermostat(ZhaEntity, ClimateEntity):
             if await self._thrm.get_occupancy() is True:
                 self._preset = PRESET_NONE
 
-        self.debug("Attribute '%s' = %s update", record.attr_name, record.value)
+        self.debug("Attribute '%s' = %s update", attr_name, value)
         self.async_write_ha_state()
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:

--- a/homeassistant/components/zha/climate.py
+++ b/homeassistant/components/zha/climate.py
@@ -609,24 +609,24 @@ class MoesThermostat(Thermostat):
         """Return only the heat mode, because the device can't be turned off."""
         return [HVACMode.HEAT]
 
-    async def async_attribute_updated(self, record):
+    async def async_attribute_updated(self, attr_id, attr_name, value):
         """Handle attribute update from device."""
-        if record.attr_name == "operation_preset":
-            if record.value == 0:
+        if attr_name == "operation_preset":
+            if value == 0:
                 self._preset = PRESET_AWAY
-            if record.value == 1:
+            if value == 1:
                 self._preset = PRESET_SCHEDULE
-            if record.value == 2:
+            if value == 2:
                 self._preset = PRESET_NONE
-            if record.value == 3:
+            if value == 3:
                 self._preset = PRESET_COMFORT
-            if record.value == 4:
+            if value == 4:
                 self._preset = PRESET_ECO
-            if record.value == 5:
+            if value == 5:
                 self._preset = PRESET_BOOST
-            if record.value == 6:
+            if value == 6:
                 self._preset = PRESET_COMPLEX
-        await super().async_attribute_updated(record)
+        await super().async_attribute_updated(attr_id, attr_name, value)
 
     async def async_preset_handler(self, preset: str, enable: bool = False) -> None:
         """Set the preset mode."""
@@ -688,22 +688,22 @@ class BecaThermostat(Thermostat):
         """Return only the heat mode, because the device can't be turned off."""
         return [HVACMode.HEAT]
 
-    async def async_attribute_updated(self, record):
+    async def async_attribute_updated(self, attr_id, attr_name, value):
         """Handle attribute update from device."""
-        if record.attr_name == "operation_preset":
-            if record.value == 0:
+        if attr_name == "operation_preset":
+            if value == 0:
                 self._preset = PRESET_AWAY
-            if record.value == 1:
+            if value == 1:
                 self._preset = PRESET_SCHEDULE
-            if record.value == 2:
+            if value == 2:
                 self._preset = PRESET_NONE
-            if record.value == 4:
+            if value == 4:
                 self._preset = PRESET_ECO
-            if record.value == 5:
+            if value == 5:
                 self._preset = PRESET_BOOST
-            if record.value == 7:
+            if value == 7:
                 self._preset = PRESET_TEMP_MANUAL
-        await super().async_attribute_updated(record)
+        await super().async_attribute_updated(attr_id, attr_name, value)
 
     async def async_preset_handler(self, preset: str, enable: bool = False) -> None:
         """Set the preset mode."""
@@ -783,20 +783,20 @@ class ZONNSMARTThermostat(Thermostat):
         ]
         self._supported_flags |= ClimateEntityFeature.PRESET_MODE
 
-    async def async_attribute_updated(self, record):
+    async def async_attribute_updated(self, attr_id, attr_name, value):
         """Handle attribute update from device."""
-        if record.attr_name == "operation_preset":
-            if record.value == 0:
+        if attr_name == "operation_preset":
+            if value == 0:
                 self._preset = PRESET_SCHEDULE
-            if record.value == 1:
+            if value == 1:
                 self._preset = PRESET_NONE
-            if record.value == 2:
+            if value == 2:
                 self._preset = self.PRESET_HOLIDAY
-            if record.value == 3:
+            if value == 3:
                 self._preset = self.PRESET_HOLIDAY
-            if record.value == 4:
+            if value == 4:
                 self._preset = self.PRESET_FROST
-        await super().async_attribute_updated(record)
+        await super().async_attribute_updated(attr_id, attr_name, value)
 
     async def async_preset_handler(self, preset: str, enable: bool = False) -> None:
         """Set the preset mode."""

--- a/homeassistant/components/zha/core/cluster_handlers/hvac.py
+++ b/homeassistant/components/zha/core/cluster_handlers/hvac.py
@@ -5,7 +5,6 @@ https://home-assistant.io/integrations/zha/
 """
 from __future__ import annotations
 
-from collections import namedtuple
 from typing import Any
 
 from zigpy.zcl.clusters import hvac
@@ -21,7 +20,6 @@ from ..const import (
 )
 from . import AttrReportConfig, ClusterHandler
 
-AttributeUpdateRecord = namedtuple("AttributeUpdateRecord", "attr_id, attr_name, value")
 REPORT_CONFIG_CLIMATE = (REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 25)
 REPORT_CONFIG_CLIMATE_DEMAND = (REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 5)
 REPORT_CONFIG_CLIMATE_DISCRETE = (REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 1)

--- a/homeassistant/components/zha/core/cluster_handlers/hvac.py
+++ b/homeassistant/components/zha/core/cluster_handlers/hvac.py
@@ -235,7 +235,9 @@ class ThermostatClusterHandler(ClusterHandler):
         )
         self.async_send_signal(
             f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}",
-            AttributeUpdateRecord(attrid, attr_name, value),
+            attrid,
+            attr_name,
+            value,
         )
 
     async def async_set_operation_mode(self, mode) -> bool:

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -854,11 +854,6 @@ class ThermostatHVACAction(Sensor, id_suffix="hvac_action"):
             return HVACAction.IDLE
         return HVACAction.OFF
 
-    @callback
-    def async_set_state(self, *args, **kwargs) -> None:
-        """Handle state update from cluster handler."""
-        self.async_write_ha_state()
-
 
 @MULTI_MATCH(
     cluster_handler_names={CLUSTER_HANDLER_THERMOSTAT},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

The "attribute_updated" signal takes 3 arguments: attribute id, attribute name and value. async_send_signal in hvac.py sends 1 argument: AttributeUpdateRecord. This means that every implementation of an entity from ThermostatCluster needs to override the signal handler (async_set_state or async_attribute_updated; depending on the assigned function name) for this specific case, while there is currently no reason to deviate from the convention (for example the Danfoss TRV entities; not merged yet).

## Proposed change
This changes the signature of the signal handlers of all climate entities and ThermostatHVACAction to accept 3 arguments.

This changes the signal emitter (ThermostatClusterHandler) to emit 3 arguments.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- This PR is related to PR: https://github.com/home-assistant/core/pull/86907
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
