### PR TITLE
Avoid core/supervisor stats API calls when no entities need them

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -57,9 +57,6 @@ from .addon_manager import AddonError, AddonInfo, AddonManager, AddonState  # no
 from .addon_panel import async_setup_addon_panel
 from .auth import async_setup_auth_view
 from .const import (
-    ADDON_UPDATE_CHANGELOG,
-    ADDON_UPDATE_INFO,
-    ADDON_UPDATE_STATS,
     ATTR_ADDON,
     ATTR_ADDONS,
     ATTR_AUTO_UPDATE,
@@ -76,6 +73,10 @@ from .const import (
     ATTR_STATE,
     ATTR_URL,
     ATTR_VERSION,
+    CONTAINER_CHANGELOG,
+    CONTAINER_INFO,
+    CONTAINER_STATS,
+    CORE_CONTAINER,
     DATA_KEY_ADDONS,
     DATA_KEY_CORE,
     DATA_KEY_HOST,
@@ -83,6 +84,7 @@ from .const import (
     DATA_KEY_SUPERVISOR,
     DATA_KEY_SUPERVISOR_ISSUES,
     DOMAIN,
+    SUPERVISOR_CONTAINER,
     SupervisorEntityModel,
 )
 from .discovery import HassioServiceInfo, async_setup_discovery_view  # noqa: F401
@@ -805,9 +807,9 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
         self.entry_id = config_entry.entry_id
         self.dev_reg = dev_reg
         self.is_hass_os = (get_info(self.hass) or {}).get("hassos") is not None
-        self._enabled_updates_by_addon: defaultdict[
-            str, dict[str, set[str]]
-        ] = defaultdict(lambda: defaultdict(set))
+        self._container_updates: defaultdict[str, dict[str, set[str]]] = defaultdict(
+            lambda: defaultdict(set)
+        )
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
@@ -910,23 +912,24 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def force_data_refresh(self, first_update: bool) -> None:
         """Force update of the addon info."""
+        container_updates = self._container_updates
+
         data = self.hass.data
         hassio = self.hassio
-        (
-            data[DATA_INFO],
-            data[DATA_CORE_INFO],
-            data[DATA_CORE_STATS],
-            data[DATA_SUPERVISOR_INFO],
-            data[DATA_SUPERVISOR_STATS],
-            data[DATA_OS_INFO],
-        ) = await asyncio.gather(
-            hassio.get_info(),
-            hassio.get_core_info(),
-            hassio.get_core_stats(),
-            hassio.get_supervisor_info(),
-            hassio.get_supervisor_stats(),
-            hassio.get_os_info(),
-        )
+        updates = {
+            DATA_INFO: hassio.get_info(),
+            DATA_CORE_INFO: hassio.get_core_info(),
+            DATA_SUPERVISOR_INFO: hassio.get_supervisor_info(),
+            DATA_OS_INFO: hassio.get_os_info(),
+        }
+        if first_update or CONTAINER_STATS in container_updates[CORE_CONTAINER]:
+            updates[DATA_CORE_STATS] = hassio.get_core_stats()
+        if first_update or CONTAINER_STATS in container_updates[SUPERVISOR_CONTAINER]:
+            updates[DATA_SUPERVISOR_STATS] = hassio.get_supervisor_stats()
+
+        results = await asyncio.gather(*updates.values())
+        for key, result in zip(updates, results):
+            data[key] = result
 
         _addon_data = data[DATA_SUPERVISOR_INFO].get("addons", [])
         all_addons: list[str] = []
@@ -940,37 +943,36 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
         # Update add-on info if its the first update or
         # there is at least one entity that needs the data.
         #
-        # When entities are added they call async_enable_addon_updates
+        # When entities are added they call async_enable_container_updates
         # to enable updates for the endpoints they need via
         # async_added_to_hass. This ensures that we only update
         # the data for the endpoints that are needed to avoid unnecessary
-        # API calls since otherwise we would fetch stats for all add-ons
+        # API calls since otherwise we would fetch stats for all containers
         # and throw them away.
         #
-        enabled_updates_by_addon = self._enabled_updates_by_addon
         for data_key, update_func, enabled_key, wanted_addons in (
             (
                 DATA_ADDONS_STATS,
                 self._update_addon_stats,
-                ADDON_UPDATE_STATS,
+                CONTAINER_STATS,
                 started_addons,
             ),
             (
                 DATA_ADDONS_CHANGELOGS,
                 self._update_addon_changelog,
-                ADDON_UPDATE_CHANGELOG,
+                CONTAINER_CHANGELOG,
                 all_addons,
             ),
-            (DATA_ADDONS_INFO, self._update_addon_info, ADDON_UPDATE_INFO, all_addons),
+            (DATA_ADDONS_INFO, self._update_addon_info, CONTAINER_INFO, all_addons),
         ):
-            data.setdefault(data_key, {}).update(
+            container_data: dict[str, Any] = data.setdefault(data_key, {})
+            container_data.update(
                 dict(
                     await asyncio.gather(
                         *[
                             update_func(slug)
                             for slug in wanted_addons
-                            if first_update
-                            or enabled_key in enabled_updates_by_addon[slug]
+                            if first_update or enabled_key in container_updates[slug]
                         ]
                     )
                 )
@@ -1004,11 +1006,11 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
         return (slug, None)
 
     @callback
-    def async_enable_addon_updates(
+    def async_enable_container_updates(
         self, slug: str, entity_id: str, types: set[str]
     ) -> CALLBACK_TYPE:
         """Enable updates for an add-on."""
-        enabled_updates = self._enabled_updates_by_addon[slug]
+        enabled_updates = self._container_updates[slug]
         for key in types:
             enabled_updates[key].add(entity_id)
 

--- a/homeassistant/components/hassio/const.py
+++ b/homeassistant/components/hassio/const.py
@@ -82,19 +82,22 @@ PLACEHOLDER_KEY_COMPONENTS = "components"
 
 ISSUE_KEY_SYSTEM_DOCKER_CONFIG = "issue_system_docker_config"
 
-ADDON_UPDATE_STATS = "stats"
-ADDON_UPDATE_CHANGELOG = "changelog"
-ADDON_UPDATE_INFO = "info"
+CORE_CONTAINER = "homeassistant"
+SUPERVISOR_CONTAINER = "hassio_supervisor"
+
+CONTAINER_STATS = "stats"
+CONTAINER_CHANGELOG = "changelog"
+CONTAINER_INFO = "info"
 
 # This is a mapping of which endpoint the key in the addon data
 # is obtained from so we know which endpoint to update when the
 # coordinator polls for updates.
 KEY_TO_UPDATE_TYPES: dict[str, set[str]] = {
-    ATTR_VERSION_LATEST: {ADDON_UPDATE_INFO, ADDON_UPDATE_CHANGELOG},
-    ATTR_MEMORY_PERCENT: {ADDON_UPDATE_STATS},
-    ATTR_CPU_PERCENT: {ADDON_UPDATE_STATS},
-    ATTR_VERSION: {ADDON_UPDATE_INFO},
-    ATTR_STATE: {ADDON_UPDATE_INFO},
+    ATTR_VERSION_LATEST: {CONTAINER_INFO, CONTAINER_CHANGELOG},
+    ATTR_MEMORY_PERCENT: {CONTAINER_STATS},
+    ATTR_CPU_PERCENT: {CONTAINER_STATS},
+    ATTR_VERSION: {CONTAINER_INFO},
+    ATTR_STATE: {CONTAINER_INFO},
 }
 
 

--- a/homeassistant/components/hassio/entity.py
+++ b/homeassistant/components/hassio/entity.py
@@ -10,12 +10,14 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from . import DOMAIN, HassioDataUpdateCoordinator
 from .const import (
     ATTR_SLUG,
+    CORE_CONTAINER,
     DATA_KEY_ADDONS,
     DATA_KEY_CORE,
     DATA_KEY_HOST,
     DATA_KEY_OS,
     DATA_KEY_SUPERVISOR,
     KEY_TO_UPDATE_TYPES,
+    SUPERVISOR_CONTAINER,
 )
 
 
@@ -52,7 +54,7 @@ class HassioAddonEntity(CoordinatorEntity[HassioDataUpdateCoordinator]):
         await super().async_added_to_hass()
         update_types = KEY_TO_UPDATE_TYPES[self.entity_description.key]
         self.async_on_remove(
-            self.coordinator.async_enable_addon_updates(
+            self.coordinator.async_enable_container_updates(
                 self._addon_slug, self.entity_id, update_types
             )
         )
@@ -136,6 +138,16 @@ class HassioSupervisorEntity(CoordinatorEntity[HassioDataUpdateCoordinator]):
             in self.coordinator.data[DATA_KEY_SUPERVISOR]
         )
 
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to updates."""
+        await super().async_added_to_hass()
+        update_types = KEY_TO_UPDATE_TYPES[self.entity_description.key]
+        self.async_on_remove(
+            self.coordinator.async_enable_container_updates(
+                SUPERVISOR_CONTAINER, self.entity_id, update_types
+            )
+        )
+
 
 class HassioCoreEntity(CoordinatorEntity[HassioDataUpdateCoordinator]):
     """Base Entity for Core."""
@@ -160,4 +172,14 @@ class HassioCoreEntity(CoordinatorEntity[HassioDataUpdateCoordinator]):
             super().available
             and DATA_KEY_CORE in self.coordinator.data
             and self.entity_description.key in self.coordinator.data[DATA_KEY_CORE]
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to updates."""
+        await super().async_added_to_hass()
+        update_types = KEY_TO_UPDATE_TYPES[self.entity_description.key]
+        self.async_on_remove(
+            self.coordinator.async_enable_container_updates(
+                CORE_CONTAINER, self.entity_id, update_types
+            )
         )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is the same as the addons but for core/supervisor as well

https://github.com/home-assistant/core/pull/101382#discussion_r1345828620

First Update / startup ( 4 addons + core/supervisor stats updated )
`2023-10-19 15:34:32.911 DEBUG (MainThread) [homeassistant.components.hassio] Finished fetching hassio data in 4.055 seconds (success: True)`
Note: I've seen users with 20 addons take up to 90s to update so this still doesn't solve the startup issue (hassio takes the most startup time of any integration on these systems).  Its a difficult problem as we need to know in advance which ones to update since even if we have separate coordinators we still have to do the first update. Something to contemplate for a future PR as this does reduce the run time once everything is up and going.

Subsequent updates
`2023-10-19 16:04:32.710 DEBUG (MainThread) [homeassistant.components.hassio] Finished fetching hassio data in 0.018 seconds (success: True)`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
