### PR TITLE
Bump zha-quirks to 0.0.105

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -24,7 +24,7 @@
     "bellows==0.36.5",
     "pyserial==3.5",
     "pyserial-asyncio==0.6",
-    "zha-quirks==0.0.104",
+    "zha-quirks==0.0.105",
     "zigpy-deconz==0.21.1",
     "zigpy==0.57.2",
     "zigpy-xbee==0.18.3",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2793,7 +2793,7 @@ zeroconf==0.118.0
 zeversolar==0.3.1
 
 # homeassistant.components.zha
-zha-quirks==0.0.104
+zha-quirks==0.0.105
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2087,7 +2087,7 @@ zeroconf==0.118.0
 zeversolar==0.3.1
 
 # homeassistant.components.zha
-zha-quirks==0.0.104
+zha-quirks==0.0.105
 
 # homeassistant.components.zha
 zigpy-deconz==0.21.1


### PR DESCRIPTION
## Proposed change
Bumps ZHA dependency `zha-quirks` to [0.0.105](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.105).
This is a minor dependency update to mainly add/fix support for the Aqara T1 door sensors (the created binary sensor wasn't updating correctly).
It also adds a quirk for some Tuya devices which don't follow ZCL spec and thus weren't working fully without the quirk.
A fix for an issue with another GLEDOPTO dimmer where the created entities were bouncing back when controlling due to an issue in the device is also included.
(The model number was just added to an existing quirk.)

No major changes were made in this release.

~~This PR is targeted for Home Assistant Core [2023.10.4](https://github.com/home-assistant/core/milestone/625).~~
Not allowed: https://github.com/home-assistant/core/pull/102113#pullrequestreview-1680623986

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #100805
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
