### PR TITLE
Fix ZHA `power_factor` attribute not initialized

### DIFF
--- a/homeassistant/components/zha/core/cluster_handlers/homeautomation.py
+++ b/homeassistant/components/zha/core/cluster_handlers/homeautomation.py
@@ -87,6 +87,7 @@ class ElectricalMeasurementClusterHandler(ClusterHandler):
         "measurement_type": True,
         "power_divisor": True,
         "power_multiplier": True,
+        "power_factor": True,
     }
 
     async def async_update(self):

--- a/homeassistant/components/zha/core/cluster_handlers/homeautomation.py
+++ b/homeassistant/components/zha/core/cluster_handlers/homeautomation.py
@@ -87,7 +87,7 @@ class ElectricalMeasurementClusterHandler(ClusterHandler):
         "measurement_type": True,
         "power_divisor": True,
         "power_multiplier": True,
-        "power_factor": False,
+        "power_factor": True,
     }
 
     async def async_update(self):

--- a/homeassistant/components/zha/core/cluster_handlers/homeautomation.py
+++ b/homeassistant/components/zha/core/cluster_handlers/homeautomation.py
@@ -87,7 +87,7 @@ class ElectricalMeasurementClusterHandler(ClusterHandler):
         "measurement_type": True,
         "power_divisor": True,
         "power_multiplier": True,
-        "power_factor": True,
+        "power_factor": False,
     }
 
     async def async_update(self):

--- a/homeassistant/components/zha/core/cluster_handlers/homeautomation.py
+++ b/homeassistant/components/zha/core/cluster_handlers/homeautomation.py
@@ -74,6 +74,7 @@ class ElectricalMeasurementClusterHandler(ClusterHandler):
         AttrReportConfig(attr="rms_voltage_max", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="ac_frequency", config=REPORT_CONFIG_OP),
         AttrReportConfig(attr="ac_frequency_max", config=REPORT_CONFIG_DEFAULT),
+        AttrReportConfig(attr="power_factor", config=REPORT_CONFIG_OP),
     )
     ZCL_INIT_ATTRS = {
         "ac_current_divisor": True,
@@ -87,7 +88,6 @@ class ElectricalMeasurementClusterHandler(ClusterHandler):
         "measurement_type": True,
         "power_divisor": True,
         "power_multiplier": True,
-        "power_factor": True,
     }
 
     async def async_update(self):

--- a/homeassistant/components/zha/core/cluster_handlers/homeautomation.py
+++ b/homeassistant/components/zha/core/cluster_handlers/homeautomation.py
@@ -74,7 +74,6 @@ class ElectricalMeasurementClusterHandler(ClusterHandler):
         AttrReportConfig(attr="rms_voltage_max", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="ac_frequency", config=REPORT_CONFIG_OP),
         AttrReportConfig(attr="ac_frequency_max", config=REPORT_CONFIG_DEFAULT),
-        AttrReportConfig(attr="power_factor", config=REPORT_CONFIG_OP),
     )
     ZCL_INIT_ATTRS = {
         "ac_current_divisor": True,
@@ -88,6 +87,7 @@ class ElectricalMeasurementClusterHandler(ClusterHandler):
         "measurement_type": True,
         "power_divisor": True,
         "power_multiplier": True,
+        "power_factor": True,
     }
 
     async def async_update(self):

--- a/tests/components/zha/zha_devices_list.py
+++ b/tests/components/zha/zha_devices_list.py
@@ -2088,11 +2088,6 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSVoltage",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_plug_maus01_rms_voltage",
             },
-            ("sensor", "00:11:22:33:44:55:66:77-1-2820-power_factor"): {
-                DEV_SIG_CLUSTER_HANDLERS: ["electrical_measurement"],
-                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementPowerFactor",
-                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_plug_maus01_power_factor",
-            },
             ("sensor", "00:11:22:33:44:55:66:77-1-0-rssi"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["basic"],
                 DEV_SIG_ENT_MAP_CLASS: "RSSISensor",


### PR DESCRIPTION
## Proposed change

TL;DR
- `power_factor` attribute was never read (so also never added to "unsupported list")
- that also caused the entity to always be created, even if the plug doesn't support `power_factor`

### Long explanation

This reads the `power_factor` attribute during device initialization. It does not set up attribute reporting, as the attribute isn't reportable according to ZCL v8: page 346 / 4-32.
As this attribute is otherwise never read automatically, it can never be added to the "unsupported attributes" list [which is used here](https://github.com/home-assistant/core/blob/f891fb6b4158b4ce2b4e59ace867915e0f656ec7/homeassistant/components/zha/sensor.py#L149-L156) to check if an entity should be created.

ZHA will now automatically read the attribute during initialization. If the device does not support the attribute, it will be added to the "unsupported attributes" list.
This causes ZHA to not create the entity if unsupported.

This (finally) fixes the issues where all plugs showed a "Power factor: Unknown" entity, as seen here (without the changes):
![image](https://github.com/home-assistant/core/assets/6409465/676facdd-8c9c-490e-9db7-3a41e164f41f)

### "Scenarios" (for plugs with energy measurement):

For newly added plugs, the attribute will be initialized during pairing. If it's supported, the power factor entity will be created.
If it's unsupported, the power factor entity will not be created at all. (<- that's new/the fix!)

For previously added smart plugs, this will cause the "Power factor" entity to become "Unavailable" (instead of "Unknown") if the device does not support power factor.
It can then be deleted from the entity registry using the UI.
For the theoretical-existing plugs that support power factor, the entity will keep existing and work correctly.

---

### Semi-relevant questions (don't matter for this PR):

The switch configuration entities explicitly check if the attribute was read once:
https://github.com/home-assistant/core/blob/f891fb6b4158b4ce2b4e59ace867915e0f656ec7/homeassistant/components/zha/switch.py#L191
1. Maybe this should be stream-lined in the future, so it's similar for all entity types and configuration or normal entity(?)

Attribute reporting and attribute initialization is set up here (for the `ElectricalMeasurement` cluster):
https://github.com/home-assistant/core/blob/6d457e808f1229c565341200c97aa10a062791eb/homeassistant/components/zha/core/cluster_handlers/homeautomation.py#L67-L90

2. Why are we setting up attribute reporting for all `_max` attributes? There are no sensor entities for them.
EDIT: This should probably be removed, but will be addressed in another PR.

### ~~First~~ approach with adding it to `ZCL_INIT_ATTRS`:

~~At first, I only added the `power_factor` attribute to the the initialization list (can be seen in the first commit). But if there's actually a plug which supports the `power_factor` attribute, we probably also want to set up the currently missing attribute reports.~~

~~3. So this PR will now also set up attribute reporting for the `power_factor` attribute. This is also set up for plugs that don't actually support the attribute.
But I guess that's fine/wanted? (already doing that for other devices/clusters which don't support all attributes where attr reporting is set up for)~~
**EDIT: That change was reverted. The attribute isn't reportable, so we can't set up attribute reporting.**


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #96857 (and many other comments/issues, also in the quirks repo)
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
