### PR TITLE
Use UOM from specs as default for DSMR sensors

### DIFF
--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -29,7 +29,10 @@ from homeassistant.const import (
     CONF_PORT,
     EVENT_HOMEASSISTANT_STOP,
     EntityCategory,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
     UnitOfEnergy,
+    UnitOfPower,
     UnitOfVolume,
 )
 from homeassistant.core import CoreState, Event, HomeAssistant, callback
@@ -85,6 +88,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         force_update=True,
         state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
     ),
     DSMRSensorEntityDescription(
         key="current_electricity_delivery",
@@ -93,6 +97,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         force_update=True,
         state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
     ),
     DSMRSensorEntityDescription(
         key="electricity_active_tariff",
@@ -111,6 +116,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         force_update=True,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
     ),
     DSMRSensorEntityDescription(
         key="electricity_used_tariff_2",
@@ -120,6 +126,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         force_update=True,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
     ),
     DSMRSensorEntityDescription(
         key="electricity_delivered_tariff_1",
@@ -129,6 +136,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         force_update=True,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
     ),
     DSMRSensorEntityDescription(
         key="electricity_delivered_tariff_2",
@@ -138,6 +146,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         force_update=True,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l1_positive",
@@ -146,6 +155,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l2_positive",
@@ -154,6 +164,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l3_positive",
@@ -162,6 +173,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l1_negative",
@@ -170,6 +182,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l2_negative",
@@ -178,6 +191,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l3_negative",
@@ -186,6 +200,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
     ),
     DSMRSensorEntityDescription(
         key="short_power_failure_count",
@@ -264,6 +279,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_voltage_l2",
@@ -273,6 +289,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_voltage_l3",
@@ -282,6 +299,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_current_l1",
@@ -291,6 +309,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_current_l2",
@@ -300,6 +319,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_current_l3",
@@ -309,6 +329,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
     ),
     DSMRSensorEntityDescription(
         key="belgium_max_power_per_phase",
@@ -319,6 +340,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
     ),
     DSMRSensorEntityDescription(
         key="belgium_max_current_per_phase",
@@ -329,6 +351,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
     ),
     DSMRSensorEntityDescription(
         key="electricity_imported_total",
@@ -338,6 +361,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         force_update=True,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
     ),
     DSMRSensorEntityDescription(
         key="electricity_exported_total",
@@ -347,6 +371,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         force_update=True,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
     ),
     DSMRSensorEntityDescription(
         key="hourly_gas_meter_reading",
@@ -357,6 +382,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         force_update=True,
         device_class=SensorDeviceClass.GAS,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
     ),
     DSMRSensorEntityDescription(
         key="belgium_5min_gas_meter_reading",
@@ -367,6 +393,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         force_update=True,
         device_class=SensorDeviceClass.GAS,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
     ),
     DSMRSensorEntityDescription(
         key="gas_meter_reading",
@@ -377,6 +404,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         force_update=True,
         device_class=SensorDeviceClass.GAS,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
     ),
 )
 
@@ -632,8 +660,8 @@ class DSMREntity(SensorEntity):
         """Return the unit of measurement of this entity, if any."""
         unit_of_measurement = self.get_dsmr_object_attr("unit")
         if unit_of_measurement in UNIT_CONVERSION:
-            return UNIT_CONVERSION[unit_of_measurement]
-        return unit_of_measurement
+            unit_of_measurement = UNIT_CONVERSION[unit_of_measurement]
+        return unit_of_measurement or self.entity_description.native_unit_of_measurement
 
     @staticmethod
     def translate_tariff(value: str, dsmr_version: str) -> str | None:

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -102,7 +102,10 @@ async def test_default_setup(hass: HomeAssistant, dsmr_connection_fixture) -> No
         power_consumption.attributes.get(ATTR_STATE_CLASS)
         == SensorStateClass.MEASUREMENT
     )
-    assert power_consumption.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
+    assert (
+        power_consumption.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        == UnitOfPower.KILO_WATT
+    )
 
     # simulate a telegram pushed from the smartmeter and parsed by dsmr_parser
     telegram_callback(telegram)
@@ -126,7 +129,7 @@ async def test_default_setup(hass: HomeAssistant, dsmr_connection_fixture) -> No
     )
     assert active_tariff.attributes.get(ATTR_OPTIONS) == ["low", "normal"]
     assert active_tariff.attributes.get(ATTR_STATE_CLASS) is None
-    assert active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ""
+    assert active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
 
     # check if gas consumption is parsed correctly
     gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption")
@@ -231,7 +234,7 @@ async def test_v4_meter(hass: HomeAssistant, dsmr_connection_fixture) -> None:
     assert active_tariff.attributes.get(ATTR_ICON) == "mdi:flash"
     assert active_tariff.attributes.get(ATTR_OPTIONS) == ["low", "normal"]
     assert active_tariff.attributes.get(ATTR_STATE_CLASS) is None
-    assert active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ""
+    assert active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
 
     # check if gas consumption is parsed correctly
     gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption")
@@ -307,7 +310,7 @@ async def test_v5_meter(hass: HomeAssistant, dsmr_connection_fixture) -> None:
     assert active_tariff.attributes.get(ATTR_ICON) == "mdi:flash"
     assert active_tariff.attributes.get(ATTR_OPTIONS) == ["low", "normal"]
     assert active_tariff.attributes.get(ATTR_STATE_CLASS) is None
-    assert active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ""
+    assert active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
 
     # check if gas consumption is parsed correctly
     gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption")
@@ -468,7 +471,7 @@ async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
     assert active_tariff.attributes.get(ATTR_ICON) == "mdi:flash"
     assert active_tariff.attributes.get(ATTR_OPTIONS) == ["low", "normal"]
     assert active_tariff.attributes.get(ATTR_STATE_CLASS) is None
-    assert active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ""
+    assert active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
 
     # check if gas consumption is parsed correctly
     gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption")
@@ -529,7 +532,7 @@ async def test_belgian_meter_low(hass: HomeAssistant, dsmr_connection_fixture) -
     assert active_tariff.attributes.get(ATTR_ICON) == "mdi:flash"
     assert active_tariff.attributes.get(ATTR_OPTIONS) == ["low", "normal"]
     assert active_tariff.attributes.get(ATTR_STATE_CLASS) is None
-    assert active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ""
+    assert active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
 
 
 async def test_swedish_meter(hass: HomeAssistant, dsmr_connection_fixture) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Set the UOM for DSMR sensors statically to avoid it from not being available at startup. Only in case of a Gas energy meter, it is expected that the unit and `device_class` can be different.
It is not a best practice to update the `device_class` after creating the entity. Alternative approaches are:
1. Correct it  using a helper when it becomes available (see https://github.com/home-assistant/core/pull/101697 for a solution) 
2. Add the entities after receiving the first telegram (usually happens within 10 sec).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #92492 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
