### PR TITLE
Introducing Distinct Color Temperature Selectors: Mireds and Kelvin

### DIFF
--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -251,9 +251,9 @@ turn_on:
             - light.ColorMode.RGBW
             - light.ColorMode.RGBWW
       selector:
-        color_temp:
-          min_mireds: 153
-          max_mireds: 500
+        color_temp_mired:
+          min: 153
+          max: 500
     kelvin:
       filter:
         attribute:
@@ -266,11 +266,9 @@ turn_on:
             - light.ColorMode.RGBWW
       advanced: true
       selector:
-        number:
+        color_temp_kelvin:
           min: 2000
           max: 6500
-          step: 100
-          unit_of_measurement: K
     brightness:
       filter:
         attribute:
@@ -624,7 +622,7 @@ toggle:
             - light.ColorMode.RGBWW
       advanced: true
       selector:
-        color_temp:
+        color_temp_mired:
     kelvin:
       filter:
         attribute:
@@ -637,11 +635,9 @@ toggle:
             - light.ColorMode.RGBWW
       advanced: true
       selector:
-        number:
+        color_temp_kelvin:
           min: 2000
           max: 6500
-          step: 100
-          unit_of_measurement: K
     brightness:
       filter:
         attribute:

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1,8 +1,9 @@
 """Selectors for Home Assistant."""
 from __future__ import annotations
 
+from abc import abstractmethod
 from collections.abc import Callable, Mapping, Sequence
-from enum import IntFlag, StrEnum
+from enum import Enum, IntFlag, StrEnum
 from functools import cache
 from typing import Any, Generic, Literal, Required, TypedDict, TypeVar, cast
 from uuid import UUID
@@ -422,23 +423,34 @@ class ColorRGBSelector(Selector[ColorRGBSelectorConfig]):
         return value
 
 
-class ColorTempSelectorConfig(TypedDict, total=False):
+ColorTemperatureUnit = Enum("ColorTemperatureUnit", ["KELVIN", "MIRED"])
+
+
+class ColorTempSelectorWithoutUnitConfig(TypedDict, total=False):
+    """Class to represent a color temp selector config whatever unit is used."""
+
+    max: int
+    min: int
+
+
+class ColorTempSelectorConfig(ColorTempSelectorWithoutUnitConfig):
     """Class to represent a color temp selector config."""
 
-    max_mireds: int
-    min_mireds: int
+    unit: ColorTemperatureUnit
 
 
-@SELECTORS.register("color_temp")
 class ColorTempSelector(Selector[ColorTempSelectorConfig]):
-    """Selector of an color temperature."""
+    """Base class for a color temperature Selector."""
 
-    selector_type = "color_temp"
+    @property
+    @abstractmethod
+    def selector_type():
+        pass
 
     CONFIG_SCHEMA = vol.Schema(
         {
-            vol.Optional("max_mireds"): vol.Coerce(int),
-            vol.Optional("min_mireds"): vol.Coerce(int),
+            vol.Optional("max"): vol.Coerce(int),
+            vol.Optional("min"): vol.Coerce(int),
         }
     )
 
@@ -451,11 +463,71 @@ class ColorTempSelector(Selector[ColorTempSelectorConfig]):
         value: int = vol.All(
             vol.Coerce(float),
             vol.Range(
-                min=self.config.get("min_mireds"),
-                max=self.config.get("max_mireds"),
+                min=self.config.get("min"),
+                max=self.config.get("max"),
             ),
         )(data)
         return value
