### PR TITLE
Add ZHA cover tilt

### DIFF
--- a/homeassistant/components/zha/core/cluster_handlers/closures.py
+++ b/homeassistant/components/zha/core/cluster_handlers/closures.py
@@ -124,8 +124,12 @@ class WindowCoveringClient(ClientClusterHandler):
 class WindowCovering(ClusterHandler):
     """Window cluster handler."""
 
-    _value_attribute_lift = 8
-    _value_attribute_tilt = 9
+    _value_attribute_lift = (
+        closures.WindowCovering.AttributeDefs.current_position_lift_percentage.id
+    )
+    _value_attribute_tilt = (
+        closures.WindowCovering.AttributeDefs.current_position_tilt_percentage.id
+    )
     REPORT_CONFIG = (
         AttrReportConfig(
             attr="current_position_lift_percentage", config=REPORT_CONFIG_IMMEDIATE

--- a/homeassistant/components/zha/core/cluster_handlers/closures.py
+++ b/homeassistant/components/zha/core/cluster_handlers/closures.py
@@ -124,10 +124,14 @@ class WindowCoveringClient(ClientClusterHandler):
 class WindowCovering(ClusterHandler):
     """Window cluster handler."""
 
-    _value_attribute = 8
+    _value_attribute_lift = 8
+    _value_attribute_tilt = 9
     REPORT_CONFIG = (
         AttrReportConfig(
             attr="current_position_lift_percentage", config=REPORT_CONFIG_IMMEDIATE
+        ),
+        AttrReportConfig(
+            attr="current_position_tilt_percentage", config=REPORT_CONFIG_IMMEDIATE
         ),
     )
 
@@ -140,8 +144,19 @@ class WindowCovering(ClusterHandler):
         if result is not None:
             self.async_send_signal(
                 f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}",
-                8,
+                self._value_attribute_lift,
                 "current_position_lift_percentage",
+                result,
+            )
+        result = await self.get_attribute_value(
+            "current_position_tilt_percentage", from_cache=False
+        )
+        self.debug("read current tilt position: %s", result)
+        if result is not None:
+            self.async_send_signal(
+                f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}",
+                self._value_attribute_tilt,
+                "current_position_tilt_percentage",
                 result,
             )
 
@@ -152,7 +167,7 @@ class WindowCovering(ClusterHandler):
         self.debug(
             "Attribute report '%s'[%s] = %s", self.cluster.name, attr_name, value
         )
-        if attrid == self._value_attribute:
+        if attrid in (self._value_attribute_lift, self._value_attribute_tilt):
             self.async_send_signal(
                 f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", attrid, attr_name, value
             )

--- a/homeassistant/components/zha/cover.py
+++ b/homeassistant/components/zha/cover.py
@@ -213,35 +213,6 @@ class ZhaCover(ZhaEntity, CoverEntity):
         """Stop the cover tilt."""
         await self.async_stop_cover()
 
