### PR TITLE
Alter OpenUV to allow for automatic updating of the protection window sensor

### DIFF
--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -121,6 +121,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass,
             DOMAIN,
             f"protection_window_automation_{automation_entity_id}",
+            breaks_in_ha_version="2024.1.0",
             is_fixable=False,
             severity=IssueSeverity.WARNING,
             translation_key="protection_window_automation",

--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -95,7 +95,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             },
         )
 
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+
     return True
+
+
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle an options update."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -102,11 +102,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass,
             DOMAIN,
             f"protection_window_automation_{automation_entity_id}",
-            breaks_in_ha_version="2024.1.0",
             is_fixable=False,
             severity=IssueSeverity.WARNING,
             translation_key="protection_window_automation",
-            translation_placeholders={"automation_entity_id": automation_entity_id},
+            translation_placeholders={
+                "automation_entity_id": automation_entity_id,
+                "protection_window_entity_id": protection_window_registry_entry.entity_id,
+            },
         )
 
     return True

--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -85,7 +85,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass,
             DOMAIN,
             f"protection_window_automation_{automation_entity_id}",
-            breaks_in_ha_version="2024.1.0",
             is_fixable=False,
             severity=IssueSeverity.WARNING,
             translation_key="protection_window_automation",

--- a/homeassistant/components/openuv/binary_sensor.py
+++ b/homeassistant/components/openuv/binary_sensor.py
@@ -164,7 +164,7 @@ class ProtectionWindowBinarySensor(OpenUvEntity, BinarySensorEntity):
                     )
                 else:
                     LOGGER.debug(
-                        "Skipping protection window state schedule (%s retries)",
+                        "Skipping protection window state schedule (%s retries attempted)",
                         self.COORDINATOR_RETRIES,
                     )
                     self._coordinator_retries = 0

--- a/homeassistant/components/openuv/binary_sensor.py
+++ b/homeassistant/components/openuv/binary_sensor.py
@@ -151,7 +151,7 @@ class ProtectionWindowBinarySensor(OpenUvEntity, BinarySensorEntity):
                     target_dt = utcnow() + timedelta(hours=1)
 
                     LOGGER.debug(
-                        "Retrying window state schedule: %s (attempt %s of %s)",
+                        "Retrying protection window state schedule at %s (attempt %s of %s)",
                         target_dt,
                         self._coordinator_retries + 1,
                         self.COORDINATOR_RETRIES,
@@ -163,7 +163,10 @@ class ProtectionWindowBinarySensor(OpenUvEntity, BinarySensorEntity):
                         self.hass, async_request_coordinator_refresh, target_dt
                     )
                 else:
-                    LOGGER.debug("Skipping window state schedule due to no data")
+                    LOGGER.debug(
+                        "Skipping protection window state schedule (%s retries)",
+                        self.COORDINATOR_RETRIES,
+                    )
                     self._coordinator_retries = 0
                 return
 

--- a/homeassistant/components/openuv/binary_sensor.py
+++ b/homeassistant/components/openuv/binary_sensor.py
@@ -147,9 +147,14 @@ class ProtectionWindowBinarySensor(OpenUvEntity, BinarySensorEntity):
                 # window data. If that happens, we should try a few more times
                 # (properly spaced out) before giving up:
                 if self._coordinator_retries < self.COORDINATOR_RETRIES:
+                    self._coordinator_retries += 1
                     target_dt = utcnow() + timedelta(hours=1)
+
                     LOGGER.debug(
-                        "Retrying protection window state schedule at %s", target_dt
+                        "Retrying window state schedule: %s (attempt %s of %s)",
+                        target_dt,
+                        self._coordinator_retries + 1,
+                        self.COORDINATOR_RETRIES,
                     )
 
                     if self._unsub_coordinator_retry:
@@ -157,11 +162,8 @@ class ProtectionWindowBinarySensor(OpenUvEntity, BinarySensorEntity):
                     self._unsub_coordinator_retry = async_track_point_in_utc_time(
                         self.hass, async_request_coordinator_refresh, target_dt
                     )
-                    self._coordinator_retries += 1
                 else:
-                    LOGGER.debug(
-                        "Skipping protection window state schedule due to no data"
-                    )
+                    LOGGER.debug("Skipping window state schedule due to no data")
                     self._coordinator_retries = 0
                 return
 

