### PR TITLE
Improve Airzone Cloud tests

### DIFF
--- a/tests/components/airzone_cloud/test_climate.py
+++ b/tests/components/airzone_cloud/test_climate.py
@@ -41,9 +41,9 @@ async def test_airzone_create_climates(hass: HomeAssistant) -> None:
     state = hass.states.get("climate.bron")
     assert state.state == HVACMode.OFF
     assert state.attributes.get(ATTR_CURRENT_HUMIDITY) is None
-    assert state.attributes.get(ATTR_CURRENT_TEMPERATURE) == 21.0
-    assert state.attributes.get(ATTR_HVAC_ACTION) == HVACAction.OFF
-    assert state.attributes.get(ATTR_HVAC_MODES) == [
+    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 21.0
+    assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.OFF
+    assert state.attributes[ATTR_HVAC_MODES] == [
         HVACMode.HEAT_COOL,
         HVACMode.COOL,
         HVACMode.HEAT,
@@ -51,28 +51,28 @@ async def test_airzone_create_climates(hass: HomeAssistant) -> None:
         HVACMode.DRY,
         HVACMode.OFF,
     ]
-    assert state.attributes.get(ATTR_MAX_TEMP) == 30
-    assert state.attributes.get(ATTR_MIN_TEMP) == 15
-    assert state.attributes.get(ATTR_TARGET_TEMP_STEP) == API_TEMPERATURE_STEP
-    assert state.attributes.get(ATTR_TEMPERATURE) == 22.0
+    assert state.attributes[ATTR_MAX_TEMP] == 30
+    assert state.attributes[ATTR_MIN_TEMP] == 15
+    assert state.attributes[ATTR_TARGET_TEMP_STEP] == API_TEMPERATURE_STEP
+    assert state.attributes[ATTR_TEMPERATURE] == 22.0
 
     # Groups
     state = hass.states.get("climate.group")
     assert state.state == HVACMode.COOL
-    assert state.attributes.get(ATTR_CURRENT_HUMIDITY) == 27
-    assert state.attributes.get(ATTR_CURRENT_TEMPERATURE) == 22.5
-    assert state.attributes.get(ATTR_HVAC_ACTION) == HVACAction.COOLING
-    assert state.attributes.get(ATTR_HVAC_MODES) == [
+    assert state.attributes[ATTR_CURRENT_HUMIDITY] == 27
+    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 22.5
+    assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.COOLING
+    assert state.attributes[ATTR_HVAC_MODES] == [
         HVACMode.COOL,
         HVACMode.HEAT,
         HVACMode.FAN_ONLY,
         HVACMode.DRY,
         HVACMode.OFF,
     ]
-    assert state.attributes.get(ATTR_MAX_TEMP) == 30
-    assert state.attributes.get(ATTR_MIN_TEMP) == 15
-    assert state.attributes.get(ATTR_TARGET_TEMP_STEP) == API_TEMPERATURE_STEP
-    assert state.attributes.get(ATTR_TEMPERATURE) == 24.0
+    assert state.attributes[ATTR_MAX_TEMP] == 30
+    assert state.attributes[ATTR_MIN_TEMP] == 15
+    assert state.attributes[ATTR_TARGET_TEMP_STEP] == API_TEMPERATURE_STEP
+    assert state.attributes[ATTR_TEMPERATURE] == 24.0
 
     # Installations
     state = hass.states.get("climate.house")
@@ -96,37 +96,37 @@ async def test_airzone_create_climates(hass: HomeAssistant) -> None:
     # Zones
     state = hass.states.get("climate.dormitorio")
     assert state.state == HVACMode.OFF
-    assert state.attributes.get(ATTR_CURRENT_HUMIDITY) == 24
-    assert state.attributes.get(ATTR_CURRENT_TEMPERATURE) == 25.0
-    assert state.attributes.get(ATTR_HVAC_ACTION) == HVACAction.OFF
-    assert state.attributes.get(ATTR_HVAC_MODES) == [
+    assert state.attributes[ATTR_CURRENT_HUMIDITY] == 24
+    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 25.0
+    assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.OFF
+    assert state.attributes[ATTR_HVAC_MODES] == [
         HVACMode.COOL,
         HVACMode.HEAT,
         HVACMode.FAN_ONLY,
         HVACMode.DRY,
         HVACMode.OFF,
     ]
-    assert state.attributes.get(ATTR_MAX_TEMP) == 30
-    assert state.attributes.get(ATTR_MIN_TEMP) == 15
-    assert state.attributes.get(ATTR_TARGET_TEMP_STEP) == API_TEMPERATURE_STEP
-    assert state.attributes.get(ATTR_TEMPERATURE) == 24.0
+    assert state.attributes[ATTR_MAX_TEMP] == 30
+    assert state.attributes[ATTR_MIN_TEMP] == 15
+    assert state.attributes[ATTR_TARGET_TEMP_STEP] == API_TEMPERATURE_STEP
+    assert state.attributes[ATTR_TEMPERATURE] == 24.0
 
     state = hass.states.get("climate.salon")
     assert state.state == HVACMode.COOL
-    assert state.attributes.get(ATTR_CURRENT_HUMIDITY) == 30
-    assert state.attributes.get(ATTR_CURRENT_TEMPERATURE) == 20.0
-    assert state.attributes.get(ATTR_HVAC_ACTION) == HVACAction.COOLING
-    assert state.attributes.get(ATTR_HVAC_MODES) == [
+    assert state.attributes[ATTR_CURRENT_HUMIDITY] == 30
+    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 20.0
+    assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.COOLING
+    assert state.attributes[ATTR_HVAC_MODES] == [
         HVACMode.COOL,
         HVACMode.HEAT,
         HVACMode.FAN_ONLY,
         HVACMode.DRY,
         HVACMode.OFF,
     ]
-    assert state.attributes.get(ATTR_MAX_TEMP) == 30
-    assert state.attributes.get(ATTR_MIN_TEMP) == 15
-    assert state.attributes.get(ATTR_TARGET_TEMP_STEP) == API_TEMPERATURE_STEP
-    assert state.attributes.get(ATTR_TEMPERATURE) == 24.0
+    assert state.attributes[ATTR_MAX_TEMP] == 30
+    assert state.attributes[ATTR_MIN_TEMP] == 15
+    assert state.attributes[ATTR_TARGET_TEMP_STEP] == API_TEMPERATURE_STEP
+    assert state.attributes[ATTR_TEMPERATURE] == 24.0
 
 
 async def test_airzone_climate_turn_on_off(hass: HomeAssistant) -> None:
@@ -441,7 +441,7 @@ async def test_airzone_climate_set_temp(hass: HomeAssistant) -> None:
         )
 
     state = hass.states.get("climate.group")
-    assert state.attributes.get(ATTR_TEMPERATURE) == 20.5
+    assert state.attributes[ATTR_TEMPERATURE] == 20.5
 
     # Installations
     with patch(
@@ -477,7 +477,7 @@ async def test_airzone_climate_set_temp(hass: HomeAssistant) -> None:
         )
 
     state = hass.states.get("climate.salon")
-    assert state.attributes.get(ATTR_TEMPERATURE) == 20.5
+    assert state.attributes[ATTR_TEMPERATURE] == 20.5
 
 
 async def test_airzone_climate_set_temp_error(hass: HomeAssistant) -> None:
@@ -501,7 +501,7 @@ async def test_airzone_climate_set_temp_error(hass: HomeAssistant) -> None:
         )
 
     state = hass.states.get("climate.bron")
-    assert state.attributes.get(ATTR_TEMPERATURE) == 22.0
+    assert state.attributes[ATTR_TEMPERATURE] == 22.0
 
     # Groups
     with patch(
@@ -519,7 +519,7 @@ async def test_airzone_climate_set_temp_error(hass: HomeAssistant) -> None:
         )
 
     state = hass.states.get("climate.group")
-    assert state.attributes.get(ATTR_TEMPERATURE) == 24.0
+    assert state.attributes[ATTR_TEMPERATURE] == 24.0
 
     # Installations
     with patch(
@@ -555,4 +555,4 @@ async def test_airzone_climate_set_temp_error(hass: HomeAssistant) -> None:
         )
 
     state = hass.states.get("climate.salon")
-    assert state.attributes.get(ATTR_TEMPERATURE) == 24.0
+    assert state.attributes[ATTR_TEMPERATURE] == 24.0


### PR DESCRIPTION
## Proposed change
Replace `attributes.get()` with `attributes[]` on Airzone Cloud tests as [suggested by @bdraco ](https://github.com/home-assistant/core/pull/101090#issuecomment-1772435392).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
