### PR TITLE
Avoid conversion of timestamps in jwt auth

### DIFF
--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -5,6 +5,7 @@ import asyncio
 from collections import OrderedDict
 from collections.abc import Mapping
 from datetime import timedelta
+import time
 from typing import Any, cast
 
 import jwt
@@ -12,7 +13,6 @@ import jwt
 from homeassistant import data_entry_flow
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.util import dt as dt_util
 
 from . import auth_store, jwt_wrapper, models
 from .const import ACCESS_TOKEN_EXPIRATION, GROUP_ID_ADMIN
@@ -505,12 +505,13 @@ class AuthManager:
 
         self._store.async_log_refresh_token_usage(refresh_token, remote_ip)
 
-        now = dt_util.utcnow()
+        now = int(time.time())
+        expire_seconds = int(refresh_token.access_token_expiration.total_seconds())
         return jwt.encode(
             {
                 "iss": refresh_token.id,
                 "iat": now,
-                "exp": now + refresh_token.access_token_expiration,
+                "exp": now + expire_seconds,
             },
             refresh_token.jwt_key,
             algorithm="HS256",

--- a/tests/auth/test_init.py
+++ b/tests/auth/test_init.py
@@ -372,6 +372,10 @@ async def test_cannot_retrieve_expired_access_token(hass: HomeAssistant) -> None
     access_token = manager.async_create_access_token(refresh_token)
     assert await manager.async_validate_access_token(access_token) is refresh_token
 
+    # We patch time directly here because we want the access token to be created with
+    # an expired time, but we do not want to freeze time so that jwt will compare it
+    # to the patched time. If we freeze time for the test it will be frozen for jwt
+    # as well and the token will not be expired.
     with patch(
         "homeassistant.auth.time.time",
         return_value=time.time()

--- a/tests/auth/test_init.py
+++ b/tests/auth/test_init.py
@@ -1,5 +1,6 @@
 """Tests for the Home Assistant auth module."""
 from datetime import timedelta
+import time
 from typing import Any
 from unittest.mock import patch
 
@@ -372,10 +373,10 @@ async def test_cannot_retrieve_expired_access_token(hass: HomeAssistant) -> None
     assert await manager.async_validate_access_token(access_token) is refresh_token
 
     with patch(
-        "homeassistant.util.dt.utcnow",
-        return_value=dt_util.utcnow()
-        - auth_const.ACCESS_TOKEN_EXPIRATION
-        - timedelta(seconds=11),
+        "homeassistant.auth.time.time",
+        return_value=time.time()
+        - auth_const.ACCESS_TOKEN_EXPIRATION.total_seconds()
+        - 11,
     ):
         access_token = manager.async_create_access_token(refresh_token)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
iat/exp/nbf can take a unix timestamp or a datetime https://pyjwt.readthedocs.io/en/stable/usage.html#issued-at-claim-iat

If a datetime object is provided it goes though a round-a-bout conversion process in:
https://github.com/jpadilla/pyjwt/blob/72ad55f6d7041ae698dc0790a690804118be50fc/jwt/api_jwt.py#L64

Avoid the conversion by using the same logic we already have in the http auth code:
https://github.com/home-assistant/core/blob/f0317f0d59ef193d826393d5cce50fe610a00010/homeassistant/components/http/auth.py#L65


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
