### PR TITLE
Add all units of measurement for selector in scrape

### DIFF
--- a/homeassistant/components/scrape/config_flow.py
+++ b/homeassistant/components/scrape/config_flow.py
@@ -128,7 +128,6 @@ SENSOR_SETUP = {
             custom_value=True,
             mode=SelectSelectorMode.DROPDOWN,
             translation_key="unit_of_measurement",
-            sort=True,
         )
     ),
 }

--- a/homeassistant/components/scrape/config_flow.py
+++ b/homeassistant/components/scrape/config_flow.py
@@ -12,7 +12,6 @@ from homeassistant.components.rest.data import DEFAULT_TIMEOUT
 from homeassistant.components.rest.schema import DEFAULT_METHOD, METHODS
 from homeassistant.components.sensor import (
     CONF_STATE_CLASS,
-    DEVICE_CLASS_UNITS as SENSOR_DEVICE_CLASS_UNITS,
     DOMAIN as SENSOR_DOMAIN,
     SensorDeviceClass,
     SensorStateClass,
@@ -35,6 +34,7 @@ from homeassistant.const import (
     CONF_VERIFY_SSL,
     HTTP_BASIC_AUTHENTICATION,
     HTTP_DIGEST_AUTHENTICATION,
+    UNITS_OF_MEASUREMENT,
 )
 from homeassistant.core import async_get_hass
 from homeassistant.helpers import config_validation as cv, entity_registry as er
@@ -124,14 +124,7 @@ SENSOR_SETUP = {
     ),
     vol.Optional(CONF_UNIT_OF_MEASUREMENT): SelectSelector(
         SelectSelectorConfig(
-            options=list(
-                {
-                    str(unit)
-                    for units in SENSOR_DEVICE_CLASS_UNITS.values()
-                    for unit in units
-                    if unit is not None
-                }
-            ),
+            options=list(UNITS_OF_MEASUREMENT),
             custom_value=True,
             mode=SelectSelectorMode.DROPDOWN,
             translation_key="unit_of_measurement",

--- a/homeassistant/components/scrape/config_flow.py
+++ b/homeassistant/components/scrape/config_flow.py
@@ -12,6 +12,7 @@ from homeassistant.components.rest.data import DEFAULT_TIMEOUT
 from homeassistant.components.rest.schema import DEFAULT_METHOD, METHODS
 from homeassistant.components.sensor import (
     CONF_STATE_CLASS,
+    DEVICE_CLASS_UNITS as SENSOR_DEVICE_CLASS_UNITS,
     DOMAIN as SENSOR_DOMAIN,
     SensorDeviceClass,
     SensorStateClass,
@@ -34,7 +35,6 @@ from homeassistant.const import (
     CONF_VERIFY_SSL,
     HTTP_BASIC_AUTHENTICATION,
     HTTP_DIGEST_AUTHENTICATION,
-    UnitOfTemperature,
 )
 from homeassistant.core import async_get_hass
 from homeassistant.helpers import config_validation as cv, entity_registry as er
@@ -124,7 +124,14 @@ SENSOR_SETUP = {
     ),
     vol.Optional(CONF_UNIT_OF_MEASUREMENT): SelectSelector(
         SelectSelectorConfig(
-            options=[cls.value for cls in UnitOfTemperature],
+            options=list(
+                {
+                    str(unit)
+                    for units in SENSOR_DEVICE_CLASS_UNITS.values()
+                    for unit in units
+                    if unit is not None
+                }
+            ),
             custom_value=True,
             mode=SelectSelectorMode.DROPDOWN,
             translation_key="unit_of_measurement",

--- a/homeassistant/components/scrape/config_flow.py
+++ b/homeassistant/components/scrape/config_flow.py
@@ -124,7 +124,7 @@ SENSOR_SETUP = {
     ),
     vol.Optional(CONF_UNIT_OF_MEASUREMENT): SelectSelector(
         SelectSelectorConfig(
-            options=list(UNITS_OF_MEASUREMENT),
+            options=sorted(UNITS_OF_MEASUREMENT),
             custom_value=True,
             mode=SelectSelectorMode.DROPDOWN,
             translation_key="unit_of_measurement",

--- a/homeassistant/components/scrape/strings.json
+++ b/homeassistant/components/scrape/strings.json
@@ -48,7 +48,7 @@
           "value_template": "Defines a template to get the state of the sensor",
           "device_class": "The type/class of the sensor to set the icon in the frontend",
           "state_class": "The state_class of the sensor",
-          "unit_of_measurement": "Choose temperature measurement or create your own"
+          "unit_of_measurement": "Choose a unit of measurement or create your own"
         }
       }
     }
@@ -189,11 +189,6 @@
         "measurement": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::measurement%]",
         "total": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::total%]",
         "total_increasing": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::total_increasing%]"
-      }
-    },
-    "unit_of_measurement": {
-      "options": {
-        "none": "No unit of measurement"
       }
     }
   }

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1051,6 +1051,58 @@ DATA_RATE_GIBIBYTES_PER_SECOND: Final = "GiB/s"
 """Deprecated: please use UnitOfDataRate.GIBIBYTES_PER_SECOND"""
 
 
+UNITS_OF_MEASUREMENT: Final[frozenset[str]] = frozenset(
+    {
+        unit
+        for unit_type in (
+            UnitOfApparentPower,
+            UnitOfPower,
+            UnitOfEnergy,
+            UnitOfElectricCurrent,
+            UnitOfElectricPotential,
+            UnitOfTemperature,
+            UnitOfTime,
+            UnitOfLength,
+            UnitOfFrequency,
+            UnitOfPressure,
+            UnitOfSoundPressure,
+            UnitOfVolume,
+            UnitOfVolumeFlowRate,
+            UnitOfMass,
+            UnitOfIrradiance,
+            UnitOfVolumetricFlux,
+            UnitOfPrecipitationDepth,
+            UnitOfSpeed,
+            UnitOfInformation,
+            UnitOfDataRate,
+        )
+        for unit in unit_type
+    }
+).union(
+    {
+        POWER_VOLT_AMPERE_REACTIVE,
+        DEGREE,
+        CURRENCY_EURO,
+        CURRENCY_DOLLAR,
+        CURRENCY_CENT,
+        AREA_SQUARE_METERS,
+        CONDUCTIVITY,
+        LIGHT_LUX,
+        UV_INDEX,
+        PERCENTAGE,
+        REVOLUTIONS_PER_MINUTE,
+        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+        CONCENTRATION_MICROGRAMS_PER_CUBIC_FOOT,
+        CONCENTRATION_PARTS_PER_CUBIC_METER,
+        CONCENTRATION_PARTS_PER_MILLION,
+        CONCENTRATION_PARTS_PER_BILLION,
+        SIGNAL_STRENGTH_DECIBELS,
+        SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    }
+)
+
+
 # States
 COMPRESSED_STATE_STATE = "s"
 COMPRESSED_STATE_ATTRIBUTES = "a"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Show all unit of measurement instead of only the one from temperature 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
