### PR TITLE
Add google calendar required feature for create event service

### DIFF
--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -240,6 +240,7 @@ async def async_setup_entry(
             SERVICE_CREATE_EVENT,
             CREATE_EVENT_SCHEMA,
             async_create_event,
+            required_features=CalendarEntityFeature.CREATE_EVENT,
         )
 
 

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -576,6 +576,59 @@ async def test_add_event_date_time(
     }
 
 
+@pytest.mark.parametrize(
+    "calendars_config",
+    [
+        [
+            {
+                "cal_id": CALENDAR_ID,
+                "entities": [
+                    {
+                        "device_id": "backyard_light",
+                        "name": "Backyard Light",
+                        "search": "#Backyard",
+                    },
+                ],
+            }
+        ],
+    ],
+)
+async def test_unsupported_create_event(
+    hass: HomeAssistant,
+    mock_calendars_yaml: Mock,
+    component_setup: ComponentSetup,
+    mock_calendars_list: ApiResult,
+    mock_insert_event: Callable[[str, dict[str, Any]], None],
+    test_api_calendar: dict[str, Any],
+    mock_events_list: ApiResult,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test service call that adds an event with a date time range."""
+
+    mock_calendars_list({"items": [test_api_calendar]})
+    mock_events_list({})
+    assert await component_setup()
+
+    start_datetime = datetime.datetime.now(tz=zoneinfo.ZoneInfo("America/Regina"))
+    delta = datetime.timedelta(days=3, hours=3)
+    end_datetime = start_datetime + delta
+
+    with pytest.raises(HomeAssistantError, match="does not support this service"):
+        await hass.services.async_call(
+            DOMAIN,
+            "create_event",
+            {
+                # **data,
+                "start_date_time": start_datetime.isoformat(),
+                "end_date_time": end_datetime.isoformat(),
+                "summary": TEST_EVENT_SUMMARY,
+                "description": TEST_EVENT_DESCRIPTION,
+            },
+            target={"entity_id": "calendar.backyard_light"},
+            blocking=True,
+        )
+
+
 async def test_add_event_failure(
     hass: HomeAssistant,
     component_setup: ComponentSetup,

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -603,7 +603,7 @@ async def test_unsupported_create_event(
     mock_events_list: ApiResult,
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
-    """Test service call that adds an event with a date time range."""
+    """Test create event service call is unsupported for virtual calendars."""
 
     mock_calendars_list({"items": [test_api_calendar]})
     mock_events_list({})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a required feature for the google calendar  create event service. Calendars that are custom based on a search string do not support creating events, since they are virtual calendars that do not actually exist.

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #101729
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
