### PR TITLE
Fix ingress sending an empty body for GET requests

### DIFF
--- a/homeassistant/components/hassio/http.py
+++ b/homeassistant/components/hassio/http.py
@@ -164,7 +164,7 @@ class HassIOView(HomeAssistantView):
                 method=request.method,
                 url=f"http://{self._host}/{quote(path)}",
                 params=request.query,
-                data=request.content,
+                data=request.content if request.method != "GET" else None,
                 headers=headers,
                 timeout=_get_timeout(path),
             )

--- a/homeassistant/components/hassio/ingress.py
+++ b/homeassistant/components/hassio/ingress.py
@@ -162,7 +162,7 @@ class HassIOIngress(HomeAssistantView):
             headers=source_header,
             params=request.query,
             allow_redirects=False,
-            data=request.content,
+            data=request.content if request.method != "GET" else None,
             timeout=ClientTimeout(total=None),
             skip_auto_headers={hdrs.CONTENT_TYPE},
         ) as result:

--- a/tests/components/hassio/test_http.py
+++ b/tests/components/hassio/test_http.py
@@ -450,9 +450,24 @@ async def test_backup_download_headers(
 
 async def test_stream(hassio_client, aioclient_mock: AiohttpClientMocker) -> None:
     """Verify that the request is a stream."""
-    aioclient_mock.get("http://127.0.0.1/app/entrypoint.js")
-    await hassio_client.get("/api/hassio/app/entrypoint.js", data="test")
+    content_type = "multipart/form-data; boundary='--webkit'"
+    aioclient_mock.post("http://127.0.0.1/backups/new/upload")
+    resp = await hassio_client.post(
+        "/api/hassio/backups/new/upload", headers={"Content-Type": content_type}
+    )
+    # Check we got right response
+    assert resp.status == HTTPStatus.OK
     assert isinstance(aioclient_mock.mock_calls[-1][2], StreamReader)
+
+
+async def test_simple_get_no_stream(
+    hassio_client, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Verify that a simple GET request is not a stream."""
+    aioclient_mock.get("http://127.0.0.1/app/entrypoint.js")
+    resp = await hassio_client.get("/api/hassio/app/entrypoint.js")
+    assert resp.status == HTTPStatus.OK
+    assert aioclient_mock.mock_calls[-1][2] is None
 
 
 async def test_entrypoint_cache_control(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Noticed this while investigating https://github.com/home-assistant/core/issues/101893 Its not the source of the issue but we shouldn't be sending content for GET requests

It looks like the supervisor uses a different solution https://github.com/home-assistant/supervisor/blob/a70f81aa0189bd7ccfc49dc7ff55e3bd3484b39b/supervisor/api/ingress.py#L207

This is the actual request ingress was making -- Notice the transfer-encoding is chunked, and its sending an empty body with `\r\n0\r\n`

```
GET /ingress/[redacted]/ping HTTP/1.1
Host:  [redacted]
User-Agent:  [redacted]
Connection: keep-alive
sec-ch-ua:  [redacted]
Accept: */*
sec-ch-ua-mobile: ?0
sec-ch-ua-platform:  [redacted]
Sec-GPC: 1
Accept-Language: en-US,en;q=0.7
Sec-Fetch-Site: same-origin
Sec-Fetch-Mode: cors
Sec-Fetch-Dest: empty
Referer: [redacted]
Cookie: ingress_session= [redacted]
X-Hass-Source: core.ingress
X-Ingress-Path: /api/hassio_ingress/[redacted]
X-Forwarded-For:  [redacted]
X-Forwarded-Host: [redacted]
X-Forwarded-Proto: https
Accept-Encoding: gzip, deflate, br
Transfer-Encoding: chunked

0

```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
