### PR TITLE
No cooldown when wake words have the same id

### DIFF
--- a/homeassistant/components/assist_pipeline/__init__.py
+++ b/homeassistant/components/assist_pipeline/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.components import stt
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_DEBUG_RECORDING_DIR, DATA_CONFIG, DOMAIN
+from .const import CONF_DEBUG_RECORDING_DIR, DATA_CONFIG, DATA_LAST_WAKE_UP, DOMAIN
 from .error import PipelineNotFound
 from .pipeline import (
     AudioSettings,
@@ -57,6 +57,9 @@ CONFIG_SCHEMA = vol.Schema(
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Assist pipeline integration."""
     hass.data[DATA_CONFIG] = config.get(DOMAIN, {})
+
+    # wake_word_id -> timestamp of last detection (monotonic_ns)
+    hass.data[DATA_LAST_WAKE_UP] = {}
 
     await async_setup_pipeline_store(hass)
     async_register_websocket_api(hass)

--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -681,7 +681,7 @@ class PipelineRun:
             wake_word_output: dict[str, Any] = {}
         else:
             # Avoid duplicate detections by checking cooldown
-            last_wake_up = self.hass.data.get(DATA_LAST_WAKE_UP)
+            last_wake_up = self.hass.data[DATA_LAST_WAKE_UP].get(result.wake_word_id)
             if last_wake_up is not None:
                 sec_since_last_wake_up = time.monotonic() - last_wake_up
                 if sec_since_last_wake_up < wake_word_settings.cooldown_seconds:
@@ -689,7 +689,7 @@ class PipelineRun:
                     raise WakeWordDetectionAborted
 
             # Record last wake up time to block duplicate detections
-            self.hass.data[DATA_LAST_WAKE_UP] = time.monotonic()
+            self.hass.data[DATA_LAST_WAKE_UP][result.wake_word_id] = time.monotonic()
 
             if result.queued_audio:
                 # Add audio that was pending at detection.

--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -681,7 +681,8 @@ class PipelineRun:
             wake_word_output: dict[str, Any] = {}
         else:
             # Avoid duplicate detections by checking cooldown
-            last_wake_up = self.hass.data[DATA_LAST_WAKE_UP].get(result.wake_word_id)
+            wake_up_key = f"{self.wake_word_entity_id}.{result.wake_word_id}"
+            last_wake_up = self.hass.data[DATA_LAST_WAKE_UP].get(wake_up_key)
             if last_wake_up is not None:
                 sec_since_last_wake_up = time.monotonic() - last_wake_up
                 if sec_since_last_wake_up < wake_word_settings.cooldown_seconds:
@@ -689,7 +690,7 @@ class PipelineRun:
                     raise WakeWordDetectionAborted
 
             # Record last wake up time to block duplicate detections
-            self.hass.data[DATA_LAST_WAKE_UP][result.wake_word_id] = time.monotonic()
+            self.hass.data[DATA_LAST_WAKE_UP][wake_up_key] = time.monotonic()
 
             if result.queued_audio:
                 # Add audio that was pending at detection.

--- a/tests/components/assist_pipeline/conftest.py
+++ b/tests/components/assist_pipeline/conftest.py
@@ -181,20 +181,34 @@ class MockWakeWordEntity(wake_word.WakeWordDetectionEntity):
     url_path = "wake_word.test"
     _attr_name = "test"
 
+    alternate_detections = False
+    detected_wake_word_index = 0
+
     async def get_supported_wake_words(self) -> list[wake_word.WakeWord]:
         """Return a list of supported wake words."""
-        return [wake_word.WakeWord(id="test_ww", name="Test Wake Word")]
+        return [
+            wake_word.WakeWord(id="test_ww", name="Test Wake Word"),
+            wake_word.WakeWord(id="test_ww_2", name="Test Wake Word 2"),
+        ]
 
     async def _async_process_audio_stream(
         self, stream: AsyncIterable[tuple[bytes, int]], wake_word_id: str | None
     ) -> wake_word.DetectionResult | None:
         """Try to detect wake word(s) in an audio stream with timestamps."""
-        if wake_word_id is None:
-            wake_word_id = (await self.get_supported_wake_words())[0].id
+        wake_words = await self.get_supported_wake_words()
+
+        if self.alternate_detections:
+            detected_id = wake_words[self.detected_wake_word_index].id
+            self.detected_wake_word_index = (self.detected_wake_word_index + 1) % len(
+                wake_words
+            )
+        else:
+            detected_id = wake_words[0].id
+
         async for chunk, timestamp in stream:
             if chunk.startswith(b"wake word"):
                 return wake_word.DetectionResult(
-                    wake_word_id=wake_word_id,
+                    wake_word_id=detected_id,
                     timestamp=timestamp,
                     queued_audio=[(b"queued audio", 0)],
                 )

--- a/tests/components/assist_pipeline/snapshots/test_websocket.ambr
+++ b/tests/components/assist_pipeline/snapshots/test_websocket.ambr
@@ -717,3 +717,111 @@
     'message': '',
   })
 # ---
+# name: test_wake_word_cooldown_different_ids
+  dict({
+    'language': 'en',
+    'pipeline': <ANY>,
+    'runner_data': dict({
+      'stt_binary_handler_id': 1,
+      'timeout': 300,
+    }),
+  })
+# ---
+# name: test_wake_word_cooldown_different_ids.1
+  dict({
+    'language': 'en',
+    'pipeline': <ANY>,
+    'runner_data': dict({
+      'stt_binary_handler_id': 1,
+      'timeout': 300,
+    }),
+  })
+# ---
+# name: test_wake_word_cooldown_different_ids.2
+  dict({
+    'entity_id': 'wake_word.test',
+    'metadata': dict({
+      'bit_rate': 16,
+      'channel': 1,
+      'codec': 'pcm',
+      'format': 'wav',
+      'sample_rate': 16000,
+    }),
+    'timeout': 3,
+  })
+# ---
+# name: test_wake_word_cooldown_different_ids.3
+  dict({
+    'entity_id': 'wake_word.test',
+    'metadata': dict({
+      'bit_rate': 16,
+      'channel': 1,
+      'codec': 'pcm',
+      'format': 'wav',
+      'sample_rate': 16000,
+    }),
+    'timeout': 3,
+  })
+# ---
+# name: test_wake_word_cooldown_different_ids.4
+  dict({
+    'wake_word_output': dict({
+      'timestamp': 0,
+      'wake_word_id': 'test_ww',
+    }),
+  })
+# ---
+# name: test_wake_word_cooldown_different_ids.5
+  dict({
+    'wake_word_output': dict({
+      'timestamp': 0,
+      'wake_word_id': 'test_ww_2',
+    }),
+  })
+# ---
+# name: test_wake_word_cooldown_same_id
+  dict({
+    'language': 'en',
+    'pipeline': <ANY>,
+    'runner_data': dict({
+      'stt_binary_handler_id': 1,
+      'timeout': 300,
+    }),
+  })
+# ---
+# name: test_wake_word_cooldown_same_id.1
+  dict({
+    'language': 'en',
+    'pipeline': <ANY>,
+    'runner_data': dict({
+      'stt_binary_handler_id': 1,
+      'timeout': 300,
+    }),
+  })
+# ---
+# name: test_wake_word_cooldown_same_id.2
+  dict({
+    'entity_id': 'wake_word.test',
+    'metadata': dict({
+      'bit_rate': 16,
+      'channel': 1,
+      'codec': 'pcm',
+      'format': 'wav',
+      'sample_rate': 16000,
+    }),
+    'timeout': 3,
+  })
+# ---
+# name: test_wake_word_cooldown_same_id.3
+  dict({
+    'entity_id': 'wake_word.test',
+    'metadata': dict({
+      'bit_rate': 16,
+      'channel': 1,
+      'codec': 'pcm',
+      'format': 'wav',
+      'sample_rate': 16000,
+    }),
+    'timeout': 3,
+  })
+# ---

--- a/tests/components/assist_pipeline/snapshots/test_websocket.ambr
+++ b/tests/components/assist_pipeline/snapshots/test_websocket.ambr
@@ -717,6 +717,68 @@
     'message': '',
   })
 # ---
+# name: test_wake_word_cooldown_different_entities
+  dict({
+    'language': 'en',
+    'pipeline': <ANY>,
+    'runner_data': dict({
+      'stt_binary_handler_id': 1,
+      'timeout': 300,
+    }),
+  })
+# ---
+# name: test_wake_word_cooldown_different_entities.1
+  dict({
+    'language': 'en',
+    'pipeline': <ANY>,
+    'runner_data': dict({
+      'stt_binary_handler_id': 1,
+      'timeout': 300,
+    }),
+  })
+# ---
+# name: test_wake_word_cooldown_different_entities.2
+  dict({
+    'entity_id': 'wake_word.test',
+    'metadata': dict({
+      'bit_rate': 16,
+      'channel': 1,
+      'codec': 'pcm',
+      'format': 'wav',
+      'sample_rate': 16000,
+    }),
+    'timeout': 3,
+  })
+# ---
+# name: test_wake_word_cooldown_different_entities.3
+  dict({
+    'entity_id': 'wake_word.test2',
+    'metadata': dict({
+      'bit_rate': 16,
+      'channel': 1,
+      'codec': 'pcm',
+      'format': 'wav',
+      'sample_rate': 16000,
+    }),
+    'timeout': 3,
+  })
+# ---
+# name: test_wake_word_cooldown_different_entities.4
+  dict({
+    'wake_word_output': dict({
+      'timestamp': 0,
+      'wake_word_id': 'test_ww',
+    }),
+  })
+# ---
+# name: test_wake_word_cooldown_different_entities.5
+  dict({
+    'wake_word_output': dict({
+      'timestamp': 0,
+      'wake_word_id': 'test_ww',
+    }),
+  })
+# ---
 # name: test_wake_word_cooldown_different_ids
   dict({
     'language': 'en',

--- a/tests/components/assist_pipeline/test_websocket.py
+++ b/tests/components/assist_pipeline/test_websocket.py
@@ -1809,14 +1809,14 @@ async def test_audio_pipeline_with_enhancements(
     assert msg["result"] == {"events": events}
 
 
-async def test_wake_word_cooldown(
+async def test_wake_word_cooldown_same_id(
     hass: HomeAssistant,
     init_components,
     mock_wake_word_provider_entity: MockWakeWordEntity,
     hass_ws_client: WebSocketGenerator,
     snapshot: SnapshotAssertion,
 ) -> None:
-    """Test that duplicate wake word detections are blocked during the cooldown period."""
+    """Test that duplicate wake word detections with the same id are blocked during the cooldown period."""
     client_1 = await hass_ws_client(hass)
     client_2 = await hass_ws_client(hass)
 
@@ -1888,3 +1888,87 @@ async def test_wake_word_cooldown(
 
     # One should be a wake up, one should be an error
     assert {event_type_1, event_type_2} == {"wake_word-end", "error"}
+
+
+async def test_wake_word_cooldown_different_ids(
+    hass: HomeAssistant,
+    init_components,
+    mock_wake_word_provider_entity: MockWakeWordEntity,
+    hass_ws_client: WebSocketGenerator,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test that duplicate wake word detections are allowed with different ids."""
+    with patch.object(mock_wake_word_provider_entity, "alternate_detections", True):
+        client_1 = await hass_ws_client(hass)
+        client_2 = await hass_ws_client(hass)
+
+        await client_1.send_json_auto_id(
+            {
+                "type": "assist_pipeline/run",
+                "start_stage": "wake_word",
+                "end_stage": "tts",
+                "input": {
+                    "sample_rate": 16000,
+                    "no_vad": True,
+                    "no_chunking": True,
+                },
+            }
+        )
+
+        await client_2.send_json_auto_id(
+            {
+                "type": "assist_pipeline/run",
+                "start_stage": "wake_word",
+                "end_stage": "tts",
+                "input": {
+                    "sample_rate": 16000,
+                    "no_vad": True,
+                    "no_chunking": True,
+                },
+            }
+        )
+
+        # result
+        msg = await client_1.receive_json()
+        assert msg["success"], msg
+
+        msg = await client_2.receive_json()
+        assert msg["success"], msg
+
+        # run start
+        msg = await client_1.receive_json()
+        assert msg["event"]["type"] == "run-start"
+        msg["event"]["data"]["pipeline"] = ANY
+        handler_id_1 = msg["event"]["data"]["runner_data"]["stt_binary_handler_id"]
+        assert msg["event"]["data"] == snapshot
+
+        msg = await client_2.receive_json()
+        assert msg["event"]["type"] == "run-start"
+        msg["event"]["data"]["pipeline"] = ANY
+        handler_id_2 = msg["event"]["data"]["runner_data"]["stt_binary_handler_id"]
+        assert msg["event"]["data"] == snapshot
+
+        # wake_word
+        msg = await client_1.receive_json()
+        assert msg["event"]["type"] == "wake_word-start"
+        assert msg["event"]["data"] == snapshot
+
+        msg = await client_2.receive_json()
+        assert msg["event"]["type"] == "wake_word-start"
+        assert msg["event"]["data"] == snapshot
+
+        # Wake both up at the same time, but they will have different wake word ids
+        await client_1.send_bytes(bytes([handler_id_1]) + b"wake word")
+        await client_2.send_bytes(bytes([handler_id_2]) + b"wake word")
+
+        # Get response events
+        msg = await client_1.receive_json()
+        event_type_1 = msg["event"]["type"]
+        assert msg["event"]["data"] == snapshot
+
+        msg = await client_2.receive_json()
+        event_type_2 = msg["event"]["type"]
+        assert msg["event"]["data"] == snapshot
+
+        # Both should wake up now
+        assert {event_type_1, event_type_2} == {"wake_word-end"}

--- a/tests/components/assist_pipeline/test_websocket.py
+++ b/tests/components/assist_pipeline/test_websocket.py
@@ -9,7 +9,7 @@ from homeassistant.components.assist_pipeline.pipeline import Pipeline, Pipeline
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
-from .conftest import MockWakeWordEntity
+from .conftest import MockWakeWordEntity, MockWakeWordEntity2
 
 from tests.typing import WebSocketGenerator
 
@@ -1972,3 +1972,135 @@ async def test_wake_word_cooldown_different_ids(
 
         # Both should wake up now
         assert {event_type_1, event_type_2} == {"wake_word-end"}
+
+
+async def test_wake_word_cooldown_different_entities(
+    hass: HomeAssistant,
+    init_components,
+    mock_wake_word_provider_entity: MockWakeWordEntity,
+    mock_wake_word_provider_entity2: MockWakeWordEntity2,
+    hass_ws_client: WebSocketGenerator,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test that duplicate wake word detections are allowed with different entities."""
+    client_pipeline = await hass_ws_client(hass)
+    await client_pipeline.send_json_auto_id(
+        {
+            "type": "assist_pipeline/pipeline/create",
+            "conversation_engine": "homeassistant",
+            "conversation_language": "en-US",
+            "language": "en",
+            "name": "pipeline_with_wake_word_1",
+            "stt_engine": "test",
+            "stt_language": "en-US",
+            "tts_engine": "test",
+            "tts_language": "en-US",
+            "tts_voice": "Arnold Schwarzenegger",
+            "wake_word_entity": mock_wake_word_provider_entity.entity_id,
+            "wake_word_id": "test_ww",
+        }
+    )
+    msg = await client_pipeline.receive_json()
+    assert msg["success"]
+    pipeline_id_1 = msg["result"]["id"]
+
+    await client_pipeline.send_json_auto_id(
+        {
+            "type": "assist_pipeline/pipeline/create",
+            "conversation_engine": "homeassistant",
+            "conversation_language": "en-US",
+            "language": "en",
+            "name": "pipeline_with_wake_word_2",
+            "stt_engine": "test",
+            "stt_language": "en-US",
+            "tts_engine": "test",
+            "tts_language": "en-US",
+            "tts_voice": "Arnold Schwarzenegger",
+            "wake_word_entity": mock_wake_word_provider_entity2.entity_id,
+            "wake_word_id": "test_ww",
+        }
+    )
+    msg = await client_pipeline.receive_json()
+    assert msg["success"]
+    pipeline_id_2 = msg["result"]["id"]
+
+    # Wake word clients
+    client_1 = await hass_ws_client(hass)
+    client_2 = await hass_ws_client(hass)
+
+    await client_1.send_json_auto_id(
+        {
+            "type": "assist_pipeline/run",
+            "pipeline": pipeline_id_1,
+            "start_stage": "wake_word",
+            "end_stage": "tts",
+            "input": {
+                "sample_rate": 16000,
+                "no_vad": True,
+                "no_chunking": True,
+            },
+        }
+    )
+
+    # Use different wake word entity
+    await client_2.send_json_auto_id(
+        {
+            "type": "assist_pipeline/run",
+            "pipeline": pipeline_id_2,
+            "start_stage": "wake_word",
+            "end_stage": "tts",
+            "input": {
+                "sample_rate": 16000,
+                "no_vad": True,
+                "no_chunking": True,
+            },
+        }
+    )
+
+    # result
+    msg = await client_1.receive_json()
+    assert msg["success"], msg
+
+    msg = await client_2.receive_json()
+    assert msg["success"], msg
+
+    # run start
+    msg = await client_1.receive_json()
+    assert msg["event"]["type"] == "run-start"
+    msg["event"]["data"]["pipeline"] = ANY
+    handler_id_1 = msg["event"]["data"]["runner_data"]["stt_binary_handler_id"]
+    assert msg["event"]["data"] == snapshot
+
+    msg = await client_2.receive_json()
+    assert msg["event"]["type"] == "run-start"
+    msg["event"]["data"]["pipeline"] = ANY
+    handler_id_2 = msg["event"]["data"]["runner_data"]["stt_binary_handler_id"]
+    assert msg["event"]["data"] == snapshot
+
+    # wake_word
+    msg = await client_1.receive_json()
+    assert msg["event"]["type"] == "wake_word-start"
+    assert msg["event"]["data"] == snapshot
+
+    msg = await client_2.receive_json()
+    assert msg["event"]["type"] == "wake_word-start"
+    assert msg["event"]["data"] == snapshot
+
+    # Wake both up at the same time.
+    # They will have the same wake word id, but different entities.
+    await client_1.send_bytes(bytes([handler_id_1]) + b"wake word")
+    await client_2.send_bytes(bytes([handler_id_2]) + b"wake word")
+
+    # Get response events
+    msg = await client_1.receive_json()
+    assert msg["event"]["type"] == "wake_word-end", msg
+    ww_id_1 = msg["event"]["data"]["wake_word_output"]["wake_word_id"]
+    assert msg["event"]["data"] == snapshot
+
+    msg = await client_2.receive_json()
+    assert msg["event"]["type"] == "wake_word-end", msg
+    ww_id_2 = msg["event"]["data"]["wake_word_output"]["wake_word_id"]
+    assert msg["event"]["data"] == snapshot
+
+    # Wake words should be the same
+    assert ww_id_1 == ww_id_2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Don't impose a "cooldown" (debouncing) when wake words have the same id unless they are from different wake word entities/providers.

This allows pipelines with different wake words or different wake word entities/providers to be activated at the same time.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
