### PR TITLE
Add better connection management for Idasen Desk

### DIFF
--- a/homeassistant/components/idasen_desk/__init__.py
+++ b/homeassistant/components/idasen_desk/__init__.py
@@ -125,7 +125,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle options update."""
     data: DeskData = hass.data[DOMAIN][entry.entry_id]
-    if entry.title != data.device_info.get(ATTR_NAME):
+    if entry.title != data.device_info[ATTR_NAME]:
         await hass.config_entries.async_reload(entry.entry_id)
 
 

--- a/homeassistant/components/idasen_desk/__init__.py
+++ b/homeassistant/components/idasen_desk/__init__.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 import logging
 
 from attr import dataclass
-from bleak import BleakError
+from bleak.exc import BleakError
 from idasen_ha import Desk
+from idasen_ha.errors import AuthFailedError
 
 from homeassistant.components import bluetooth
 from homeassistant.config_entries import ConfigEntry
@@ -15,7 +16,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
     Platform,
 )
-from homeassistant.core import Event, HomeAssistant
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -28,41 +29,84 @@ PLATFORMS: list[Platform] = [Platform.COVER]
 _LOGGER = logging.getLogger(__name__)
 
 
+class IdasenDeskCoordinator(DataUpdateCoordinator):
+    """Class to manage updates for the Idasen Desk."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        logger: logging.Logger,
+        name: str,
+        address: str,
+    ) -> None:
+        """Init IdasenDeskCoordinator."""
+
+        super().__init__(hass, logger, name=name)
+        self._address = address
+        self._expected_connected = False
+
+        self.desk = Desk(self.async_set_updated_data)
+
+    async def connect(self) -> bool:
+        """Connect to desk."""
+        _LOGGER.debug("Trying to connect %s", self._address)
+        ble_device = bluetooth.async_ble_device_from_address(
+            self.hass, self._address, connectable=True
+        )
+        if ble_device is None:
+            return False
+        self._expected_connected = True
+        await self.desk.connect(ble_device)
+        return True
+
+    async def disconnect(self) -> None:
+        """Disconnect from desk."""
+        _LOGGER.debug("Disconnecting from %s", self._address)
+        self._expected_connected = False
+        await self.desk.disconnect()
+
+    @callback
+    def async_set_updated_data(self, data: int | None) -> None:
+        """Handle data update."""
+        if self._expected_connected:
+            if not self.desk.is_connected:
+                _LOGGER.debug("Desk disconnected. Reconnecting")
+                self.hass.async_create_task(self.connect())
+        elif self.desk.is_connected:
+            _LOGGER.warning("Desk is connected but should not be. Disconnecting")
+            self.hass.async_create_task(self.desk.disconnect())
+        return super().async_set_updated_data(data)
+
+
 @dataclass
 class DeskData:
     """Data for the Idasen Desk integration."""
 
-    desk: Desk
     address: str
     device_info: DeviceInfo
-    coordinator: DataUpdateCoordinator
+    coordinator: IdasenDeskCoordinator
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up IKEA Idasen from a config entry."""
     address: str = entry.data[CONF_ADDRESS].upper()
 
-    coordinator: DataUpdateCoordinator = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        name=entry.title,
+    coordinator: IdasenDeskCoordinator = IdasenDeskCoordinator(
+        hass, _LOGGER, entry.title, address
     )
 
-    desk = Desk(coordinator.async_set_updated_data)
     device_info = DeviceInfo(
         name=entry.title,
         connections={(dr.CONNECTION_BLUETOOTH, address)},
     )
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = DeskData(
-        desk, address, device_info, coordinator
+        address, device_info, coordinator
     )
 
-    ble_device = bluetooth.async_ble_device_from_address(
-        hass, address, connectable=True
-    )
     try:
-        await desk.connect(ble_device)
-    except (TimeoutError, BleakError) as ex:
+        if not await coordinator.connect():
+            raise ConfigEntryNotReady(f"Unable to connect to desk {address}")
+    except (AuthFailedError, TimeoutError, BleakError, Exception) as ex:
         raise ConfigEntryNotReady(f"Unable to connect to desk {address}") from ex
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -70,7 +114,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def _async_stop(event: Event) -> None:
         """Close the connection."""
-        await desk.disconnect()
+        await coordinator.disconnect()
 
     entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_stop)
@@ -81,7 +125,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle options update."""
     data: DeskData = hass.data[DOMAIN][entry.entry_id]
