### PR TITLE
Remove invalid attribute reporting for `enhanced_current_hue` in ZHA

### DIFF
--- a/homeassistant/components/zha/core/cluster_handlers/lighting.py
+++ b/homeassistant/components/zha/core/cluster_handlers/lighting.py
@@ -32,7 +32,6 @@ class ColorClusterHandler(ClusterHandler):
         AttrReportConfig(attr="current_x", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="current_y", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="current_hue", config=REPORT_CONFIG_DEFAULT),
-        AttrReportConfig(attr="enhanced_current_hue", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="current_saturation", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="color_temperature", config=REPORT_CONFIG_DEFAULT),
     )
@@ -44,6 +43,7 @@ class ColorClusterHandler(ClusterHandler):
         "color_temp_physical_max": True,
         "color_capabilities": True,
         "color_loop_active": False,
+        "enhanced_current_hue": False,
         "start_up_color_temperature": True,
         "options": True,
     }


### PR DESCRIPTION
## Proposed change

Whilst working on [another PR](https://github.com/home-assistant/core/pull/102133), I noticed that ZHA tries to set up attribute reporting for the `enhanced_current_hue` on my Hue lights (which support enhanced Hue).
That always fails:
```python
2023-10-17 02:42:39.940 DEBUG (MainThread) [homeassistant.components.zha.core.cluster_handlers] [0xD916:11:0x0300]: Failed to configure reporting for '['enhanced_current_hue']' on 'light_color' cluster: [ConfigureReportingResponseRecord(status=<Status.UNREPORTABLE_ATTRIBUTE: 140>, direction=<ReportingDirection.SendReports: 0>, attrid=16384)]
2023-10-17 02:42:39.940 DEBUG (MainThread) [homeassistant.components.zha.core.cluster_handlers] [0xD916:11:0x0300]: finished cluster handler configuration
```

### Change:
This removes setting up attribute reporting for `enhanced_current_hue`, as the attribute cannot be set up for attribute reporting. (See ZCL v8: page no. 375 / 5-5 (and page no. 406 / 5-36))

Even for lights that support enhanced Hue, this is an `UNREPORTABLE_ATTRIBUTE`.
This attribute is still read at startup and polled every 45 to 75 minutes though.

(Due to various reasons, we also do not even use any attribute reports on the `Color` cluster for light entities at all.)


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
