### PR TITLE
Revert "Update numpy to 1.26.1"

### DIFF
--- a/homeassistant/components/compensation/manifest.json
+++ b/homeassistant/components/compensation/manifest.json
@@ -4,5 +4,5 @@
   "codeowners": ["@Petro31"],
   "documentation": "https://www.home-assistant.io/integrations/compensation",
   "iot_class": "calculated",
-  "requirements": ["numpy==1.26.1"]
+  "requirements": ["numpy==1.26.0"]
 }

--- a/homeassistant/components/iqvia/manifest.json
+++ b/homeassistant/components/iqvia/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["pyiqvia"],
-  "requirements": ["numpy==1.26.1", "pyiqvia==2022.04.0"]
+  "requirements": ["numpy==1.26.0", "pyiqvia==2022.04.0"]
 }

--- a/homeassistant/components/opencv/manifest.json
+++ b/homeassistant/components/opencv/manifest.json
@@ -4,5 +4,5 @@
   "codeowners": [],
   "documentation": "https://www.home-assistant.io/integrations/opencv",
   "iot_class": "local_push",
-  "requirements": ["numpy==1.26.1", "opencv-python-headless==4.6.0.66"]
+  "requirements": ["numpy==1.26.0", "opencv-python-headless==4.6.0.66"]
 }

--- a/homeassistant/components/stream/manifest.json
+++ b/homeassistant/components/stream/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["PyTurboJPEG==1.7.1", "ha-av==10.1.1", "numpy==1.26.1"]
+  "requirements": ["PyTurboJPEG==1.7.1", "ha-av==10.1.1", "numpy==1.26.0"]
 }

--- a/homeassistant/components/tensorflow/manifest.json
+++ b/homeassistant/components/tensorflow/manifest.json
@@ -9,7 +9,7 @@
     "tensorflow==2.5.0",
     "tf-models-official==2.5.0",
     "pycocotools==2.0.6",
-    "numpy==1.26.1",
+    "numpy==1.26.0",
     "Pillow==10.0.1"
   ]
 }

--- a/homeassistant/components/trend/manifest.json
+++ b/homeassistant/components/trend/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/trend",
   "iot_class": "calculated",
   "quality_scale": "internal",
