### PR TITLE
Dynamic wake word loading for Wyoming

### DIFF
--- a/homeassistant/components/wake_word/__init__.py
+++ b/homeassistant/components/wake_word/__init__.py
@@ -86,9 +86,8 @@ class WakeWordDetectionEntity(RestoreEntity):
         """Return the state of the entity."""
         return self.__last_detected
 
-    @property
     @abstractmethod
-    def supported_wake_words(self) -> list[WakeWord]:
+    async def get_supported_wake_words(self) -> list[WakeWord]:
         """Return a list of supported wake words."""
 
     @abstractmethod
@@ -133,8 +132,9 @@ class WakeWordDetectionEntity(RestoreEntity):
         vol.Required("entity_id"): cv.entity_domain(DOMAIN),
     }
 )
+@websocket_api.async_response
 @callback
-def websocket_entity_info(
+async def websocket_entity_info(
     hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict
 ) -> None:
     """Get info about wake word entity."""
@@ -149,5 +149,5 @@ def websocket_entity_info(
 
     connection.send_result(
         msg["id"],
-        {"wake_words": entity.supported_wake_words},
+        {"wake_words": (await entity.get_supported_wake_words())},
     )

--- a/tests/components/assist_pipeline/conftest.py
+++ b/tests/components/assist_pipeline/conftest.py
@@ -181,8 +181,7 @@ class MockWakeWordEntity(wake_word.WakeWordDetectionEntity):
     url_path = "wake_word.test"
     _attr_name = "test"
 
-    @property
-    def supported_wake_words(self) -> list[wake_word.WakeWord]:
+    async def get_supported_wake_words(self) -> list[wake_word.WakeWord]:
         """Return a list of supported wake words."""
         return [wake_word.WakeWord(id="test_ww", name="Test Wake Word")]
 
@@ -191,7 +190,7 @@ class MockWakeWordEntity(wake_word.WakeWordDetectionEntity):
     ) -> wake_word.DetectionResult | None:
         """Try to detect wake word(s) in an audio stream with timestamps."""
         if wake_word_id is None:
-            wake_word_id = self.supported_wake_words[0].id
+            wake_word_id = (await self.get_supported_wake_words())[0].id
         async for chunk, timestamp in stream:
             if chunk.startswith(b"wake word"):
                 return wake_word.DetectionResult(

--- a/tests/components/wake_word/test_init.py
+++ b/tests/components/wake_word/test_init.py
@@ -1,6 +1,9 @@
 """Test wake_word component setup."""
+import asyncio
 from collections.abc import AsyncIterable, Generator
+from functools import partial
 from pathlib import Path
+from unittest.mock import patch
 
 from freezegun import freeze_time
 import pytest
@@ -293,7 +296,7 @@ async def test_list_wake_words_unknown_entity(
     setup: MockProviderEntity,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
-    """Test that the list_wake_words websocket command works."""
+    """Test that the list_wake_words websocket command handles unknown entity."""
     client = await hass_ws_client(hass)
     await client.send_json(
         {
@@ -307,3 +310,28 @@ async def test_list_wake_words_unknown_entity(
 
     assert not msg["success"]
     assert msg["error"] == {"code": "not_found", "message": "Entity not found"}
+
+
+async def test_list_wake_words_timeout(
+    hass: HomeAssistant,
+    setup: MockProviderEntity,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test that the list_wake_words websocket command handles unknown entity."""
+    client = await hass_ws_client(hass)
+
+    with patch.object(
+        setup, "get_supported_wake_words", partial(asyncio.sleep, 1)
+    ), patch("homeassistant.components.wake_word.TIMEOUT_FETCH_WAKE_WORDS", 0):
+        await client.send_json(
+            {
+                "id": 5,
+                "type": "wake_word/info",
+                "entity_id": setup.entity_id,
+            }
+        )
+
+        msg = await client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"] == {"code": "timeout", "message": "Timeout fetching wake words"}

--- a/tests/components/wake_word/test_init.py
+++ b/tests/components/wake_word/test_init.py
@@ -37,8 +37,7 @@ class MockProviderEntity(wake_word.WakeWordDetectionEntity):
     url_path = "wake_word.test"
     _attr_name = "test"
 
-    @property
-    def supported_wake_words(self) -> list[wake_word.WakeWord]:
+    async def get_supported_wake_words(self) -> list[wake_word.WakeWord]:
         """Return a list of supported wake words."""
         return [
             wake_word.WakeWord(id="test_ww", name="Test Wake Word"),
@@ -50,7 +49,7 @@ class MockProviderEntity(wake_word.WakeWordDetectionEntity):
     ) -> wake_word.DetectionResult | None:
         """Try to detect wake word(s) in an audio stream with timestamps."""
         if wake_word_id is None:
-            wake_word_id = self.supported_wake_words[0].id
+            wake_word_id = (await self.get_supported_wake_words())[0].id
 
         async for _chunk, timestamp in stream:
             if timestamp >= 2000:

--- a/tests/components/wyoming/test_wake_word.py
+++ b/tests/components/wyoming/test_wake_word.py
@@ -6,12 +6,13 @@ from unittest.mock import patch
 
 from syrupy.assertion import SnapshotAssertion
 from wyoming.asr import Transcript
+from wyoming.info import Info, WakeModel, WakeProgram
 from wyoming.wake import Detection
 
 from homeassistant.components import wake_word
 from homeassistant.core import HomeAssistant
 
-from . import MockAsyncTcpClient
+from . import TEST_ATTR, MockAsyncTcpClient
 
 
 async def test_support(hass: HomeAssistant, init_wyoming_wake_word) -> None:
@@ -157,3 +158,55 @@ async def test_detect_message_with_wrong_wake_word(
         result = await entity.async_process_audio_stream(audio_stream(), "my-wake-word")
 
     assert result is None
+
+
+async def test_dynamic_wake_word_info(
+    hass: HomeAssistant, init_wyoming_wake_word
+) -> None:
+    """Test that supported wake words are loaded dynamically."""
+    entity = wake_word.async_get_wake_word_detection_entity(
+        hass, "wake_word.test_wake_word"
+    )
+    assert entity is not None
+
+    # Original info
+    assert (await entity.get_supported_wake_words()) == [
+        wake_word.WakeWord("Test Model", "Test Model")
+    ]
+
+    new_info = Info(
+        wake=[
+            WakeProgram(
+                name="dynamic",
+                description="Dynamic Wake Word",
+                installed=True,
+                attribution=TEST_ATTR,
+                models=[
+                    WakeModel(
+                        name="ww1",
+                        description="Wake Word 1",
+                        installed=True,
+                        attribution=TEST_ATTR,
+                        languages=[],
+                    ),
+                    WakeModel(
+                        name="ww2",
+                        description="Wake Word 2",
+                        installed=True,
+                        attribution=TEST_ATTR,
+                        languages=[],
+                    ),
+                ],
+            )
+        ]
+    )
+
+    # Different Wyoming info will be fetched
+    with patch(
+        "homeassistant.components.wyoming.wake_word.load_wyoming_info",
+        return_value=new_info,
+    ):
+        assert (await entity.get_supported_wake_words()) == [
+            wake_word.WakeWord("ww1", "Wake Word 1"),
+            wake_word.WakeWord("ww2", "Wake Word 2"),
+        ]

--- a/tests/components/wyoming/test_wake_word.py
+++ b/tests/components/wyoming/test_wake_word.py
@@ -24,7 +24,7 @@ async def test_support(hass: HomeAssistant, init_wyoming_wake_word) -> None:
     )
     assert entity is not None
 
-    assert entity.supported_wake_words == [
+    assert (await entity.get_supported_wake_words()) == [
         wake_word.WakeWord(id="Test Model", name="Test Model")
     ]
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The list of available wake words is now loaded from the Wyoming client dynamically. This allows for dropping in a new wake word model into the openWakeWord add-on and have it appear immediately in the Voice Assistant dialog (without reloading the Wyoming integration).

For this to work, the `supported_wake_words` property of `WakeWordDetectionEntity` has been changed to an async method named `get_supported_wake_words`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
