### PR TITLE
Revert aiohttp to 3.8.5 for Python 3.11

### DIFF
--- a/homeassistant/components/hassio/http.py
+++ b/homeassistant/components/hassio/http.py
@@ -157,7 +157,7 @@ class HassIOView(HomeAssistantView):
                 if path == "backups/new/upload":
                     # We need to reuse the full content type that includes the boundary
                     # pylint: disable-next=protected-access
-                    headers[CONTENT_TYPE] = request._stored_content_type  # type: ignore[assignment]
+                    headers[CONTENT_TYPE] = request._stored_content_type
 
         try:
             client = await self._websession.request(

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -65,8 +65,10 @@ async def _noop_wait(*args: Any, **kwargs: Any) -> None:
     return
 
 
-# pylint: disable-next=protected-access
-web.BaseSite._wait = _noop_wait  # type: ignore[method-assign]
+# TODO: Remove version check with aiohttp 3.9.0  # pylint: disable=fixme
+if sys.version_info >= (3, 12):
+    # pylint: disable-next=protected-access
+    web.BaseSite._wait = _noop_wait  # type: ignore[method-assign]
 
 
 class HassClientResponse(aiohttp.ClientResponse):

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
+from ssl import SSLContext
 import sys
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, cast
@@ -288,7 +289,7 @@ def _async_get_connector(
         return cast(aiohttp.BaseConnector, hass.data[key])
 
     if verify_ssl:
-        ssl_context = ssl_util.get_default_context()
+        ssl_context: bool | SSLContext = ssl_util.get_default_context()
     else:
         ssl_context = ssl_util.get_default_no_verify_context()
 

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,5 +1,6 @@
 aiodiscover==1.5.1
-aiohttp==3.9.0b0
+aiohttp==3.8.5;python_version<'3.12'
+aiohttp==3.9.0b0;python_version>='3.12'
 aiohttp_cors==0.7.0
 astral==2.2
 async-upnp-client==0.36.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ classifiers = [
 ]
 requires-python = ">=3.11.0"
 dependencies    = [
-    "aiohttp==3.9.0b0",
+    "aiohttp==3.9.0b0;python_version>='3.12'",
+    "aiohttp==3.8.5;python_version<'3.12'",
     "astral==2.2",
     "attrs==23.1.0",
     "atomicwrites-homeassistant==1.4.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 -c homeassistant/package_constraints.txt
 
 # Home Assistant Core
-aiohttp==3.9.0b0
+aiohttp==3.9.0b0;python_version>='3.12'
+aiohttp==3.8.5;python_version<'3.12'
 astral==2.2
 attrs==23.1.0
 atomicwrites-homeassistant==1.4.1

--- a/tests/components/generic/test_camera.py
+++ b/tests/components/generic/test_camera.py
@@ -1,6 +1,7 @@
 """The tests for generic camera component."""
 import asyncio
 from http import HTTPStatus
+import sys
 from unittest.mock import patch
 
 import aiohttp
@@ -163,10 +164,17 @@ async def test_limit_refetch(
 
     hass.states.async_set("sensor.temp", "5")
 
-    with pytest.raises(aiohttp.ServerTimeoutError), patch(
-        "asyncio.timeout", side_effect=asyncio.TimeoutError()
-    ):
-        resp = await client.get("/api/camera_proxy/camera.config_test")
+    # TODO: Remove version check with aiohttp 3.9.0
+    if sys.version_info >= (3, 12):
+        with pytest.raises(aiohttp.ServerTimeoutError), patch(
+            "asyncio.timeout", side_effect=asyncio.TimeoutError()
+        ):
+            resp = await client.get("/api/camera_proxy/camera.config_test")
+    else:
+        with pytest.raises(aiohttp.ServerTimeoutError), patch(
+            "async_timeout.timeout", side_effect=asyncio.TimeoutError()
+        ):
+            resp = await client.get("/api/camera_proxy/camera.config_test")
 
     assert respx.calls.call_count == 1
     assert resp.status == HTTPStatus.OK

--- a/tests/util/test_aiohttp.py
+++ b/tests/util/test_aiohttp.py
@@ -1,4 +1,6 @@
 """Test aiohttp request helper."""
+import sys
+
 from aiohttp import web
 
 from homeassistant.util import aiohttp
@@ -48,11 +50,22 @@ def test_serialize_text() -> None:
 def test_serialize_body_str() -> None:
     """Test serializing a response with a str as body."""
     response = web.Response(status=201, body="Hello")
-    assert aiohttp.serialize_response(response) == {
-        "status": 201,
-        "body": "Hello",
-        "headers": {"Content-Type": "text/plain; charset=utf-8"},
-    }
+    # TODO: Remove version check with aiohttp 3.9.0
+    if sys.version_info >= (3, 12):
+        assert aiohttp.serialize_response(response) == {
+            "status": 201,
+            "body": "Hello",
+            "headers": {"Content-Type": "text/plain; charset=utf-8"},
+        }
+    else:
+        assert aiohttp.serialize_response(response) == {
+            "status": 201,
+            "body": "Hello",
+            "headers": {
+                "Content-Length": "5",
+                "Content-Type": "text/plain; charset=utf-8",
+            },
+        }
 
 
 def test_serialize_body_None() -> None:


### PR DESCRIPTION
## Proposed change
Similar to #101913 but for `dev` this time.

This PR reverts the aiohttp upgrade on Python 3.11 only! This will allow us to continue testing Python 3.12 while addressing the recent regression.
- https://github.com/home-assistant/core/issues/101893

Original PR to update aiohttp to `3.9.0b0:
- #101627

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
