### PR TITLE
Add get/set services to schedule component

### DIFF
--- a/homeassistant/components/schedule/const.py
+++ b/homeassistant/components/schedule/const.py
@@ -9,6 +9,7 @@ CONF_FRIDAY: Final = "friday"
 CONF_FROM: Final = "from"
 CONF_MONDAY: Final = "monday"
 CONF_SATURDAY: Final = "saturday"
+CONF_SCHEDULE: Final = "schedule"
 CONF_SUNDAY: Final = "sunday"
 CONF_THURSDAY: Final = "thursday"
 CONF_TO: Final = "to"
@@ -35,3 +36,6 @@ WEEKDAY_TO_CONF: Final = {
     5: CONF_SATURDAY,
     6: CONF_SUNDAY,
 }
+
+SERVICE_GET: Final = "get"
+SERVICE_SET: Final = "set"

--- a/homeassistant/components/schedule/services.yaml
+++ b/homeassistant/components/schedule/services.yaml
@@ -1,1 +1,45 @@
 reload:
+
+get:
+  fields:
+    entity_id:
+      required: true
+      selector:
+        entity:
+          filter:
+            - domain: schedule
+
+set:
+  fields:
+    entity_id:
+      required: true
+      selector:
+        entity:
+          filter:
+            - domain: schedule
+    schedule:
+      example: |
+        monday:
+          - from: "09:00:00"
+            to: "12:00:00"
+          - from: "17:00:00"
+            to: "19:00:00"
+        tuesday:
+          - from: "12:00:00"
+            to: "15:00:00"
+        wednesday:
+          - from: "09:00:00"
+            to: "11:00:00"
+        thursday:
+          - from: "09:00:00"
+            to: "15:00:00"
+        friday:
+          - from: "09:00:00"
+            to: "11:00:00"
+        saturday: []
+        sunday:
+          - from: "09:00:00"
+            to: "11:00:00"
+      required: true
+      selector:
+        object:

--- a/homeassistant/components/schedule/strings.json
+++ b/homeassistant/components/schedule/strings.json
@@ -25,6 +25,30 @@
     "reload": {
       "name": "[%key:common::action::reload%]",
       "description": "Reloads schedules from the YAML-configuration."
+    },
+    "get": {
+      "name": "Get",
+      "description": "Retrieve a schedule.",
+      "fields": {
+        "entity_id": {
+          "name": "Entity",
+          "description": "Schedule entity to retrieve the schedule from."
+        }
+      }
+    },
+    "set": {
+      "name": "Set",
+      "description": "Set a schedule (overwriting the existing).",
+      "fields": {
+        "entity_id": {
+          "name": "Entity",
+          "description": "Schedule entity to update."
+        },
+        "schedule": {
+          "name": "Schedule",
+          "description": "Full new schedule (will be replaced). If a day is not specified, all schedules for this day will be removed."
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds to services to the schedule component: `schedule.get` and `schedule.set`. The main goal is to provide a way to interact with schedule helpers through scripts/automations.

I have only implemented the retrieval of a single stored schedule as well as the update of an existing one for use with automations. Creation/deletion/renaming should still be done through the helper UI.

Example usecase: 
I have a TRV that works automatically on its own schedule stored on the device where I can schedule ON times (TRV goes to target_temperature_high) and OFF times (TRV goes to target_temperature_low). I want to control these schedules via the HA UI (I do have a script that sends/reads data from the TRV).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://community.home-assistant.io/t/new-schedule-entity-so-it-can-be-used-in-integrations/468072
- Link to documentation pull request: tbd

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
