### PR TITLE
Add peak usage sensors to dsmr

### DIFF
--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -350,6 +350,22 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
     DSMRSensorEntityDescription(
+        key="belgium_current_average_demand",
+        translation_key="current_average_demand",
+        obis_reference=obis_references.BELGIUM_CURRENT_AVERAGE_DEMAND,
+        dsmr_versions={"5B"},
+        force_update=True,
+        device_class=SensorDeviceClass.POWER,
+    ),
+    DSMRSensorEntityDescription(
+        key="belgium_maximum_demand_current_month",
+        translation_key="maximum_demand_current_month",
+        obis_reference=obis_references.BELGIUM_MAXIMUM_DEMAND_MONTH,
+        dsmr_versions={"5B"},
+        force_update=True,
+        device_class=SensorDeviceClass.POWER,
+    ),
+    DSMRSensorEntityDescription(
         key="hourly_gas_meter_reading",
         translation_key="gas_meter_reading",
         obis_reference=obis_references.HOURLY_GAS_METER_READING,

--- a/homeassistant/components/dsmr/strings.json
+++ b/homeassistant/components/dsmr/strings.json
@@ -76,6 +76,12 @@
       "gas_meter_reading": {
         "name": "Gas consumption"
       },
+      "current_average_demand": {
+        "name": "Current average demand"
+      },
+      "maximum_demand_current_month": {
+        "name": "Maximum demand current month"
+      },
       "instantaneous_active_power_l1_negative": {
         "name": "Power production phase L1"
       },

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -430,7 +430,11 @@ async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
     """Test if Belgian meter is correctly parsed."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
-    from dsmr_parser.obis_references import ELECTRICITY_ACTIVE_TARIFF
+    from dsmr_parser.obis_references import (
+        BELGIUM_CURRENT_AVERAGE_DEMAND,
+        BELGIUM_MAXIMUM_DEMAND_MONTH,
+        ELECTRICITY_ACTIVE_TARIFF,
+    )
     from dsmr_parser.objects import CosemObject, MBusObject
 
     entry_data = {
@@ -451,6 +455,17 @@ async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(745.695), "unit": "m3"},
+            ],
+        ),
+        BELGIUM_CURRENT_AVERAGE_DEMAND: CosemObject(
+            BELGIUM_CURRENT_AVERAGE_DEMAND,
+            [{"value": Decimal(1.75), "unit": "kW"}],
+        ),
+        BELGIUM_MAXIMUM_DEMAND_MONTH: MBusObject(
+            BELGIUM_MAXIMUM_DEMAND_MONTH,
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642218)},
+                {"value": Decimal(4.11), "unit": "kW"},
             ],
         ),
         ELECTRICITY_ACTIVE_TARIFF: CosemObject(
@@ -483,6 +498,20 @@ async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
     assert active_tariff.attributes.get(ATTR_OPTIONS) == ["low", "normal"]
     assert active_tariff.attributes.get(ATTR_STATE_CLASS) is None
     assert active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ""
+
+    # check current average demand is parsed correctly
+    avg_demand = hass.states.get("sensor.electricity_meter_current_average_demand")
+    assert avg_demand.state == "1.75"
+    assert avg_demand.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPower.KILO_WATT
+    assert avg_demand.attributes.get(ATTR_STATE_CLASS) is None
+
+    # check max average demand is parsed correctly
+    max_demand = hass.states.get(
+        "sensor.electricity_meter_maximum_demand_current_month"
+    )
+    assert max_demand.state == "4.11"
+    assert max_demand.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPower.KILO_WATT
+    assert max_demand.attributes.get(ATTR_STATE_CLASS) is None
 
     # check if gas consumption is parsed correctly
     gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds 2 peak usage sensors.
Depends on https://github.com/home-assistant/core/pull/102225

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
