### PR TITLE
Update zwave_js/hard_reset_controller WS cmd

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -2477,6 +2477,7 @@ async def websocket_hard_reset_controller(
             connection.send_message(
                 websocket_api.event_message(msg[ID], {"device_id": device.id})
             )
+            async_cleanup()
 
     connection.subscriptions[msg["id"]] = async_cleanup
     msg[DATA_UNSUBSCRIBE] = unsubs = [

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -2464,4 +2464,13 @@ async def websocket_hard_reset_controller(
 ) -> None:
     """Hard reset controller."""
     await driver.async_hard_reset()
-    connection.send_result(msg[ID])
+
+    def _check_for_ready(device: dr.DeviceEntry) -> None:
+        """Check if controller is ready."""
+        if entry.entry_id in device.config_entries:
+            msg[DATA_UNSUBSCRIBE][0]()
+            connection.send_result(msg[ID], device.id)
+
+    msg[DATA_UNSUBSCRIBE] = [
+        async_dispatcher_connect(hass, EVENT_DEVICE_ADDED_TO_REGISTRY, _check_for_ready)
+    ]

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -2475,16 +2475,12 @@ async def websocket_hard_reset_controller(
     def _handle_device_added(device: dr.DeviceEntry) -> None:
         """Handle device is added."""
         if entry.entry_id in device.config_entries:
-            connection.send_message(
-                websocket_api.event_message(msg[ID], {"device_id": device.id})
-            )
+            connection.send_result(msg[ID], device.id)
             async_cleanup()
 
-    connection.subscriptions[msg["id"]] = async_cleanup
     msg[DATA_UNSUBSCRIBE] = unsubs = [
         async_dispatcher_connect(
             hass, EVENT_DEVICE_ADDED_TO_REGISTRY, _handle_device_added
         )
     ]
     await driver.async_hard_reset()
-    connection.send_result(msg[ID])

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -2473,4 +2473,4 @@ async def websocket_hard_reset_controller(
     msg[DATA_UNSUBSCRIBE] = [
         async_dispatcher_connect(hass, EVENT_DEVICE_ADDED_TO_REGISTRY, _check_for_ready)
     ]
-    await driver.async_hard_reset()
+    hass.async_create_task(driver.async_hard_reset())

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -2464,6 +2464,7 @@ async def websocket_hard_reset_controller(
 ) -> None:
     """Hard reset controller."""
 
+    @callback
     def _check_for_ready(device: dr.DeviceEntry) -> None:
         """Check if controller is ready."""
         if entry.entry_id in device.config_entries:

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -2463,7 +2463,6 @@ async def websocket_hard_reset_controller(
     driver: Driver,
 ) -> None:
     """Hard reset controller."""
-    await driver.async_hard_reset()
 
     def _check_for_ready(device: dr.DeviceEntry) -> None:
         """Check if controller is ready."""
@@ -2474,3 +2473,4 @@ async def websocket_hard_reset_controller(
     msg[DATA_UNSUBSCRIBE] = [
         async_dispatcher_connect(hass, EVENT_DEVICE_ADDED_TO_REGISTRY, _check_for_ready)
     ]
+    await driver.async_hard_reset()

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -2469,6 +2469,7 @@ async def websocket_hard_reset_controller(
         """Remove signal listeners."""
         for unsub in unsubs:
             unsub()
+        unsubs.clear()
 
     @callback
     def _handle_device_added(device: dr.DeviceEntry) -> None:

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -665,9 +665,19 @@ def logic_group_zdb5100_state_fixture():
 # model fixtures
 
 
+@pytest.fixture(name="listen_block")
+def mock_listen_block_fixture():
+    """Mock a listen block."""
+    return asyncio.Event()
+
+
 @pytest.fixture(name="client")
 def mock_client_fixture(
-    controller_state, controller_node_state, version_state, log_config_state
+    controller_state,
+    controller_node_state,
+    version_state,
+    log_config_state,
+    listen_block,
 ):
     """Mock a client."""
     with patch(
@@ -681,9 +691,8 @@ def mock_client_fixture(
 
         async def listen(driver_ready: asyncio.Event) -> None:
             driver_ready.set()
-            listen_block = asyncio.Event()
             await listen_block.wait()
-            pytest.fail("Listen wasn't canceled!")
+            # pytest.fail("Listen wasn't canceled!")
 
         async def disconnect():
             client.connected = False

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -692,7 +692,6 @@ def mock_client_fixture(
         async def listen(driver_ready: asyncio.Event) -> None:
             driver_ready.set()
             await listen_block.wait()
-            # pytest.fail("Listen wasn't canceled!")
 
         async def disconnect():
             client.connected = False

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -4653,7 +4653,11 @@ async def test_subscribe_node_statistics(
 
 
 async def test_hard_reset_controller(
-    hass: HomeAssistant, client, integration, hass_ws_client: WebSocketGenerator
+    hass: HomeAssistant,
+    client,
+    integration,
+    listen_block,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test that the hard_reset_controller WS API call works."""
     entry = integration
@@ -4673,7 +4677,9 @@ async def test_hard_reset_controller(
         }
     )
 
-    await hass.config_entries.async_reload(entry.entry_id)
+    listen_block.set()
+    listen_block.clear()
+    await hass.async_block_till_done()
 
     msg = await ws_client.receive_json()
     assert msg["result"] == device.id

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -4672,17 +4672,15 @@ async def test_hard_reset_controller(
             ENTRY_ID: entry.entry_id,
         }
     )
-    msg = await ws_client.receive_json()
-    assert msg["result"] is None
-    assert msg["success"]
-
-    assert len(client.async_send_command.call_args_list) == 1
-    assert client.async_send_command.call_args[0][0] == {"command": "driver.hard_reset"}
 
     await hass.config_entries.async_reload(entry.entry_id)
 
     msg = await ws_client.receive_json()
-    assert msg["event"]["device_id"] == device.id
+    assert msg["result"] == device.id
+    assert msg["success"]
+
+    assert len(client.async_send_command.call_args_list) == 1
+    assert client.async_send_command.call_args[0][0] == {"command": "driver.hard_reset"}
 
     # Test FailedZWaveCommand is caught
     with patch(

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -79,12 +79,10 @@ from homeassistant.components.zwave_js.api import (
 from homeassistant.components.zwave_js.const import (
     CONF_DATA_COLLECTION_OPTED_IN,
     DOMAIN,
-    EVENT_DEVICE_ADDED_TO_REGISTRY,
 )
 from homeassistant.components.zwave_js.helpers import get_device_id
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from tests.common import MockUser
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
@@ -4681,7 +4679,7 @@ async def test_hard_reset_controller(
     assert len(client.async_send_command.call_args_list) == 1
     assert client.async_send_command.call_args[0][0] == {"command": "driver.hard_reset"}
 
-    async_dispatcher_send(hass, EVENT_DEVICE_ADDED_TO_REGISTRY, device)
+    await hass.config_entries.async_reload(entry.entry_id)
 
     msg = await ws_client.receive_json()
     assert msg["event"]["device_id"] == device.id


### PR DESCRIPTION
## Proposed change
This PR needs adjustments based on the conversation in https://github.com/home-assistant/frontend/pull/18216

@MartinHjelmare you are allowed to say you told me so... 🙂 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/18216

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
