### PR TITLE
Increase timeouts in Minecraft Server

### DIFF
--- a/homeassistant/components/minecraft_server/__init__.py
+++ b/homeassistant/components/minecraft_server/__init__.py
@@ -39,7 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
     except MinecraftServerAddressError as error:
         raise ConfigEntryError(
-            f"Server address in configuration entry is invalid ({repr(error)}: {error})"
+            f"Server address in configuration entry is invalid: {error}"
         ) from error
 
     # Create coordinator instance.
@@ -109,8 +109,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         except MinecraftServerAddressError as error:
             host_only_lookup_success = False
             _LOGGER.debug(
-                "Hostname (without port) cannot be parsed (%s: %s), trying again with port",
-                repr(error),
+                "Hostname (without port) cannot be parsed, trying again with port: %s",
                 error,
             )
 
@@ -120,8 +119,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                 MinecraftServer(MinecraftServerType.JAVA_EDITION, address)
             except MinecraftServerAddressError as error:
                 _LOGGER.exception(
-                    "Can't migrate configuration entry due to error while parsing server address (%s: %s), try again later",
-                    repr(error),
+                    "Can't migrate configuration entry due to error while parsing server address, try again later: %s",
                     error,
                 )
                 return False

--- a/homeassistant/components/minecraft_server/__init__.py
+++ b/homeassistant/components/minecraft_server/__init__.py
@@ -39,7 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
     except MinecraftServerAddressError as error:
         raise ConfigEntryError(
-            f"Server address in configuration entry is invalid (error: {error})"
+            f"Server address in configuration entry is invalid ({repr(error)}: {error})"
         ) from error
 
     # Create coordinator instance.
@@ -109,7 +109,8 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         except MinecraftServerAddressError as error:
             host_only_lookup_success = False
             _LOGGER.debug(
-                "Hostname (without port) cannot be parsed (error: %s), trying again with port",
+                "Hostname (without port) cannot be parsed (%s: %s), trying again with port",
+                repr(error),
                 error,
             )
 
@@ -119,7 +120,8 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                 MinecraftServer(MinecraftServerType.JAVA_EDITION, address)
             except MinecraftServerAddressError as error:
                 _LOGGER.exception(
-                    "Can't migrate configuration entry due to error while parsing server address (error: %s), try again later",
+                    "Can't migrate configuration entry due to error while parsing server address (%s: %s), try again later",
+                    repr(error),
                     error,
                 )
                 return False

--- a/homeassistant/components/minecraft_server/api.py
+++ b/homeassistant/components/minecraft_server/api.py
@@ -12,7 +12,7 @@ from mcstatus.status_response import BedrockStatusResponse, JavaStatusResponse
 _LOGGER = logging.getLogger(__name__)
 
 LOOKUP_TIMEOUT: float = 10
-DATA_UPDATE_TIMEOUT: float = 3.33
+DATA_UPDATE_TIMEOUT: float = 10
 DATA_UPDATE_RETRIES: int = 3
 
 
@@ -66,7 +66,7 @@ class MinecraftServer:
                 self._server = BedrockServer.lookup(address, timeout=LOOKUP_TIMEOUT)
         except (ValueError, LifetimeTimeout) as error:
             raise MinecraftServerAddressError(
-                f"{server_type} server address '{address}' is invalid ({repr(error)}: {error})"
+                f"Lookup of '{address}' failed: {self._get_error_message(error)}"
             ) from error
 
         self._server.timeout = DATA_UPDATE_TIMEOUT
@@ -89,22 +89,12 @@ class MinecraftServer:
         """Get updated data from the server, supporting both Java and Bedrock Edition servers."""
         status_response: BedrockStatusResponse | JavaStatusResponse
 
-        for trial in range(DATA_UPDATE_RETRIES):
-            try:
-                status_response = await self._server.async_status(tries=1)
-                break
-            except OSError as error:
-                _LOGGER.debug(
-                    "Fetching data from '%s' failed, trial %s/%s (%s: %s)",
-                    self._address,
-                    (trial + 1),
-                    DATA_UPDATE_RETRIES,
-                    repr(error),
-                    error,
-                )
-
-        if trial >= (DATA_UPDATE_RETRIES - 1):
-            raise MinecraftServerConnectionError("Fetching data from the server failed")
+        try:
+            status_response = await self._server.async_status(tries=DATA_UPDATE_RETRIES)
+        except OSError as error:
+            raise MinecraftServerConnectionError(
+                f"Status request to '{self._address}' failed: {self._get_error_message(error)}"
+            ) from error
 
         if isinstance(status_response, JavaStatusResponse):
             data = self._extract_java_data(status_response)
@@ -149,3 +139,11 @@ class MinecraftServer:
             game_mode=status_response.gamemode,
             map_name=status_response.map_name,
         )
+
+    def _get_error_message(self, error: BaseException) -> str:
+        """Get error message of an exception."""
+        if not str(error):
+            # Fallback to error type in case of an empty error message.
+            return repr(error)
+
+        return str(error)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Increase the reliability of initialization and cyclic data updates to fix sensors becoming occasionally unavailable:
- The `mcstatus` APIs `lookup` and `status` have a default timeout of 3 seconds. It can be overriden by passing an argument to the `lookup` API. This timeout is then re-used for the `status` API. This PR increases the timeout of the `lookup` and `status` API from 3 to 10 seconds.

Improve log messages:
- Print the type of the exception, in case `error` message is empty. 
- Remove duplicate log messages (e.g. error message in `api` and `coordinator` were very similar)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #90485
- This PR is related to issue: n.a.
- Link to documentation pull request: n.a.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
