### PR TITLE
Migrate HomeKit AID storage when an entity changes unique id

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -1042,7 +1042,9 @@ class HomeKit:
         if self.status != STATUS_RUNNING:
             return
         async with self._reset_lock:
+            assert self.aid_storage
             self.status = STATUS_STOPPED
+            self.aid_storage.async_stop()
             assert self._cancel_reload_dispatcher is not None
             self._cancel_reload_dispatcher()
             _LOGGER.debug("Driver stop for %s", self._name)

--- a/homeassistant/components/homekit/aidmanager.py
+++ b/homeassistant/components/homekit/aidmanager.py
@@ -130,11 +130,10 @@ class AccessoryAidStorage:
         ):
             return
         old_system_unique_id = get_system_unique_id(new_entry, old_unique_id)
-        if not (old_aid := self.allocations.pop(old_system_unique_id, None)):
-            return
-        new_system_unique_id = get_system_unique_id(new_entry, new_entry.unique_id)
-        self.allocations[new_system_unique_id] = old_aid
-        self.async_schedule_save()
+        if old_aid := self.allocations.pop(old_system_unique_id, None):
+            new_system_unique_id = get_system_unique_id(new_entry, new_entry.unique_id)
+            self.allocations[new_system_unique_id] = old_aid
+            self.async_schedule_save()
 
     def get_or_allocate_aid(self, unique_id: str | None, entity_id: str) -> int:
         """Allocate (and return) a new aid for an accessory."""

--- a/homeassistant/components/homekit/type_triggers.py
+++ b/homeassistant/components/homekit/type_triggers.py
@@ -51,7 +51,9 @@ class DeviceTriggerAccessory(HomeAccessory):
             if (entity_id_or_uuid := trigger.get("entity_id")) and (
                 entry := ent_reg.async_get(entity_id_or_uuid)
             ):
-                unique_id += f"-entity_unique_id:{get_system_unique_id(entry)}"
+                unique_id += (
+                    f"-entity_unique_id:{get_system_unique_id(entry, entry.unique_id)}"
+                )
                 entity_id = entry.entity_id
             trigger_name_parts = []
             if entity_id and (state := self.hass.states.get(entity_id)):

--- a/tests/components/homekit/test_aidmanager.py
+++ b/tests/components/homekit/test_aidmanager.py
@@ -66,9 +66,9 @@ async def test_aid_generation(
             == 1751603975
         )
 
-    aid_storage.delete_aid(get_system_unique_id(light_ent))
-    aid_storage.delete_aid(get_system_unique_id(light_ent2))
-    aid_storage.delete_aid(get_system_unique_id(remote_ent))
+    aid_storage.delete_aid(get_system_unique_id(light_ent, light_ent.unique_id))
+    aid_storage.delete_aid(get_system_unique_id(light_ent2, light_ent2.unique_id))
+    aid_storage.delete_aid(get_system_unique_id(remote_ent, remote_ent.unique_id))
     aid_storage.delete_aid("non-existent-one")
 
     for _ in range(0, 2):

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -841,6 +841,7 @@ async def test_homekit_start_with_a_device(
     await async_init_entry(hass, entry)
     homekit = _mock_homekit(hass, entry, HOMEKIT_MODE_BRIDGE, None, devices=[device_id])
     homekit.driver = hk_driver
+    homekit.aid_storage = MagicMock()
 
     with patch(f"{PATH_HOMEKIT}.get_accessory", side_effect=Exception), patch(
         f"{PATH_HOMEKIT}.async_show_setup_message"
@@ -868,6 +869,7 @@ async def test_homekit_stop(hass: HomeAssistant) -> None:
     homekit.driver.async_stop = AsyncMock()
     homekit.bridge = Mock()
     homekit.bridge.accessories = {}
+    homekit.aid_storage = MagicMock()
 
     assert homekit.status == STATUS_READY
     await homekit.async_stop()

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -2263,13 +2263,12 @@ async def test_handle_unique_id_change(
         f"{PATH_HOMEKIT}.HomeKit", homekit
     ):
         await homekit.async_start()
-    await hass.async_block_till_done()
+        await hass.async_block_till_done()
     assert homekit.aid_storage.allocations == {"demo.light.unique": 176109313}
     entity_registry.async_update_entity(light.entity_id, new_unique_id="new_unique")
     await hass.async_block_till_done()
     # Verify that the old unique id is removed from the allocations
     # and that the new unique id assumes the old aid
     assert homekit.aid_storage.allocations == {"demo.light.new_unique": 176109313}
-
     await homekit.async_stop()
     await hass.async_block_till_done()

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -2265,6 +2265,7 @@ async def test_handle_unique_id_change(
         await homekit.async_start()
         await hass.async_block_till_done()
     assert homekit.aid_storage.allocations == {"demo.light.unique": 176109313}
+    entity_registry.async_update_entity(light.entity_id, device_class="any")
     entity_registry.async_update_entity(light.entity_id, new_unique_id="new_unique")
     await hass.async_block_till_done()
     # Verify that the old unique id is removed from the allocations


### PR DESCRIPTION
This is the original design which listened for entity registry change events but it doesn't work because HomeKit can miss the unique id changes because integrations can migrate them when HomeKit isn't setup, or even running yet.

It has been replaced by #102123 and will be closed when that merges as this is only here for reference to show why the listening for changes approach doesn't work.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate HomeKit AID storage when an entity changes unique id

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