-  "requirements": ["numpy==1.26.1"]
+  "requirements": ["numpy==1.26.0"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -112,7 +112,7 @@ httpcore==0.18.0
 hyperframe>=5.2.0
 
 # Ensure we run compatible with musllinux build env
-numpy==1.26.1
+numpy==1.26.0
 
 # Prevent dependency conflicts between sisyphus-control and aioambient
 # until upper bounds for sisyphus-control have been updated

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1329,7 +1329,7 @@ numato-gpio==0.10.0
 # homeassistant.components.stream
 # homeassistant.components.tensorflow
 # homeassistant.components.trend
-numpy==1.26.1
+numpy==1.26.0
 
 # homeassistant.components.oasa_telematics
 oasatelematics==0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1034,7 +1034,7 @@ numato-gpio==0.10.0
 # homeassistant.components.stream
 # homeassistant.components.tensorflow
 # homeassistant.components.trend
-numpy==1.26.1
+numpy==1.26.0
 
 # homeassistant.components.google
 oauth2client==4.1.3

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -113,7 +113,7 @@ httpcore==0.18.0
 hyperframe>=5.2.0
 
 # Ensure we run compatible with musllinux build env
-numpy==1.26.1
+numpy==1.26.0
 
 # Prevent dependency conflicts between sisyphus-control and aioambient
 # until upper bounds for sisyphus-control have been updated


### PR DESCRIPTION
Reverts home-assistant/core#102021

numpy 1.26.1 is causing some pretty interesting failures on my production systems. Downgrading it back to 1.26.0 resolves the issue:

```
Oct 15 10:02:48 homeassistant homeassistant[547]: 2023-10-15 00:02:48.978 ERROR (MainThread) [homeassistant.setup] Setup failed for cloud: Unable to import component: Error importing numpy: you should not try to import numpy from
Oct 15 10:02:48 homeassistant homeassistant[547]:         its source directory; please exit the numpy source tree, and relaunch
Oct 15 10:02:48 homeassistant homeassistant[547]:         your python interpreter from there.
Oct 15 10:02:48 homeassistant homeassistant[547]: Traceback (most recent call last):
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "/usr/local/lib/python3.11/site-packages/numpy/core/__init__.py", line 24, in <module>
Oct 15 10:02:48 homeassistant homeassistant[547]:     from . import multiarray
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "/usr/local/lib/python3.11/site-packages/numpy/core/multiarray.py", line 10, in <module>
Oct 15 10:02:48 homeassistant homeassistant[547]:     from . import overrides
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "/usr/local/lib/python3.11/site-packages/numpy/core/overrides.py", line 8, in <module>
Oct 15 10:02:48 homeassistant homeassistant[547]:     from numpy.core._multiarray_umath import (
Oct 15 10:02:48 homeassistant homeassistant[547]: ImportError: Error loading shared library ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ: No error information (needed by /usr/local/lib/python3.11/site-packages/numpy/core/../../numpy.libs/libopenblasp-r0-250824a8.3.23.so)
Oct 15 10:02:48 homeassistant homeassistant[547]: 
Oct 15 10:02:48 homeassistant homeassistant[547]: During handling of the above exception, another exception occurred:
Oct 15 10:02:48 homeassistant homeassistant[547]: 
Oct 15 10:02:48 homeassistant homeassistant[547]: Traceback (most recent call last):
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "/usr/local/lib/python3.11/site-packages/numpy/__init__.py", line 130, in <module>
Oct 15 10:02:48 homeassistant homeassistant[547]:     from numpy.__config__ import show as show_config
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "/usr/local/lib/python3.11/site-packages/numpy/__config__.py", line 4, in <module>
Oct 15 10:02:48 homeassistant homeassistant[547]:     from numpy.core._multiarray_umath import (
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "/usr/local/lib/python3.11/site-packages/numpy/core/__init__.py", line 50, in <module>
Oct 15 10:02:48 homeassistant homeassistant[547]:     raise ImportError(msg)
Oct 15 10:02:48 homeassistant homeassistant[547]: ImportError: 
Oct 15 10:02:48 homeassistant homeassistant[547]: 
Oct 15 10:02:48 homeassistant homeassistant[547]: IMPORTANT: PLEASE READ THIS FOR ADVICE ON HOW TO SOLVE THIS ISSUE!
Oct 15 10:02:48 homeassistant homeassistant[547]: 
Oct 15 10:02:48 homeassistant homeassistant[547]: Importing the numpy C-extensions failed. This error can happen for
Oct 15 10:02:48 homeassistant homeassistant[547]: many reasons, often due to issues with your setup or how NumPy was
Oct 15 10:02:48 homeassistant homeassistant[547]: installed.
Oct 15 10:02:48 homeassistant homeassistant[547]: 
Oct 15 10:02:48 homeassistant homeassistant[547]: We have compiled some common reasons and troubleshooting tips at:
Oct 15 10:02:48 homeassistant homeassistant[547]: 
Oct 15 10:02:48 homeassistant homeassistant[547]:     https://numpy.org/devdocs/user/troubleshooting-importerror.html
Oct 15 10:02:48 homeassistant homeassistant[547]: 
Oct 15 10:02:48 homeassistant homeassistant[547]: Please note and check the following:
Oct 15 10:02:48 homeassistant homeassistant[547]: 
Oct 15 10:02:48 homeassistant homeassistant[547]:   * The Python version is: Python3.11 from "/usr/local/bin/python3"
Oct 15 10:02:48 homeassistant homeassistant[547]:   * The NumPy version is: "1.26.1"
Oct 15 10:02:48 homeassistant homeassistant[547]: 
Oct 15 10:02:48 homeassistant homeassistant[547]: and make sure that they are the versions you expect.
Oct 15 10:02:48 homeassistant homeassistant[547]: Please carefully study the documentation linked above for further help.
Oct 15 10:02:48 homeassistant homeassistant[547]: 
Oct 15 10:02:48 homeassistant homeassistant[547]: Original error was: Error loading shared library ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ: No error information (needed by /usr/local/lib/python3.11/site-packages/numpy/core/../../numpy.libs/libopenblasp-r0-250824a8.3.23.so)
Oct 15 10:02:48 homeassistant homeassistant[547]: 
Oct 15 10:02:48 homeassistant homeassistant[547]: 
Oct 15 10:02:48 homeassistant homeassistant[547]: The above exception was the direct cause of the following exception:
Oct 15 10:02:48 homeassistant homeassistant[547]: 
Oct 15 10:02:48 homeassistant homeassistant[547]: Traceback (most recent call last):
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "/usr/src/homeassistant/homeassistant/setup.py", line 215, in _async_setup_component
Oct 15 10:02:48 homeassistant homeassistant[547]:     component = integration.get_component()
Oct 15 10:02:48 homeassistant homeassistant[547]:                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "/usr/src/homeassistant/homeassistant/loader.py", line 816, in get_component
Oct 15 10:02:48 homeassistant homeassistant[547]:     ComponentProtocol, importlib.import_module(self.pkg_path)
Oct 15 10:02:48 homeassistant homeassistant[547]:                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "/usr/local/lib/python3.11/importlib/__init__.py", line 126, in import_module
Oct 15 10:02:48 homeassistant homeassistant[547]:     return _bootstrap._gcd_import(name[level:], package, level)
Oct 15 10:02:48 homeassistant homeassistant[547]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "<frozen importlib._bootstrap_external>", line 940, in exec_module
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "/usr/src/homeassistant/homeassistant/components/cloud/__init__.py", line 12, in <module>
Oct 15 10:02:48 homeassistant homeassistant[547]:     from homeassistant.components import alexa, google_assistant
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "/usr/src/homeassistant/homeassistant/components/alexa/__init__.py", line 19, in <module>
Oct 15 10:02:48 homeassistant homeassistant[547]:     from . import flash_briefings, intent, smart_home
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "/usr/src/homeassistant/homeassistant/components/alexa/smart_home.py", line 18, in <module>
Oct 15 10:02:48 homeassistant homeassistant[547]:     from .config import AbstractConfig
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "/usr/src/homeassistant/homeassistant/components/alexa/config.py", line 15, in <module>
Oct 15 10:02:48 homeassistant homeassistant[547]:     from .state_report import async_enable_proactive_mode
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "/usr/src/homeassistant/homeassistant/components/alexa/state_report.py", line 37, in <module>
Oct 15 10:02:48 homeassistant homeassistant[547]:     from .entities import ENTITY_ADAPTERS, AlexaEntity, generate_alexa_id
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "/usr/src/homeassistant/homeassistant/components/alexa/entities.py", line 8, in <module>
Oct 15 10:02:48 homeassistant homeassistant[547]:     from homeassistant.components import (
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "/usr/src/homeassistant/homeassistant/components/camera/__init__.py", line 29, in <module>
Oct 15 10:02:48 homeassistant homeassistant[547]:     from homeassistant.components.stream import (
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "/usr/src/homeassistant/homeassistant/components/stream/__init__.py", line 61, in <module>
Oct 15 10:02:48 homeassistant homeassistant[547]:     from .core import (
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "/usr/src/homeassistant/homeassistant/components/stream/core.py", line 14, in <module>
Oct 15 10:02:48 homeassistant homeassistant[547]:     import numpy as np
Oct 15 10:02:48 homeassistant homeassistant[547]:   File "/usr/local/lib/python3.11/site-packages/numpy/__init__.py", line 135, in <module>
Oct 15 10:02:48 homeassistant homeassistant[547]:     raise ImportError(msg) from e
Oct 15 10:02:48 homeassistant homeassistant[547]: ImportError: Error importing numpy: you should not try to import numpy from
Oct 15 10:02:48 homeassistant homeassistant[547]:         its source directory; please exit the numpy source tree, and relaunch
Oct 15 10:02:48 homeassistant homeassistant[547]:         your python interpreter from there.

```