### PR TITLE
Fix error handling on subscribe when mqtt is not initialized

### DIFF
--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -176,7 +176,13 @@ async def async_subscribe(
         raise HomeAssistantError(
             f"Cannot subscribe to topic '{topic}', MQTT is not enabled"
         )
-    mqtt_data = get_mqtt_data(hass)
+    try:
+        mqtt_data = get_mqtt_data(hass)
+    except KeyError as ex:
+        raise HomeAssistantError(
+            f"Cannot subscribe to topic '{topic}', "
+            "make sure MQTT is set up correctly"
+        ) from ex
     async_remove = await mqtt_data.client.async_subscribe(
         topic,
         catch_log_exception(

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -959,6 +959,17 @@ async def test_subscribe_topic(
         unsub()
 
 
+async def test_subscribe_topic_not_initialize(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+) -> None:
+    """Test the subscription of a topic when MQTT was not initialized."""
+    with pytest.raises(
+        HomeAssistantError, match=r".*make sure MQTT is set up correctly"
+    ):
+        await mqtt.async_subscribe(hass, "test-topic", record_calls)
+
+
 @patch("homeassistant.components.mqtt.client.INITIAL_SUBSCRIBE_COOLDOWN", 0.0)
 @patch("homeassistant.components.mqtt.client.UNSUBSCRIBE_COOLDOWN", 0.2)
 async def test_subscribe_and_resubscribe(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When an automation trigger is set up, and it tries to subscribe an MQTT topic, while MQTT was not inialized correctly (e.g. becase of a yaml configuration failure), mqtt will throw an unhandled KeyError exception like:

```
2023-10-11 15:41:37.812 DEBUG (MainThread) [homeassistant.components.mqtt.trigger] Attaching MQTT trigger for topic: 'test/trigger', payload: 'now'
2023-10-11 15:41:37.848 INFO (MainThread) [homeassistant.components.automation.test_trigger] Initialized trigger Test trigger
2023-10-11 15:41:37.850 ERROR (MainThread) [homeassistant.components.automation.test_mqtt_trigger] Error setting up trigger test_mqtt_trigger
Traceback (most recent call last):
  File "/workspaces/core/homeassistant/components/mqtt/trigger.py", line 101, in async_attach_trigger
    remove = await mqtt.async_subscribe(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/mqtt/client.py", line 179, in async_subscribe
    mqtt_data = get_mqtt_data(hass)
                ^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/mqtt/util.py", line 180, in get_mqtt_data
    mqtt_data = hass.data[DATA_MQTT]
                ~~~~~~~~~^^^^^^^^^^^
KeyError: 'mqtt'
2023-10-11 15:41:37.856 INFO (MainThread) [homeassistant.components.automation.test_98664] Initialized trigger Test #98664
```

This PR makes sure this type of error is handled correctly, so we get something like:

```
2023-10-11 15:39:08.530 ERROR (MainThread) [homeassistant.components.automation.test_mqtt_trigger] Got error 'Unable to subscribe MQTT topic test/trigger. Makes sure the MQTT integration is set up correctly' when setting up triggers for test_mqtt_trigger
```

`get_mqtt_data` is used to expose an internal dataclass, to ensure typing, and it is set when `mqtt` is initialized the first time.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
