### PR TITLE
Avoid more device_class lookups for number entities when writing state

### DIFF
--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -218,8 +218,13 @@ class NumberEntity(Entity):
     @property
     def capability_attributes(self) -> dict[str, Any]:
         """Return capability attributes."""
-        min_value = self.min_value
-        max_value = self.max_value
+        device_class = self.device_class
+        min_value = self._convert_to_state_value(
+            self.native_min_value, floor_decimal, device_class
+        )
+        max_value = self._convert_to_state_value(
+            self.native_max_value, ceil_decimal, device_class
+        )
         return {
             ATTR_MIN: min_value,
             ATTR_MAX: max_value,
@@ -259,7 +264,9 @@ class NumberEntity(Entity):
     @final
     def min_value(self) -> float:
         """Return the minimum value."""
-        return self._convert_to_state_value(self.native_min_value, floor_decimal)
+        return self._convert_to_state_value(
+            self.native_min_value, floor_decimal, self.device_class
+        )
 
     @property
     def native_max_value(self) -> float:
@@ -277,7 +284,9 @@ class NumberEntity(Entity):
     @final
     def max_value(self) -> float:
         """Return the maximum value."""
-        return self._convert_to_state_value(self.native_max_value, ceil_decimal)
+        return self._convert_to_state_value(
+            self.native_max_value, ceil_decimal, self.device_class
+        )
 
     @property
     def native_step(self) -> float | None:
@@ -365,7 +374,7 @@ class NumberEntity(Entity):
         """Return the entity value to represent the entity state."""
         if (native_value := self.native_value) is None:
             return native_value
-        return self._convert_to_state_value(native_value, round)
+        return self._convert_to_state_value(native_value, round, self.device_class)
 
     def set_native_value(self, value: float) -> None:
         """Set new value."""
@@ -386,12 +395,15 @@ class NumberEntity(Entity):
         await self.hass.async_add_executor_job(self.set_value, value)
 
     def _convert_to_state_value(
-        self, value: float, method: Callable[[float, int], float]
+        self,
+        value: float,
+        method: Callable[[float, int], float],
+        device_class: NumberDeviceClass | None,
     ) -> float:
         """Convert a value in the number's native unit to the configured unit."""
         # device_class is checked first since most of the time we can avoid
         # the unit conversion
-        if (device_class := self.device_class) not in UNIT_CONVERTERS:
+        if device_class not in UNIT_CONVERTERS:
             return value
 
         native_unit_of_measurement = self.native_unit_of_measurement

--- a/tests/components/number/test_init.py
+++ b/tests/components/number/test_init.py
@@ -8,6 +8,7 @@ import pytest
 from homeassistant.components.number import (
     ATTR_MAX,
     ATTR_MIN,
+    ATTR_MODE,
     ATTR_STEP,
     ATTR_VALUE,
     DOMAIN,
@@ -227,6 +228,12 @@ async def test_attributes(hass: HomeAssistant) -> None:
     assert number.step == 1.0
     assert number.unit_of_measurement is None
     assert number.value == 0.5
+    assert number.capability_attributes == {
+        ATTR_MAX: 100.0,
+        ATTR_MIN: 0.0,
+        ATTR_MODE: NumberMode.AUTO,
+        ATTR_STEP: 1.0,
+    }
 
     number_2 = MockNumberEntity()
     number_2.hass = hass
@@ -235,6 +242,12 @@ async def test_attributes(hass: HomeAssistant) -> None:
     assert number_2.step == 0.1
     assert number_2.unit_of_measurement == "native_cats"
     assert number_2.value == 0.5
+    assert number_2.capability_attributes == {
+        ATTR_MAX: 0.5,
+        ATTR_MIN: -0.5,
+        ATTR_MODE: NumberMode.AUTO,
+        ATTR_STEP: 0.1,
+    }
 
     number_3 = MockNumberEntityAttr()
     number_3.hass = hass
@@ -243,6 +256,12 @@ async def test_attributes(hass: HomeAssistant) -> None:
     assert number_3.step == 100.0
     assert number_3.unit_of_measurement == "native_dogs"
     assert number_3.value == 500.0
+    assert number_3.capability_attributes == {
+        ATTR_MAX: 1000.0,
+        ATTR_MIN: -1000.0,
+        ATTR_MODE: NumberMode.AUTO,
+        ATTR_STEP: 100.0,
+    }
 
     number_4 = MockNumberEntityDescr()
     number_4.hass = hass
@@ -251,6 +270,12 @@ async def test_attributes(hass: HomeAssistant) -> None:
     assert number_4.step == 2.0
     assert number_4.unit_of_measurement == "native_rabbits"
     assert number_4.value is None
+    assert number_4.capability_attributes == {
+        ATTR_MAX: 10.0,
+        ATTR_MIN: -10.0,
+        ATTR_MODE: NumberMode.AUTO,
+        ATTR_STEP: 2.0,
+    }
 
 
 async def test_sync_set_value(hass: HomeAssistant) -> None:


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I missed some more in min/max value


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
