### PR TITLE
Delete optional schema keys, when they are not present

### DIFF
--- a/homeassistant/helpers/schema_config_entry_flow.py
+++ b/homeassistant/helpers/schema_config_entry_flow.py
@@ -171,17 +171,36 @@ class SchemaCommonFlowHandler:
 
         if user_input is not None:
             # User input was validated successfully, update options
-            self._options.update(user_input)
-            if data_schema and data_schema.schema:
-                for key in data_schema.schema:
-                    if isinstance(key, vol.Optional) and key not in user_input:
-                        # Key not present, delete keys old value (if present) too
-                        self._options.pop(key, None)
+            self._update_and_remove_omitted_opional_keys(
+                self._options, user_input, data_schema
+            )
 
         if user_input is not None or form_step.schema is None:
             return await self._show_next_step_or_create_entry(form_step)
 
         return await self._show_next_step(step_id)
+
+    def _update_and_remove_omitted_opional_keys(
+        self,
+        values: dict[str, Any],
+        user_input: dict[str, Any],
+        data_schema: vol.Schema | None,
+    ) -> None:
+        values.update(user_input)
+        if data_schema and data_schema.schema:
+            for key in data_schema.schema:
+                if (
+                    isinstance(key, vol.Optional)
+                    and key not in user_input
+                    and not (
+                        # don't remove advanced keys, if they are hidden
+                        key.description
+                        and key.description.get("advanced")
+                        and not self._handler.show_advanced_options
+                    )
+                ):
+                    # Key not present, delete keys old value (if present) too
+                    values.pop(key, None)
 
     async def _show_next_step_or_create_entry(
         self, form_step: SchemaFlowFormStep
@@ -226,14 +245,9 @@ class SchemaCommonFlowHandler:
         if user_input:
             # We don't want to mutate the existing options
             suggested_values = copy.deepcopy(suggested_values)
-            suggested_values.update(user_input)
-            if (
-                data_schema := await self._get_schema(form_step)
-            ) and data_schema.schema:
-                for key in data_schema.schema:
-                    if isinstance(key, vol.Optional) and key not in user_input:
-                        # Key not present, delete keys old value (if present) too
-                        suggested_values.pop(key, None)
+            self._update_and_remove_omitted_opional_keys(
+                suggested_values, user_input, await self._get_schema(form_step)
+            )
 
         if data_schema.schema:
             # Make a copy of the schema with suggested values set to saved options

--- a/homeassistant/helpers/schema_config_entry_flow.py
+++ b/homeassistant/helpers/schema_config_entry_flow.py
@@ -172,6 +172,11 @@ class SchemaCommonFlowHandler:
         if user_input is not None:
             # User input was validated successfully, update options
             self._options.update(user_input)
+            if data_schema and data_schema.schema:
+                for key in data_schema.schema:
+                    if isinstance(key, vol.Optional) and key not in user_input:
+                        # Key not present, delete keys old value (if present) too
+                        self._options.pop(key, None)
 
         if user_input is not None or form_step.schema is None:
             return await self._show_next_step_or_create_entry(form_step)
@@ -222,6 +227,13 @@ class SchemaCommonFlowHandler:
             # We don't want to mutate the existing options
             suggested_values = copy.deepcopy(suggested_values)
             suggested_values.update(user_input)
+            if (
+                data_schema := await self._get_schema(form_step)
+            ) and data_schema.schema:
+                for key in data_schema.schema:
+                    if isinstance(key, vol.Optional) and key not in user_input:
+                        # Key not present, delete keys old value (if present) too
+                        suggested_values.pop(key, None)
 
         if data_schema.schema:
             # Make a copy of the schema with suggested values set to saved options

--- a/homeassistant/helpers/schema_config_entry_flow.py
+++ b/homeassistant/helpers/schema_config_entry_flow.py
@@ -171,7 +171,7 @@ class SchemaCommonFlowHandler:
 
         if user_input is not None:
             # User input was validated successfully, update options
-            self._update_and_remove_omitted_opional_keys(
+            self._update_and_remove_omitted_optional_keys(
                 self._options, user_input, data_schema
             )
 
@@ -245,7 +245,7 @@ class SchemaCommonFlowHandler:
         if user_input:
             # We don't want to mutate the existing options
             suggested_values = copy.deepcopy(suggested_values)
-            self._update_and_remove_omitted_opional_keys(
+            self._update_and_remove_omitted_optional_keys(
                 suggested_values, user_input, await self._get_schema(form_step)
             )
 

--- a/homeassistant/helpers/schema_config_entry_flow.py
+++ b/homeassistant/helpers/schema_config_entry_flow.py
@@ -180,7 +180,7 @@ class SchemaCommonFlowHandler:
 
         return await self._show_next_step(step_id)
 
-    def _update_and_remove_omitted_opional_keys(
+    def _update_and_remove_omitted_optional_keys(
         self,
         values: dict[str, Any],
         user_input: dict[str, Any],

--- a/tests/helpers/test_schema_config_entry_flow.py
+++ b/tests/helpers/test_schema_config_entry_flow.py
@@ -671,3 +671,80 @@ async def test_options_flow_state(hass: HomeAssistant) -> None:
         "idx_from_flow_state": "blublu",
         "option1": "blabla",
     }
+
+
+async def test_options_flow_omit_optional_key(
+    hass: HomeAssistant, manager: data_entry_flow.FlowManager
+) -> None:
+    """Test handling of advanced options in options flow."""
+    manager.hass = hass
+
+    OPTIONS_SCHEMA = vol.Schema(
+        {
+            vol.Optional("optional_no_default"): str,
+            vol.Optional("optional_default", default="a very reasonable default"): str,
+            vol.Optional("advanced_no_default", description={"advanced": True}): str,
+            vol.Optional(
+                "advanced_default",
+                default="a very reasonable default",
+                description={"advanced": True},
+            ): str,
+        }
+    )
+
+    OPTIONS_FLOW: dict[str, SchemaFlowFormStep | SchemaFlowMenuStep] = {
+        "init": SchemaFlowFormStep(OPTIONS_SCHEMA)
+    }
+
+    class TestFlow(MockSchemaConfigFlowHandler, domain="test"):
+        config_flow = {}
+        options_flow = OPTIONS_FLOW
+
+    mock_integration(hass, MockModule("test"))
+    mock_entity_platform(hass, "config_flow.test", None)
+    config_entry = MockConfigEntry(
+        data={},
+        domain="test",
+        options={
+            "optional_no_default": "abc123",
+            "optional_default": "not default",
+            "advanced_no_default": "abc123",
+            "advanced_default": "not default",
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    # Start flow in basic mode
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert list(result["data_schema"].schema.keys()) == [
+        "optional_no_default",
+        "optional_default",
+    ]
+
+    result = await hass.config_entries.options.async_configure(result["flow_id"], {})
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        "advanced_default": "not default",
+        "advanced_no_default": "abc123",
+        "optional_default": "a very reasonable default",
+    }
+
+    # Start flow in advanced mode
+    result = await hass.config_entries.options.async_init(
+        config_entry.entry_id, context={"show_advanced_options": True}
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert list(result["data_schema"].schema.keys()) == [
+        "optional_no_default",
+        "optional_default",
+        "advanced_no_default",
+        "advanced_default",
+    ]
+
+    result = await hass.config_entries.options.async_configure(result["flow_id"], {})
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        "advanced_default": "a very reasonable default",
+        "optional_default": "a very reasonable default",
+    }

--- a/tests/helpers/test_schema_config_entry_flow.py
+++ b/tests/helpers/test_schema_config_entry_flow.py
@@ -673,7 +673,7 @@ async def test_options_flow_state(hass: HomeAssistant) -> None:
     }
 
 
-async def test_options_flow_omit_optional_key(
+async def test_options_flow_omit_optional_keys(
     hass: HomeAssistant, manager: data_entry_flow.FlowManager
 ) -> None:
     """Test handling of advanced options in options flow."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

An optional key without default value will not be present in the `user_input` dict if no value was specified.
Before this change, the `SchemaCommonFlowHandler` only updates the `options`/`suggested_values` with the `user_input`. As the optional key was not present in `user_input`, the key in the options will not be updated; therefore, the old value will still be used.

With this change, after updating the `options`/`suggested_values`. We iterate over all optional keys of the current step's schema and delete the key if it doesn't existed in the `user_input`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
