### PR TITLE
Make location types in co2signal translatable

### DIFF
--- a/homeassistant/components/co2signal/config_flow.py
+++ b/homeassistant/components/co2signal/config_flow.py
@@ -9,15 +9,20 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 
 from .const import CONF_COUNTRY_CODE, DOMAIN
 from .coordinator import get_data
 from .exceptions import APIRatelimitExceeded, InvalidAuth
 from .util import get_extra_name
 
-TYPE_USE_HOME = "Use home location"
-TYPE_SPECIFY_COORDINATES = "Specify coordinates"
-TYPE_SPECIFY_COUNTRY = "Specify country code"
+TYPE_USE_HOME = "use_home_location"
+TYPE_SPECIFY_COORDINATES = "specify_coordinates"
+TYPE_SPECIFY_COUNTRY = "specify_country_code"
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -32,11 +37,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         data_schema = vol.Schema(
             {
-                vol.Required("location", default=TYPE_USE_HOME): vol.In(
-                    (
-                        TYPE_USE_HOME,
-                        TYPE_SPECIFY_COORDINATES,
-                        TYPE_SPECIFY_COUNTRY,
+                vol.Required("location"): SelectSelector(
+                    SelectSelectorConfig(
+                        translation_key="location",
+                        mode=SelectSelectorMode.LIST,
+                        options=[
+                            TYPE_USE_HOME,
+                            TYPE_SPECIFY_COORDINATES,
+                            TYPE_SPECIFY_COUNTRY,
+                        ],
                     )
                 ),
                 vol.Required(CONF_API_KEY): cv.string,

--- a/homeassistant/components/co2signal/strings.json
+++ b/homeassistant/components/co2signal/strings.json
@@ -50,5 +50,14 @@
         }
       }
     }
+  },
+  "selector": {
+    "location": {
+      "options": {
+        "use_home_location": "Use home location",
+        "specify_coordinates": "Specify coordinates",
+        "specify_country_code": "Specify country code"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Proposed change
Currently the location type selector is not translatable in the `co2signal` config flow. This PR makes it translatable by using a select selector.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #102120
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
