### PR TITLE
Remove unused variables in ZHA lighting cluster handler

### DIFF
--- a/homeassistant/components/zha/core/cluster_handlers/lighting.py
+++ b/homeassistant/components/zha/core/cluster_handlers/lighting.py
@@ -25,7 +25,6 @@ class ColorClientClusterHandler(ClientClusterHandler):
 class ColorClusterHandler(ClusterHandler):
     """Color cluster handler."""
 
-    CAPABILITIES_COLOR_XY = 0x08
     REPORT_CONFIG = (
         AttrReportConfig(attr="current_x", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="current_y", config=REPORT_CONFIG_DEFAULT),
@@ -51,7 +50,7 @@ class ColorClusterHandler(ClusterHandler):
         """Return ZCL color capabilities of the light."""
         color_capabilities = self.cluster.get("color_capabilities")
         if color_capabilities is None:
-            return lighting.Color.ColorCapabilities(self.CAPABILITIES_COLOR_XY)
+            return lighting.Color.ColorCapabilities.XY_attributes
         return lighting.Color.ColorCapabilities(color_capabilities)
 
     @property

--- a/homeassistant/components/zha/core/cluster_handlers/lighting.py
+++ b/homeassistant/components/zha/core/cluster_handlers/lighting.py
@@ -26,7 +26,6 @@ class ColorClusterHandler(ClusterHandler):
     """Color cluster handler."""
 
     CAPABILITIES_COLOR_XY = 0x08
-    CAPABILITIES_COLOR_TEMP = 0x10
     REPORT_CONFIG = (
         AttrReportConfig(attr="current_x", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="current_y", config=REPORT_CONFIG_DEFAULT),

--- a/homeassistant/components/zha/core/cluster_handlers/lighting.py
+++ b/homeassistant/components/zha/core/cluster_handlers/lighting.py
@@ -27,7 +27,6 @@ class ColorClusterHandler(ClusterHandler):
 
     CAPABILITIES_COLOR_XY = 0x08
     CAPABILITIES_COLOR_TEMP = 0x10
-    UNSUPPORTED_ATTRIBUTE = 0x86
     REPORT_CONFIG = (
         AttrReportConfig(attr="current_x", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="current_y", config=REPORT_CONFIG_DEFAULT),


### PR DESCRIPTION
## Proposed change
This cleans up the ZHA lighting cluster handler a bit by removing two unused class attributes:
- `UNSUPPORTED_ATTRIBUTE` (unused since https://github.com/home-assistant/core/pull/43149/)
- `CAPABILITIES_COLOR_TEMP` (unused since https://github.com/home-assistant/core/pull/76305/)

It also changes the `color_capabilities` method/property to use zigpy's `ColorCapabilities.XY_attributes` directly (instead of creating a `ColorCapabilities` object with the now removed `CAPABILITIES_COLOR_XY` attribute).

All of these changes are just "code quality improvements".

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