-    async def async_update(self) -> None:
-        """Attempt to retrieve the open/close state of the cover."""
-        await super().async_update()
-        await self.async_get_state()
-
-    async def async_get_state(self, from_cache=True):
-        """Fetch the current state."""
-        _LOGGER.debug("polling current state")
-        if self._cover_cluster_handler:
-            pos = await self._cover_cluster_handler.get_attribute_value(
-                "current_position_lift_percentage", from_cache=from_cache
-            )
-            _LOGGER.debug("read pos=%s", pos)
-            if pos is not None:
-                self._current_position = 100 - pos
-                self._state = (
-                    STATE_OPEN if self.current_cover_position > 0 else STATE_CLOSED
-                )
-            else:
-                self._current_position = None
-                self._state = None
-
-            tilt_pos = await self._cover_cluster_handler.get_attribute_value(
-                "current_position_tilt_percentage", from_cache=from_cache
-            )
-            _LOGGER.debug("read tilt pos=%s", tilt_pos)
-            if tilt_pos is not None:
-                self._tilt_position = 100 - tilt_pos
-
 
 @MULTI_MATCH(
     cluster_handler_names={

--- a/homeassistant/components/zha/cover.py
+++ b/homeassistant/components/zha/cover.py
@@ -11,6 +11,7 @@ from zigpy.zcl.foundation import Status
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
     ATTR_POSITION,
+    ATTR_TILT_POSITION,
     CoverDeviceClass,
     CoverEntity,
 )
@@ -80,6 +81,7 @@ class ZhaCover(ZhaEntity, CoverEntity):
         super().__init__(unique_id, zha_device, cluster_handlers, **kwargs)
         self._cover_cluster_handler = self.cluster_handlers.get(CLUSTER_HANDLER_COVER)
         self._current_position = None
+        self._tilt_position = None
 
     async def async_added_to_hass(self) -> None:
         """Run when about to be added to hass."""
@@ -94,6 +96,10 @@ class ZhaCover(ZhaEntity, CoverEntity):
         self._state = last_state.state
         if "current_position" in last_state.attributes:
             self._current_position = last_state.attributes["current_position"]
+        if "current_tilt_position" in last_state.attributes:
+            self._tilt_position = last_state.attributes[
+                "current_tilt_position"
+            ]  # first allocation activate tilt
 
     @property
     def is_closed(self) -> bool | None:
@@ -120,15 +126,26 @@ class ZhaCover(ZhaEntity, CoverEntity):
         """
         return self._current_position
 
+    @property
+    def current_cover_tilt_position(self) -> int | None:
+        """Return the current tilt position of the cover."""
+        return self._tilt_position
+
     @callback
     def async_set_position(self, attr_id, attr_name, value):
         """Handle position update from cluster handler."""
-        _LOGGER.debug("setting position: %s", value)
-        self._current_position = 100 - value
+        _LOGGER.debug("setting position: %s %s %s", attr_id, attr_name, value)
+        if attr_name == "current_position_lift_percentage":
+            self._current_position = 100 - value
+        elif attr_name == "current_position_tilt_percentage":
+            self._tilt_position = 100 - value
+
         if self._current_position == 0:
             self._state = STATE_CLOSED
         elif self._current_position == 100:
             self._state = STATE_OPEN
+        else:
+            self._state = None
         self.async_write_ha_state()
 
     @callback
@@ -145,12 +162,22 @@ class ZhaCover(ZhaEntity, CoverEntity):
             raise HomeAssistantError(f"Failed to open cover: {res[1]}")
         self.async_update_state(STATE_OPENING)
 
+    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+        """Open the cover tilt."""
+        await self._cover_cluster_handler.go_to_tilt_percentage(0)
+
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the window cover."""
         res = await self._cover_cluster_handler.down_close()
         if res[1] is not Status.SUCCESS:
             raise HomeAssistantError(f"Failed to close cover: {res[1]}")
         self.async_update_state(STATE_CLOSING)
+
+    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+        """Close the cover tilt."""
+        res = await self._cover_cluster_handler.go_to_tilt_percentage(100)
+        if not isinstance(res, Exception) and res[1] is Status.SUCCESS:
+            self.async_update_state(STATE_CLOSING)
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the roller shutter to a specific position."""
@@ -162,6 +189,11 @@ class ZhaCover(ZhaEntity, CoverEntity):
             STATE_CLOSING if new_pos < self._current_position else STATE_OPENING
         )
 
+    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+        """Move the cover til to a specific position."""
+        new_pos = kwargs[ATTR_TILT_POSITION]
+        await self._cover_cluster_handler.go_to_tilt_percentage(100 - new_pos)
+
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the window cover."""
         res = await self._cover_cluster_handler.stop()
@@ -169,6 +201,10 @@ class ZhaCover(ZhaEntity, CoverEntity):
             raise HomeAssistantError(f"Failed to stop cover: {res[1]}")
         self._state = STATE_OPEN if self._current_position > 0 else STATE_CLOSED
         self.async_write_ha_state()
+
+    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+        """Stop the cover tilt."""
+        await self._cover_cluster_handler.stop()
 
     async def async_update(self) -> None:
         """Attempt to retrieve the open/close state of the cover."""
@@ -192,6 +228,13 @@ class ZhaCover(ZhaEntity, CoverEntity):
             else:
                 self._current_position = None
                 self._state = None
+            pos = await self._cover_cluster_handler.get_attribute_value(
+                "current_position_tilt_percentage", from_cache=from_cache
+            )
+            _LOGGER.debug("read tilt pos=%s", pos)
+
+            if pos is not None:
+                self._tilt_position = 100 - pos
 
 
 @MULTI_MATCH(

--- a/homeassistant/components/zha/cover.py
+++ b/homeassistant/components/zha/cover.py
@@ -144,8 +144,6 @@ class ZhaCover(ZhaEntity, CoverEntity):
             self._state = STATE_CLOSED
         elif self._current_position == 100:
             self._state = STATE_OPEN
-        else:
-            self._state = None
         self.async_write_ha_state()
 
     @callback
@@ -164,7 +162,10 @@ class ZhaCover(ZhaEntity, CoverEntity):
 
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Open the cover tilt."""
-        await self._cover_cluster_handler.go_to_tilt_percentage(0)
+        res = await self._cover_cluster_handler.go_to_tilt_percentage(0)
+        if res[1] is not Status.SUCCESS:
+            raise HomeAssistantError(f"Failed to open cover tilt: {res[1]}")
+        self.async_update_state(STATE_OPENING)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the window cover."""
@@ -176,8 +177,9 @@ class ZhaCover(ZhaEntity, CoverEntity):
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Close the cover tilt."""
         res = await self._cover_cluster_handler.go_to_tilt_percentage(100)
-        if not isinstance(res, Exception) and res[1] is Status.SUCCESS:
-            self.async_update_state(STATE_CLOSING)
+        if res[1] is not Status.SUCCESS:
+            raise HomeAssistantError(f"Failed to close cover tilt: {res[1]}")
+        self.async_update_state(STATE_CLOSING)
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the roller shutter to a specific position."""
@@ -192,7 +194,12 @@ class ZhaCover(ZhaEntity, CoverEntity):
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the cover til to a specific position."""
         new_pos = kwargs[ATTR_TILT_POSITION]
-        await self._cover_cluster_handler.go_to_tilt_percentage(100 - new_pos)
+        res = await self._cover_cluster_handler.go_to_tilt_percentage(100 - new_pos)
+        if res[1] is not Status.SUCCESS:
+            raise HomeAssistantError(f"Failed to set cover tilt position: {res[1]}")
+        self.async_update_state(
+            STATE_CLOSING if new_pos < self._tilt_position else STATE_OPENING
+        )
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the window cover."""
@@ -204,7 +211,7 @@ class ZhaCover(ZhaEntity, CoverEntity):
 
     async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
         """Stop the cover tilt."""
-        await self._cover_cluster_handler.stop()
+        await self.async_stop_cover()
 
     async def async_update(self) -> None:
         """Attempt to retrieve the open/close state of the cover."""
@@ -219,7 +226,6 @@ class ZhaCover(ZhaEntity, CoverEntity):
                 "current_position_lift_percentage", from_cache=from_cache
             )
             _LOGGER.debug("read pos=%s", pos)
-
             if pos is not None:
                 self._current_position = 100 - pos
                 self._state = (
@@ -228,13 +234,13 @@ class ZhaCover(ZhaEntity, CoverEntity):
             else:
                 self._current_position = None
                 self._state = None
-            pos = await self._cover_cluster_handler.get_attribute_value(
+
+            tilt_pos = await self._cover_cluster_handler.get_attribute_value(
                 "current_position_tilt_percentage", from_cache=from_cache
             )
-            _LOGGER.debug("read tilt pos=%s", pos)
-
-            if pos is not None:
-                self._tilt_position = 100 - pos
+            _LOGGER.debug("read tilt pos=%s", tilt_pos)
+            if tilt_pos is not None:
+                self._tilt_position = 100 - tilt_pos
 
 
 @MULTI_MATCH(

--- a/tests/components/zha/test_cover.py
+++ b/tests/components/zha/test_cover.py
@@ -11,6 +11,7 @@ import zigpy.zcl.foundation as zcl_f
 
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
+    ATTR_CURRENT_TILT_POSITION,
     ATTR_TILT_POSITION,
     DOMAIN as COVER_DOMAIN,
     SERVICE_CLOSE_COVER,
@@ -33,6 +34,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import CoreState, HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_component import async_update_entity
 
 from .common import (
     async_enable_traffic,
@@ -70,7 +72,7 @@ def zigpy_cover_device(zigpy_device_mock):
     endpoints = {
         1: {
             SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
-            SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.IAS_ZONE,
+            SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.WINDOW_COVERING_DEVICE,
             SIG_EP_INPUT: [closures.WindowCovering.cluster_id],
             SIG_EP_OUTPUT: [],
         }
@@ -136,8 +138,10 @@ async def test_cover(
 
     # load up cover domain
     cluster = zigpy_cover_device.endpoints.get(1).window_covering
-    cluster.PLUGGED_ATTR_READS = {"current_position_lift_percentage": 100}
-    cluster.PLUGGED_ATTR_READS = {"current_position_tilt_percentage": 100}
+    cluster.PLUGGED_ATTR_READS = {
+        "current_position_lift_percentage": 65,
+        "current_position_tilt_percentage": 42,
+    }
     zha_device = await zha_device_joined_restored(zigpy_cover_device)
     assert cluster.read_attributes.call_count == 1
     assert "current_position_lift_percentage" in cluster.read_attributes.call_args[0][0]
@@ -154,6 +158,16 @@ async def test_cover(
     await async_enable_traffic(hass, [zha_device])
     await hass.async_block_till_done()
 
+    # test update
+    prev_call_count = cluster.read_attributes.call_count
+    await async_update_entity(hass, entity_id)
+    assert cluster.read_attributes.call_count == prev_call_count + 2
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_OPEN
+    assert state.attributes[ATTR_CURRENT_POSITION] == 35
+    assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 58
+
     # test that the state has changed from unavailable to off
     await send_attributes_report(hass, cluster, {0: 0, 8: 100, 1: 1})
     assert hass.states.get(entity_id).state == STATE_CLOSED
@@ -162,11 +176,11 @@ async def test_cover(
     await send_attributes_report(hass, cluster, {0: 1, 8: 0, 1: 100})
     assert hass.states.get(entity_id).state == STATE_OPEN
 
-    # test that the state remains
+    # test that the state remains after tilting to 100%
     await send_attributes_report(hass, cluster, {0: 0, 9: 100, 1: 1})
     assert hass.states.get(entity_id).state == STATE_OPEN
 
-    # test to see the state remains
+    # test to see the state remains after tilting to 0%
     await send_attributes_report(hass, cluster, {0: 1, 9: 0, 1: 100})
     assert hass.states.get(entity_id).state == STATE_OPEN
 
@@ -301,7 +315,10 @@ async def test_cover_failures(
 
     # load up cover domain
     cluster = zigpy_cover_device.endpoints.get(1).window_covering
-    cluster.PLUGGED_ATTR_READS = {"current_position_lift_percentage": 100}
+    cluster.PLUGGED_ATTR_READS = {
+        "current_position_lift_percentage": None,
+        "current_position_tilt_percentage": 42,
+    }
     zha_device = await zha_device_joined_restored(zigpy_cover_device)
 
     entity_id = find_entity_id(Platform.COVER, zha_device, hass)
@@ -311,11 +328,17 @@ async def test_cover_failures(
     # test that the cover was created and that it is unavailable
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
+    # test update returned None
+    prev_call_count = cluster.read_attributes.call_count
+    await async_update_entity(hass, entity_id)
+    assert cluster.read_attributes.call_count == prev_call_count + 2
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+
     # allow traffic to flow through the gateway and device
     await async_enable_traffic(hass, [zha_device])
     await hass.async_block_till_done()
 
-    # test that the state has changed from unavailable to off
+    # test that the state has changed from unavailable to closed
     await send_attributes_report(hass, cluster, {0: 0, 8: 100, 1: 1})
     assert hass.states.get(entity_id).state == STATE_CLOSED
 
@@ -344,6 +367,26 @@ async def test_cover_failures(
             == closures.WindowCovering.ServerCommandDefs.down_close.id
         )
 
+    with patch(
+        "zigpy.zcl.Cluster.request",
+        return_value=Default_Response(
+            command_id=closures.WindowCovering.ServerCommandDefs.go_to_tilt_percentage.id,
+            status=zcl_f.Status.UNSUP_CLUSTER_COMMAND,
+        ),
+    ):
+        with pytest.raises(HomeAssistantError, match=r"Failed to close cover tilt"):
+            await hass.services.async_call(
+                COVER_DOMAIN,
+                SERVICE_CLOSE_COVER_TILT,
+                {"entity_id": entity_id},
+                blocking=True,
+            )
+        assert cluster.request.call_count == 1
+        assert (
+            cluster.request.call_args[0][1]
+            == closures.WindowCovering.ServerCommandDefs.go_to_tilt_percentage.id
+        )
+
     # open from UI
     with patch(
         "zigpy.zcl.Cluster.request",
@@ -363,6 +406,26 @@ async def test_cover_failures(
         assert (
             cluster.request.call_args[0][1]
             == closures.WindowCovering.ServerCommandDefs.up_open.id
+        )
+
+    with patch(
+        "zigpy.zcl.Cluster.request",
+        return_value=Default_Response(
+            command_id=closures.WindowCovering.ServerCommandDefs.go_to_tilt_percentage.id,
+            status=zcl_f.Status.UNSUP_CLUSTER_COMMAND,
+        ),
+    ):
+        with pytest.raises(HomeAssistantError, match=r"Failed to open cover tilt"):
+            await hass.services.async_call(
+                COVER_DOMAIN,
+                SERVICE_OPEN_COVER_TILT,
+                {"entity_id": entity_id},
+                blocking=True,
+            )
+        assert cluster.request.call_count == 1
+        assert (
+            cluster.request.call_args[0][1]
+            == closures.WindowCovering.ServerCommandDefs.go_to_tilt_percentage.id
         )
 
     # set position UI
@@ -385,6 +448,28 @@ async def test_cover_failures(
         assert (
             cluster.request.call_args[0][1]
             == closures.WindowCovering.ServerCommandDefs.go_to_lift_percentage.id
+        )
+
+    with patch(
+        "zigpy.zcl.Cluster.request",
+        return_value=Default_Response(
+            command_id=closures.WindowCovering.ServerCommandDefs.go_to_tilt_percentage.id,
+            status=zcl_f.Status.UNSUP_CLUSTER_COMMAND,
+        ),
+    ):
+        with pytest.raises(
+            HomeAssistantError, match=r"Failed to set cover tilt position"
+        ):
+            await hass.services.async_call(
+                COVER_DOMAIN,
+                SERVICE_SET_COVER_TILT_POSITION,
+                {"entity_id": entity_id, "tilt_position": 42},
+                blocking=True,
+            )
+        assert cluster.request.call_count == 1
+        assert (
+            cluster.request.call_args[0][1]
+            == closures.WindowCovering.ServerCommandDefs.go_to_tilt_percentage.id
         )
 
     # stop from UI
@@ -585,11 +670,10 @@ async def test_shade(
         assert cluster_level.request.call_args[0][1] in (0x0003, 0x0007)
 
 
-async def test_restore_state(
+async def test_shade_restore_state(
     hass: HomeAssistant, zha_device_restored, zigpy_shade_device
 ) -> None:
     """Ensure states are restored on startup."""
-
     mock_restore_cache(
         hass,
         (
@@ -607,9 +691,36 @@ async def test_restore_state(
     entity_id = find_entity_id(Platform.COVER, zha_device, hass)
     assert entity_id is not None
 
-    # test that the cover was created and that it is unavailable
+    # test that the cover was created and that it is available
     assert hass.states.get(entity_id).state == STATE_OPEN
     assert hass.states.get(entity_id).attributes[ATTR_CURRENT_POSITION] == 50
+
+
+async def test_cover_restore_state(
+    hass: HomeAssistant, zha_device_restored, zigpy_cover_device
+) -> None:
+    """Ensure states are restored on startup."""
+    mock_restore_cache(
+        hass,
+        (
+            State(
+                "cover.fakemanufacturer_fakemodel_cover",
+                STATE_OPEN,
+                {ATTR_CURRENT_POSITION: 50, ATTR_CURRENT_TILT_POSITION: 42},
+            ),
+        ),
+    )
+
+    hass.state = CoreState.starting
+
+    zha_device = await zha_device_restored(zigpy_cover_device)
+    entity_id = find_entity_id(Platform.COVER, zha_device, hass)
+    assert entity_id is not None
+
+    # test that the cover was created and that it is available
+    assert hass.states.get(entity_id).state == STATE_OPEN
+    assert hass.states.get(entity_id).attributes[ATTR_CURRENT_POSITION] == 50
+    assert hass.states.get(entity_id).attributes[ATTR_CURRENT_TILT_POSITION] == 42
 
 
 async def test_keen_vent(

--- a/tests/components/zha/test_cover.py
+++ b/tests/components/zha/test_cover.py
@@ -181,9 +181,7 @@ async def test_cover(
         assert cluster.request.call_args[0][2].command.name == "down_close"
         assert cluster.request.call_args[1]["expect_reply"] is True
 
-    with patch(
-        "zigpy.zcl.Cluster.request", return_value=mock_coro([0x1, zcl_f.Status.SUCCESS])
-    ):
+    with patch("zigpy.zcl.Cluster.request", return_value=[0x1, zcl_f.Status.SUCCESS]):
         await hass.services.async_call(
             COVER_DOMAIN,
             SERVICE_CLOSE_COVER_TILT,
@@ -208,9 +206,7 @@ async def test_cover(
         assert cluster.request.call_args[0][2].command.name == "up_open"
         assert cluster.request.call_args[1]["expect_reply"] is True
 
-    with patch(
-        "zigpy.zcl.Cluster.request", return_value=mock_coro([0x0, zcl_f.Status.SUCCESS])
-    ):
+    with patch("zigpy.zcl.Cluster.request", return_value=[0x0, zcl_f.Status.SUCCESS]):
         await hass.services.async_call(
             COVER_DOMAIN,
             SERVICE_OPEN_COVER_TILT,
@@ -239,9 +235,7 @@ async def test_cover(
         assert cluster.request.call_args[0][3] == 53
         assert cluster.request.call_args[1]["expect_reply"] is True
 
-    with patch(
-        "zigpy.zcl.Cluster.request", return_value=mock_coro([0x5, zcl_f.Status.SUCCESS])
-    ):
+    with patch("zigpy.zcl.Cluster.request", return_value=[0x5, zcl_f.Status.SUCCESS]):
         await hass.services.async_call(
             COVER_DOMAIN,
             SERVICE_SET_COVER_TILT_POSITION,
@@ -266,9 +260,7 @@ async def test_cover(
         assert cluster.request.call_args[0][2].command.name == "stop"
         assert cluster.request.call_args[1]["expect_reply"] is True
 
-    with patch(
-        "zigpy.zcl.Cluster.request", return_value=mock_coro([0x2, zcl_f.Status.SUCCESS])
-    ):
+    with patch("zigpy.zcl.Cluster.request", return_value=[0x2, zcl_f.Status.SUCCESS]):
         await hass.services.async_call(
             COVER_DOMAIN,
             SERVICE_STOP_COVER_TILT,
@@ -287,9 +279,7 @@ async def test_cover(
     assert hass.states.get(entity_id).state == STATE_OPEN
 
     # test toggle
-    with patch(
-        "zigpy.zcl.Cluster.request", return_value=mock_coro([0x2, zcl_f.Status.SUCCESS])
-    ):
+    with patch("zigpy.zcl.Cluster.request", return_value=[0x2, zcl_f.Status.SUCCESS]):
         await hass.services.async_call(
             COVER_DOMAIN,
             SERVICE_TOGGLE_COVER_TILT,

--- a/tests/components/zha/test_cover.py
+++ b/tests/components/zha/test_cover.py
@@ -11,11 +11,17 @@ import zigpy.zcl.foundation as zcl_f
 
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
+    ATTR_TILT_POSITION,
     DOMAIN as COVER_DOMAIN,
     SERVICE_CLOSE_COVER,
+    SERVICE_CLOSE_COVER_TILT,
     SERVICE_OPEN_COVER,
+    SERVICE_OPEN_COVER_TILT,
     SERVICE_SET_COVER_POSITION,
+    SERVICE_SET_COVER_TILT_POSITION,
     SERVICE_STOP_COVER,
+    SERVICE_STOP_COVER_TILT,
+    SERVICE_TOGGLE_COVER_TILT,
 )
 from homeassistant.components.zha.core.const import ZHA_EVENT
 from homeassistant.const import (
@@ -131,9 +137,11 @@ async def test_cover(
     # load up cover domain
     cluster = zigpy_cover_device.endpoints.get(1).window_covering
     cluster.PLUGGED_ATTR_READS = {"current_position_lift_percentage": 100}
+    cluster.PLUGGED_ATTR_READS = {"current_position_tilt_percentage": 100}
     zha_device = await zha_device_joined_restored(zigpy_cover_device)
     assert cluster.read_attributes.call_count == 1
     assert "current_position_lift_percentage" in cluster.read_attributes.call_args[0][0]
+    assert "current_position_tilt_percentage" in cluster.read_attributes.call_args[0][0]
 
     entity_id = find_entity_id(Platform.COVER, zha_device, hass)
     assert entity_id is not None
@@ -154,6 +162,14 @@ async def test_cover(
     await send_attributes_report(hass, cluster, {0: 1, 8: 0, 1: 100})
     assert hass.states.get(entity_id).state == STATE_OPEN
 
+    # test that the state remains
+    await send_attributes_report(hass, cluster, {0: 0, 9: 100, 1: 1})
+    assert hass.states.get(entity_id).state == STATE_OPEN
+
+    # test to see the state remains
+    await send_attributes_report(hass, cluster, {0: 1, 9: 0, 1: 100})
+    assert hass.states.get(entity_id).state == STATE_OPEN
+
     # close from UI
     with patch("zigpy.zcl.Cluster.request", return_value=[0x1, zcl_f.Status.SUCCESS]):
         await hass.services.async_call(
@@ -165,6 +181,22 @@ async def test_cover(
         assert cluster.request.call_args[0][2].command.name == "down_close"
         assert cluster.request.call_args[1]["expect_reply"] is True
 
+    with patch(
+        "zigpy.zcl.Cluster.request", return_value=mock_coro([0x1, zcl_f.Status.SUCCESS])
+    ):
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_CLOSE_COVER_TILT,
+            {"entity_id": entity_id},
+            blocking=True,
+        )
+        assert cluster.request.call_count == 1
+        assert cluster.request.call_args[0][0] is False
+        assert cluster.request.call_args[0][1] == 0x08
+        assert cluster.request.call_args[0][2].command.name == "go_to_tilt_percentage"
+        assert cluster.request.call_args[0][3] == 100
+        assert cluster.request.call_args[1]["expect_reply"] is True
+
     # open from UI
     with patch("zigpy.zcl.Cluster.request", return_value=[0x0, zcl_f.Status.SUCCESS]):
         await hass.services.async_call(
@@ -174,6 +206,22 @@ async def test_cover(
         assert cluster.request.call_args[0][0] is False
         assert cluster.request.call_args[0][1] == 0x00
         assert cluster.request.call_args[0][2].command.name == "up_open"
+        assert cluster.request.call_args[1]["expect_reply"] is True
+
+    with patch(
+        "zigpy.zcl.Cluster.request", return_value=mock_coro([0x0, zcl_f.Status.SUCCESS])
+    ):
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_OPEN_COVER_TILT,
+            {"entity_id": entity_id},
+            blocking=True,
+        )
+        assert cluster.request.call_count == 1
+        assert cluster.request.call_args[0][0] is False
+        assert cluster.request.call_args[0][1] == 0x08
+        assert cluster.request.call_args[0][2].command.name == "go_to_tilt_percentage"
+        assert cluster.request.call_args[0][3] == 0
         assert cluster.request.call_args[1]["expect_reply"] is True
 
     # set position UI
@@ -191,6 +239,22 @@ async def test_cover(
         assert cluster.request.call_args[0][3] == 53
         assert cluster.request.call_args[1]["expect_reply"] is True
 
+    with patch(
+        "zigpy.zcl.Cluster.request", return_value=mock_coro([0x5, zcl_f.Status.SUCCESS])
+    ):
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_SET_COVER_TILT_POSITION,
+            {"entity_id": entity_id, ATTR_TILT_POSITION: 47},
+            blocking=True,
+        )
+        assert cluster.request.call_count == 1
+        assert cluster.request.call_args[0][0] is False
+        assert cluster.request.call_args[0][1] == 0x08
+        assert cluster.request.call_args[0][2].command.name == "go_to_tilt_percentage"
+        assert cluster.request.call_args[0][3] == 53
+        assert cluster.request.call_args[1]["expect_reply"] is True
+
     # stop from UI
     with patch("zigpy.zcl.Cluster.request", return_value=[0x2, zcl_f.Status.SUCCESS]):
         await hass.services.async_call(
@@ -202,10 +266,42 @@ async def test_cover(
         assert cluster.request.call_args[0][2].command.name == "stop"
         assert cluster.request.call_args[1]["expect_reply"] is True
 
+    with patch(
+        "zigpy.zcl.Cluster.request", return_value=mock_coro([0x2, zcl_f.Status.SUCCESS])
+    ):
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_STOP_COVER_TILT,
+            {"entity_id": entity_id},
+            blocking=True,
+        )
+        assert cluster.request.call_count == 1
+        assert cluster.request.call_args[0][0] is False
+        assert cluster.request.call_args[0][1] == 0x02
+        assert cluster.request.call_args[0][2].command.name == "stop"
+        assert cluster.request.call_args[1]["expect_reply"] is True
+
     # test rejoin
     cluster.PLUGGED_ATTR_READS = {"current_position_lift_percentage": 0}
     await async_test_rejoin(hass, zigpy_cover_device, [cluster], (1,))
     assert hass.states.get(entity_id).state == STATE_OPEN
+
+    # test toggle
+    with patch(
+        "zigpy.zcl.Cluster.request", return_value=mock_coro([0x2, zcl_f.Status.SUCCESS])
+    ):
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_TOGGLE_COVER_TILT,
+            {"entity_id": entity_id},
+            blocking=True,
+        )
+        assert cluster.request.call_count == 1
+        assert cluster.request.call_args[0][0] is False
+        assert cluster.request.call_args[0][1] == 0x08
+        assert cluster.request.call_args[0][2].command.name == "go_to_tilt_percentage"
+        assert cluster.request.call_args[0][3] == 100
+        assert cluster.request.call_args[1]["expect_reply"] is True
 
 
 async def test_cover_failures(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds support to control cover tilt as defined in Zigbee Cluster Library Specification (rev 8) 7.4.2.1.2.9.
There are multiple devices waiting for this support:
- Ubisys J1
- NodOn SIN-4-RS-20
- [Insta GmbH Nexentro Blinds Actuator Mini](https://github.com/zigpy/zha-device-handlers/issues/1397)

This PR is a duplicate of #93301, which is currently stale despite our numerous attempts to contact the author @josef109.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: [zha-device-handlers#1397](https://github.com/zigpy/zha-device-handlers/issues/1397)
- This PR is related to issue: #93301
- Link to documentation pull request: <none>

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
