### PR TITLE
Add mode parameter to custom intent scripts

### DIFF
--- a/homeassistant/components/intent_script/__init__.py
+++ b/homeassistant/components/intent_script/__init__.py
@@ -32,6 +32,7 @@ CONF_TITLE = "title"
 CONF_CONTENT = "content"
 CONF_TEXT = "text"
 CONF_ASYNC_ACTION = "async_action"
+CONF_SCRIPT_MODE = "script_mode"
 
 DEFAULT_CONF_ASYNC_ACTION = False
 
@@ -43,6 +44,9 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(
                     CONF_ASYNC_ACTION, default=DEFAULT_CONF_ASYNC_ACTION
                 ): cv.boolean,
+                vol.Optional(
+                    CONF_SCRIPT_MODE, default=script.DEFAULT_SCRIPT_MODE
+                ): vol.In(script.SCRIPT_MODE_CHOICES),
                 vol.Optional(CONF_CARD): {
                     vol.Optional(CONF_TYPE, default="simple"): cv.string,
                     vol.Required(CONF_TITLE): cv.template,
@@ -87,8 +91,13 @@ def async_load_intents(hass: HomeAssistant, intents: dict[str, ConfigType]) -> N
 
     for intent_type, conf in intents.items():
         if CONF_ACTION in conf:
+            script_mode: str = conf.get(CONF_SCRIPT_MODE, script.DEFAULT_SCRIPT_MODE)
             conf[CONF_ACTION] = script.Script(
-                hass, conf[CONF_ACTION], f"Intent Script {intent_type}", DOMAIN
+                hass,
+                conf[CONF_ACTION],
+                f"Intent Script {intent_type}",
+                DOMAIN,
+                script_mode=script_mode,
             )
         intent.async_register(hass, ScriptIntentHandler(intent_type, conf))
 

--- a/homeassistant/components/intent_script/__init__.py
+++ b/homeassistant/components/intent_script/__init__.py
@@ -6,6 +6,7 @@ from typing import Any, TypedDict
 
 import voluptuous as vol
 
+from homeassistant.components.script import CONF_MODE
 from homeassistant.const import CONF_TYPE, SERVICE_RELOAD
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import (
@@ -32,7 +33,6 @@ CONF_TITLE = "title"
 CONF_CONTENT = "content"
 CONF_TEXT = "text"
 CONF_ASYNC_ACTION = "async_action"
-CONF_SCRIPT_MODE = "script_mode"
 
 DEFAULT_CONF_ASYNC_ACTION = False
 
@@ -44,9 +44,9 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(
                     CONF_ASYNC_ACTION, default=DEFAULT_CONF_ASYNC_ACTION
                 ): cv.boolean,
-                vol.Optional(
-                    CONF_SCRIPT_MODE, default=script.DEFAULT_SCRIPT_MODE
-                ): vol.In(script.SCRIPT_MODE_CHOICES),
+                vol.Optional(CONF_MODE, default=script.DEFAULT_SCRIPT_MODE): vol.In(
+                    script.SCRIPT_MODE_CHOICES
+                ),
                 vol.Optional(CONF_CARD): {
                     vol.Optional(CONF_TYPE, default="simple"): cv.string,
                     vol.Required(CONF_TITLE): cv.template,
@@ -91,7 +91,7 @@ def async_load_intents(hass: HomeAssistant, intents: dict[str, ConfigType]) -> N
 
     for intent_type, conf in intents.items():
         if CONF_ACTION in conf:
-            script_mode: str = conf.get(CONF_SCRIPT_MODE, script.DEFAULT_SCRIPT_MODE)
+            script_mode: str = conf.get(CONF_MODE, script.DEFAULT_SCRIPT_MODE)
             conf[CONF_ACTION] = script.Script(
                 hass,
                 conf[CONF_ACTION],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a `mode` parameter to custom `intent_script`s to prevent the behavior described in #102199. Allows an intent to have multiple instances running in parallel

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #102199 
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29401

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