+
+
+@SELECTORS.register("color_temp_mired")
+class ColorTempMiredSelector(ColorTempSelector):
+    """Selector of a color temperature."""
+
+    selector_type = "color_temp_mired"
+
+    def __init__(
+        self, config: ColorTempSelectorWithoutUnitConfig | None = None
+    ) -> None:
+        """Instantiate a selector."""
+        super().__init__(
+            ColorTempSelectorConfig(**config, unit=ColorTemperatureUnit.MIRED)
+        )
+
+
+@SELECTORS.register("color_temp_kelvin")
+class ColorTempKelvinSelector(ColorTempSelector):
+    """Selector of a color temperature."""
+
+    selector_type = "color_temp_kelvin"
+
+    def __init__(
+        self, config: ColorTempSelectorWithoutUnitConfig | None = None
+    ) -> None:
+        """Instantiate a selector."""
+        super().__init__(
+            ColorTempSelectorConfig(**config, unit=ColorTemperatureUnit.KELVIN)
+        )
+
+
+class OldColorTempSelectorConfig(TypedDict, total=False):
+    """Class to represent the old color temp selector config that only supports mired."""
+
+    max_mireds: int
+    min_mireds: int
+
+
+@SELECTORS.register("color_temp")
+class OldColorTempSelector(ColorTempMiredSelector):
+    """Selector of a color temperature."""
+
+    CONFIG_SCHEMA = vol.Schema(
+        {
+            vol.Optional("max_mireds"): vol.Coerce(int),
+            vol.Optional("min_mireds"): vol.Coerce(int),
+        }
+    )
+
+    def __init__(self, config: OldColorTempSelectorConfig | None = None) -> None:
+        """Map the old settings to the new ones."""
+
+        # TODO throw a deprecation warning here?
+        new_config = ColorTempSelectorWithoutUnitConfig()
+        if "min_mireds" in config:
+            new_config["min"] = config.min_mireds
+        if "max_mireds" in config:
+            new_config["max"] = config.max_mireds
+        super().__init__(new_config)
 
 
 class ConditionSelectorConfig(TypedDict):

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -909,12 +909,58 @@ def test_rgb_color_selector_schema(
         ),
     ),
 )
-def test_color_tempselector_schema(
+def test_old_color_tempselector_schema(
     schema, valid_selections, invalid_selections
 ) -> None:
-    """Test color_temp selector."""
+    """Test the old color_temp selector."""
 
     _test_selector("color_temp", schema, valid_selections, invalid_selections)
+
+
+@pytest.mark.parametrize(
+    ("schema", "valid_selections", "invalid_selections"),
+    (
+        (
+            {},
+            (100, 100.0),
+            (None, "abc", [100]),
+        ),
+        (
+            {"min": 100, "max": 200},
+            (100, 200),
+            (99, 201),
+        ),
+    ),
+)
+def test_color_temp_mired_selector_schema(
+    schema, valid_selections, invalid_selections
+) -> None:
+    """Test color_temp_mired selector."""
+
+    _test_selector("color_temp_mired", schema, valid_selections, invalid_selections)
+
+
+@pytest.mark.parametrize(
+    ("schema", "valid_selections", "invalid_selections"),
+    (
+        (
+            {},
+            (100, 100.0),
+            (None, "abc", [100]),
+        ),
+        (
+            {"min": 1000, "max": 2000},
+            (1000, 2000),
+            (999, 2001),
+        ),
+    ),
+)
+def test_color_temp_kelvin_selector_schema(
+    schema, valid_selections, invalid_selections
+) -> None:
+    """Test color_temp_kelvin selector."""
+
+    _test_selector("color_temp_kelvin", schema, valid_selections, invalid_selections)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This merge request introduces two distinct selectors for color temperature: one in mireds (`color_temp_mired:`) and another in kelvin (`color_temp_kelvin:`). Previously, we only had a single selector that implicitly used mireds (`color_temp:`). This change makes it more intuitive and easier for users, especially since many are familiar with the kelvin scale. 

Before this change, users who wanted to specify temperatures in kelvin had to use the mired selector and then convert, which was cumbersome. Now, they can use the `color_temp_kelvin:` selector directly, simplifying the process. It's worth noting that the original `color_temp:` selector remains for backward compatibility, but moving forward, the recommendation is to use the new selectors.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/18217
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29347

- This PR fixes or closes issue: fixes home-assistant/frontend#17144 #95762 
- This PR is related to issue: home-assistant/frontend#16958


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
