### PR TITLE
Do not fail MQTT setup if covers configured via yaml can't be validated

### DIFF
--- a/homeassistant/components/mqtt/config_integration.py
+++ b/homeassistant/components/mqtt/config_integration.py
@@ -15,7 +15,6 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv
 
 from . import (
-    cover as cover_platform,
     event as event_platform,
     number as number_platform,
     sensor as sensor_platform,
@@ -42,10 +41,7 @@ CONFIG_SCHEMA_BASE = vol.Schema(
         Platform.BUTTON.value: vol.All(cv.ensure_list, [dict]),
         Platform.CAMERA.value: vol.All(cv.ensure_list, [dict]),
         Platform.CLIMATE.value: vol.All(cv.ensure_list, [dict]),
-        Platform.COVER.value: vol.All(
-            cv.ensure_list,
-            [cover_platform.PLATFORM_SCHEMA_MODERN],  # type: ignore[has-type]
-        ),
+        Platform.COVER.value: vol.All(cv.ensure_list, [dict]),
         Platform.DEVICE_TRACKER.value: vol.All(cv.ensure_list, [dict]),
         Platform.EVENT.value: vol.All(
             cv.ensure_list,

--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from contextlib import suppress
-import functools
 import logging
 from typing import Any
 
@@ -31,7 +30,7 @@ from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.service_info.mqtt import ReceivePayloadType
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.json import JSON_DECODE_EXCEPTIONS, json_loads
 
 from . import subscription
@@ -48,7 +47,7 @@ from .debug_info import log_messages
 from .mixins import (
     MQTT_ENTITY_COMMON_SCHEMA,
     MqttEntity,
-    async_setup_entry_helper,
+    async_mqtt_entry_helper,
     write_state_on_attr_change,
 )
 from .models import MqttCommandTemplate, MqttValueTemplate, ReceiveMessage
@@ -220,21 +219,15 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up MQTT cover through YAML and through MQTT discovery."""
-    setup = functools.partial(
-        _async_setup_entity, hass, async_add_entities, config_entry=config_entry
+    await async_mqtt_entry_helper(
+        hass,
+        config_entry,
+        MqttCover,
+        cover.DOMAIN,
+        async_add_entities,
+        DISCOVERY_SCHEMA,
+        PLATFORM_SCHEMA_MODERN,
     )
-    await async_setup_entry_helper(hass, cover.DOMAIN, setup, DISCOVERY_SCHEMA)
-
-
-async def _async_setup_entity(
-    hass: HomeAssistant,
-    async_add_entities: AddEntitiesCallback,
-    config: ConfigType,
-    config_entry: ConfigEntry,
-    discovery_data: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the MQTT Cover."""
-    async_add_entities([MqttCover(hass, config, config_entry, discovery_data)])
 
 
 class MqttCover(MqttEntity, CoverEntity):

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -891,11 +891,9 @@ async def test_optimistic_position(
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test optimistic position is not supported."""
-    with pytest.raises(AssertionError):
-        await mqtt_mock_entry()
+    assert await mqtt_mock_entry()
     assert (
-        "Invalid config for [mqtt]: 'set_position_topic' must be set together with 'position_topic'"
-        in caplog.text
+        "'set_position_topic' must be set together with 'position_topic'" in caplog.text
     )
 
 
@@ -2663,9 +2661,8 @@ async def test_invalid_device_class(
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test the setting of an invalid device class."""
-    with pytest.raises(AssertionError):
-        await mqtt_mock_entry()
-    assert "Invalid config for [mqtt]: expected CoverDeviceClass" in caplog.text
+    assert await mqtt_mock_entry()
+    assert "expected CoverDeviceClass" in caplog.text
 
 
 async def test_setting_attribute_via_mqtt_json_message(
@@ -3402,8 +3399,7 @@ async def test_set_position_topic_without_get_position_topic_error(
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test error when set_position_topic is used without position_topic."""
-    with pytest.raises(AssertionError):
-        await mqtt_mock_entry()
+    assert await mqtt_mock_entry()
     assert (
         f"'{CONF_SET_POSITION_TOPIC}' must be set together with '{CONF_GET_POSITION_TOPIC}'."
     ) in caplog.text
@@ -3429,8 +3425,7 @@ async def test_value_template_without_state_topic_error(
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test error when value_template is used and state_topic is missing."""
-    with pytest.raises(AssertionError):
-        await mqtt_mock_entry()
+    assert await mqtt_mock_entry()
     assert (
         f"'{CONF_VALUE_TEMPLATE}' must be set together with '{CONF_STATE_TOPIC}'."
     ) in caplog.text
@@ -3456,8 +3451,7 @@ async def test_position_template_without_position_topic_error(
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test error when position_template is used and position_topic is missing."""
-    with pytest.raises(AssertionError):
-        await mqtt_mock_entry()
+    assert await mqtt_mock_entry()
     assert (
         f"'{CONF_GET_POSITION_TEMPLATE}' must be set together with '{CONF_GET_POSITION_TOPIC}'."
         in caplog.text
@@ -3484,8 +3478,7 @@ async def test_set_position_template_without_set_position_topic(
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test error when set_position_template is used and set_position_topic is missing."""
-    with pytest.raises(AssertionError):
-        await mqtt_mock_entry()
+    assert await mqtt_mock_entry()
     assert (
         f"'{CONF_SET_POSITION_TEMPLATE}' must be set together with '{CONF_SET_POSITION_TOPIC}'."
         in caplog.text
@@ -3512,8 +3505,7 @@ async def test_tilt_command_template_without_tilt_command_topic(
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test error when tilt_command_template is used and tilt_command_topic is missing."""
-    with pytest.raises(AssertionError):
-        await mqtt_mock_entry()
+    assert await mqtt_mock_entry()
     assert (
         f"'{CONF_TILT_COMMAND_TEMPLATE}' must be set together with '{CONF_TILT_COMMAND_TOPIC}'."
         in caplog.text
@@ -3540,8 +3532,7 @@ async def test_tilt_status_template_without_tilt_status_topic_topic(
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test error when tilt_status_template is used and tilt_status_topic is missing."""
-    with pytest.raises(AssertionError):
-        await mqtt_mock_entry()
+    assert await mqtt_mock_entry()
     assert (
         f"'{CONF_TILT_STATUS_TEMPLATE}' must be set together with '{CONF_TILT_STATUS_TOPIC}'."
         in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow up on #101373.
Ensures the mqtt entry does not fail to set up when the config of one or more manual configured item is violating the config schema.

- This PR enables this feature for the `cover` platform.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
