### PR TITLE
Add HassNevermind intent (bump intents package)

### DIFF
--- a/homeassistant/components/conversation/manifest.json
+++ b/homeassistant/components/conversation/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["hassil==1.2.5", "home-assistant-intents==2023.10.2"]
+  "requirements": ["hassil==1.2.5", "home-assistant-intents==2023.10.16"]
 }

--- a/homeassistant/components/intent/__init__.py
+++ b/homeassistant/components/intent/__init__.py
@@ -56,6 +56,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         hass,
         GetStateIntentHandler(),
     )
+    intent.async_register(
+        hass,
+        NevermindIntentHandler(),
+    )
 
     return True
 
@@ -204,6 +208,16 @@ class GetStateIntentHandler(intent.IntentHandler):
         response.async_set_states(matched_states, unmatched_states)
 
         return response
+
+
+class NevermindIntentHandler(intent.IntentHandler):
+    """Takes no action."""
+
+    intent_type = intent.INTENT_NEVERMIND
+
+    async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
+        """Doe not do anything, and produces an empty response."""
+        return intent_obj.create_response()
 
 
 async def _async_process_intent(hass: HomeAssistant, domain: str, platform):

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -31,6 +31,7 @@ INTENT_TURN_OFF = "HassTurnOff"
 INTENT_TURN_ON = "HassTurnOn"
 INTENT_TOGGLE = "HassToggle"
 INTENT_GET_STATE = "HassGetState"
+INTENT_NEVERMIND = "HassNevermind"
 
 SLOT_SCHEMA = vol.Schema({}, extra=vol.ALLOW_EXTRA)
 

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -23,7 +23,7 @@ hass-nabucasa==0.73.0
 hassil==1.2.5
 home-assistant-bluetooth==1.10.3
 home-assistant-frontend==20231005.0
-home-assistant-intents==2023.10.2
+home-assistant-intents==2023.10.16
 httpx==0.25.0
 ifaddr==0.2.0
 janus==1.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1009,7 +1009,7 @@ holidays==0.28
 home-assistant-frontend==20231005.0
 
 # homeassistant.components.conversation
-home-assistant-intents==2023.10.2
+home-assistant-intents==2023.10.16
 
 # homeassistant.components.home_connect
 homeconnect==0.7.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -798,7 +798,7 @@ holidays==0.28
 home-assistant-frontend==20231005.0
 
 # homeassistant.components.conversation
-home-assistant-intents==2023.10.2
+home-assistant-intents==2023.10.16
 
 # homeassistant.components.home_connect
 homeconnect==0.7.2

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -283,3 +283,13 @@ async def test_shopping_list_add_item(
     assert result.response.speech == {
         "plain": {"speech": "Added apples", "extra_data": None}
     }
+
+
+async def test_nevermind_item(hass: HomeAssistant, init_components) -> None:
+    """Test HassNevermind intent through the default agent."""
+    result = await conversation.async_converse(hass, "nevermind", None, Context())
+    assert result.response.intent is not None
+    assert result.response.intent.intent_type == intent.INTENT_NEVERMIND
+
+    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert not result.response.speech


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a new intent: `HassNevermind`, which is available in `homeassistant-intents` version 2023.10.16: https://github.com/home-assistant/intents/compare/2023.10.2...2023.10.16

This intent takes no actions, and returns an empty response. It is intended for cancelling a request via voice, for example when a false wake word activation occurs or you forget what you were going to say.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
