### PR TITLE
Fix mysensors battery level attribute

### DIFF
--- a/homeassistant/components/mysensors/device.py
+++ b/homeassistant/components/mysensors/device.py
@@ -8,7 +8,7 @@ from typing import Any
 from mysensors import BaseAsyncGateway, Sensor
 from mysensors.sensor import ChildSensor
 
-from homeassistant.const import STATE_OFF, STATE_ON, Platform
+from homeassistant.const import ATTR_BATTERY_LEVEL, STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -212,6 +212,8 @@ class MySensorsChildEntity(MySensorNodeEntity):
 
         attr[ATTR_CHILD_ID] = self.child_id
         attr[ATTR_DESCRIPTION] = self._child.description
+        # We should deprecate the battery level attribute in the future.
+        attr[ATTR_BATTERY_LEVEL] = self._node.battery_level
 
         set_req = self.gateway.const.SetReq
         for value_type, value in self._values.items():

--- a/tests/components/mysensors/test_binary_sensor.py
+++ b/tests/components/mysensors/test_binary_sensor.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from mysensors.sensor import Sensor
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
-from homeassistant.const import ATTR_DEVICE_CLASS
+from homeassistant.const import ATTR_BATTERY_LEVEL, ATTR_DEVICE_CLASS
 from homeassistant.core import HomeAssistant
 
 
