### PR TITLE
Do not fail MQTT setup if vacuum's configured via yaml can't be validated

### DIFF
--- a/homeassistant/components/mqtt/config_integration.py
+++ b/homeassistant/components/mqtt/config_integration.py
@@ -35,7 +35,6 @@ from . import (
     switch as switch_platform,
     text as text_platform,
     update as update_platform,
-    vacuum as vacuum_platform,
     water_heater as water_heater_platform,
 )
 from .const import (
@@ -136,10 +135,7 @@ CONFIG_SCHEMA_BASE = vol.Schema(
             cv.ensure_list,
             [update_platform.PLATFORM_SCHEMA_MODERN],  # type: ignore[has-type]
         ),
-        Platform.VACUUM.value: vol.All(
-            cv.ensure_list,
-            [vacuum_platform.PLATFORM_SCHEMA_MODERN],  # type: ignore[has-type]
-        ),
+        Platform.VACUUM.value: vol.All(cv.ensure_list, [dict]),
         Platform.WATER_HEATER.value: vol.All(
             cv.ensure_list,
             [water_heater_platform.PLATFORM_SCHEMA_MODERN],  # type: ignore[has-type]

--- a/homeassistant/components/mqtt/vacuum/__init__.py
+++ b/homeassistant/components/mqtt/vacuum/__init__.py
@@ -5,30 +5,29 @@
 
 from __future__ import annotations
 
-import functools
 import logging
 
 import voluptuous as vol
 
 from homeassistant.components import vacuum
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, async_get_hass, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.typing import ConfigType
 
 from ..const import DOMAIN
-from ..mixins import async_setup_entry_helper
+from ..mixins import async_mqtt_entry_helper
 from .schema import CONF_SCHEMA, LEGACY, MQTT_VACUUM_SCHEMA, STATE
 from .schema_legacy import (
     DISCOVERY_SCHEMA_LEGACY,
     PLATFORM_SCHEMA_LEGACY_MODERN,
-    async_setup_entity_legacy,
+    MqttVacuum,
 )
 from .schema_state import (
     DISCOVERY_SCHEMA_STATE,
     PLATFORM_SCHEMA_STATE_MODERN,
-    async_setup_entity_state,
+    MqttStateVacuum,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -39,13 +38,13 @@ MQTT_VACUUM_DOCS_URL = "https://www.home-assistant.io/integrations/vacuum.mqtt/"
 # The legacy schema for MQTT vacuum was deprecated with HA Core 2023.8.0
 # and will be removed with HA Core 2024.2.0
 def warn_for_deprecation_legacy_schema(
-    hass: HomeAssistant, config: ConfigType, discovery_data: DiscoveryInfoType | None
+    hass: HomeAssistant, config: ConfigType, discovery: bool
 ) -> None:
     """Warn for deprecation of legacy schema."""
     if config[CONF_SCHEMA] == STATE:
         return
 
-    key_suffix = "yaml" if discovery_data is None else "discovery"
+    key_suffix = "discovery" if discovery else "yaml"
     translation_key = f"deprecation_mqtt_legacy_vacuum_{key_suffix}"
     async_create_issue(
         hass,
@@ -63,6 +62,7 @@ def warn_for_deprecation_legacy_schema(
     )
 
 
+@callback
 def validate_mqtt_vacuum_discovery(config_value: ConfigType) -> ConfigType:
     """Validate MQTT vacuum schema."""
 
@@ -71,9 +71,12 @@ def validate_mqtt_vacuum_discovery(config_value: ConfigType) -> ConfigType:
 
     schemas = {LEGACY: DISCOVERY_SCHEMA_LEGACY, STATE: DISCOVERY_SCHEMA_STATE}
     config: ConfigType = schemas[config_value[CONF_SCHEMA]](config_value)
+    hass = async_get_hass()
+    warn_for_deprecation_legacy_schema(hass, config, True)
     return config
 
 
+@callback
 def validate_mqtt_vacuum_modern(config_value: ConfigType) -> ConfigType:
     """Validate MQTT vacuum modern schema."""
 
@@ -85,6 +88,10 @@ def validate_mqtt_vacuum_modern(config_value: ConfigType) -> ConfigType:
         STATE: PLATFORM_SCHEMA_STATE_MODERN,
     }
     config: ConfigType = schemas[config_value[CONF_SCHEMA]](config_value)
+    # The legacy schema for MQTT vacuum was deprecated with HA Core 2023.8.0
+    # and will be removed with HA Core 2024.2.0
+    hass = async_get_hass()
+    warn_for_deprecation_legacy_schema(hass, config, False)
     return config
 
 
@@ -103,28 +110,13 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up MQTT vacuum through YAML and through MQTT discovery."""
-    setup = functools.partial(
-        _async_setup_entity, hass, async_add_entities, config_entry=config_entry
-    )
-    await async_setup_entry_helper(hass, vacuum.DOMAIN, setup, DISCOVERY_SCHEMA)
-
-
-async def _async_setup_entity(
-    hass: HomeAssistant,
-    async_add_entities: AddEntitiesCallback,
-    config: ConfigType,
-    config_entry: ConfigEntry,
-    discovery_data: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the MQTT vacuum."""
-
-    # The legacy schema for MQTT vacuum was deprecated with HA Core 2023.8.0
-    # and will be removed with HA Core 2024.2.0
-    warn_for_deprecation_legacy_schema(hass, config, discovery_data)
-    setup_entity = {
-        LEGACY: async_setup_entity_legacy,
-        STATE: async_setup_entity_state,
-    }
-    await setup_entity[config[CONF_SCHEMA]](
-        hass, config, async_add_entities, config_entry, discovery_data
+    await async_mqtt_entry_helper(
+        hass,
+        config_entry,
+        None,
+        vacuum.DOMAIN,
+        async_add_entities,
+        DISCOVERY_SCHEMA,
+        PLATFORM_SCHEMA_MODERN,
+        {"legacy": MqttVacuum, "state": MqttStateVacuum},
     )

--- a/homeassistant/components/mqtt/vacuum/schema_legacy.py
+++ b/homeassistant/components/mqtt/vacuum/schema_legacy.py
@@ -17,14 +17,12 @@ from homeassistant.components.vacuum import (
     VacuumEntity,
     VacuumEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_SUPPORTED_FEATURES, CONF_NAME
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.icon import icon_for_battery_level
 from homeassistant.helpers.json import json_dumps
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.typing import ConfigType
 
 from .. import subscription
 from ..config import MQTT_BASE_SCHEMA
@@ -199,17 +197,6 @@ _COMMANDS = {
         "status": "Returning home...",
     },
 }
-
-
-async def async_setup_entity_legacy(
-    hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    config_entry: ConfigEntry,
-    discovery_data: DiscoveryInfoType | None,
-) -> None:
-    """Set up a MQTT Vacuum Legacy."""
-    async_add_entities([MqttVacuum(hass, config, config_entry, discovery_data)])
 
 
 class MqttVacuum(MqttEntity, VacuumEntity):

--- a/homeassistant/components/mqtt/vacuum/schema_state.py
+++ b/homeassistant/components/mqtt/vacuum/schema_state.py
@@ -23,7 +23,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.json import json_dumps
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util.json import json_loads_object
@@ -154,17 +153,6 @@ PLATFORM_SCHEMA_STATE_MODERN = (
 )
 
 DISCOVERY_SCHEMA_STATE = PLATFORM_SCHEMA_STATE_MODERN.extend({}, extra=vol.REMOVE_EXTRA)
-
-
-async def async_setup_entity_state(
-    hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    config_entry: ConfigEntry,
-    discovery_data: DiscoveryInfoType | None,
-) -> None:
-    """Set up a State MQTT Vacuum."""
-    async_add_entities([MqttStateVacuum(hass, config, config_entry, discovery_data)])
 
 
 class MqttStateVacuum(MqttEntity, StateVacuumEntity):

--- a/tests/components/mqtt/test_legacy_vacuum.py
+++ b/tests/components/mqtt/test_legacy_vacuum.py
@@ -642,12 +642,8 @@ async def test_missing_templates(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test to make sure missing template is not allowed."""
-    with pytest.raises(AssertionError):
-        await mqtt_mock_entry()
-    assert (
-        "Invalid config for [mqtt]: some but not all values in the same group of inclusion"
-        in caplog.text
-    )
+    assert await mqtt_mock_entry()
+    assert "some but not all values in the same group of inclusion" in caplog.text
 
 
 @pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG_2])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow up on #101373.
Ensures the mqtt entry does not fail to set up when the config of one or more manual configured item is violating the config schema.

- This PR enables this feature for the `vacuum` platform.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