-    if entry.title != data.device_info[ATTR_NAME]:
+    if entry.title != data.device_info.get(ATTR_NAME):
         await hass.config_entries.async_reload(entry.entry_id)
 
 
@@ -89,7 +133,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         data: DeskData = hass.data[DOMAIN].pop(entry.entry_id)
-        await data.desk.disconnect()
+        await data.coordinator.disconnect()
         bluetooth.async_rediscover_address(hass, data.address)
 
     return unload_ok

--- a/homeassistant/components/idasen_desk/config_flow.py
+++ b/homeassistant/components/idasen_desk/config_flow.py
@@ -6,7 +6,8 @@ from typing import Any
 
 from bleak.exc import BleakError
 from bluetooth_data_tools import human_readable_name
-from idasen_ha import AuthFailedError, Desk
+from idasen_ha import Desk
+from idasen_ha.errors import AuthFailedError
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -61,9 +62,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             self._abort_if_unique_id_configured()
 
-            desk = Desk(None)
+            desk = Desk(None, monitor_height=False)
             try:
-                await desk.connect(discovery_info.device, monitor_height=False)
+                await desk.connect(discovery_info.device, auto_reconnect=False)
             except AuthFailedError as err:
                 _LOGGER.exception("AuthFailedError", exc_info=err)
                 errors["base"] = "auth_failed"

--- a/homeassistant/components/idasen_desk/cover.py
+++ b/homeassistant/components/idasen_desk/cover.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from idasen_ha import Desk
-
 from homeassistant.components.cover import (
     ATTR_POSITION,
     CoverDeviceClass,
@@ -54,7 +52,7 @@ class IdasenDeskCover(CoordinatorEntity, CoverEntity):
     ) -> None:
         """Initialize an Idasen Desk cover."""
         super().__init__(coordinator)
-        self._desk: Desk = coordinator.desk
+        self._desk = coordinator.desk
         self._attr_name = device_info.get(ATTR_NAME)
         self._attr_unique_id = address
         self._attr_device_info = device_info

--- a/homeassistant/components/idasen_desk/cover.py
+++ b/homeassistant/components/idasen_desk/cover.py
@@ -53,7 +53,7 @@ class IdasenDeskCover(CoordinatorEntity, CoverEntity):
         """Initialize an Idasen Desk cover."""
         super().__init__(coordinator)
         self._desk = coordinator.desk
-        self._attr_name = device_info.get(ATTR_NAME)
+        self._attr_name = device_info[ATTR_NAME]
         self._attr_unique_id = address
         self._attr_device_info = device_info
 

--- a/homeassistant/components/idasen_desk/cover.py
+++ b/homeassistant/components/idasen_desk/cover.py
@@ -1,7 +1,6 @@
 """Idasen Desk integration cover platform."""
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from idasen_ha import Desk
@@ -17,15 +16,10 @@ from homeassistant.const import ATTR_NAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import DeskData
+from . import DeskData, IdasenDeskCoordinator
 from .const import DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -36,7 +30,7 @@ async def async_setup_entry(
     """Set up the cover platform for Idasen Desk."""
     data: DeskData = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
-        [IdasenDeskCover(data.desk, data.address, data.device_info, data.coordinator)]
+        [IdasenDeskCover(data.address, data.device_info, data.coordinator)]
     )
 
 
@@ -54,15 +48,14 @@ class IdasenDeskCover(CoordinatorEntity, CoverEntity):
 
     def __init__(
         self,
-        desk: Desk,
         address: str,
         device_info: DeviceInfo,
-        coordinator: DataUpdateCoordinator,
+        coordinator: IdasenDeskCoordinator,
     ) -> None:
         """Initialize an Idasen Desk cover."""
         super().__init__(coordinator)
-        self._desk = desk
-        self._attr_name = device_info[ATTR_NAME]
+        self._desk: Desk = coordinator.desk
+        self._attr_name = device_info.get(ATTR_NAME)
         self._attr_unique_id = address
         self._attr_device_info = device_info
 

--- a/homeassistant/components/idasen_desk/manifest.json
+++ b/homeassistant/components/idasen_desk/manifest.json
@@ -11,5 +11,5 @@
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/idasen_desk",
   "iot_class": "local_push",
