### PR TITLE
Set category and enabled by default of Minecraft Server sensors

### DIFF
--- a/homeassistant/components/minecraft_server/sensor.py
+++ b/homeassistant/components/minecraft_server/sensor.py
@@ -47,7 +47,7 @@ class MinecraftServerEntityDescriptionMixin:
 
     value_fn: Callable[[MinecraftServerData], StateType]
     attributes_fn: Callable[[MinecraftServerData], MutableMapping[str, Any]] | None
-    supported_server_types: list[MinecraftServerType]
+    supported_server_types: set[MinecraftServerType]
 
 
 @dataclass
@@ -77,10 +77,10 @@ SENSOR_DESCRIPTIONS = [
         icon=ICON_VERSION,
         value_fn=lambda data: data.version,
         attributes_fn=None,
-        supported_server_types=[
+        supported_server_types={
             MinecraftServerType.JAVA_EDITION,
             MinecraftServerType.BEDROCK_EDITION,
-        ],
+        },
     ),
     MinecraftServerSensorEntityDescription(
         key=KEY_PROTOCOL_VERSION,
@@ -88,10 +88,10 @@ SENSOR_DESCRIPTIONS = [
         icon=ICON_PROTOCOL_VERSION,
         value_fn=lambda data: data.protocol_version,
         attributes_fn=None,
-        supported_server_types=[
+        supported_server_types={
             MinecraftServerType.JAVA_EDITION,
             MinecraftServerType.BEDROCK_EDITION,
-        ],
+        },
     ),
     MinecraftServerSensorEntityDescription(
         key=KEY_PLAYERS_MAX,
@@ -100,10 +100,10 @@ SENSOR_DESCRIPTIONS = [
         icon=ICON_PLAYERS_MAX,
         value_fn=lambda data: data.players_max,
         attributes_fn=None,
-        supported_server_types=[
+        supported_server_types={
             MinecraftServerType.JAVA_EDITION,
             MinecraftServerType.BEDROCK_EDITION,
-        ],
+        },
     ),
     MinecraftServerSensorEntityDescription(
         key=KEY_LATENCY,
@@ -113,10 +113,10 @@ SENSOR_DESCRIPTIONS = [
         icon=ICON_LATENCY,
         value_fn=lambda data: data.latency,
         attributes_fn=None,
-        supported_server_types=[
+        supported_server_types={
             MinecraftServerType.JAVA_EDITION,
             MinecraftServerType.BEDROCK_EDITION,
-        ],
+        },
     ),
     MinecraftServerSensorEntityDescription(
         key=KEY_MOTD,
@@ -124,10 +124,10 @@ SENSOR_DESCRIPTIONS = [
         icon=ICON_MOTD,
         value_fn=lambda data: data.motd,
         attributes_fn=None,
-        supported_server_types=[
+        supported_server_types={
             MinecraftServerType.JAVA_EDITION,
             MinecraftServerType.BEDROCK_EDITION,
-        ],
+        },
     ),
     MinecraftServerSensorEntityDescription(
         key=KEY_PLAYERS_ONLINE,
@@ -136,10 +136,10 @@ SENSOR_DESCRIPTIONS = [
         icon=ICON_PLAYERS_ONLINE,
         value_fn=lambda data: data.players_online,
         attributes_fn=get_extra_state_attributes_players_list,
-        supported_server_types=[
+        supported_server_types={
             MinecraftServerType.JAVA_EDITION,
             MinecraftServerType.BEDROCK_EDITION,
-        ],
+        },
     ),
     MinecraftServerSensorEntityDescription(
         key=KEY_EDITION,
@@ -147,9 +147,9 @@ SENSOR_DESCRIPTIONS = [
         icon=ICON_EDITION,
         value_fn=lambda data: data.edition,
         attributes_fn=None,
-        supported_server_types=[
+        supported_server_types={
             MinecraftServerType.BEDROCK_EDITION,
-        ],
+        },
     ),
     MinecraftServerSensorEntityDescription(
         key=KEY_GAME_MODE,
@@ -157,9 +157,9 @@ SENSOR_DESCRIPTIONS = [
         icon=ICON_GAME_MODE,
         value_fn=lambda data: data.game_mode,
         attributes_fn=None,
-        supported_server_types=[
+        supported_server_types={
             MinecraftServerType.BEDROCK_EDITION,
-        ],
+        },
     ),
     MinecraftServerSensorEntityDescription(
         key=KEY_MAP_NAME,
@@ -167,9 +167,9 @@ SENSOR_DESCRIPTIONS = [
         icon=ICON_MAP_NAME,
         value_fn=lambda data: data.map_name,
         attributes_fn=None,
-        supported_server_types=[
+        supported_server_types={
             MinecraftServerType.BEDROCK_EDITION,
-        ],
+        },
     ),
 ]
 

--- a/homeassistant/components/minecraft_server/sensor.py
+++ b/homeassistant/components/minecraft_server/sensor.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_TYPE, UnitOfTime
+from homeassistant.const import CONF_TYPE, EntityCategory, UnitOfTime
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
@@ -92,6 +92,8 @@ SENSOR_DESCRIPTIONS = [
             MinecraftServerType.JAVA_EDITION,
             MinecraftServerType.BEDROCK_EDITION,
         },
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
     MinecraftServerSensorEntityDescription(
         key=KEY_PLAYERS_MAX,
@@ -104,6 +106,7 @@ SENSOR_DESCRIPTIONS = [
             MinecraftServerType.JAVA_EDITION,
             MinecraftServerType.BEDROCK_EDITION,
         },
+        entity_registry_enabled_default=False,
     ),
     MinecraftServerSensorEntityDescription(
         key=KEY_LATENCY,
@@ -117,6 +120,7 @@ SENSOR_DESCRIPTIONS = [
             MinecraftServerType.JAVA_EDITION,
             MinecraftServerType.BEDROCK_EDITION,
         },
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     MinecraftServerSensorEntityDescription(
         key=KEY_MOTD,
@@ -150,6 +154,7 @@ SENSOR_DESCRIPTIONS = [
         supported_server_types={
             MinecraftServerType.BEDROCK_EDITION,
         },
+        entity_registry_enabled_default=False,
     ),
     MinecraftServerSensorEntityDescription(
         key=KEY_GAME_MODE,

--- a/homeassistant/components/minecraft_server/sensor.py
+++ b/homeassistant/components/minecraft_server/sensor.py
@@ -81,6 +81,7 @@ SENSOR_DESCRIPTIONS = [
             MinecraftServerType.JAVA_EDITION,
             MinecraftServerType.BEDROCK_EDITION,
         },
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     MinecraftServerSensorEntityDescription(
         key=KEY_PROTOCOL_VERSION,
@@ -154,6 +155,7 @@ SENSOR_DESCRIPTIONS = [
         supported_server_types={
             MinecraftServerType.BEDROCK_EDITION,
         },
+        entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
     MinecraftServerSensorEntityDescription(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Set sensor categories to `DIAGNOSTIC`:
  - latency: ✅ 
  - motd: ❌ 
  - players_max: ❌ 
  - players_online: ❌ 
  - protocol_version: ✅ 
  - version: ✅ 
  - edition: ✅ 
  - game_mode: ❌ 
  - map_name: ❌ 
- Set sensor disabled by default:
  - latency: ❌ 
  - motd:  ❌ 
  - players_max: ✅ 
  - players_online: ❌ 
  - protocol_version: ✅ 
  - version: ❌ 
  - edition: ✅ 
  - game_mode: ❌ 
  - map_name:  ❌ 
- Use `set` instead of `list` for supported server types


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: n.a.
- This PR is related to issue: n.a.
- Link to documentation pull request: n.a.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