--- a/homeassistant/components/openuv/binary_sensor.py
+++ b/homeassistant/components/openuv/binary_sensor.py
@@ -36,7 +36,7 @@ async def async_setup_entry(
             ProtectionWindowBinarySensor(
                 coordinators[DATA_PROTECTION_WINDOW],
                 # We inline a simple entity description here because this entity will
-                # still inherit from OpenUvEntity (which requires a descsription):
+                # still inherit from OpenUvEntity (which requires a description):
                 BinarySensorEntityDescription(key=TYPE_PROTECTION_WINDOW),
             )
         ]

--- a/homeassistant/components/openuv/binary_sensor.py
+++ b/homeassistant/components/openuv/binary_sensor.py
@@ -163,8 +163,8 @@ class ProtectionWindowBinarySensor(OpenUvEntity, BinarySensorEntity):
                         self.hass, async_request_coordinator_refresh, target_dt
                     )
                 else:
-                    LOGGER.debug(
-                        "Skipping protection window state schedule (%s retries attempted)",
+                    LOGGER.warning(
+                        "Cannot schedule protection window update (bad data after %s retries)",
                         self.COORDINATOR_RETRIES,
                     )
                     self._coordinator_retries = 0

--- a/homeassistant/components/openuv/binary_sensor.py
+++ b/homeassistant/components/openuv/binary_sensor.py
@@ -94,10 +94,10 @@ class ProtectionWindowBinarySensor(OpenUvEntity, BinarySensorEntity):
         return attrs
 
     @property
-    def is_on(self) -> bool | None:
+    def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
         if (window := self._get_current_window()) is None:
-            return None
+            return False
         return window.from_dt_utc <= utcnow() <= window.to_dt_utc
 
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/openuv/binary_sensor.py
+++ b/homeassistant/components/openuv/binary_sensor.py
@@ -34,11 +34,10 @@ async def async_setup_entry(
         [
             ProtectionWindowBinarySensor(
                 coordinators[DATA_PROTECTION_WINDOW],
-                BinarySensorEntityDescription(
-                    key=TYPE_PROTECTION_WINDOW,
-                    translation_key="protection_window",
-                    icon="mdi:sunglasses",
-                ),
+                # We inline a simple entity description here because this entity will
+                # still inherit from OpenUvEntity, which requires an entity description
+                # to be defined:
+                BinarySensorEntityDescription(key=TYPE_PROTECTION_WINDOW),
             )
         ]
     )
@@ -54,6 +53,9 @@ class ProtectionWindow:
 
 class ProtectionWindowBinarySensor(OpenUvEntity, BinarySensorEntity):
     """Define a binary sensor for OpenUV."""
+
+    _attr_icon = "mdi:sunglasses"
+    _attr_translation_key = "protection_window"
 
     COORDINATOR_KEYS = ("from_time", "to_time")
 
@@ -140,3 +142,11 @@ class ProtectionWindowBinarySensor(OpenUvEntity, BinarySensorEntity):
         self.async_on_remove(
             self.coordinator.async_add_listener(async_schedule_state_changes)
         )
+
+    async def async_update(self) -> None:
+        """Update the entity.
+
+        Since protection window data is only updated once per day (and handled
+        automatically), this disables the generic entity update service to prevent
+        unnecessary API waste.
+        """

--- a/homeassistant/components/openuv/binary_sensor.py
+++ b/homeassistant/components/openuv/binary_sensor.py
@@ -57,9 +57,6 @@ class ProtectionWindowBinarySensor(OpenUvEntity, BinarySensorEntity):
     _attr_icon = "mdi:sunglasses"
     _attr_translation_key = "protection_window"
 
-    COORDINATOR_KEYS = ("from_time", "to_time")
-    COORDINATOR_RETRIES = 3
-
     @callback
     def _get_current_window(self) -> ProtectionWindow | None:
         """Get the current window start/end datetimes (if they exist) from data."""

--- a/homeassistant/components/openuv/binary_sensor.py
+++ b/homeassistant/components/openuv/binary_sensor.py
@@ -142,11 +142,3 @@ class ProtectionWindowBinarySensor(OpenUvEntity, BinarySensorEntity):
         self.async_on_remove(
             self.coordinator.async_add_listener(async_schedule_state_changes)
         )
-
-    async def async_update(self) -> None:
-        """Update the entity.
-
-        Since protection window data is only updated once per day (and handled
-        automatically), this disables the generic entity update service to prevent
-        unnecessary API waste.
-        """

--- a/homeassistant/components/openuv/binary_sensor.py
+++ b/homeassistant/components/openuv/binary_sensor.py
@@ -1,7 +1,8 @@
 """Support for OpenUV binary sensors."""
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
+from enum import StrEnum
 from typing import Any
 
 from homeassistant.components.binary_sensor import (
@@ -9,7 +10,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util.dt import as_local, parse_datetime, utcnow
@@ -43,7 +44,7 @@ async def async_setup_entry(
     )
 
 
-@dataclass
+@dataclass(frozen=True)
 class ProtectionWindow:
     """Define a protection window."""
 
@@ -51,11 +52,65 @@ class ProtectionWindow:
     to_dt_utc: datetime
 
 
+class ProtectionWindowBoundary(StrEnum):
+    """Define a protection window boundary."""
+
+    START = "start"
+    END = "end"
+
+
+@dataclass
+class ScheduledProtectionWindowStateChange:
+    """Define a representation of a scheduled protection window state change."""
+
+    hass: HomeAssistant
+    boundary: ProtectionWindowBoundary
+    target: datetime
+    update_state_method: Callable[[datetime], None]
+    _unsub_state_change_callback: CALLBACK_TYPE | None = None
+
+    @callback
+    def async_deregister(self) -> None:
+        """Deregister the scheduled state change."""
+        if self._unsub_state_change_callback:
+            self._unsub_state_change_callback()
+            self._unsub_state_change_callback = None
+
+    @callback
+    def async_schedule(self, target: datetime) -> None:
+        """Schedule the state change."""
+        if self._unsub_state_change_callback and target == self.target:
+            # If a state change has already been scheduled for the same datetime, just
+            # return:
+            return
+
+        LOGGER.debug(
+            "Scheduling a protection window state change: %s (%s)",
+            self.boundary,
+            self.target,
+        )
+        if self._unsub_state_change_callback:
+            self._unsub_state_change_callback()
+        self._unsub_state_change_callback = async_track_point_in_utc_time(
+            self.hass, self.update_state_method, self.target
+        )
+
+
 class ProtectionWindowBinarySensor(OpenUvEntity, BinarySensorEntity):
     """Define a binary sensor for OpenUV."""
 
     _attr_icon = "mdi:sunglasses"
     _attr_translation_key = "protection_window"
+
+    def __init__(
+        self, coordinator: OpenUvCoordinator, description: BinarySensorEntityDescription
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator, description)
+
+        self._scheduled_state_changes: dict[
+            ProtectionWindowBoundary, ScheduledProtectionWindowStateChange
+        ] = {}
 
     @callback
     def _get_current_window(self) -> ProtectionWindow | None:
@@ -110,12 +165,21 @@ class ProtectionWindowBinarySensor(OpenUvEntity, BinarySensorEntity):
             self.async_write_ha_state()
 
         @callback
-        def async_schedule_state_change(target: datetime) -> None:
+        def async_schedule_state_change(
+            boundary: ProtectionWindowBoundary, target: datetime
+        ) -> None:
             """Schedule an entity state change based upon a datetime."""
-            LOGGER.debug("Scheduling a protection window state change at %s", target)
-            self.async_on_remove(
-                async_track_point_in_utc_time(self.hass, async_update_state, target)
-            )
+            if (state_change := self._scheduled_state_changes.get(boundary)) is None:
+                state_change = self._scheduled_state_changes[
+                    boundary
+                ] = ScheduledProtectionWindowStateChange(
+                    hass=self.hass,
+                    boundary=boundary,
+                    target=target,
+                    update_state_method=async_update_state,
+                )
+
+            state_change.async_schedule(target)
 
         @callback
         def async_schedule_state_changes() -> None:
@@ -125,13 +189,22 @@ class ProtectionWindowBinarySensor(OpenUvEntity, BinarySensorEntity):
 
             now = utcnow()
             if now < window.from_dt_utc:
-                async_schedule_state_change(window.from_dt_utc)
-                async_schedule_state_change(window.to_dt_utc)
-            elif now < window.to_dt_utc:
-                async_schedule_state_change(window.to_dt_utc)
+                async_schedule_state_change(
+                    ProtectionWindowBoundary.START, window.from_dt_utc
+                )
+            if now < window.to_dt_utc:
+                async_schedule_state_change(
+                    ProtectionWindowBoundary.END, window.to_dt_utc
+                )
 
         self.async_on_remove(
             self.coordinator.async_add_listener(async_schedule_state_changes)
         )
 
         async_schedule_state_changes()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        for state_change in self._scheduled_state_changes.values():
+            state_change.async_deregister()
+        self._scheduled_state_changes = {}

--- a/homeassistant/components/openuv/binary_sensor.py
+++ b/homeassistant/components/openuv/binary_sensor.py
@@ -36,8 +36,7 @@ async def async_setup_entry(
             ProtectionWindowBinarySensor(
                 coordinators[DATA_PROTECTION_WINDOW],
                 # We inline a simple entity description here because this entity will
-                # still inherit from OpenUvEntity, which requires an entity description
-                # to be defined:
+                # still inherit from OpenUvEntity (which requires a descsription):
                 BinarySensorEntityDescription(key=TYPE_PROTECTION_WINDOW),
             )
         ]

--- a/homeassistant/components/openuv/coordinator.py
+++ b/homeassistant/components/openuv/coordinator.py
@@ -2,17 +2,28 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from datetime import datetime, timedelta
 from typing import Any, cast
 
+from pyopenuv import Client
 from pyopenuv.errors import InvalidApiKeyError, OpenUvError
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.debounce import Debouncer
+from homeassistant.helpers.event import async_track_utc_time_change
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import LOGGER
+from .const import (
+    CONF_FROM_WINDOW,
+    CONF_TO_WINDOW,
+    DATA_PROTECTION_WINDOW,
+    DATA_UV,
+    DEFAULT_FROM_WINDOW,
+    DEFAULT_TO_WINDOW,
+    LOGGER,
+)
 
 DEFAULT_DEBOUNCER_COOLDOWN_SECONDS = 15 * 60
 
@@ -26,19 +37,18 @@ class OpenUvCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def __init__(
         self,
         hass: HomeAssistant,
-        *,
         entry: ConfigEntry,
+        client: Client,
+        *,
         name: str,
-        latitude: str,
-        longitude: str,
-        update_method: Callable[[], Awaitable[dict[str, Any]]],
+        update_interval: timedelta | None = None,
     ) -> None:
         """Initialize."""
         super().__init__(
             hass,
             LOGGER,
             name=name,
-            update_method=update_method,
+            update_interval=update_interval,
             request_refresh_debouncer=Debouncer(
                 hass,
                 LOGGER,
@@ -47,14 +57,99 @@ class OpenUvCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             ),
         )
 
+        self._client = client
         self._entry = entry
-        self.latitude = latitude
-        self.longitude = longitude
+        self.latitude = client.latitude
+        self.longitude = client.longitude
+
+
+class ProtectionWindowCoordinator(OpenUvCoordinator):
+    """Define an OpenUV data coordinator for protection window data."""
+
+    DATA_KEYS = ("from_time", "to_time")
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry, client: Client) -> None:
+        """Initialize."""
+        super().__init__(
+            hass,
+            entry,
+            client,
+            name=DATA_PROTECTION_WINDOW,
+            update_interval=timedelta(minutes=30),
+        )
+
+        self.window_calculated: bool = False
+
+    @callback
+    def _async_is_data_valid(self, data: dict[str, Any]) -> bool:
+        """Validate protection window data from OpenUV."""
+        if not all(key in data for key in self.DATA_KEYS):
+            LOGGER.debug("Protection window data is incomplete: %s", data)
+            return False
+        return True
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch data from OpenUV."""
+        if self.window_calculated:
+            # If the window has already been calculated, return the existing data
+            # (which, by default, won't call listeners) and save an API call:
+            return self.data
+
+        low = self._entry.options.get(CONF_FROM_WINDOW, DEFAULT_FROM_WINDOW)
+        high = self._entry.options.get(CONF_TO_WINDOW, DEFAULT_TO_WINDOW)
+
+        try:
+            data = await self._client.uv_protection_window(low=low, high=high)
+        except InvalidApiKeyError as err:
+            raise ConfigEntryAuthFailed("Invalid API key") from err
+        except OpenUvError as err:
+            raise UpdateFailed(str(err)) from err
+
+        data = data["result"]
+
+        if self._async_is_data_valid(data):
+            # If the protection window data is valid, set the flag to indicate that
+            # the window has been calculated (to prevent further API updates until the
+            # flag is the next day):
+            self.window_calculated = True
+
+        return data
+
+    async def async_config_entry_first_refresh(self) -> None:
+        """Refresh data for the first time when a config entry is setup."""
+
+        @callback
+        def async_reset_window_check(_: datetime) -> None:
+            """Reset the flag that indicates if the window has been calculated."""
+            self.window_calculated = False
+
+        self._entry.async_on_unload(
+            # Reset the flag that indicates if the window has been calculated at
+            # midnight every day:
+            async_track_utc_time_change(
+                self.hass,
+                async_reset_window_check,
+                hour=0,
+                minute=0,
+                second=0,
+                local=True,
+            )
+        )
+
+        await super().async_config_entry_first_refresh()
+
+
+class UvIndexCoordinator(OpenUvCoordinator):
+    """Define an OpenUV data coordinator for UV data."""
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry, client: Client) -> None:
+        """Initialize."""
+        super().__init__(hass, entry, client, name=DATA_UV)
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from OpenUV."""
         try:
-            data = await self.update_method()
+            data = await self._client.uv_index()
         except InvalidApiKeyError as err:
             raise ConfigEntryAuthFailed("Invalid API key") from err
         except OpenUvError as err:

--- a/homeassistant/components/openuv/coordinator.py
+++ b/homeassistant/components/openuv/coordinator.py
@@ -80,14 +80,6 @@ class ProtectionWindowCoordinator(OpenUvCoordinator):
 
         self.window_calculated: bool = False
 
-    @callback
-    def _async_is_data_valid(self, data: dict[str, Any]) -> bool:
-        """Validate protection window data from OpenUV."""
-        if not all(key in data for key in self.DATA_KEYS):
-            LOGGER.debug("Protection window data is incomplete: %s", data)
-            return False
-        return True
-
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from OpenUV."""
         if self.window_calculated:
@@ -107,10 +99,10 @@ class ProtectionWindowCoordinator(OpenUvCoordinator):
 
         data = data["result"]
 
-        if self._async_is_data_valid(data):
-            # If the protection window data is valid, set the flag to indicate that
-            # the window has been calculated (to prevent further API updates until the
-            # flag is the next day):
+        if all(key in data for key in self.DATA_KEYS):
+            # The OpenUV API can sometimes return a successful response that's missing
+            # the protection window data; if the appropriate keys exist, mark the data
+            # as valid:
             self.window_calculated = True
 
         return data

--- a/homeassistant/components/openuv/coordinator.py
+++ b/homeassistant/components/openuv/coordinator.py
@@ -85,6 +85,7 @@ class ProtectionWindowCoordinator(OpenUvCoordinator):
         if self.window_calculated:
             # If the window has already been calculated, return the existing data
             # (which, by default, won't call listeners) and save an API call:
+            LOGGER.debug("Protection window already calculated")
             return self.data
 
         low = self._entry.options.get(CONF_FROM_WINDOW, DEFAULT_FROM_WINDOW)
@@ -103,6 +104,7 @@ class ProtectionWindowCoordinator(OpenUvCoordinator):
             # The OpenUV API can sometimes return a successful response that's missing
             # the protection window data; if the appropriate keys exist, mark the data
             # as valid:
+            LOGGER.debug("Protection window calculated")
             self.window_calculated = True
 
         return data
@@ -113,6 +115,7 @@ class ProtectionWindowCoordinator(OpenUvCoordinator):
         @callback
         def async_reset_window_check(_: datetime) -> None:
             """Reset the flag that indicates if the window has been calculated."""
+            LOGGER.debug("Resetting protection window check flag")
             self.window_calculated = False
 
         self._entry.async_on_unload(

--- a/homeassistant/components/openuv/strings.json
+++ b/homeassistant/components/openuv/strings.json
@@ -85,8 +85,8 @@
   },
   "issues": {
     "protection_window_automation": {
-      "title": "Deprecated protection window automation",
-      "description": "OpenUV can now automatically update the protection window binary sensor; automations that manually update this entity with the `homeassistant.update_entity` are deprecated. Please remove the `{automation_entity_id}` automation."
+      "title": "Protection window automation no longer required",
+      "description": "OpenUV can now automatically update the protection window binary sensor; you are no longer required to call the `homeassistant.update_entity` service with `{protection_window_entity_id}` as a target and may remove the `{automation_entity_id}` automation."
     }
   }
 }

--- a/homeassistant/components/openuv/strings.json
+++ b/homeassistant/components/openuv/strings.json
@@ -82,5 +82,11 @@
         "name": "Skin type 6 safe exposure time"
       }
     }
+  },
+  "issues": {
+    "protection_window_automation": {
+      "title": "Deprecated protection window automation",
+      "description": "OpenUV can now automatically update the protection window binary sensor; automations that manually update this entity with the `homeassistant.update_entity` are deprecated. Please remove the `{automation_entity_id}` automation."
+    }
   }
 }

--- a/homeassistant/components/openuv/strings.json
+++ b/homeassistant/components/openuv/strings.json
@@ -86,7 +86,7 @@
   "issues": {
     "protection_window_automation": {
       "title": "Manually updating the protection window is no longer required",
-      "description": "OpenUV can now automatically update the `{protection_window_entity_id}` entity; you are no longer required to call the `homeassistant.update_entity` service on this entity and should remove the `{automation_entity_id}` automation."
+      "description": "OpenUV can now automatically update the `{protection_window_entity_id}` entity; you are no longer required to call the `homeassistant.update_entity` service on this entity and should remove the `{automation_entity_id}` automation to prevent unnecessary API calls."
     }
   }
 }

--- a/homeassistant/components/openuv/strings.json
+++ b/homeassistant/components/openuv/strings.json
@@ -86,7 +86,7 @@
   "issues": {
     "protection_window_automation": {
       "title": "Protection window automation no longer required",
-      "description": "OpenUV can now automatically update the protection window binary sensor; you are no longer required to call the `homeassistant.update_entity` service with `{protection_window_entity_id}` as a target and may remove the `{automation_entity_id}` automation."
+      "description": "OpenUV can now automatically update `{protection_window_entity_id}`; you are no longer required to call the `homeassistant.update_entity` service on it and may remove the `{automation_entity_id}` automation."
     }
   }
 }

--- a/homeassistant/components/openuv/strings.json
+++ b/homeassistant/components/openuv/strings.json
@@ -85,8 +85,8 @@
   },
   "issues": {
     "protection_window_automation": {
-      "title": "Protection window automation no longer required",
-      "description": "OpenUV can now automatically update `{protection_window_entity_id}`; you are no longer required to call the `homeassistant.update_entity` service on it and may remove the `{automation_entity_id}` automation."
+      "title": "Manually updating the protection window is no longer required",
+      "description": "OpenUV can now automatically update the `{protection_window_entity_id}` entity; you are no longer required to call the `homeassistant.update_entity` service on this entity and should remove the `{automation_entity_id}` automation."
     }
   }
 }

--- a/tests/components/openuv/conftest.py
+++ b/tests/components/openuv/conftest.py
@@ -5,7 +5,11 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from homeassistant.components.openuv import CONF_FROM_WINDOW, CONF_TO_WINDOW, DOMAIN
+from homeassistant.components.openuv.const import (
+    CONF_FROM_WINDOW,
+    CONF_TO_WINDOW,
+    DOMAIN,
+)
 from homeassistant.const import (
     CONF_API_KEY,
     CONF_ELEVATION,

--- a/tests/components/openuv/test_config_flow.py
+++ b/tests/components/openuv/test_config_flow.py
@@ -6,7 +6,11 @@ import pytest
 import voluptuous as vol
 
 from homeassistant import data_entry_flow
-from homeassistant.components.openuv import CONF_FROM_WINDOW, CONF_TO_WINDOW, DOMAIN
+from homeassistant.components.openuv.const import (
+    CONF_FROM_WINDOW,
+    CONF_TO_WINDOW,
+    DOMAIN,
+)
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.const import (
     CONF_API_KEY,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
OpenUV entities are manually updated by calling the `homeassistant.update_entity` service to protect API overruns. Recently, I learned that the protection window API response contains the datetimes at which the protection window begins and ends; this means we no longer need to call `homeassistant.update_entity` on this entity.

Therefore, this PR does two things:

1. Introduces automatic updating of the protection window entity
2. Creates repair items for every automation that references the protection window binary sensor

No. 2 is technically not a deprecation, as users are still free to update the sensor ad hoc with `homeassistant.update_entity` (I currently don't have plans to remove this capability).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/101732
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
