### PR TITLE
Update Withings measurements incrementally after the first update

### DIFF
--- a/homeassistant/components/withings/coordinator.py
+++ b/homeassistant/components/withings/coordinator.py
@@ -1,9 +1,10 @@
 """Withings coordinator."""
 from abc import abstractmethod
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import TypeVar
 
 from aiowithings import (
+    MeasurementGroup,
     MeasurementType,
     NotificationCategory,
     SleepSummary,
@@ -33,6 +34,7 @@ class WithingsDataUpdateCoordinator(DataUpdateCoordinator[_T]):
 
     config_entry: ConfigEntry
     _default_update_interval: timedelta | None = UPDATE_INTERVAL
+    _last_valid_update: datetime | None = None
 
     def __init__(self, hass: HomeAssistant, client: WithingsClient) -> None:
         """Initialize the Withings data coordinator."""
@@ -80,15 +82,32 @@ class WithingsMeasurementDataUpdateCoordinator(
             NotificationCategory.ACTIVITY,
             NotificationCategory.PRESSURE,
         }
+        self._previous_data: dict[MeasurementType, float] = {}
 
     async def _internal_update_data(self) -> dict[MeasurementType, float]:
         """Retrieve measurement data."""
+        if self._last_valid_update is None:
+            measurements = await self._measurements_last_two_weeks()
+        else:
+            measurements = await self._measurements_since_last_valid_update()
+
+        if measurements:
+            self._last_valid_update = measurements[0].taken_at
+            aggregated_measurements = aggregate_measurements(measurements)
+            self._previous_data.update(aggregated_measurements)
+        return self._previous_data
+
+    async def _measurements_last_two_weeks(self) -> list[MeasurementGroup]:
+        """Retrieve measurements from the last two weeks."""
         now = dt_util.utcnow()
-        startdate = now - timedelta(days=7)
+        startdate = now - timedelta(days=14)
 
-        response = await self._client.get_measurement_in_period(startdate, now)
+        return await self._client.get_measurement_in_period(startdate, now)
 
-        return aggregate_measurements(response)
+    async def _measurements_since_last_valid_update(self) -> list[MeasurementGroup]:
+        """Retrieve measurements since the last valid update."""
+        assert self._last_valid_update
+        return await self._client.get_measurement_since(self._last_valid_update)
 
 
 class WithingsSleepDataUpdateCoordinator(

--- a/tests/components/withings/conftest.py
+++ b/tests/components/withings/conftest.py
@@ -151,6 +151,7 @@ def mock_withings():
     mock = AsyncMock(spec=WithingsClient)
     mock.get_devices.return_value = devices
     mock.get_measurement_in_period.return_value = measurement_groups
+    mock.get_measurement_since.return_value = measurement_groups
     mock.get_sleep_summary_since.return_value = sleep_summaries
     mock.list_notification_configurations.return_value = notifications
 

--- a/tests/components/withings/fixtures/get_meas_1.json
+++ b/tests/components/withings/fixtures/get_meas_1.json
@@ -1,0 +1,97 @@
+[
+  {
+    "grpid": 1,
+    "attrib": 0,
+    "date": 1618605055,
+    "created": 1618605055,
+    "modified": 1618605055,
+    "category": 1,
+    "deviceid": "91a7e556c2022ef54dca6e07a853c3193734d148",
+    "hash_deviceid": "91a7e556c2022ef54dca6e07a853c3193734d148",
+    "measures": [
+      {
+        "type": 1,
+        "unit": 0,
+        "value": 71
+      },
+      {
+        "type": 8,
+        "unit": 0,
+        "value": 5
+      },
+      {
+        "type": 5,
+        "unit": 0,
+        "value": 60
+      },
+      {
+        "type": 76,
+        "unit": 0,
+        "value": 50
+      },
+      {
+        "type": 88,
+        "unit": 0,
+        "value": 10
+      },
+      {
+        "type": 4,
+        "unit": 0,
+        "value": 2
+      },
+      {
+        "type": 12,
+        "unit": 0,
+        "value": 40
+      },
+      {
+        "type": 71,
+        "unit": 0,
+        "value": 40
+      },
+      {
+        "type": 73,
+        "unit": 0,
+        "value": 20
+      },
+      {
+        "type": 6,
+        "unit": -3,
+        "value": 70
+      },
+      {
+        "type": 9,
+        "unit": 0,
+        "value": 70
+      },
+      {
+        "type": 10,
+        "unit": 0,
+        "value": 100
+      },
+      {
+        "type": 11,
+        "unit": 0,
+        "value": 60
+      },
+      {
+        "type": 54,
+        "unit": -2,
+        "value": 95
+      },
+      {
+        "type": 77,
+        "unit": -2,
+        "value": 95
+      },
+      {
+        "type": 91,
+        "unit": 0,
+        "value": 100
+      }
+    ],
+    "modelid": 45,
+    "model": "BPM Connect",
+    "comment": null
+  }
+]

--- a/tests/components/withings/test_init.py
+++ b/tests/components/withings/test_init.py
@@ -212,6 +212,7 @@ async def test_webhooks_request_data(
 
     client = await hass_client_no_auth()
 
+    assert withings.get_measurement_since.call_count == 0
     assert withings.get_measurement_in_period.call_count == 1
 
     await call_webhook(
@@ -220,7 +221,8 @@ async def test_webhooks_request_data(
         {"userid": USER_ID, "appli": NotificationCategory.WEIGHT},
         client,
     )
-    assert withings.get_measurement_in_period.call_count == 2
+    assert withings.get_measurement_since.call_count == 1
+    assert withings.get_measurement_in_period.call_count == 1
 
 
 @pytest.mark.parametrize(
@@ -240,7 +242,7 @@ async def test_triggering_reauth(
     """Test triggering reauth."""
     await setup_integration(hass, polling_config_entry, False)
 
-    withings.get_measurement_in_period.side_effect = error
+    withings.get_measurement_since.side_effect = error
     freezer.tick(timedelta(minutes=10))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()

--- a/tests/components/withings/test_sensor.py
+++ b/tests/components/withings/test_sensor.py
@@ -2,6 +2,7 @@
 from datetime import timedelta
 from unittest.mock import AsyncMock
 
+from aiowithings import MeasurementGroup
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy import SnapshotAssertion
@@ -16,7 +17,11 @@ from homeassistant.helpers import entity_registry as er
 from . import setup_integration
 from .conftest import USER_ID
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+    load_json_array_fixture,
+)
 
 
 async def async_get_entity_id(
@@ -57,7 +62,7 @@ async def test_update_failed(
     """Test all entities."""
     await setup_integration(hass, polling_config_entry, False)
 
-    withings.get_measurement_in_period.side_effect = Exception
+    withings.get_measurement_since.side_effect = Exception
     freezer.tick(timedelta(minutes=10))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
@@ -65,3 +70,49 @@ async def test_update_failed(
     state = hass.states.get("sensor.henk_weight")
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
+
+
+async def test_update_updates_incrementally(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    withings: AsyncMock,
+    polling_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test fetching new data updates since the last valid update."""
+    await setup_integration(hass, polling_config_entry, False)
+
+    async def _skip_10_minutes() -> None:
+        freezer.tick(timedelta(minutes=10))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    meas_json = load_json_array_fixture("withings/get_meas_1.json")
+    measurement_groups = [
+        MeasurementGroup.from_api(measurement) for measurement in meas_json
+    ]
+
+    assert withings.get_measurement_since.call_args_list == []
+    await _skip_10_minutes()
+    assert (
+        str(withings.get_measurement_since.call_args_list[0].args[0])
+        == "2019-08-01 12:00:00+00:00"
+    )
+
+    withings.get_measurement_since.return_value = measurement_groups
+    await _skip_10_minutes()
+    assert (
+        str(withings.get_measurement_since.call_args_list[1].args[0])
+        == "2019-08-01 12:00:00+00:00"
+    )
+
+    await _skip_10_minutes()
+    assert (
+        str(withings.get_measurement_since.call_args_list[2].args[0])
+        == "2021-04-16 20:30:55+00:00"
+    )
+
+    state = hass.states.get("sensor.henk_weight")
+    assert state is not None
+    assert state.state == "71"
+    assert len(withings.get_measurement_in_period.call_args_list) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Previously the integration would fetch data from the last 7 days and aggregated that at every poll. This was leading to missing data if you did not have a measurement stored in the last 7 days (How much such measurement is still worth is a different question).

In this change I am extending this period to 14 days, possibly causing some extra load at the startup of the integration since it can process more data. But it will now store the timestamp of the last update, and uses that to only request new data in follow up updates. This way, for example in a polling situation, the aggregation only happens once instead of every 10 minutes or when there is new data found.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
