### PR TITLE
Create entities for tplink powerstrips main controls

### DIFF
--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -129,8 +129,8 @@ async def async_setup_entry(
         # Historically we only add the children if the device is a strip
         for child in parent.children:
             entities.extend(_async_sensors_for_device(child))
-    else:
-        entities.extend(_async_sensors_for_device(parent))
+
+    entities.extend(_async_sensors_for_device(parent))
 
     async_add_entities(entities)
 

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -36,8 +36,8 @@ async def async_setup_entry(
         _LOGGER.debug("Initializing strip with %s sockets", len(device.children))
         for child in device.children:
             entities.append(SmartPlugSwitchChild(device, coordinator, child))
-    elif device.is_plug:
-        entities.append(SmartPlugSwitch(device, coordinator))
+
+    entities.append(SmartPlugSwitch(device, coordinator))
 
     entities.append(SmartPlugLedSwitch(device, coordinator))
 

--- a/tests/components/tplink/test_switch.py
+++ b/tests/components/tplink/test_switch.py
@@ -142,9 +142,8 @@ async def test_strip(hass: HomeAssistant) -> None:
         await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
         await hass.async_block_till_done()
 
-    # Verify we only create entities for the children
-    # since this is what the previous version did
-    assert hass.states.get("switch.my_strip") is None
+    main_entity = hass.states.get("switch.my_strip")
+    assert main_entity.state == STATE_ON
 
     entity_id = "switch.my_strip_plug0"
     state = hass.states.get(entity_id)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR modifies the logic to create entities also for the main device of powerstrips, as I cannot recall any reasonable reason why this should not be done.
Previously, the entities were only created for the child sockets which does not allow controlling the whole power strip as a whole.

The master switch is turned on if any of the child sockets are on, and turning it off will turn off the whole device.
Note, that the previous state is not recovered when turning the whole strip on, but all sockets will be turned on.

The values for emeter sensors (if applicable) are a sum of values from all children, except that the voltage is the average voltage.

The screenshots below shows how this looks for a kp303 strip with a single socket turned on.

![image](https://github.com/home-assistant/core/assets/3705853/0336a825-0538-4f12-930b-61a318eec2d0)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
