### PR TITLE
Do not fail MQTT setup if humidifiers configured via yaml can't be validated

### DIFF
--- a/homeassistant/components/mqtt/config_integration.py
+++ b/homeassistant/components/mqtt/config_integration.py
@@ -18,7 +18,6 @@ from . import (
     button as button_platform,
     cover as cover_platform,
     event as event_platform,
-    humidifier as humidifier_platform,
     lawn_mower as lawn_mower_platform,
     lock as lock_platform,
     number as number_platform,
@@ -62,10 +61,7 @@ CONFIG_SCHEMA_BASE = vol.Schema(
             [event_platform.PLATFORM_SCHEMA_MODERN],  # type: ignore[has-type]
         ),
         Platform.FAN.value: vol.All(cv.ensure_list, [dict]),
-        Platform.HUMIDIFIER.value: vol.All(
-            cv.ensure_list,
-            [humidifier_platform.PLATFORM_SCHEMA_MODERN],  # type: ignore[has-type]
-        ),
+        Platform.HUMIDIFIER.value: vol.All(cv.ensure_list, [dict]),
         Platform.IMAGE.value: vol.All(cv.ensure_list, [dict]),
         Platform.LAWN_MOWER.value: vol.All(
             cv.ensure_list,

--- a/homeassistant/components/mqtt/humidifier.py
+++ b/homeassistant/components/mqtt/humidifier.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-import functools
 import logging
 from typing import Any
 
@@ -33,7 +32,7 @@ from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.template import Template
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.typing import ConfigType
 
 from . import subscription
 from .config import MQTT_RW_SCHEMA
@@ -55,7 +54,7 @@ from .debug_info import log_messages
 from .mixins import (
     MQTT_ENTITY_COMMON_SCHEMA,
     MqttEntity,
-    async_setup_entry_helper,
+    async_mqtt_entry_helper,
     write_state_on_attr_change,
 )
 from .models import (
@@ -192,21 +191,15 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up MQTT humidifier through YAML and through MQTT discovery."""
-    setup = functools.partial(
-        _async_setup_entity, hass, async_add_entities, config_entry=config_entry
+    await async_mqtt_entry_helper(
+        hass,
+        config_entry,
+        MqttHumidifier,
+        humidifier.DOMAIN,
+        async_add_entities,
+        DISCOVERY_SCHEMA,
+        PLATFORM_SCHEMA_MODERN,
     )
-    await async_setup_entry_helper(hass, humidifier.DOMAIN, setup, DISCOVERY_SCHEMA)
-
-
-async def _async_setup_entity(
-    hass: HomeAssistant,
-    async_add_entities: AddEntitiesCallback,
-    config: ConfigType,
-    config_entry: ConfigEntry,
-    discovery_data: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the MQTT humidifier."""
-    async_add_entities([MqttHumidifier(hass, config, config_entry, discovery_data)])
 
 
 class MqttHumidifier(MqttEntity, HumidifierEntity):

--- a/tests/components/mqtt/test_humidifier.py
+++ b/tests/components/mqtt/test_humidifier.py
@@ -142,9 +142,8 @@ async def test_fail_setup_if_no_command_topic(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test if command fails with command topic."""
-    with pytest.raises(AssertionError):
-        await mqtt_mock_entry()
-    assert "Invalid config for [mqtt]: required key not provided" in caplog.text
+    assert await mqtt_mock_entry()
+    assert "required key not provided" in caplog.text
 
 
 @pytest.mark.parametrize(
@@ -934,11 +933,11 @@ async def test_attributes(
 @pytest.mark.parametrize(
     ("hass_config", "valid"),
     [
-        (
+        (  # test valid case 1
             {
                 mqtt.DOMAIN: {
                     humidifier.DOMAIN: {
-                        "name": "test_valid_1",
+                        "name": "test",
                         "command_topic": "command-topic",
                         "target_humidity_command_topic": "humidity-command-topic",
                     }
@@ -946,11 +945,11 @@ async def test_attributes(
             },
             True,
         ),
-        (
+        (  # test valid case 2
             {
                 mqtt.DOMAIN: {
                     humidifier.DOMAIN: {
-                        "name": "test_valid_2",
+                        "name": "test",
                         "command_topic": "command-topic",
                         "target_humidity_command_topic": "humidity-command-topic",
                         "device_class": "humidifier",
@@ -959,11 +958,11 @@ async def test_attributes(
             },
             True,
         ),
-        (
+        (  # test valid case 3
             {
                 mqtt.DOMAIN: {
                     humidifier.DOMAIN: {
-                        "name": "test_valid_3",
+                        "name": "test",
                         "command_topic": "command-topic",
                         "target_humidity_command_topic": "humidity-command-topic",
                         "device_class": "dehumidifier",
@@ -972,11 +971,11 @@ async def test_attributes(
             },
             True,
         ),
-        (
+        (  # test valid case 4
             {
                 mqtt.DOMAIN: {
                     humidifier.DOMAIN: {
-                        "name": "test_valid_4",
+                        "name": "test",
                         "command_topic": "command-topic",
                         "target_humidity_command_topic": "humidity-command-topic",
                         "device_class": None,
@@ -985,11 +984,11 @@ async def test_attributes(
             },
             True,
         ),
-        (
+        (  # test invalid device_class
             {
                 mqtt.DOMAIN: {
                     humidifier.DOMAIN: {
-                        "name": "test_invalid_device_class",
+                        "name": "test",
                         "command_topic": "command-topic",
                         "target_humidity_command_topic": "humidity-command-topic",
                         "device_class": "notsupporedSpeci@l",
@@ -998,11 +997,11 @@ async def test_attributes(
             },
             False,
         ),
-        (
+        (  # test mode_command_topic without modes
             {
                 mqtt.DOMAIN: {
                     humidifier.DOMAIN: {
-                        "name": "test_mode_command_without_modes",
+                        "name": "test",
                         "command_topic": "command-topic",
                         "target_humidity_command_topic": "humidity-command-topic",
                         "mode_command_topic": "mode-command-topic",
@@ -1011,11 +1010,11 @@ async def test_attributes(
             },
             False,
         ),
-        (
+        (  # test invalid humidity min max case 1
             {
                 mqtt.DOMAIN: {
                     humidifier.DOMAIN: {
-                        "name": "test_invalid_humidity_min_max_1",
+                        "name": "test",
                         "command_topic": "command-topic",
                         "target_humidity_command_topic": "humidity-command-topic",
                         "min_humidity": 0,
@@ -1025,11 +1024,11 @@ async def test_attributes(
             },
             False,
         ),
-        (
+        (  # test invalid humidity min max case 2
             {
                 mqtt.DOMAIN: {
                     humidifier.DOMAIN: {
-                        "name": "test_invalid_humidity_min_max_2",
+                        "name": "test",
                         "command_topic": "command-topic",
                         "target_humidity_command_topic": "humidity-command-topic",
                         "max_humidity": 20,
@@ -1039,11 +1038,11 @@ async def test_attributes(
             },
             False,
         ),
-        (
+        (  # test invalid mode, is reset payload
             {
                 mqtt.DOMAIN: {
                     humidifier.DOMAIN: {
-                        "name": "test_invalid_mode_is_reset",
+                        "name": "test",
                         "command_topic": "command-topic",
                         "target_humidity_command_topic": "humidity-command-topic",
                         "mode_command_topic": "mode-command-topic",
@@ -1061,11 +1060,9 @@ async def test_validity_configurations(
     valid: bool,
 ) -> None:
     """Test validity of configurations."""
-    if valid:
-        await mqtt_mock_entry()
-        return
-    with pytest.raises(AssertionError):
-        await mqtt_mock_entry()
+    await mqtt_mock_entry()
+    state = hass.states.get("humidifier.test")
+    assert (state is not None) == valid
 
 
 @pytest.mark.parametrize(
@@ -1167,14 +1164,11 @@ async def test_supported_features(
     features: humidifier.HumidifierEntityFeature | None,
 ) -> None:
     """Test supported features."""
+    await mqtt_mock_entry()
+    state = hass.states.get(f"humidifier.{name}")
+    assert (state is not None) == success
     if success:
-        await mqtt_mock_entry()
-
-        state = hass.states.get(f"humidifier.{name}")
         assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == features
-        return
-    with pytest.raises(AssertionError):
-        await mqtt_mock_entry()
 
 
 @pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow up on #101373.
Ensures the mqtt entry does not fail to set up when the config of one or more manual configured item is violating the config schema.

- This PR enables this feature for the `humidifier` platform.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
