### PR TITLE
Support for enocean central command switching (e.g. used for Eltako F…

### DIFF
--- a/homeassistant/components/enocean/light.py
+++ b/homeassistant/components/enocean/light.py
@@ -84,6 +84,9 @@ class EnOceanLight(EnOceanEntity, LightEntity):
         self._attr_unique_id = str(combine_hex(dev_id))
         self._attr_name = dev_name
         self._command_type = command_type
+        if command_type == CentralCommandType.SWITCHING:
+            self._attr_color_mode = ColorMode.ONOFF
+            self._attr_supported_color_modes = {ColorMode.ONOFF}
 
     def __dimming_command_on(self, kwargs: Any) -> list[int]:
         if (brightness := kwargs.get(ATTR_BRIGHTNESS)) is not None:

--- a/homeassistant/components/enocean/light.py
+++ b/homeassistant/components/enocean/light.py
@@ -1,6 +1,7 @@
 """Support for EnOcean light sources."""
 from __future__ import annotations
 
+from enum import Enum
 import math
 from typing import Any
 
@@ -21,7 +22,17 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .device import EnOceanEntity
 
+
+class CentralCommandType(Enum):
+    """Class to represent different central command types."""
+
+    SWITCHING = 1
+    DIMMING = 2
+
+
 CONF_SENDER_ID = "sender_id"
+
+CONF_COMMAND_TYPE = "command_type"
 
 DEFAULT_NAME = "EnOcean Light"
 
@@ -30,6 +41,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_ID, default=[]): vol.All(cv.ensure_list, [vol.Coerce(int)]),
         vol.Required(CONF_SENDER_ID): vol.All(cv.ensure_list, [vol.Coerce(int)]),
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(
+            CONF_COMMAND_TYPE, default=CentralCommandType.DIMMING.name
+        ): cv.enum(CentralCommandType),
     }
 )
 
@@ -44,8 +58,9 @@ def setup_platform(
     sender_id: list[int] = config[CONF_SENDER_ID]
     dev_name: str = config[CONF_NAME]
     dev_id: list[int] = config[CONF_ID]
+    command_type: CentralCommandType = config[CONF_COMMAND_TYPE]
 
-    add_entities([EnOceanLight(sender_id, dev_id, dev_name)])
+    add_entities([EnOceanLight(sender_id, dev_id, dev_name, command_type)])
 
 
 class EnOceanLight(EnOceanEntity, LightEntity):
@@ -56,22 +71,45 @@ class EnOceanLight(EnOceanEntity, LightEntity):
     _attr_brightness = 50
     _attr_is_on = False
 
-    def __init__(self, sender_id: list[int], dev_id: list[int], dev_name: str) -> None:
+    def __init__(
+        self,
+        sender_id: list[int],
+        dev_id: list[int],
+        dev_name: str,
+        command_type: CentralCommandType,
+    ) -> None:
         """Initialize the EnOcean light source."""
         super().__init__(dev_id)
         self._sender_id = sender_id
         self._attr_unique_id = str(combine_hex(dev_id))
         self._attr_name = dev_name
+        self._command_type = command_type
 
-    def turn_on(self, **kwargs: Any) -> None:
-        """Turn the light source on or sets a specific dimmer value."""
+    def __dimming_command_on(self, kwargs: Any) -> list[int]:
         if (brightness := kwargs.get(ATTR_BRIGHTNESS)) is not None:
             self._attr_brightness = brightness
 
         bval = math.floor(self._attr_brightness / 256.0 * 100.0)
         if bval == 0:
-            bval = 1
-        command = [0xA5, 0x02, bval, 0x01, 0x09]
+            bval = 128
+        return [0xA5, 0x02, bval, 0x01, 0x09]
+
+    def __switching_command_on(self, kwargs: Any) -> list[int]:
+        return [0xA5, 0x01, 0x00, 0x00, 0x09]
+
+    def __dimming_command_off(self) -> list[int]:
+        return [0xA5, 0x02, 0x00, 0x00, 0x08]
+
+    def __switching_command_off(self) -> list[int]:
+        return [0xA5, 0x01, 0x00, 0x00, 0x08]
+
+    def turn_on(self, **kwargs: Any) -> None:
+        """Turn the light source on or sets a specific dimmer value."""
+        match self._command_type:
+            case CentralCommandType.SWITCHING:
+                command = self.__switching_command_on(kwargs)
+            case CentralCommandType.DIMMING:
+                command = self.__dimming_command_on(kwargs)
         command.extend(self._sender_id)
         command.extend([0x00])
         self.send_command(command, [], 0x01)
@@ -79,7 +117,11 @@ class EnOceanLight(EnOceanEntity, LightEntity):
 
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the light source off."""
-        command = [0xA5, 0x02, 0x00, 0x01, 0x09]
+        match self._command_type:
+            case CentralCommandType.SWITCHING:
+                command = self.__switching_command_off()
+            case CentralCommandType.DIMMING:
+                command = self.__dimming_command_off()
         command.extend(self._sender_id)
         command.extend([0x00])
         self.send_command(command, [], 0x01)
@@ -90,9 +132,16 @@ class EnOceanLight(EnOceanEntity, LightEntity):
 
         Dimmer devices like Eltako FUD61 send telegram in different RORGs.
         We only care about the 4BS (0xA5).
+
+        Light switches like Eltako F4SR14-LED sends only on RORG RPS (0xF6)
         """
         if packet.data[0] == 0xA5 and packet.data[1] == 0x02:
             val = packet.data[2]
+            onoff_val = packet.data[4]
             self._attr_brightness = math.floor(val / 100.0 * 256.0)
-            self._attr_is_on = bool(val != 0)
+            self._attr_is_on = onoff_val == 0x09
+            self.schedule_update_ha_state()
+        elif packet.data[0] == 0xF6:
+            val = packet.data[1]
+            self._attr_is_on = val == 0x70
             self.schedule_update_ha_state()


### PR DESCRIPTION
…14SR-LED)

## Proposed change
Until now the enocean integration only supported lights that were controllable by a central command with the dimming subtype. This change enables lights that are controllable by central command switching. Dimming is still the default, but that can be changed in the entity configuration.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
