### PR TITLE
Do not fail MQTT setup if fans configured via yaml can't be validated

### DIFF
--- a/homeassistant/components/mqtt/config_integration.py
+++ b/homeassistant/components/mqtt/config_integration.py
@@ -22,7 +22,6 @@ from . import (
     cover as cover_platform,
     device_tracker as device_tracker_platform,
     event as event_platform,
-    fan as fan_platform,
     humidifier as humidifier_platform,
     image as image_platform,
     lawn_mower as lawn_mower_platform,
@@ -84,10 +83,7 @@ CONFIG_SCHEMA_BASE = vol.Schema(
             cv.ensure_list,
             [event_platform.PLATFORM_SCHEMA_MODERN],  # type: ignore[has-type]
         ),
-        Platform.FAN.value: vol.All(
-            cv.ensure_list,
-            [fan_platform.PLATFORM_SCHEMA_MODERN],  # type: ignore[has-type]
-        ),
+        Platform.FAN.value: vol.All(cv.ensure_list, [dict]),
         Platform.HUMIDIFIER.value: vol.All(
             cv.ensure_list,
             [humidifier_platform.PLATFORM_SCHEMA_MODERN],  # type: ignore[has-type]

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-import functools
 import logging
 import math
 from typing import Any
@@ -30,7 +29,7 @@ from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.template import Template
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.percentage import (
     int_states_in_range,
     percentage_to_ranged_value,
@@ -53,7 +52,7 @@ from .debug_info import log_messages
 from .mixins import (
     MQTT_ENTITY_COMMON_SCHEMA,
     MqttEntity,
-    async_setup_entry_helper,
+    async_mqtt_entry_helper,
     write_state_on_attr_change,
 )
 from .models import (
@@ -200,21 +199,15 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up MQTT fan through YAML and through MQTT discovery."""
-    setup = functools.partial(
-        _async_setup_entity, hass, async_add_entities, config_entry=config_entry
+    await async_mqtt_entry_helper(
+        hass,
+        config_entry,
+        MqttFan,
+        fan.DOMAIN,
+        async_add_entities,
+        DISCOVERY_SCHEMA,
+        PLATFORM_SCHEMA_MODERN,
     )
-    await async_setup_entry_helper(hass, fan.DOMAIN, setup, DISCOVERY_SCHEMA)
-
-
-async def _async_setup_entity(
-    hass: HomeAssistant,
-    async_add_entities: AddEntitiesCallback,
-    config: ConfigType,
-    config_entry: ConfigEntry,
-    discovery_data: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the MQTT fan."""
-    async_add_entities([MqttFan(hass, config, config_entry, discovery_data)])
 
 
 class MqttFan(MqttEntity, FanEntity):

--- a/tests/components/mqtt/test_fan.py
+++ b/tests/components/mqtt/test_fan.py
@@ -96,9 +96,8 @@ async def test_fail_setup_if_no_command_topic(
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test if command fails with command topic."""
-    with pytest.raises(AssertionError):
-        await mqtt_mock_entry()
-    assert "Invalid config for [mqtt]: required key not provided" in caplog.text
+    assert await mqtt_mock_entry()
+    assert "required key not provided" in caplog.text
 
 
 @pytest.mark.parametrize(
@@ -1584,7 +1583,7 @@ async def test_attributes(
 
 
 @pytest.mark.parametrize(
-    ("name", "hass_config", "success", "features"),
+    ("name", "hass_config", "success", "features", "error_message"),
     [
         (
             "test1",
@@ -1598,6 +1597,7 @@ async def test_attributes(
             },
             True,
             fan.FanEntityFeature(0),
+            None,
         ),
         (
             "test2",
@@ -1612,6 +1612,7 @@ async def test_attributes(
             },
             True,
             fan.FanEntityFeature.OSCILLATE,
+            None,
         ),
         (
             "test3",
@@ -1626,6 +1627,7 @@ async def test_attributes(
             },
             True,
             fan.FanEntityFeature.SET_SPEED,
+            None,
         ),
         (
             "test4",
@@ -1640,6 +1642,7 @@ async def test_attributes(
             },
             False,
             None,
+            "some but not all values in the same group of inclusion 'preset_modes'",
         ),
         (
             "test5",
@@ -1655,6 +1658,7 @@ async def test_attributes(
             },
             True,
             fan.FanEntityFeature.PRESET_MODE,
+            None,
         ),
         (
             "test6",
@@ -1670,6 +1674,7 @@ async def test_attributes(
             },
             True,
             fan.FanEntityFeature.PRESET_MODE,
+            None,
         ),
         (
             "test7",
@@ -1684,6 +1689,7 @@ async def test_attributes(
             },
             True,
             fan.FanEntityFeature.SET_SPEED,
+            None,
         ),
         (
             "test8",
@@ -1699,6 +1705,7 @@ async def test_attributes(
             },
             True,
             fan.FanEntityFeature.OSCILLATE | fan.FanEntityFeature.SET_SPEED,
+            None,
         ),
         (
             "test9",
@@ -1714,6 +1721,7 @@ async def test_attributes(
             },
             True,
             fan.FanEntityFeature.PRESET_MODE,
+            None,
         ),
         (
             "test10",
@@ -1729,6 +1737,7 @@ async def test_attributes(
             },
             True,
             fan.FanEntityFeature.PRESET_MODE,
+            None,
         ),
         (
             "test11",
@@ -1745,6 +1754,7 @@ async def test_attributes(
             },
             True,
             fan.FanEntityFeature.PRESET_MODE | fan.FanEntityFeature.OSCILLATE,
+            None,
         ),
         (
             "test12",
@@ -1761,6 +1771,7 @@ async def test_attributes(
             },
             True,
             fan.FanEntityFeature.SET_SPEED,
+            None,
         ),
         (
             "test13",
@@ -1777,6 +1788,7 @@ async def test_attributes(
             },
             False,
             None,
+            "not a valid value",
         ),
         (
             "test14",
@@ -1793,13 +1805,14 @@ async def test_attributes(
             },
             False,
             None,
+            "not a valid value",
         ),
         (
             "test15",
             {
                 mqtt.DOMAIN: {
                     fan.DOMAIN: {
-                        "name": "test7reset_payload_in_preset_modes_a",
+                        "name": "test15",
                         "command_topic": "command-topic",
                         "preset_mode_command_topic": "preset-mode-command-topic",
                         "preset_modes": ["auto", "smart", "normal", "None"],
@@ -1808,6 +1821,7 @@ async def test_attributes(
             },
             False,
             None,
+            "preset_modes must not contain payload_reset_preset_mode",
         ),
         (
             "test16",
@@ -1824,6 +1838,7 @@ async def test_attributes(
             },
             True,
             fan.FanEntityFeature.PRESET_MODE,
+            "some error",
         ),
         (
             "test17",
@@ -1838,25 +1853,27 @@ async def test_attributes(
             },
             True,
             fan.FanEntityFeature.DIRECTION,
+            "some error",
         ),
     ],
 )
 async def test_supported_features(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
     name: str,
     success: bool,
-    features,
+    features: fan.FanEntityFeature | None,
+    error_message: str | None,
 ) -> None:
     """Test optimistic mode without state topic."""
+    await mqtt_mock_entry()
+    state = hass.states.get(f"fan.{name}")
+    assert (state is not None) == success
     if success:
-        await mqtt_mock_entry()
-
-        state = hass.states.get(f"fan.{name}")
         assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == features
         return
-    with pytest.raises(AssertionError):
-        await mqtt_mock_entry()
+    assert error_message in caplog.text
 
 
 @pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow up on #101373.
Ensures the mqtt entry does not fail to set up when the config of one or more manual configured item is violating the config schema.

- This PR enables this feature for the `fan` 
platform.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