@@ -23,6 +23,7 @@ async def test_door_sensor(
     assert state
     assert state.state == "off"
     assert state.attributes[ATTR_DEVICE_CLASS] == BinarySensorDeviceClass.DOOR
+    assert state.attributes[ATTR_BATTERY_LEVEL] == 0
 
     receive_message("1;1;1;0;16;1\n")
     await hass.async_block_till_done()

--- a/tests/components/mysensors/test_climate.py
+++ b/tests/components/mysensors/test_climate.py
@@ -19,7 +19,7 @@ from homeassistant.components.climate import (
     SERVICE_SET_TEMPERATURE,
     HVACMode,
 )
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_BATTERY_LEVEL, ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 
 
@@ -36,6 +36,7 @@ async def test_hvac_node_auto(
 
     assert state
     assert state.state == HVACMode.OFF
+    assert state.attributes[ATTR_BATTERY_LEVEL] == 0
 
     # Test set hvac mode auto
     await hass.services.async_call(
@@ -150,6 +151,7 @@ async def test_hvac_node_heat(
 
     assert state
     assert state.state == HVACMode.OFF
+    assert state.attributes[ATTR_BATTERY_LEVEL] == 0
 
     # Test set hvac mode heat
     await hass.services.async_call(
@@ -259,6 +261,7 @@ async def test_hvac_node_cool(
 
     assert state
     assert state.state == HVACMode.OFF
+    assert state.attributes[ATTR_BATTERY_LEVEL] == 0
 
     # Test set hvac mode heat
     await hass.services.async_call(

--- a/tests/components/mysensors/test_cover.py
+++ b/tests/components/mysensors/test_cover.py
@@ -19,7 +19,7 @@ from homeassistant.components.cover import (
     STATE_OPEN,
     STATE_OPENING,
 )
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_BATTERY_LEVEL, ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 
 
@@ -37,6 +37,7 @@ async def test_cover_node_percentage(
     assert state
     assert state.state == STATE_CLOSED
     assert state.attributes[ATTR_CURRENT_POSITION] == 0
+    assert state.attributes[ATTR_BATTERY_LEVEL] == 0
 
     await hass.services.async_call(
         COVER_DOMAIN,

--- a/tests/components/mysensors/test_device_tracker.py
+++ b/tests/components/mysensors/test_device_tracker.py
@@ -6,7 +6,12 @@ from collections.abc import Callable
 from mysensors.sensor import Sensor
 
 from homeassistant.components.device_tracker import ATTR_SOURCE_TYPE, SourceType
-from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, STATE_NOT_HOME
+from homeassistant.const import (
+    ATTR_BATTERY_LEVEL,
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
+    STATE_NOT_HOME,
+)
 from homeassistant.core import HomeAssistant
 
 
@@ -32,6 +37,7 @@ async def test_gps_sensor(
     assert state.attributes[ATTR_SOURCE_TYPE] == SourceType.GPS
     assert state.attributes[ATTR_LATITUDE] == float(latitude)
     assert state.attributes[ATTR_LONGITUDE] == float(longitude)
+    assert state.attributes[ATTR_BATTERY_LEVEL] == 0
 
     latitude = "40.782"
     longitude = "-73.965"

--- a/tests/components/mysensors/test_light.py
+++ b/tests/components/mysensors/test_light.py
@@ -12,6 +12,7 @@ from homeassistant.components.light import (
     ATTR_RGBW_COLOR,
     DOMAIN as LIGHT_DOMAIN,
 )
+from homeassistant.const import ATTR_BATTERY_LEVEL
 from homeassistant.core import HomeAssistant
 
 
@@ -28,6 +29,7 @@ async def test_dimmer_node(
 
     assert state
     assert state.state == "off"
+    assert state.attributes[ATTR_BATTERY_LEVEL] == 0
 
     # Test turn on
     await hass.services.async_call(
@@ -108,6 +110,7 @@ async def test_rgb_node(
 
     assert state
     assert state.state == "off"
+    assert state.attributes[ATTR_BATTERY_LEVEL] == 0
 
     # Test turn on
     await hass.services.async_call(
@@ -218,6 +221,7 @@ async def test_rgbw_node(
 
     assert state
     assert state.state == "off"
+    assert state.attributes[ATTR_BATTERY_LEVEL] == 0
 
     # Test turn on
     await hass.services.async_call(

--- a/tests/components/mysensors/test_remote.py
+++ b/tests/components/mysensors/test_remote.py
@@ -14,7 +14,12 @@ from homeassistant.components.remote import (
     SERVICE_LEARN_COMMAND,
     SERVICE_SEND_COMMAND,
 )
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.const import (
+    ATTR_BATTERY_LEVEL,
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
 from homeassistant.core import HomeAssistant
 
 
@@ -31,6 +36,7 @@ async def test_ir_transceiver(
 
     assert state
     assert state.state == "off"
+    assert state.attributes[ATTR_BATTERY_LEVEL] == 0
 
     # Test turn on
     await hass.services.async_call(

--- a/tests/components/mysensors/test_sensor.py
+++ b/tests/components/mysensors/test_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
+    ATTR_BATTERY_LEVEL,
     ATTR_DEVICE_CLASS,
     ATTR_ICON,
     ATTR_UNIT_OF_MEASUREMENT,
@@ -41,6 +42,7 @@ async def test_gps_sensor(
 
     assert state
     assert state.state == "40.741894,-73.989311,12"
+    assert state.attributes[ATTR_BATTERY_LEVEL] == 0
 
     altitude = 0
     new_coords = "40.782,-73.965"
@@ -67,6 +69,7 @@ async def test_ir_transceiver(
 
     assert state
     assert state.state == "test_code"
+    assert state.attributes[ATTR_BATTERY_LEVEL] == 0
 
     receive_message("1;1;1;0;50;new_code\n")
     await hass.async_block_till_done()
@@ -87,6 +90,7 @@ async def test_battery_entity(
     state = hass.states.get(battery_entity_id)
     assert state
     assert state.state == "42"
+    assert ATTR_BATTERY_LEVEL not in state.attributes
 
     receive_message("1;255;3;0;0;84\n")
     await hass.async_block_till_done()
@@ -94,6 +98,7 @@ async def test_battery_entity(
     state = hass.states.get(battery_entity_id)
     assert state
     assert state.state == "84"
+    assert ATTR_BATTERY_LEVEL not in state.attributes
 
 
 async def test_power_sensor(
@@ -111,6 +116,7 @@ async def test_power_sensor(
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.POWER
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfPower.WATT
     assert state.attributes[ATTR_STATE_CLASS] is SensorStateClass.MEASUREMENT
+    assert state.attributes[ATTR_BATTERY_LEVEL] == 0
 
 
 async def test_energy_sensor(
@@ -128,6 +134,7 @@ async def test_energy_sensor(
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.ENERGY
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfEnergy.KILO_WATT_HOUR
     assert state.attributes[ATTR_STATE_CLASS] is SensorStateClass.TOTAL_INCREASING
+    assert state.attributes[ATTR_BATTERY_LEVEL] == 0
 
 
 async def test_sound_sensor(
@@ -144,6 +151,7 @@ async def test_sound_sensor(
     assert state.state == "10"
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.SOUND_PRESSURE
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "dB"
+    assert state.attributes[ATTR_BATTERY_LEVEL] == 0
 
 
 async def test_distance_sensor(
@@ -161,6 +169,7 @@ async def test_distance_sensor(
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.DISTANCE
     assert ATTR_ICON not in state.attributes
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "cm"
+    assert state.attributes[ATTR_BATTERY_LEVEL] == 0
 
 
 @pytest.mark.parametrize(
@@ -193,3 +202,4 @@ async def test_temperature_sensor(
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.TEMPERATURE
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == unit
     assert state.attributes[ATTR_STATE_CLASS] is SensorStateClass.MEASUREMENT
+    assert state.attributes[ATTR_BATTERY_LEVEL] == 0

--- a/tests/components/mysensors/test_switch.py
+++ b/tests/components/mysensors/test_switch.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, call
 from mysensors.sensor import Sensor
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import ATTR_BATTERY_LEVEL
 from homeassistant.core import HomeAssistant
 
 
@@ -23,6 +24,7 @@ async def test_relay_node(
 
     assert state
     assert state.state == "off"
+    assert state.attributes[ATTR_BATTERY_LEVEL] == 0
 
     await hass.services.async_call(
         SWITCH_DOMAIN,

--- a/tests/components/mysensors/test_text.py
+++ b/tests/components/mysensors/test_text.py
@@ -12,7 +12,7 @@ from homeassistant.components.text import (
     DOMAIN as TEXT_DOMAIN,
     SERVICE_SET_VALUE,
 )
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_BATTERY_LEVEL, ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 
 
@@ -29,6 +29,7 @@ async def test_text_node(
 
     assert state
     assert state.state == "test"
+    assert state.attributes[ATTR_BATTERY_LEVEL] == 0
 
     await hass.services.async_call(
         TEXT_DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Restore the battery level state attribute which was mitakenly removed in the PR that added the battery level entity.
- We should deprecate the attribute properly before removing it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #101628
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
