### PR TITLE
Address late review from wallbox coordinator move

### DIFF
--- a/homeassistant/components/wallbox/const.py
+++ b/homeassistant/components/wallbox/const.py
@@ -56,37 +56,3 @@ class ChargerStatus(StrEnum):
     WAITING_MID_SAFETY = "Waiting MID safety margin exceeded"
     WAITING_IN_QUEUE_ECO_SMART = "Waiting in queue by Eco-Smart"
     UNKNOWN = "Unknown"
-
-
-# Translation of StatusId based on Wallbox portal code:
-# https://my.wallbox.com/src/utilities/charger/chargerStatuses.js
-CHARGER_STATUS: dict[int, ChargerStatus] = {
-    0: ChargerStatus.DISCONNECTED,
-    14: ChargerStatus.ERROR,
-    15: ChargerStatus.ERROR,
-    161: ChargerStatus.READY,
-    162: ChargerStatus.READY,
-    163: ChargerStatus.DISCONNECTED,
-    164: ChargerStatus.WAITING,
-    165: ChargerStatus.LOCKED,
-    166: ChargerStatus.UPDATING,
-    177: ChargerStatus.SCHEDULED,
-    178: ChargerStatus.PAUSED,
-    179: ChargerStatus.SCHEDULED,
-    180: ChargerStatus.WAITING_FOR_CAR,
-    181: ChargerStatus.WAITING_FOR_CAR,
-    182: ChargerStatus.PAUSED,
-    183: ChargerStatus.WAITING_IN_QUEUE_POWER_SHARING,
-    184: ChargerStatus.WAITING_IN_QUEUE_POWER_SHARING,
-    185: ChargerStatus.WAITING_IN_QUEUE_POWER_BOOST,
-    186: ChargerStatus.WAITING_IN_QUEUE_POWER_BOOST,
-    187: ChargerStatus.WAITING_MID_FAILED,
-    188: ChargerStatus.WAITING_MID_SAFETY,
-    189: ChargerStatus.WAITING_IN_QUEUE_ECO_SMART,
-    193: ChargerStatus.CHARGING,
-    194: ChargerStatus.CHARGING,
-    195: ChargerStatus.CHARGING,
-    196: ChargerStatus.DISCHARGING,
-    209: ChargerStatus.LOCKED,
-    210: ChargerStatus.LOCKED_CAR_CONNECTED,
-}

--- a/homeassistant/components/wallbox/coordinator.py
+++ b/homeassistant/components/wallbox/coordinator.py
@@ -19,7 +19,6 @@ from .const import (
     CHARGER_ENERGY_PRICE_KEY,
     CHARGER_LOCKED_UNLOCKED_KEY,
     CHARGER_MAX_CHARGING_CURRENT_KEY,
-    CHARGER_STATUS,
     CHARGER_STATUS_DESCRIPTION_KEY,
     CHARGER_STATUS_ID_KEY,
     CODE_KEY,
@@ -29,6 +28,39 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+# Translation of StatusId based on Wallbox portal code:
+# https://my.wallbox.com/src/utilities/charger/chargerStatuses.js
+CHARGER_STATUS: dict[int, ChargerStatus] = {
+    0: ChargerStatus.DISCONNECTED,
+    14: ChargerStatus.ERROR,
+    15: ChargerStatus.ERROR,
+    161: ChargerStatus.READY,
+    162: ChargerStatus.READY,
+    163: ChargerStatus.DISCONNECTED,
+    164: ChargerStatus.WAITING,
+    165: ChargerStatus.LOCKED,
+    166: ChargerStatus.UPDATING,
+    177: ChargerStatus.SCHEDULED,
+    178: ChargerStatus.PAUSED,
+    179: ChargerStatus.SCHEDULED,
+    180: ChargerStatus.WAITING_FOR_CAR,
+    181: ChargerStatus.WAITING_FOR_CAR,
+    182: ChargerStatus.PAUSED,
+    183: ChargerStatus.WAITING_IN_QUEUE_POWER_SHARING,
+    184: ChargerStatus.WAITING_IN_QUEUE_POWER_SHARING,
+    185: ChargerStatus.WAITING_IN_QUEUE_POWER_BOOST,
+    186: ChargerStatus.WAITING_IN_QUEUE_POWER_BOOST,
+    187: ChargerStatus.WAITING_MID_FAILED,
+    188: ChargerStatus.WAITING_MID_SAFETY,
+    189: ChargerStatus.WAITING_IN_QUEUE_ECO_SMART,
+    193: ChargerStatus.CHARGING,
+    194: ChargerStatus.CHARGING,
+    195: ChargerStatus.CHARGING,
+    196: ChargerStatus.DISCHARGING,
+    209: ChargerStatus.LOCKED,
+    210: ChargerStatus.LOCKED_CAR_CONNECTED,
+}
 
 
 class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):


### PR DESCRIPTION
## Proposed change
Address late review comment https://github.com/home-assistant/core/pull/101577#discussion_r1349790219: Move `CARGER_STATUS` to the coordinator module, as it is only used their.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
