### PR TITLE
Skip CalDAV calendars that do not support events

### DIFF
--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -114,8 +114,19 @@ def setup_platform(
                 )
             )
 
-        # Create a default calendar if there was no custom one
+        # Create a default calendar if there was no custom one for all calendars
+        # that support events.
         if not config[CONF_CUSTOM_CALENDARS]:
+            if (
+                supported_components := calendar.get_supported_components()
+            ) and "VEVENT" not in supported_components:
+                _LOGGER.debug(
+                    "Ignoring calendar '%s' (components=%s)",
+                    calendar.name,
+                    supported_components,
+                )
+                continue
+
             name = calendar.name
             device_id = calendar.name
             entity_id = generate_entity_id(ENTITY_ID_FORMAT, device_id, hass=hass)

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -1078,6 +1078,8 @@ async def test_calendar_components(
         _mock_calendar("Calendar 1", supported_components=["VEVENT"]),
         _mock_calendar("Calendar 2", supported_components=["VEVENT", "VJOURNAL"]),
         _mock_calendar("Calendar 3", supported_components=["VTODO"]),
+        # Fallback to allow when no components are supported to be conservative
+        _mock_calendar("Calendar 4", supported_components=[]),
     ]
     with patch(
         "homeassistant.components.caldav.calendar.caldav.DAVClient",
@@ -1096,5 +1098,10 @@ async def test_calendar_components(
     assert state.name == "Calendar 2"
     assert state.state == STATE_OFF
 
+    # No entity created for To-do only component
     state = hass.states.get("calendar.calendar_3")
     assert not state
+
+    state = hass.states.get("calendar.calendar_4")
+    assert state.name == "Calendar 4"
+    assert state.state == STATE_OFF

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -375,14 +375,16 @@ def _mocked_dav_client(*names, calendars=None):
     return client
 
 
-def _mock_calendar(name):
+def _mock_calendar(name, supported_components=None):
     calendar = Mock()
     events = []
     for idx, event in enumerate(EVENTS):
         events.append(Event(None, "%d.ics" % idx, event, calendar, str(idx)))
-
+    if supported_components is None:
+        supported_components = ["VEVENT"]
     calendar.search = MagicMock(return_value=events)
     calendar.name = name
+    calendar.get_supported_components = MagicMock(return_value=supported_components)
     return calendar
 
 
@@ -1066,3 +1068,33 @@ async def test_get_events_custom_calendars(
             "rrule": None,
         }
     ]
+
+
+async def test_calendar_components(
+    hass: HomeAssistant,
+) -> None:
+    """Test that only calendars that support events are created."""
+    calendars = [
+        _mock_calendar("Calendar 1", supported_components=["VEVENT"]),
+        _mock_calendar("Calendar 2", supported_components=["VEVENT", "VJOURNAL"]),
+        _mock_calendar("Calendar 3", supported_components=["VTODO"]),
+    ]
+    with patch(
+        "homeassistant.components.caldav.calendar.caldav.DAVClient",
+        return_value=_mocked_dav_client(calendars=calendars),
+    ):
+        assert await async_setup_component(
+            hass, "calendar", {"calendar": CALDAV_CONFIG}
+        )
+        await hass.async_block_till_done()
+
+    state = hass.states.get("calendar.calendar_1")
+    assert state.name == "Calendar 1"
+    assert state.state == STATE_OFF
+
+    state = hass.states.get("calendar.calendar_2")
+    assert state.name == "Calendar 2"
+    assert state.state == STATE_OFF
+
+    state = hass.states.get("calendar.calendar_3")
+    assert not state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Skip creating a calendar entity for CalDAV calendars that do not support events, for example calendars that only support "VTODO" such as iCloud reminders.

This is pulled out as a separate PR for preparing to provide support To-do Lists in Home Assistant via the todo platform (https://github.com/home-assistant/architecture/discussions/962)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #86221
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
