### PR TITLE
Add support for changing Enphase battery backup modes

### DIFF
--- a/homeassistant/components/enphase_envoy/manifest.json
+++ b/homeassistant/components/enphase_envoy/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/enphase_envoy",
   "iot_class": "local_polling",
   "loggers": ["pyenphase"],
-  "requirements": ["pyenphase==1.12.0"],
+  "requirements": ["pyenphase==1.13.0"],
   "zeroconf": [
     {
       "type": "_enphase-envoy._tcp.local."

--- a/homeassistant/components/enphase_envoy/number.py
+++ b/homeassistant/components/enphase_envoy/number.py
@@ -1,7 +1,7 @@
 """Number platform for Enphase Envoy solar energy monitor."""
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -44,7 +44,7 @@ class EnvoyStorageSettingsRequiredKeysMixin:
     """Mixin for required keys."""
 
     value_fn: Callable[[EnvoyStorageSettings], float]
-    update_fn: Callable[[Envoy, float], Coroutine[Any, Any, dict[str, Any]]]
+    update_fn: Callable[[Envoy, float], Awaitable[dict[str, Any]]]
 
 
 @dataclass

--- a/homeassistant/components/enphase_envoy/number.py
+++ b/homeassistant/components/enphase_envoy/number.py
@@ -1,10 +1,13 @@
 """Number platform for Enphase Envoy solar energy monitor."""
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
+from typing import Any
 
-from pyenphase import EnvoyDryContactSettings
+from pyenphase import Envoy, EnvoyDryContactSettings
+from pyenphase.const import SupportedFeatures
+from pyenphase.models.tariff import EnvoyStorageSettings
 
 from homeassistant.components.number import (
     NumberDeviceClass,
@@ -12,7 +15,7 @@ from homeassistant.components.number import (
     NumberEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
+from homeassistant.const import PERCENTAGE, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -36,6 +39,21 @@ class EnvoyRelayNumberEntityDescription(
     """Describes an Envoy Dry Contact Relay number entity."""
 
 
+@dataclass
+class EnvoyStorageSettingsRequiredKeysMixin:
+    """Mixin for required keys."""
+
+    value_fn: Callable[[EnvoyStorageSettings], float]
+    update_fn: Callable[[Envoy, float], Coroutine[Any, Any, dict[str, Any]]]
+
+
+@dataclass
+class EnvoyStorageSettingsNumberEntityDescription(
+    NumberEntityDescription, EnvoyStorageSettingsRequiredKeysMixin
+):
+    """Describes an Envoy storage mode number entity."""
+
+
 RELAY_ENTITIES = (
     EnvoyRelayNumberEntityDescription(
         key="soc_low",
@@ -50,6 +68,17 @@ RELAY_ENTITIES = (
         device_class=NumberDeviceClass.BATTERY,
         entity_category=EntityCategory.CONFIG,
         value_fn=lambda relay: relay.soc_high,
+    ),
+)
+
+STORAGE_SETTINGS_ENTITIES = (
+    EnvoyStorageSettingsNumberEntityDescription(
+        key="reserve_soc",
+        translation_key="reserve_soc",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=NumberDeviceClass.BATTERY,
+        value_fn=lambda storage_settings: storage_settings.reserved_soc,
+        update_fn=lambda envoy, value: envoy.set_reserve_soc(int(value)),
     ),
 )
 
@@ -69,6 +98,15 @@ async def async_setup_entry(
             EnvoyRelayNumberEntity(coordinator, entity, relay)
             for entity in RELAY_ENTITIES
             for relay in envoy_data.dry_contact_settings
+        )
+    if (
+        envoy_data.tariff
+        and envoy_data.tariff.storage_settings
+        and coordinator.envoy.supported_features & SupportedFeatures.ENCHARGE
+    ):
+        entities.extend(
+            EnvoyStorageSettingsNumberEntity(coordinator, entity)
+            for entity in STORAGE_SETTINGS_ENTITIES
         )
     async_add_entities(entities)
 
@@ -113,4 +151,43 @@ class EnvoyRelayNumberEntity(EnvoyBaseEntity, NumberEntity):
         await self.envoy.update_dry_contact(
             {"id": self._relay_id, self.entity_description.key: int(value)}
         )
+        await self.coordinator.async_request_refresh()
+
+
+class EnvoyStorageSettingsNumberEntity(EnvoyBaseEntity, NumberEntity):
+    """Representation of an Enphase storage settings number entity."""
+
+    entity_description: EnvoyStorageSettingsNumberEntityDescription
+
+    def __init__(
+        self,
+        coordinator: EnphaseUpdateCoordinator,
+        description: EnvoyStorageSettingsNumberEntityDescription,
+    ) -> None:
+        """Initialize the Enphase relay number entity."""
+        super().__init__(coordinator, description)
+        self.envoy = coordinator.envoy
+        assert self.data.enpower is not None
+        enpower = self.data.enpower
+        self._serial_number = enpower.serial_number
+        self._attr_unique_id = f"{self._serial_number}_{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._serial_number)},
+            manufacturer="Enphase",
+            model="Enpower",
+            name=f"Enpower {self._serial_number}",
+            sw_version=str(enpower.firmware_version),
+            via_device=(DOMAIN, self.envoy_serial_num),
+        )
+
+    @property
+    def native_value(self) -> float:
+        """Return the state of the storage setting entity."""
+        assert self.data.tariff is not None
+        assert self.data.tariff.storage_settings is not None
+        return self.entity_description.value_fn(self.data.tariff.storage_settings)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the storage setting."""
+        await self.entity_description.update_fn(self.envoy, value)
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/enphase_envoy/number.py
+++ b/homeassistant/components/enphase_envoy/number.py
@@ -71,15 +71,13 @@ RELAY_ENTITIES = (
     ),
 )
 
-STORAGE_SETTINGS_ENTITIES = (
-    EnvoyStorageSettingsNumberEntityDescription(
-        key="reserve_soc",
-        translation_key="reserve_soc",
-        native_unit_of_measurement=PERCENTAGE,
-        device_class=NumberDeviceClass.BATTERY,
-        value_fn=lambda storage_settings: storage_settings.reserved_soc,
-        update_fn=lambda envoy, value: envoy.set_reserve_soc(int(value)),
-    ),
+STORAGE_RESERVE_SOC_ENTITY = EnvoyStorageSettingsNumberEntityDescription(
+    key="reserve_soc",
+    translation_key="reserve_soc",
+    native_unit_of_measurement=PERCENTAGE,
+    device_class=NumberDeviceClass.BATTERY,
+    value_fn=lambda storage_settings: storage_settings.reserved_soc,
+    update_fn=lambda envoy, value: envoy.set_reserve_soc(int(value)),
 )
 
 
@@ -104,9 +102,8 @@ async def async_setup_entry(
         and envoy_data.tariff.storage_settings
         and coordinator.envoy.supported_features & SupportedFeatures.ENCHARGE
     ):
-        entities.extend(
-            EnvoyStorageSettingsNumberEntity(coordinator, entity)
-            for entity in STORAGE_SETTINGS_ENTITIES
+        entities.append(
+            EnvoyStorageSettingsNumberEntity(coordinator, STORAGE_RESERVE_SOC_ENTITY)
         )
     async_add_entities(entities)
 

--- a/homeassistant/components/enphase_envoy/select.py
+++ b/homeassistant/components/enphase_envoy/select.py
@@ -6,7 +6,9 @@ from dataclasses import dataclass
 from typing import Any
 
 from pyenphase import Envoy, EnvoyDryContactSettings
+from pyenphase.const import SupportedFeatures
 from pyenphase.models.dry_contacts import DryContactAction, DryContactMode
+from pyenphase.models.tariff import EnvoyStorageMode, EnvoyStorageSettings
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -36,6 +38,21 @@ class EnvoyRelaySelectEntityDescription(
     """Describes an Envoy Dry Contact Relay select entity."""
 
 
+@dataclass
+class EnvoyStorageSettingsRequiredKeysMixin:
+    """Mixin for required keys."""
+
+    value_fn: Callable[[EnvoyStorageSettings], str]
+    update_fn: Callable[[Envoy, str], Coroutine[Any, Any, dict[str, Any]]]
+
+
+@dataclass
+class EnvoyStorageSettingsSelectEntityDescription(
+    SelectEntityDescription, EnvoyStorageSettingsRequiredKeysMixin
+):
+    """Describes an Envoy storage settings select entity."""
+
+
 RELAY_MODE_MAP = {
     DryContactMode.MANUAL: "standard",
     DryContactMode.STATE_OF_CHARGE: "battery",
@@ -50,6 +67,14 @@ RELAY_ACTION_MAP = {
 REVERSE_RELAY_ACTION_MAP = {v: k for k, v in RELAY_ACTION_MAP.items()}
 MODE_OPTIONS = list(REVERSE_RELAY_MODE_MAP)
 ACTION_OPTIONS = list(REVERSE_RELAY_ACTION_MAP)
+
+STORAGE_MODE_MAP = {
+    EnvoyStorageMode.BACKUP: "backup",
+    EnvoyStorageMode.SELF_CONSUMPTION: "self_consumption",
+    EnvoyStorageMode.SAVINGS: "savings",
+}
+REVERSE_STORAGE_MODE_MAP = {v: k for k, v in STORAGE_MODE_MAP.items()}
+STORAGE_MODE_OPTIONS = list(REVERSE_STORAGE_MODE_MAP)
 
 RELAY_ENTITIES = (
     EnvoyRelaySelectEntityDescription(
@@ -101,6 +126,17 @@ RELAY_ENTITIES = (
         ),
     ),
 )
+STORAGE_SETTINGS_ENTITIES = (
+    EnvoyStorageSettingsSelectEntityDescription(
+        key="storage_mode",
+        translation_key="storage_mode",
+        options=STORAGE_MODE_OPTIONS,
+        value_fn=lambda storage_settings: STORAGE_MODE_MAP[storage_settings.mode],
+        update_fn=lambda envoy, value: envoy.set_storage_mode(
+            REVERSE_STORAGE_MODE_MAP[value]
+        ),
+    ),
+)
 
 
 async def async_setup_entry(
@@ -118,6 +154,15 @@ async def async_setup_entry(
             EnvoyRelaySelectEntity(coordinator, entity, relay)
             for entity in RELAY_ENTITIES
             for relay in envoy_data.dry_contact_settings
+        )
+    if (
+        envoy_data.tariff
+        and envoy_data.tariff.storage_settings
+        and coordinator.envoy.supported_features & SupportedFeatures.ENCHARGE
+    ):
+        entities.extend(
+            EnvoyStorageSettingsSelectEntity(coordinator, entity)
+            for entity in STORAGE_SETTINGS_ENTITIES
         )
     async_add_entities(entities)
 
@@ -163,4 +208,44 @@ class EnvoyRelaySelectEntity(EnvoyBaseEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Update the relay."""
         await self.entity_description.update_fn(self.envoy, self.relay, option)
+        await self.coordinator.async_request_refresh()
+
+
+class EnvoyStorageSettingsSelectEntity(EnvoyBaseEntity, SelectEntity):
+    """Representation of an Enphase storage settings select entity."""
+
+    entity_description: EnvoyStorageSettingsSelectEntityDescription
+
+    def __init__(
+        self,
+        coordinator: EnphaseUpdateCoordinator,
+        description: EnvoyStorageSettingsSelectEntityDescription,
+    ) -> None:
+        """Initialize the Enphase storage settings select entity."""
+        super().__init__(coordinator, description)
+        self.envoy = coordinator.envoy
+        assert coordinator.envoy.data is not None
+        assert coordinator.envoy.data.enpower is not None
+        enpower = coordinator.envoy.data.enpower
+        self._serial_number = enpower.serial_number
+        self._attr_unique_id = f"{self._serial_number}_{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._serial_number)},
+            manufacturer="Enphase",
+            model="Enpower",
+            name=f"Enpower {self._serial_number}",
+            sw_version=str(enpower.firmware_version),
+            via_device=(DOMAIN, self.envoy_serial_num),
+        )
+
+    @property
+    def current_option(self) -> str:
+        """Return the state of the select entity."""
+        assert self.data.tariff is not None
+        assert self.data.tariff.storage_settings is not None
+        return self.entity_description.value_fn(self.data.tariff.storage_settings)
+
+    async def async_select_option(self, option: str) -> None:
+        """Update the relay."""
+        await self.entity_description.update_fn(self.envoy, option)
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/enphase_envoy/strings.json
+++ b/homeassistant/components/enphase_envoy/strings.json
@@ -39,6 +39,9 @@
       },
       "restore_battery_level": {
         "name": "Restore battery level"
+      },
+      "reserve_soc": {
+        "name": "Reserve battery level"
       }
     },
     "select": {
@@ -74,6 +77,14 @@
           "not_powered": "[%key:component::enphase_envoy::entity::select::relay_grid_action::state::not_powered%]",
           "schedule": "[%key:component::enphase_envoy::entity::select::relay_grid_action::state::schedule%]",
           "none": "[%key:component::enphase_envoy::entity::select::relay_grid_action::state::none%]"
+        }
+      },
+      "storage_mode": {
+        "name": "Storage Mode",
+        "state": {
+          "self_consumption": "Self consumption",
+          "backup": "Full backup",
+          "savings": "Savings mode"
         }
       }
     },

--- a/homeassistant/components/enphase_envoy/strings.json
+++ b/homeassistant/components/enphase_envoy/strings.json
@@ -80,7 +80,7 @@
         }
       },
       "storage_mode": {
-        "name": "Storage Mode",
+        "name": "Storage mode",
         "state": {
           "self_consumption": "Self consumption",
           "backup": "Full backup",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1691,7 +1691,7 @@ pyedimax==0.2.1
 pyefergy==22.1.1
 
 # homeassistant.components.enphase_envoy
-pyenphase==1.12.0
+pyenphase==1.13.0
 
 # homeassistant.components.envisalink
 pyenvisalink==4.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1273,7 +1273,7 @@ pyeconet==0.1.20
 pyefergy==22.1.1
 
 # homeassistant.components.enphase_envoy
-pyenphase==1.12.0
+pyenphase==1.13.0
 
 # homeassistant.components.everlights
 pyeverlights==0.1.0


### PR DESCRIPTION
## Proposed change
Adds a `select` entity to set the storage mode for an Enphase battery system, and a `number` entity to set the reserve battery level when the mode is not full backup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29455

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