-  "requirements": ["idasen-ha==1.4.1"]
+  "requirements": ["idasen-ha==2.3"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1051,7 +1051,7 @@ ical==5.0.1
 icmplib==3.0
 
 # homeassistant.components.idasen_desk
-idasen-ha==1.4.1
+idasen-ha==2.3
 
 # homeassistant.components.network
 ifaddr==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -831,7 +831,7 @@ ical==5.0.1
 icmplib==3.0
 
 # homeassistant.components.idasen_desk
-idasen-ha==1.4.1
+idasen-ha==2.3
 
 # homeassistant.components.network
 ifaddr==0.2.0

--- a/tests/components/idasen_desk/conftest.py
+++ b/tests/components/idasen_desk/conftest.py
@@ -10,6 +10,10 @@ import pytest
 @pytest.fixture(autouse=True)
 def mock_bluetooth(enable_bluetooth):
     """Auto mock bluetooth."""
+    with mock.patch(
+        "homeassistant.components.idasen_desk.bluetooth.async_ble_device_from_address"
+    ):
+        yield MagicMock()
 
 
 @pytest.fixture(autouse=False)
@@ -18,14 +22,22 @@ def mock_desk_api():
     with mock.patch("homeassistant.components.idasen_desk.Desk") as desk_patched:
         mock_desk = MagicMock()
 
-        def mock_init(update_callback: Callable[[int | None], None] | None):
+        def mock_init(
+            update_callback: Callable[[int | None], None] | None,
+            monitor_height: bool = True,
+        ):
             mock_desk.trigger_update_callback = update_callback
             return mock_desk
 
         desk_patched.side_effect = mock_init
 
-        async def mock_connect(ble_device, monitor_height: bool = True):
+        async def mock_connect(ble_device):
             mock_desk.is_connected = True
+            mock_desk.trigger_update_callback(None)
+
+        async def mock_disconnect():
+            mock_desk.is_connected = False
+            mock_desk.trigger_update_callback(None)
 
         async def mock_move_to(height: float):
             mock_desk.height_percent = height
@@ -38,12 +50,13 @@ def mock_desk_api():
             await mock_move_to(0)
 
         mock_desk.connect = AsyncMock(side_effect=mock_connect)
-        mock_desk.disconnect = AsyncMock()
+        mock_desk.disconnect = AsyncMock(side_effect=mock_disconnect)
         mock_desk.move_to = AsyncMock(side_effect=mock_move_to)
         mock_desk.move_up = AsyncMock(side_effect=mock_move_up)
         mock_desk.move_down = AsyncMock(side_effect=mock_move_down)
         mock_desk.stop = AsyncMock()
         mock_desk.height_percent = 60
         mock_desk.is_moving = False
+        mock_desk.address = "AA:BB:CC:DD:EE:FF"
 
         yield mock_desk

--- a/tests/components/idasen_desk/test_config_flow.py
+++ b/tests/components/idasen_desk/test_config_flow.py
@@ -1,8 +1,8 @@
 """Test the IKEA Idasen Desk config flow."""
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
-from bleak import BleakError
-from idasen_ha import AuthFailedError
+from bleak.exc import BleakError
+from idasen_ha.errors import AuthFailedError
 import pytest
 
 from homeassistant import config_entries
@@ -260,7 +260,9 @@ async def test_bluetooth_step_success(hass: HomeAssistant) -> None:
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
-    with patch("homeassistant.components.idasen_desk.config_flow.Desk.connect"), patch(
+    with patch(
+        "homeassistant.components.idasen_desk.config_flow.Desk.connect"
+    ) as desk_connect, patch(
         "homeassistant.components.idasen_desk.config_flow.Desk.disconnect"
     ), patch(
         "homeassistant.components.idasen_desk.async_setup_entry",
@@ -281,3 +283,4 @@ async def test_bluetooth_step_success(hass: HomeAssistant) -> None:
     }
     assert result2["result"].unique_id == IDASEN_DISCOVERY_INFO.address
     assert len(mock_setup_entry.mock_calls) == 1
+    desk_connect.assert_called_with(ANY, auto_reconnect=False)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds better connection management, by automatically reconnecting in case of a
disconnect. It is a split from a bigger PR: https://github.com/home-assistant/core/pull/100830

Diff for the supporting lib: https://github.com/abmantis/idasen-ha/compare/1.4.1...2.3

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
