### PR TITLE
2023.10.4

### DIFF
--- a/homeassistant/components/aemet/__init__.py
+++ b/homeassistant/components/aemet/__init__.py
@@ -1,5 +1,6 @@
 """The AEMET OpenData component."""
 
+import asyncio
 import logging
 
 from aemet_opendata.exceptions import TownNotFound
@@ -8,6 +9,7 @@ from aemet_opendata.interface import AEMET, ConnectionOptions
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client
 
 from .const import (
@@ -37,6 +39,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except TownNotFound as err:
         _LOGGER.error(err)
         return False
+    except asyncio.TimeoutError as err:
+        raise ConfigEntryNotReady("AEMET OpenData API timed out") from err
 
     weather_coordinator = WeatherUpdateCoordinator(hass, aemet)
     await weather_coordinator.async_config_entry_first_refresh()

--- a/homeassistant/components/airzone/manifest.json
+++ b/homeassistant/components/airzone/manifest.json
@@ -11,5 +11,5 @@
   "documentation": "https://www.home-assistant.io/integrations/airzone",
   "iot_class": "local_polling",
   "loggers": ["aioairzone"],
-  "requirements": ["aioairzone==0.6.8"]
+  "requirements": ["aioairzone==0.6.9"]
 }

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -18,7 +18,7 @@
     "bleak-retry-connector==3.2.1",
     "bluetooth-adapters==0.16.1",
     "bluetooth-auto-recovery==1.2.3",
-    "bluetooth-data-tools==1.12.0",
+    "bluetooth-data-tools==1.13.0",
     "dbus-fast==2.12.0"
   ]
 }

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -19,6 +19,6 @@
     "bluetooth-adapters==0.16.1",
     "bluetooth-auto-recovery==1.2.3",
     "bluetooth-data-tools==1.12.0",
-    "dbus-fast==2.11.1"
+    "dbus-fast==2.12.0"
   ]
 }

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -483,7 +483,7 @@ class CalendarEntity(Entity):
 
     _entity_component_unrecorded_attributes = frozenset({"description"})
 
-    _alarm_unsubs: list[CALLBACK_TYPE] = []
+    _alarm_unsubs: list[CALLBACK_TYPE] | None = None
 
     @property
     def event(self) -> CalendarEvent | None:
@@ -528,6 +528,8 @@ class CalendarEntity(Entity):
         the current or upcoming event.
         """
         super().async_write_ha_state()
+        if self._alarm_unsubs is None:
+            self._alarm_unsubs = []
         _LOGGER.debug(
             "Clearing %s alarms (%s)", self.entity_id, len(self._alarm_unsubs)
         )
@@ -571,9 +573,9 @@ class CalendarEntity(Entity):
 
         To be extended by integrations.
         """
-        for unsub in self._alarm_unsubs:
+        for unsub in self._alarm_unsubs or ():
             unsub()
-        self._alarm_unsubs.clear()
+        self._alarm_unsubs = None
 
     async def async_get_events(
         self,

--- a/homeassistant/components/duotecno/manifest.json
+++ b/homeassistant/components/duotecno/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/duotecno",
   "iot_class": "local_push",
-  "requirements": ["pyDuotecno==2023.10.0"]
+  "requirements": ["pyDuotecno==2023.10.1"]
 }

--- a/homeassistant/components/esphome/bluetooth/client.py
+++ b/homeassistant/components/esphome/bluetooth/client.py
@@ -25,8 +25,11 @@ from aioesphomeapi import (
     BluetoothProxyFeature,
     DeviceInfo,
 )
-from aioesphomeapi.connection import APIConnectionError, TimeoutAPIError
-from aioesphomeapi.core import BluetoothGATTAPIError
+from aioesphomeapi.core import (
+    APIConnectionError,
+    BluetoothGATTAPIError,
+    TimeoutAPIError,
+)
 from async_interrupt import interrupt
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.client import BaseBleakClient, NotifyCallback

--- a/homeassistant/components/esphome/bluetooth/client.py
+++ b/homeassistant/components/esphome/bluetooth/client.py
@@ -392,8 +392,8 @@ class ESPHomeClient(BaseBleakClient):
         return await self._disconnect()
 
     async def _disconnect(self) -> bool:
-        self._async_disconnected_cleanup()
         await self._client.bluetooth_device_disconnect(self._address_as_int)
+        self._async_ble_device_disconnected()
         await self._wait_for_free_connection_slot(DISCONNECT_TIMEOUT)
         return True
 

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -538,7 +538,7 @@ class ESPHomeManager:
             on_connect=self.on_connect,
             on_disconnect=self.on_disconnect,
             zeroconf_instance=self.zeroconf_instance,
-            name=self.host,
+            name=entry.data.get(CONF_DEVICE_NAME, self.host),
             on_connect_error=self.on_connect_error,
         )
         self.reconnect_logic = reconnect_logic

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -16,7 +16,7 @@
   "loggers": ["aioesphomeapi", "noiseprotocol"],
   "requirements": [
     "async-interrupt==1.1.1",
-    "aioesphomeapi==18.0.6",
+    "aioesphomeapi==18.0.7",
     "bluetooth-data-tools==1.13.0",
     "esphome-dashboard-api==1.2.3"
   ],

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -16,7 +16,7 @@
   "loggers": ["aioesphomeapi", "noiseprotocol"],
   "requirements": [
     "async-interrupt==1.1.1",
-    "aioesphomeapi==18.0.4",
+    "aioesphomeapi==18.0.6",
     "bluetooth-data-tools==1.12.0",
     "esphome-dashboard-api==1.2.3"
   ],

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -16,7 +16,7 @@
   "loggers": ["aioesphomeapi", "noiseprotocol"],
   "requirements": [
     "async-interrupt==1.1.1",
-    "aioesphomeapi==17.0.1",
+    "aioesphomeapi==17.1.4",
     "bluetooth-data-tools==1.12.0",
     "esphome-dashboard-api==1.2.3"
   ],

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -16,7 +16,7 @@
   "loggers": ["aioesphomeapi", "noiseprotocol"],
   "requirements": [
     "async-interrupt==1.1.1",
-    "aioesphomeapi==17.1.4",
+    "aioesphomeapi==17.1.5",
     "bluetooth-data-tools==1.12.0",
     "esphome-dashboard-api==1.2.3"
   ],

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -16,7 +16,7 @@
   "loggers": ["aioesphomeapi", "noiseprotocol"],
   "requirements": [
     "async-interrupt==1.1.1",
-    "aioesphomeapi==18.0.3",
+    "aioesphomeapi==18.0.4",
     "bluetooth-data-tools==1.12.0",
     "esphome-dashboard-api==1.2.3"
   ],

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -16,7 +16,7 @@
   "loggers": ["aioesphomeapi", "noiseprotocol"],
   "requirements": [
     "async-interrupt==1.1.1",
-    "aioesphomeapi==18.0.1",
+    "aioesphomeapi==18.0.3",
     "bluetooth-data-tools==1.12.0",
     "esphome-dashboard-api==1.2.3"
   ],

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -17,7 +17,7 @@
   "requirements": [
     "async-interrupt==1.1.1",
     "aioesphomeapi==18.0.6",
-    "bluetooth-data-tools==1.12.0",
+    "bluetooth-data-tools==1.13.0",
     "esphome-dashboard-api==1.2.3"
   ],
   "zeroconf": ["_esphomelib._tcp.local."]

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -16,7 +16,7 @@
   "loggers": ["aioesphomeapi", "noiseprotocol"],
   "requirements": [
     "async-interrupt==1.1.1",
-    "aioesphomeapi==17.1.5",
+    "aioesphomeapi==17.2.0",
     "bluetooth-data-tools==1.12.0",
     "esphome-dashboard-api==1.2.3"
   ],

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -16,7 +16,7 @@
   "loggers": ["aioesphomeapi", "noiseprotocol"],
   "requirements": [
     "async-interrupt==1.1.1",
-    "aioesphomeapi==17.2.0",
+    "aioesphomeapi==18.0.1",
     "bluetooth-data-tools==1.12.0",
     "esphome-dashboard-api==1.2.3"
   ],

--- a/homeassistant/components/esphome/voice_assistant.py
+++ b/homeassistant/components/esphome/voice_assistant.py
@@ -55,6 +55,8 @@ _VOICE_ASSISTANT_EVENT_TYPES: EsphomeEnumMapper[
         VoiceAssistantEventType.VOICE_ASSISTANT_TTS_END: PipelineEventType.TTS_END,
         VoiceAssistantEventType.VOICE_ASSISTANT_WAKE_WORD_START: PipelineEventType.WAKE_WORD_START,
         VoiceAssistantEventType.VOICE_ASSISTANT_WAKE_WORD_END: PipelineEventType.WAKE_WORD_END,
+        VoiceAssistantEventType.VOICE_ASSISTANT_STT_VAD_START: PipelineEventType.STT_VAD_START,
+        VoiceAssistantEventType.VOICE_ASSISTANT_STT_VAD_END: PipelineEventType.STT_VAD_END,
     }
 )
 
@@ -296,6 +298,10 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
             if self.transport is None:
                 return
 
+            self.handle_event(
+                VoiceAssistantEventType.VOICE_ASSISTANT_TTS_STREAM_START, {}
+            )
+
             _extension, audio_bytes = await tts.async_get_media_source_audio(
                 self.hass,
                 media_id,
@@ -321,4 +327,7 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
                 sample_offset += samples_in_chunk
 
         finally:
+            self.handle_event(
+                VoiceAssistantEventType.VOICE_ASSISTANT_TTS_STREAM_END, {}
+            )
             self._tts_done.set()

--- a/homeassistant/components/esphome/voice_assistant.py
+++ b/homeassistant/components/esphome/voice_assistant.py
@@ -163,7 +163,7 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
         try:
             event_type = _VOICE_ASSISTANT_EVENT_TYPES.from_hass(event.type)
         except KeyError:
-            _LOGGER.warning("Received unknown pipeline event type: %s", event.type)
+            _LOGGER.debug("Received unknown pipeline event type: %s", event.type)
             return
 
         data_to_send = None

--- a/homeassistant/components/google_maps/device_tracker.py
+++ b/homeassistant/components/google_maps/device_tracker.py
@@ -118,9 +118,7 @@ class GoogleMapsScanner:
                 )
                 _LOGGER.debug("%s < %s", last_seen, self._prev_seen[dev_id])
                 continue
-            if last_seen == self._prev_seen.get(dev_id, last_seen) and hasattr(
-                self, "success_init"
-            ):
+            if last_seen == self._prev_seen.get(dev_id):
                 _LOGGER.debug(
                     "Ignoring %s update because timestamp "
                     "is the same as the last timestamp %s",

--- a/homeassistant/components/ld2410_ble/manifest.json
+++ b/homeassistant/components/ld2410_ble/manifest.json
@@ -20,5 +20,5 @@
   "documentation": "https://www.home-assistant.io/integrations/ld2410_ble",
   "integration_type": "device",
   "iot_class": "local_push",
-  "requirements": ["bluetooth-data-tools==1.12.0", "ld2410-ble==0.1.1"]
+  "requirements": ["bluetooth-data-tools==1.13.0", "ld2410-ble==0.1.1"]
 }

--- a/homeassistant/components/led_ble/manifest.json
+++ b/homeassistant/components/led_ble/manifest.json
@@ -32,5 +32,5 @@
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/led_ble",
   "iot_class": "local_polling",
-  "requirements": ["bluetooth-data-tools==1.12.0", "led-ble==1.0.1"]
+  "requirements": ["bluetooth-data-tools==1.13.0", "led-ble==1.0.1"]
 }

--- a/homeassistant/components/matter/climate.py
+++ b/homeassistant/components/matter/climate.py
@@ -250,9 +250,9 @@ class MatterClimate(MatterEntity, ClimateEntity):
             self._attr_min_temp = DEFAULT_MIN_TEMP
         # update max_temp
         if self._attr_hvac_mode in (HVACMode.COOL, HVACMode.HEAT_COOL):
-            attribute = clusters.Thermostat.Attributes.AbsMaxHeatSetpointLimit
-        else:
             attribute = clusters.Thermostat.Attributes.AbsMaxCoolSetpointLimit
+        else:
+            attribute = clusters.Thermostat.Attributes.AbsMaxHeatSetpointLimit
         if (value := self._get_temperature_in_degrees(attribute)) is not None:
             self._attr_max_temp = value
         else:

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -176,7 +176,13 @@ async def async_subscribe(
         raise HomeAssistantError(
             f"Cannot subscribe to topic '{topic}', MQTT is not enabled"
         )
-    mqtt_data = get_mqtt_data(hass)
+    try:
+        mqtt_data = get_mqtt_data(hass)
+    except KeyError as ex:
+        raise HomeAssistantError(
+            f"Cannot subscribe to topic '{topic}', "
+            "make sure MQTT is set up correctly"
+        ) from ex
     async_remove = await mqtt_data.client.async_subscribe(
         topic,
         catch_log_exception(

--- a/homeassistant/components/nina/manifest.json
+++ b/homeassistant/components/nina/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/nina",
   "iot_class": "cloud_polling",
   "loggers": ["pynina"],
-  "requirements": ["PyNINA==0.3.2"]
+  "requirements": ["PyNINA==0.3.3"]
 }

--- a/homeassistant/components/opower/manifest.json
+++ b/homeassistant/components/opower/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/opower",
   "iot_class": "cloud_polling",
   "loggers": ["opower"],
-  "requirements": ["opower==0.0.35"]
+  "requirements": ["opower==0.0.36"]
 }

--- a/homeassistant/components/private_ble_device/manifest.json
+++ b/homeassistant/components/private_ble_device/manifest.json
@@ -6,5 +6,5 @@
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/private_ble_device",
   "iot_class": "local_push",
-  "requirements": ["bluetooth-data-tools==1.12.0"]
+  "requirements": ["bluetooth-data-tools==1.13.0"]
 }

--- a/homeassistant/components/rdw/manifest.json
+++ b/homeassistant/components/rdw/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "quality_scale": "platinum",
-  "requirements": ["vehicle==1.0.1"]
+  "requirements": ["vehicle==2.0.0"]
 }

--- a/homeassistant/components/screenlogic/manifest.json
+++ b/homeassistant/components/screenlogic/manifest.json
@@ -15,5 +15,5 @@
   "documentation": "https://www.home-assistant.io/integrations/screenlogic",
   "iot_class": "local_push",
   "loggers": ["screenlogicpy"],
-  "requirements": ["screenlogicpy==0.9.2"]
+  "requirements": ["screenlogicpy==0.9.3"]
 }

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from asyncio import run_coroutine_threadsafe
-import datetime as dt
 from datetime import timedelta
 import logging
 from typing import Any
@@ -27,7 +26,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util.dt import utc_from_timestamp
+from homeassistant.util.dt import utcnow
 
 from . import HomeAssistantSpotifyData
 from .browse_media import async_browse_media_internal
@@ -198,13 +197,6 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
         ):
             return None
         return self._currently_playing["progress_ms"] / 1000
-
-    @property
-    def media_position_updated_at(self) -> dt.datetime | None:
-        """When was the position of the current playing media valid."""
-        if not self._currently_playing:
-            return None
-        return utc_from_timestamp(self._currently_playing["timestamp"] / 1000)
 
     @property
     def media_image_url(self) -> str | None:
@@ -413,6 +405,9 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
             additional_types=[MediaType.EPISODE]
         )
         self._currently_playing = current or {}
+        # Record the last updated time, because Spotify's timestamp property is unreliable
+        # and doesn't actually return the fetch time as is mentioned in the API description
+        self._attr_media_position_updated_at = utcnow() if current is not None else None
 
         context = self._currently_playing.get("context") or {}
 

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -13,7 +13,7 @@
     "velbus-packet",
     "velbus-protocol"
   ],
-  "requirements": ["velbus-aio==2023.10.0"],
+  "requirements": ["velbus-aio==2023.10.1"],
   "usb": [
     {
       "vid": "10CF",

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -13,7 +13,7 @@
     "velbus-packet",
     "velbus-protocol"
   ],
-  "requirements": ["velbus-aio==2023.2.0"],
+  "requirements": ["velbus-aio==2023.10.0"],
   "usb": [
     {
       "vid": "10CF",

--- a/homeassistant/components/velbus/sensor.py
+++ b/homeassistant/components/velbus/sensor.py
@@ -45,25 +45,18 @@ class VelbusSensor(VelbusEntity, SensorEntity):
         """Initialize a sensor Velbus entity."""
         super().__init__(channel)
         self._is_counter: bool = counter
-        # define the unique id
         if self._is_counter:
-            self._attr_unique_id = f"{self._attr_unique_id}-counter"
-        # define the name
-        if self._is_counter:
-            self._attr_name = f"{self._attr_name}-counter"
-        # define the device class
-        if self._is_counter:
-            self._attr_device_class = SensorDeviceClass.POWER
-        elif channel.is_counter_channel():
             self._attr_device_class = SensorDeviceClass.ENERGY
+            self._attr_icon = "mdi:counter"
+            self._attr_name = f"{self._attr_name}-counter"
+            self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+            self._attr_unique_id = f"{self._attr_unique_id}-counter"
+        elif channel.is_counter_channel():
+            self._attr_device_class = SensorDeviceClass.POWER
+            self._attr_state_class = SensorStateClass.MEASUREMENT
         elif channel.is_temperature():
             self._attr_device_class = SensorDeviceClass.TEMPERATURE
-        # define the icon
-        if self._is_counter:
-            self._attr_icon = "mdi:counter"
-        # the state class
-        if self._is_counter:
-            self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+            self._attr_state_class = SensorStateClass.MEASUREMENT
         else:
             self._attr_state_class = SensorStateClass.MEASUREMENT
         # unit

--- a/homeassistant/components/venstar/sensor.py
+++ b/homeassistant/components/venstar/sensor.py
@@ -146,17 +146,13 @@ class VenstarSensor(VenstarEntity, SensorEntity):
         super().__init__(coordinator, config)
         self.entity_description = entity_description
         self.sensor_name = sensor_name
+        self._attr_name = entity_description.name_fn(sensor_name)
         self._config = config
 
     @property
     def unique_id(self):
         """Return the unique id."""
         return f"{self._config.entry_id}_{self.sensor_name.replace(' ', '_')}_{self.entity_description.key}"
-
-    @property
-    def name(self):
-        """Return the name of the device."""
-        return self.entity_description.name_fn(self.sensor_name)
 
     @property
     def native_value(self) -> int:

--- a/homeassistant/components/waqi/manifest.json
+++ b/homeassistant/components/waqi/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/waqi",
   "iot_class": "cloud_polling",
   "loggers": ["aiowaqi"],
-  "requirements": ["aiowaqi==2.0.0"]
+  "requirements": ["aiowaqi==2.1.0"]
 }

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,7 +21,7 @@
     "universal_silabs_flasher"
   ],
   "requirements": [
-    "bellows==0.36.5",
+    "bellows==0.36.7",
     "pyserial==3.5",
     "pyserial-asyncio==0.6",
     "zha-quirks==0.0.105",
@@ -29,7 +29,7 @@
     "zigpy==0.57.2",
     "zigpy-xbee==0.18.3",
     "zigpy-zigate==0.11.0",
-    "zigpy-znp==0.11.5",
+    "zigpy-znp==0.11.6",
     "universal-silabs-flasher==0.0.14",
     "pyserial-asyncio-fast==0.11"
   ],

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -24,7 +24,7 @@
     "bellows==0.36.5",
     "pyserial==3.5",
     "pyserial-asyncio==0.6",
-    "zha-quirks==0.0.104",
+    "zha-quirks==0.0.105",
     "zigpy-deconz==0.21.1",
     "zigpy==0.57.2",
     "zigpy-xbee==0.18.3",

--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -259,9 +259,11 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
     def _current_mode_setpoint_enums(self) -> list[ThermostatSetpointType]:
         """Return the list of enums that are relevant to the current thermostat mode."""
         if self._current_mode is None or self._current_mode.value is None:
-            # Thermostat(valve) with no support for setting a mode
-            # is considered heating-only
-            return [ThermostatSetpointType.HEATING]
+            # Thermostat with no support for setting a mode is just a setpoint
+            if self.info.primary_value.property_key is None:
+                return []
+            return [ThermostatSetpointType(int(self.info.primary_value.property_key))]
+
         return THERMOSTAT_MODE_SETPOINT_MAP.get(int(self._current_mode.value), [])
 
     @property

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -163,12 +163,12 @@
       }
     },
     "device_config_file_changed": {
-      "title": "Z-Wave device configuration file changed: {device_name}",
+      "title": "Device configuration file changed: {device_name}",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "Z-Wave device configuration file changed: {device_name}",
-            "description": "Z-Wave JS discovers a lot of device metadata by interviewing the device. However, some of the information has to be loaded from a configuration file. Some of this information is only evaluated once, during the device interview.\n\nWhen a device config file is updated, this information may be stale and and the device must be re-interviewed to pick up the changes.\n\n This is not a required operation and device functionality will be impacted during the re-interview process, but you may see improvements for your device once it is complete.\n\nIf you'd like to proceed, click on SUBMIT below. The re-interview will take place in the background."
+            "title": "Device configuration file changed: {device_name}",
+            "description": "The device configuration file for {device_name} has changed.\n\nZ-Wave JS discovers a lot of device metadata by interviewing the device. However, some of the information has to be loaded from a configuration file. Some of this information is only evaluated once, during the device interview.\n\nWhen a device config file is updated, this information may be stale and and the device must be re-interviewed to pick up the changes.\n\n This is not a required operation and device functionality will be impacted during the re-interview process, but you may see improvements for your device once it is complete.\n\nIf you'd like to proceed, click on SUBMIT below. The re-interview will take place in the background."
           }
         },
         "abort": {

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -7,7 +7,7 @@ from typing import Final
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2023
 MINOR_VERSION: Final = 10
-PATCH_VERSION: Final = "3"
+PATCH_VERSION: Final = "4"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 11, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -15,7 +15,7 @@ bluetooth-data-tools==1.12.0
 certifi>=2021.5.30
 ciso8601==2.3.0
 cryptography==41.0.4
-dbus-fast==2.11.1
+dbus-fast==2.12.0
 fnv-hash-fast==0.4.1
 ha-av==10.1.1
 hass-nabucasa==0.71.0

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -11,7 +11,7 @@ bleak-retry-connector==3.2.1
 bleak==0.21.1
 bluetooth-adapters==0.16.1
 bluetooth-auto-recovery==1.2.3
-bluetooth-data-tools==1.12.0
+bluetooth-data-tools==1.13.0
 certifi>=2021.5.30
 ciso8601==2.3.0
 cryptography==41.0.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2023.10.3"
+version     = "2023.10.4"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1383,7 +1383,7 @@ openwrt-luci-rpc==1.1.16
 openwrt-ubus-rpc==0.0.2
 
 # homeassistant.components.opower
-opower==0.0.35
+opower==0.0.36
 
 # homeassistant.components.oralb
 oralb-ble==0.17.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1538,7 +1538,7 @@ pyCEC==0.5.2
 pyControl4==1.1.0
 
 # homeassistant.components.duotecno
-pyDuotecno==2023.10.0
+pyDuotecno==2023.10.1
 
 # homeassistant.components.eight_sleep
 pyEight==0.3.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -231,7 +231,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==18.0.1
+aioesphomeapi==18.0.3
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -231,7 +231,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==17.2.0
+aioesphomeapi==18.0.1
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2651,7 +2651,7 @@ vallox-websocket-api==3.3.0
 vehicle==1.0.1
 
 # homeassistant.components.velbus
-velbus-aio==2023.10.0
+velbus-aio==2023.10.1
 
 # homeassistant.components.venstar
 venstarcolortouch==0.19

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -231,7 +231,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==18.0.3
+aioesphomeapi==18.0.4
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -645,7 +645,7 @@ datadog==0.15.0
 datapoint==0.9.8
 
 # homeassistant.components.bluetooth
-dbus-fast==2.11.1
+dbus-fast==2.12.0
 
 # homeassistant.components.debugpy
 debugpy==1.8.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2648,7 +2648,7 @@ uvcclient==0.11.0
 vallox-websocket-api==3.3.0
 
 # homeassistant.components.rdw
-vehicle==1.0.1
+vehicle==2.0.0
 
 # homeassistant.components.velbus
 velbus-aio==2023.10.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2787,7 +2787,7 @@ zeroconf==0.115.2
 zeversolar==0.3.1
 
 # homeassistant.components.zha
-zha-quirks==0.0.104
+zha-quirks==0.0.105
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.9

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -80,7 +80,7 @@ PyMetno==0.11.0
 PyMicroBot==0.0.9
 
 # homeassistant.components.nina
-PyNINA==0.3.2
+PyNINA==0.3.3
 
 # homeassistant.components.mobile_app
 # homeassistant.components.owntracks

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -231,7 +231,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==17.0.1
+aioesphomeapi==17.1.4
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -231,7 +231,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==17.1.4
+aioesphomeapi==17.1.5
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -231,7 +231,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==17.1.5
+aioesphomeapi==17.2.0
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -553,7 +553,7 @@ bluetooth-auto-recovery==1.2.3
 # homeassistant.components.ld2410_ble
 # homeassistant.components.led_ble
 # homeassistant.components.private_ble_device
-bluetooth-data-tools==1.12.0
+bluetooth-data-tools==1.13.0
 
 # homeassistant.components.bond
 bond-async==0.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -189,7 +189,7 @@ aioairq==0.2.4
 aioairzone-cloud==0.2.3
 
 # homeassistant.components.airzone
-aioairzone==0.6.8
+aioairzone==0.6.9
 
 # homeassistant.components.ambient_station
 aioambient==2023.04.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -512,7 +512,7 @@ beautifulsoup4==4.12.2
 # beewi-smartclim==0.0.10
 
 # homeassistant.components.zha
-bellows==0.36.5
+bellows==0.36.7
 
 # homeassistant.components.bmw_connected_drive
 bimmer-connected==0.14.1
@@ -2805,7 +2805,7 @@ zigpy-xbee==0.18.3
 zigpy-zigate==0.11.0
 
 # homeassistant.components.zha
-zigpy-znp==0.11.5
+zigpy-znp==0.11.6
 
 # homeassistant.components.zha
 zigpy==0.57.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -372,7 +372,7 @@ aiovlc==0.1.0
 aiovodafone==0.3.1
 
 # homeassistant.components.waqi
-aiowaqi==2.0.0
+aiowaqi==2.1.0
 
 # homeassistant.components.watttime
 aiowatttime==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -231,7 +231,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==18.0.4
+aioesphomeapi==18.0.6
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2372,7 +2372,7 @@ satel-integra==0.3.7
 scapy==2.5.0
 
 # homeassistant.components.screenlogic
-screenlogicpy==0.9.2
+screenlogicpy==0.9.3
 
 # homeassistant.components.scsgate
 scsgate==0.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2651,7 +2651,7 @@ vallox-websocket-api==3.3.0
 vehicle==1.0.1
 
 # homeassistant.components.velbus
-velbus-aio==2023.2.0
+velbus-aio==2023.10.0
 
 # homeassistant.components.venstar
 venstarcolortouch==0.19

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -231,7 +231,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==18.0.6
+aioesphomeapi==18.0.7
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1966,7 +1966,7 @@ uvcclient==0.11.0
 vallox-websocket-api==3.3.0
 
 # homeassistant.components.rdw
-vehicle==1.0.1
+vehicle==2.0.0
 
 # homeassistant.components.velbus
 velbus-aio==2023.10.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -347,7 +347,7 @@ aiovlc==0.1.0
 aiovodafone==0.3.1
 
 # homeassistant.components.waqi
-aiowaqi==2.0.0
+aiowaqi==2.1.0
 
 # homeassistant.components.watttime
 aiowatttime==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -528,7 +528,7 @@ datadog==0.15.0
 datapoint==0.9.8
 
 # homeassistant.components.bluetooth
-dbus-fast==2.11.1
+dbus-fast==2.12.0
 
 # homeassistant.components.debugpy
 debugpy==1.8.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1759,7 +1759,7 @@ samsungtvws[async,encrypted]==2.6.0
 scapy==2.5.0
 
 # homeassistant.components.screenlogic
-screenlogicpy==0.9.2
+screenlogicpy==0.9.3
 
 # homeassistant.components.backup
 securetar==2023.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -467,7 +467,7 @@ bluetooth-auto-recovery==1.2.3
 # homeassistant.components.ld2410_ble
 # homeassistant.components.led_ble
 # homeassistant.components.private_ble_device
-bluetooth-data-tools==1.12.0
+bluetooth-data-tools==1.13.0
 
 # homeassistant.components.bond
 bond-async==0.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -436,7 +436,7 @@ base36==0.1.1
 beautifulsoup4==4.12.2
 
 # homeassistant.components.zha
-bellows==0.36.5
+bellows==0.36.7
 
 # homeassistant.components.bmw_connected_drive
 bimmer-connected==0.14.1
@@ -2093,7 +2093,7 @@ zigpy-xbee==0.18.3
 zigpy-zigate==0.11.0
 
 # homeassistant.components.zha
-zigpy-znp==0.11.5
+zigpy-znp==0.11.6
 
 # homeassistant.components.zha
 zigpy==0.57.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -212,7 +212,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==18.0.3
+aioesphomeapi==18.0.4
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2081,7 +2081,7 @@ zeroconf==0.115.2
 zeversolar==0.3.1
 
 # homeassistant.components.zha
-zha-quirks==0.0.104
+zha-quirks==0.0.105
 
 # homeassistant.components.zha
 zigpy-deconz==0.21.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -70,7 +70,7 @@ PyMetno==0.11.0
 PyMicroBot==0.0.9
 
 # homeassistant.components.nina
-PyNINA==0.3.2
+PyNINA==0.3.3
 
 # homeassistant.components.mobile_app
 # homeassistant.components.owntracks

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -212,7 +212,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==18.0.1
+aioesphomeapi==18.0.3
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -212,7 +212,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==17.1.5
+aioesphomeapi==17.2.0
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1171,7 +1171,7 @@ pyCEC==0.5.2
 pyControl4==1.1.0
 
 # homeassistant.components.duotecno
-pyDuotecno==2023.10.0
+pyDuotecno==2023.10.1
 
 # homeassistant.components.eight_sleep
 pyEight==0.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -212,7 +212,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==18.0.4
+aioesphomeapi==18.0.6
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -212,7 +212,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==17.2.0
+aioesphomeapi==18.0.1
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -170,7 +170,7 @@ aioairq==0.2.4
 aioairzone-cloud==0.2.3
 
 # homeassistant.components.airzone
-aioairzone==0.6.8
+aioairzone==0.6.9
 
 # homeassistant.components.ambient_station
 aioambient==2023.04.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1969,7 +1969,7 @@ vallox-websocket-api==3.3.0
 vehicle==1.0.1
 
 # homeassistant.components.velbus
-velbus-aio==2023.2.0
+velbus-aio==2023.10.0
 
 # homeassistant.components.venstar
 venstarcolortouch==0.19

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -212,7 +212,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==18.0.6
+aioesphomeapi==18.0.7
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1969,7 +1969,7 @@ vallox-websocket-api==3.3.0
 vehicle==1.0.1
 
 # homeassistant.components.velbus
-velbus-aio==2023.10.0
+velbus-aio==2023.10.1
 
 # homeassistant.components.venstar
 venstarcolortouch==0.19

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -212,7 +212,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==17.0.1
+aioesphomeapi==17.1.4
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1061,7 +1061,7 @@ openerz-api==0.2.0
 openhomedevice==2.2.0
 
 # homeassistant.components.opower
-opower==0.0.35
+opower==0.0.36
 
 # homeassistant.components.oralb
 oralb-ble==0.17.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -212,7 +212,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==17.1.4
+aioesphomeapi==17.1.5
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/tests/components/esphome/conftest.py
+++ b/tests/components/esphome/conftest.py
@@ -129,6 +129,7 @@ def mock_client(mock_device_info) -> APIClient:
     mock_client.connect = AsyncMock()
     mock_client.disconnect = AsyncMock()
     mock_client.list_entities_services = AsyncMock(return_value=([], []))
+    mock_client.address = "127.0.0.1"
     mock_client.api_version = APIVersion(99, 99)
 
     with patch("homeassistant.components.esphome.APIClient", mock_client), patch(

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -959,6 +959,17 @@ async def test_subscribe_topic(
         unsub()
 
 
+async def test_subscribe_topic_not_initialize(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+) -> None:
+    """Test the subscription of a topic when MQTT was not initialized."""
+    with pytest.raises(
+        HomeAssistantError, match=r".*make sure MQTT is set up correctly"
+    ):
+        await mqtt.async_subscribe(hass, "test-topic", record_calls)
+
+
 @patch("homeassistant.components.mqtt.client.INITIAL_SUBSCRIBE_COOLDOWN", 0.0)
 @patch("homeassistant.components.mqtt.client.UNSUBSCRIBE_COOLDOWN", 0.2)
 async def test_subscribe_and_resubscribe(

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -662,6 +662,12 @@ def logic_group_zdb5100_state_fixture():
     return json.loads(load_fixture("zwave_js/logic_group_zdb5100_state.json"))
 
 
+@pytest.fixture(name="climate_intermatic_pe653_state", scope="session")
+def climate_intermatic_pe653_state_fixture():
+    """Load Intermatic PE653 Pool Control node state fixture data."""
+    return json.loads(load_fixture("zwave_js/climate_intermatic_pe653_state.json"))
+
+
 # model fixtures
 
 
@@ -1288,5 +1294,13 @@ def nice_ibt4zwave_fixture(client, nice_ibt4zwave_state):
 def logic_group_zdb5100_fixture(client, logic_group_zdb5100_state):
     """Mock a ZDB5100 light node."""
     node = Node(client, copy.deepcopy(logic_group_zdb5100_state))
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="climate_intermatic_pe653")
+def climate_intermatic_pe653_fixture(client, climate_intermatic_pe653_state):
+    """Mock an Intermatic PE653 node."""
+    node = Node(client, copy.deepcopy(climate_intermatic_pe653_state))
     client.driver.controller.nodes[node.node_id] = node
     return node

--- a/tests/components/zwave_js/fixtures/climate_intermatic_pe653_state.json
+++ b/tests/components/zwave_js/fixtures/climate_intermatic_pe653_state.json
@@ -1,0 +1,4508 @@
+{
+  "nodeId": 19,
+  "index": 0,
+  "status": 4,
+  "ready": true,
+  "isListening": true,
+  "isRouting": true,
+  "isSecure": false,
+  "manufacturerId": 5,
+  "productId": 1619,
+  "productType": 20549,
+  "firmwareVersion": "3.9",
+  "deviceConfig": {
+    "filename": "/data/db/devices/0x0005/pe653.json",
+    "isEmbedded": true,
+    "manufacturer": "Intermatic",
+    "manufacturerId": 5,
+    "label": "PE653",
+    "description": "Pool Control",
+    "devices": [
+      {
+        "productType": 20549,
+        "productId": 1619
+      }
+    ],
+    "firmwareVersion": {
+      "min": "0.0",
+      "max": "255.255"
+    },
+    "preferred": false,
+    "associations": {},
+    "paramInformation": {
+      "_map": {}
+    },
+    "compat": {
+      "addCCs": {},
+      "overrideQueries": {
+        "overrides": {}
+      }
+    }
+  },
+  "label": "PE653",
+  "endpointCountIsDynamic": false,
+  "endpointsHaveIdenticalCapabilities": false,
+  "individualEndpointCount": 39,
+  "aggregatedEndpointCount": 0,
+  "interviewAttempts": 1,
+  "endpoints": [
+    {
+      "nodeId": 19,
+      "index": 0,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 145,
+          "name": "Manufacturer Proprietary",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 115,
+          "name": "Powerlevel",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 114,
+          "name": "Manufacturer Specific",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 134,
+          "name": "Version",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 129,
+          "name": "Clock",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 96,
+          "name": "Multi Channel",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 112,
+          "name": "Configuration",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 133,
+          "name": "Association",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 67,
+          "name": "Thermostat Setpoint",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 49,
+          "name": "Multilevel Sensor",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 48,
+          "name": "Binary Sensor",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 1,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 145,
+          "name": "Manufacturer Proprietary",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 115,
+          "name": "Powerlevel",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 112,
+          "name": "Configuration",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 67,
+          "name": "Thermostat Setpoint",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 49,
+          "name": "Multilevel Sensor",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 48,
+          "name": "Binary Sensor",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 114,
+          "name": "Manufacturer Specific",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 134,
+          "name": "Version",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 129,
+          "name": "Clock",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 133,
+          "name": "Association",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 2,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 49,
+          "name": "Multilevel Sensor",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 3,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 49,
+          "name": "Multilevel Sensor",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 4,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 49,
+          "name": "Multilevel Sensor",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 5,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 49,
+          "name": "Multilevel Sensor",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 6,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 7,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 8,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 9,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 10,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 11,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 12,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 13,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 14,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 15,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 16,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 17,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 18,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 19,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 49,
+          "name": "Multilevel Sensor",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 20,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 49,
+          "name": "Multilevel Sensor",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 21,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 49,
+          "name": "Multilevel Sensor",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 22,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 49,
+          "name": "Multilevel Sensor",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 23,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 49,
+          "name": "Multilevel Sensor",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 24,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 25,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 26,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 27,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 28,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 29,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 30,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 31,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 32,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 33,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 34,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 35,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 36,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 37,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 38,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    },
+    {
+      "nodeId": 19,
+      "index": 39,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 16,
+          "label": "Binary Switch"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Binary Power Switch"
+        },
+        "mandatorySupportedCCs": [32, 37, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 37,
+          "name": "Binary Switch",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    }
+  ],
+  "values": [
+    {
+      "endpoint": 0,
+      "commandClass": 67,
+      "commandClassName": "Thermostat Setpoint",
+      "property": "setpoint",
+      "propertyKey": 7,
+      "propertyName": "setpoint",
+      "propertyKeyName": "Furnace",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Setpoint (Furnace)",
+        "ccSpecific": {
+          "setpointType": 7
+        },
+        "unit": "°F",
+        "stateful": true,
+        "secret": false
+      },
+      "value": 60
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 1,
+      "propertyKey": 2,
+      "propertyName": "Installed Pump Type",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Installed Pump Type",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "states": {
+          "0": "One Speed",
+          "1": "Two Speed"
+        },
+        "valueSize": 2,
+        "format": 0,
+        "allowManualEntry": false,
+        "isFromConfig": true,
+        "name": "Installed Pump Type"
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 1,
+      "propertyKey": 1,
+      "propertyName": "Booster (Cleaner) Pump Installed",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Booster (Cleaner) Pump Installed",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "states": {
+          "0": "Disable",
+          "1": "Enable"
+        },
+        "valueSize": 2,
+        "format": 1,
+        "allowManualEntry": false,
+        "isFromConfig": true,
+        "name": "Booster (Cleaner) Pump Installed"
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 1,
+      "propertyKey": 65280,
+      "propertyName": "Booster (Cleaner) Pump Operation Mode",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Set the filter pump mode to use when the booster (cleaner) pump is running.",
+        "label": "Booster (Cleaner) Pump Operation Mode",
+        "default": 1,
+        "min": 1,
+        "max": 6,
+        "states": {
+          "1": "Disable",
+          "2": "Circuit 1",
+          "3": "VSP Speed 1",
+          "4": "VSP Speed 2",
+          "5": "VSP Speed 3",
+          "6": "VSP Speed 4"
+        },
+        "valueSize": 2,
+        "format": 0,
+        "allowManualEntry": false,
+        "isFromConfig": true,
+        "name": "Booster (Cleaner) Pump Operation Mode",
+        "info": "Set the filter pump mode to use when the booster (cleaner) pump is running."
+      },
+      "value": 1
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 2,
+      "propertyKey": 65280,
+      "propertyName": "Heater Cooldown Period",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Heater Cooldown Period",
+        "default": -1,
+        "min": -1,
+        "max": 15,
+        "states": {
+          "0": "Heater installed with no cooldown",
+          "-1": "No heater installed"
+        },
+        "unit": "minutes",
+        "valueSize": 2,
+        "format": 0,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Heater Cooldown Period"
+      },
+      "value": 2
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 2,
+      "propertyKey": 1,
+      "propertyName": "Heater Safety Setting",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Prevent the heater from turning on while the pump is off.",
+        "label": "Heater Safety Setting",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "states": {
+          "0": "Disable",
+          "1": "Enable"
+        },
+        "valueSize": 2,
+        "format": 1,
+        "allowManualEntry": false,
+        "isFromConfig": true,
+        "name": "Heater Safety Setting",
+        "info": "Prevent the heater from turning on while the pump is off."
+      },
+      "value": 1
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 3,
+      "propertyKey": 4278190080,
+      "propertyName": "Water Temperature Offset",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Water Temperature Offset",
+        "default": 0,
+        "min": -5,
+        "max": 5,
+        "unit": "°F",
+        "valueSize": 4,
+        "format": 0,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Water Temperature Offset"
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 3,
+      "propertyKey": 16711680,
+      "propertyName": "Air/Freeze Temperature Offset",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Air/Freeze Temperature Offset",
+        "default": 0,
+        "min": -5,
+        "max": 5,
+        "unit": "°F",
+        "valueSize": 4,
+        "format": 0,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Air/Freeze Temperature Offset"
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 3,
+      "propertyKey": 65280,
+      "propertyName": "Solar Temperature Offset",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Solar Temperature Offset",
+        "default": 0,
+        "min": -5,
+        "max": 5,
+        "unit": "°F",
+        "valueSize": 4,
+        "format": 0,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Solar Temperature Offset"
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 22,
+      "propertyName": "Pool/Spa Configuration",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Pool/Spa Configuration",
+        "default": 0,
+        "min": 0,
+        "max": 2,
+        "states": {
+          "0": "Pool",
+          "1": "Spa",
+          "2": "Both"
+        },
+        "valueSize": 1,
+        "format": 0,
+        "allowManualEntry": false,
+        "isFromConfig": true,
+        "name": "Pool/Spa Configuration"
+      },
+      "value": 2
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 23,
+      "propertyName": "Spa Mode Pump Speed",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Requires pool/spa configuration.",
+        "label": "Spa Mode Pump Speed",
+        "default": 1,
+        "min": 1,
+        "max": 6,
+        "states": {
+          "1": "Disabled",
+          "2": "Circuit 1",
+          "3": "VSP Speed 1",
+          "4": "VSP Speed 2",
+          "5": "VSP Speed 3",
+          "6": "VSP Speed 4"
+        },
+        "valueSize": 1,
+        "format": 0,
+        "allowManualEntry": false,
+        "isFromConfig": true,
+        "name": "Spa Mode Pump Speed",
+        "info": "Requires pool/spa configuration."
+      },
+      "value": 1
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 32,
+      "propertyName": "Variable Speed Pump - Speed 1",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Requires connected variable speed pump.",
+        "label": "Variable Speed Pump - Speed 1",
+        "default": 750,
+        "min": 400,
+        "max": 3450,
+        "unit": "RPM",
+        "valueSize": 2,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Variable Speed Pump - Speed 1",
+        "info": "Requires connected variable speed pump."
+      },
+      "value": 1400
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 33,
+      "propertyName": "Variable Speed Pump - Speed 2",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Requires connected variable speed pump.",
+        "label": "Variable Speed Pump - Speed 2",
+        "default": 1500,
+        "min": 400,
+        "max": 3450,
+        "unit": "RPM",
+        "valueSize": 2,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Variable Speed Pump - Speed 2",
+        "info": "Requires connected variable speed pump."
+      },
+      "value": 1700
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 34,
+      "propertyName": "Variable Speed Pump - Speed 3",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Requires connected variable speed pump.",
+        "label": "Variable Speed Pump - Speed 3",
+        "default": 2350,
+        "min": 400,
+        "max": 3450,
+        "unit": "RPM",
+        "valueSize": 2,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Variable Speed Pump - Speed 3",
+        "info": "Requires connected variable speed pump."
+      },
+      "value": 2500
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 35,
+      "propertyName": "Variable Speed Pump - Speed 4",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Requires connected variable speed pump.",
+        "label": "Variable Speed Pump - Speed 4",
+        "default": 3110,
+        "min": 400,
+        "max": 3450,
+        "unit": "RPM",
+        "valueSize": 2,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Variable Speed Pump - Speed 4",
+        "info": "Requires connected variable speed pump."
+      },
+      "value": 2500
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 49,
+      "propertyName": "Variable Speed Pump - Max Speed",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Requires connected variable speed pump.",
+        "label": "Variable Speed Pump - Max Speed",
+        "default": 3450,
+        "min": 400,
+        "max": 3450,
+        "unit": "RPM",
+        "valueSize": 2,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Variable Speed Pump - Max Speed",
+        "info": "Requires connected variable speed pump."
+      },
+      "value": 3000
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 50,
+      "propertyKey": 4278190080,
+      "propertyName": "Freeze Protection: Temperature",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Freeze Protection: Temperature",
+        "default": 0,
+        "min": 0,
+        "max": 44,
+        "states": {
+          "0": "Disabled",
+          "40": "40 °F",
+          "41": "41 °F",
+          "42": "42 °F",
+          "43": "43 °F",
+          "44": "44 °F"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": false,
+        "isFromConfig": true,
+        "name": "Freeze Protection: Temperature"
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 50,
+      "propertyKey": 65536,
+      "propertyName": "Freeze Protection: Turn On Circuit 1",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Freeze Protection: Turn On Circuit 1",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "states": {
+          "0": "Disable",
+          "1": "Enable"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": false,
+        "isFromConfig": true,
+        "name": "Freeze Protection: Turn On Circuit 1"
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 50,
+      "propertyKey": 131072,
+      "propertyName": "Freeze Protection: Turn On Circuit 2",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Freeze Protection: Turn On Circuit 2",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "states": {
+          "0": "Disable",
+          "1": "Enable"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": false,
+        "isFromConfig": true,
+        "name": "Freeze Protection: Turn On Circuit 2"
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 50,
+      "propertyKey": 262144,
+      "propertyName": "Freeze Protection: Turn On Circuit 3",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Freeze Protection: Turn On Circuit 3",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "states": {
+          "0": "Disable",
+          "1": "Enable"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": false,
+        "isFromConfig": true,
+        "name": "Freeze Protection: Turn On Circuit 3"
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 50,
+      "propertyKey": 524288,
+      "propertyName": "Freeze Protection: Turn On Circuit 4",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Freeze Protection: Turn On Circuit 4",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "states": {
+          "0": "Disable",
+          "1": "Enable"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": false,
+        "isFromConfig": true,
+        "name": "Freeze Protection: Turn On Circuit 4"
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 50,
+      "propertyKey": 1048576,
+      "propertyName": "Freeze Protection: Turn On Circuit 5",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Freeze Protection: Turn On Circuit 5",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "states": {
+          "0": "Disable",
+          "1": "Enable"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": false,
+        "isFromConfig": true,
+        "name": "Freeze Protection: Turn On Circuit 5"
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 50,
+      "propertyKey": 65280,
+      "propertyName": "Freeze Protection: Turn On VSP Speed",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Requires variable speed pump and connected air/freeze sensor.",
+        "label": "Freeze Protection: Turn On VSP Speed",
+        "default": 0,
+        "min": 0,
+        "max": 5,
+        "states": {
+          "0": "None",
+          "2": "VSP Speed 1",
+          "3": "VSP Speed 2",
+          "4": "VSP Speed 3",
+          "5": "VSP Speed 4"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": false,
+        "isFromConfig": true,
+        "name": "Freeze Protection: Turn On VSP Speed",
+        "info": "Requires variable speed pump and connected air/freeze sensor."
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 50,
+      "propertyKey": 128,
+      "propertyName": "Freeze Protection: Turn On Heater",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Requires heater and connected air/freeze sensor.",
+        "label": "Freeze Protection: Turn On Heater",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "states": {
+          "0": "Disable",
+          "1": "Enable"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": false,
+        "isFromConfig": true,
+        "name": "Freeze Protection: Turn On Heater",
+        "info": "Requires heater and connected air/freeze sensor."
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 50,
+      "propertyKey": 127,
+      "propertyName": "Freeze Protection: Pool/Spa Cycle Time",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Requires pool/spa configuration and connected air/freeze sensor.",
+        "label": "Freeze Protection: Pool/Spa Cycle Time",
+        "default": 0,
+        "min": 0,
+        "max": 30,
+        "unit": "minutes",
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Freeze Protection: Pool/Spa Cycle Time",
+        "info": "Requires pool/spa configuration and connected air/freeze sensor."
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 4,
+      "propertyName": "Circuit 1 Schedule 1",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Start time (first two bytes, little endian) and stop time (last two bytes, little endian) of schedule in minutes past midnight, e.g. 12:05am (0x0500) to 3:00pm (0x8403) is entered as 83919875. Set to 4294967295 (0xffffffff) to disable.",
+        "label": "Circuit 1 Schedule 1",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Circuit 1 Schedule 1",
+        "info": "Start time (first two bytes, little endian) and stop time (last two bytes, little endian) of schedule in minutes past midnight, e.g. 12:05am (0x0500) to 3:00pm (0x8403) is entered as 83919875. Set to 4294967295 (0xffffffff) to disable."
+      },
+      "value": 1979884035
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 5,
+      "propertyName": "Circuit 1 Schedule 2",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Circuit 1 Schedule 2",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Circuit 1 Schedule 2",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 6,
+      "propertyName": "Circuit 1 Schedule 3",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Circuit 1 Schedule 3",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Circuit 1 Schedule 3",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 7,
+      "propertyName": "Circuit 2 Schedule 1",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Circuit 2 Schedule 1",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Circuit 2 Schedule 1",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 8,
+      "propertyName": "Circuit 2 Schedule 2",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Circuit 2 Schedule 2",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Circuit 2 Schedule 2",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 9,
+      "propertyName": "Circuit 2 Schedule 3",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Circuit 2 Schedule 3",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Circuit 2 Schedule 3",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 10,
+      "propertyName": "Circuit 3 Schedule 1",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Circuit 3 Schedule 1",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Circuit 3 Schedule 1",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 11,
+      "propertyName": "Circuit 3 Schedule 2",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Circuit 3 Schedule 2",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Circuit 3 Schedule 2",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 12,
+      "propertyName": "Circuit 3 Schedule 3",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Circuit 3 Schedule 3",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Circuit 3 Schedule 3",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 13,
+      "propertyName": "Circuit 4 Schedule 1",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Circuit 4 Schedule 1",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Circuit 4 Schedule 1",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 14,
+      "propertyName": "Circuit 4 Schedule 2",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Circuit 4 Schedule 2",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Circuit 4 Schedule 2",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 15,
+      "propertyName": "Circuit 4 Schedule 3",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Circuit 4 Schedule 3",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Circuit 4 Schedule 3",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 16,
+      "propertyName": "Circuit 5 Schedule 1",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Circuit 5 Schedule 1",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Circuit 5 Schedule 1",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 17,
+      "propertyName": "Circuit 5 Schedule 2",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Circuit 5 Schedule 2",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Circuit 5 Schedule 2",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 18,
+      "propertyName": "Circuit 5 Schedule 3",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Circuit 5 Schedule 3",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Circuit 5 Schedule 3",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 19,
+      "propertyName": "Pool/Spa Mode Schedule 1",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Pool/Spa Mode Schedule 1",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Pool/Spa Mode Schedule 1",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 20,
+      "propertyName": "Pool/Spa Mode Schedule 2",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Pool/Spa Mode Schedule 2",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Pool/Spa Mode Schedule 2",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 21,
+      "propertyName": "Pool/Spa Mode Schedule 3",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Pool/Spa Mode Schedule 3",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Pool/Spa Mode Schedule 3",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 36,
+      "propertyName": "Variable Speed Pump Speed 1 Schedule 1",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Variable Speed Pump Speed 1 Schedule 1",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Variable Speed Pump Speed 1 Schedule 1",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 37,
+      "propertyName": "Variable Speed Pump Speed 1 Schedule 2",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Variable Speed Pump Speed 1 Schedule 2",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Variable Speed Pump Speed 1 Schedule 2",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 38,
+      "propertyName": "Variable Speed Pump Speed 1 Schedule 3",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Variable Speed Pump Speed 1 Schedule 3",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Variable Speed Pump Speed 1 Schedule 3",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 39,
+      "propertyName": "Variable Speed Pump Speed 2 Schedule 1",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Variable Speed Pump Speed 2 Schedule 1",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Variable Speed Pump Speed 2 Schedule 1",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 1476575235
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 40,
+      "propertyName": "Variable Speed Pump Speed 2 Schedule 2",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Variable Speed Pump Speed 2 Schedule 2",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Variable Speed Pump Speed 2 Schedule 2",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 41,
+      "propertyName": "Variable Speed Pump Speed 2 Schedule 3",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Variable Speed Pump Speed 2 Schedule 3",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Variable Speed Pump Speed 2 Schedule 3",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 42,
+      "propertyName": "Variable Speed Pump Speed 3 Schedule 1",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Variable Speed Pump Speed 3 Schedule 1",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Variable Speed Pump Speed 3 Schedule 1",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 43,
+      "propertyName": "Variable Speed Pump Speed 3 Schedule 2",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Variable Speed Pump Speed 3 Schedule 2",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Variable Speed Pump Speed 3 Schedule 2",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 44,
+      "propertyName": "Variable Speed Pump Speed 3 Schedule 3",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Variable Speed Pump Speed 3 Schedule 3",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Variable Speed Pump Speed 3 Schedule 3",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 45,
+      "propertyName": "Variable Speed Pump Speed 4 Schedule 1",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Variable Speed Pump Speed 4 Schedule 1",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Variable Speed Pump Speed 4 Schedule 1",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 46,
+      "propertyName": "Variable Speed Pump Speed 4 Schedule 2",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Variable Speed Pump Speed 4 Schedule 2",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Variable Speed Pump Speed 4 Schedule 2",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 47,
+      "propertyName": "Variable Speed Pump Speed 4 Schedule 3",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Refer to parameter 4 for usage.",
+        "label": "Variable Speed Pump Speed 4 Schedule 3",
+        "default": 4294967295,
+        "min": 0,
+        "max": 4294967295,
+        "states": {
+          "4294967295": "Disabled"
+        },
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "name": "Variable Speed Pump Speed 4 Schedule 3",
+        "info": "Refer to parameter 4 for usage."
+      },
+      "value": 4294967295
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "manufacturerId",
+      "propertyName": "manufacturerId",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Manufacturer ID",
+        "min": 0,
+        "max": 65535,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 5
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "productType",
+      "propertyName": "productType",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Product type",
+        "min": 0,
+        "max": 65535,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 20549
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "productId",
+      "propertyName": "productId",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Product ID",
+        "min": 0,
+        "max": 65535,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 1619
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "libraryType",
+      "propertyName": "libraryType",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Library type",
+        "states": {
+          "0": "Unknown",
+          "1": "Static Controller",
+          "2": "Controller",
+          "3": "Enhanced Slave",
+          "4": "Slave",
+          "5": "Installer",
+          "6": "Routing Slave",
+          "7": "Bridge Controller",
+          "8": "Device under Test",
+          "9": "N/A",
+          "10": "AV Remote",
+          "11": "AV Device"
+        },
+        "stateful": true,
+        "secret": false
+      },
+      "value": 6
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "protocolVersion",
+      "propertyName": "protocolVersion",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave protocol version",
+        "stateful": true,
+        "secret": false
+      },
+      "value": "2.78"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "firmwareVersions",
+      "propertyName": "firmwareVersions",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "string[]",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave chip firmware versions",
+        "stateful": true,
+        "secret": false
+      },
+      "value": ["3.9"]
+    },
+    {
+      "endpoint": 1,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      },
+      "value": true
+    },
+    {
+      "endpoint": 1,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      },
+      "value": false
+    },
+    {
+      "endpoint": 1,
+      "commandClass": 48,
+      "commandClassName": "Binary Sensor",
+      "property": "Any",
+      "propertyName": "Any",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Sensor state (Any)",
+        "ccSpecific": {
+          "sensorType": 255
+        },
+        "stateful": true,
+        "secret": false
+      },
+      "value": false
+    },
+    {
+      "endpoint": 1,
+      "commandClass": 49,
+      "commandClassName": "Multilevel Sensor",
+      "property": "Air temperature",
+      "propertyName": "Air temperature",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Air temperature",
+        "ccSpecific": {
+          "sensorType": 1,
+          "scale": 1
+        },
+        "unit": "°F",
+        "stateful": true,
+        "secret": false
+      },
+      "value": 81,
+      "nodeId": 19
+    },
+    {
+      "endpoint": 1,
+      "commandClass": 67,
+      "commandClassName": "Thermostat Setpoint",
+      "property": "setpoint",
+      "propertyKey": 1,
+      "propertyName": "setpoint",
+      "propertyKeyName": "Heating",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Setpoint (Heating)",
+        "ccSpecific": {
+          "setpointType": 1
+        },
+        "unit": "°F",
+        "stateful": true,
+        "secret": false
+      },
+      "value": 39
+    },
+    {
+      "endpoint": 2,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      },
+      "value": false
+    },
+    {
+      "endpoint": 2,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 2,
+      "commandClass": 49,
+      "commandClassName": "Multilevel Sensor",
+      "property": "Air temperature",
+      "propertyName": "Air temperature",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Air temperature",
+        "ccSpecific": {
+          "sensorType": 1,
+          "scale": 1
+        },
+        "unit": "°F",
+        "stateful": true,
+        "secret": false
+      },
+      "value": 84,
+      "nodeId": 19
+    },
+    {
+      "endpoint": 3,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      },
+      "value": false
+    },
+    {
+      "endpoint": 3,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      },
+      "value": false
+    },
+    {
+      "endpoint": 3,
+      "commandClass": 49,
+      "commandClassName": "Multilevel Sensor",
+      "property": "Air temperature",
+      "propertyName": "Air temperature",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Air temperature",
+        "ccSpecific": {
+          "sensorType": 1,
+          "scale": 1
+        },
+        "unit": "°F",
+        "stateful": true,
+        "secret": false
+      },
+      "value": 86,
+      "nodeId": 19
+    },
+    {
+      "endpoint": 4,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      },
+      "value": false
+    },
+    {
+      "endpoint": 4,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      },
+      "value": false
+    },
+    {
+      "endpoint": 4,
+      "commandClass": 49,
+      "commandClassName": "Multilevel Sensor",
+      "property": "Air temperature",
+      "propertyName": "Air temperature",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Air temperature",
+        "ccSpecific": {
+          "sensorType": 1,
+          "scale": 1
+        },
+        "unit": "°F",
+        "stateful": true,
+        "secret": false
+      },
+      "value": 80,
+      "nodeId": 19
+    },
+    {
+      "endpoint": 5,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      },
+      "value": false
+    },
+    {
+      "endpoint": 5,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 5,
+      "commandClass": 49,
+      "commandClassName": "Multilevel Sensor",
+      "property": "Air temperature",
+      "propertyName": "Air temperature",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Air temperature",
+        "ccSpecific": {
+          "sensorType": 1,
+          "scale": 1
+        },
+        "unit": "°F",
+        "stateful": true,
+        "secret": false
+      },
+      "value": 83,
+      "nodeId": 19
+    },
+    {
+      "endpoint": 6,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 6,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 7,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 7,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 8,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 8,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 9,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 9,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 10,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 10,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 11,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 11,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 12,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 12,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 13,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 13,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 14,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 14,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 15,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 15,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 16,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      },
+      "value": false
+    },
+    {
+      "endpoint": 16,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 17,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      },
+      "value": true
+    },
+    {
+      "endpoint": 17,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 18,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      },
+      "value": false
+    },
+    {
+      "endpoint": 18,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 19,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      },
+      "value": false
+    },
+    {
+      "endpoint": 19,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 20,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      },
+      "value": false
+    },
+    {
+      "endpoint": 20,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 21,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 21,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 22,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 22,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 23,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 23,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 24,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 24,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 25,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 25,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 26,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 26,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 27,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 27,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 28,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 28,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 29,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 29,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 30,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 30,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 31,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 31,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 32,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      },
+      "value": false
+    },
+    {
+      "endpoint": 32,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 33,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      },
+      "value": false
+    },
+    {
+      "endpoint": 33,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 34,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      },
+      "value": false
+    },
+    {
+      "endpoint": 34,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 35,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      },
+      "value": false
+    },
+    {
+      "endpoint": 35,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 36,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      },
+      "value": false
+    },
+    {
+      "endpoint": 36,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 37,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      },
+      "value": false
+    },
+    {
+      "endpoint": 37,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 38,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      },
+      "value": false
+    },
+    {
+      "endpoint": 38,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 39,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      },
+      "value": true
+    },
+    {
+      "endpoint": 39,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    }
+  ],
+  "isFrequentListening": false,
+  "maxDataRate": 40000,
+  "supportedDataRates": [40000],
+  "protocolVersion": 2,
+  "supportsBeaming": true,
+  "supportsSecurity": false,
+  "nodeType": 1,
+  "deviceClass": {
+    "basic": {
+      "key": 4,
+      "label": "Routing Slave"
+    },
+    "generic": {
+      "key": 16,
+      "label": "Binary Switch"
+    },
+    "specific": {
+      "key": 1,
+      "label": "Binary Power Switch"
+    },
+    "mandatorySupportedCCs": [32, 37, 39],
+    "mandatoryControlledCCs": []
+  },
+  "interviewStage": "Complete",
+  "deviceDatabaseUrl": "https://devices.zwave-js.io/?jumpTo=0x0005:0x5045:0x0653:3.9",
+  "highestSecurityClass": -1,
+  "isControllerNode": false,
+  "keepAwake": false
+}

--- a/tests/components/zwave_js/test_climate.py
+++ b/tests/components/zwave_js/test_climate.py
@@ -792,3 +792,196 @@ async def test_thermostat_raise_repair_issue_and_warning_when_setting_fan_preset
         "Dry and Fan preset modes are deprecated and will be removed in Home Assistant 2024.2. Please use the corresponding Dry and Fan HVAC modes instead"
         in caplog.text
     )
+
+
+async def test_multi_setpoint_thermostat(
+    hass: HomeAssistant, client, climate_intermatic_pe653, integration
+) -> None:
+    """Test a thermostat with multiple setpoints."""
+    node = climate_intermatic_pe653
+
+    heating_entity_id = "climate.pool_control_2"
+    heating = hass.states.get(heating_entity_id)
+    assert heating
+    assert heating.state == HVACMode.HEAT
+    assert heating.attributes[ATTR_TEMPERATURE] == 3.9
+    assert heating.attributes[ATTR_HVAC_MODES] == [HVACMode.HEAT]
+    assert (
+        heating.attributes[ATTR_SUPPORTED_FEATURES]
+        == ClimateEntityFeature.TARGET_TEMPERATURE
+    )
+
+    furnace_entity_id = "climate.pool_control"
+    furnace = hass.states.get(furnace_entity_id)
+    assert furnace
+    assert furnace.state == HVACMode.HEAT
+    assert furnace.attributes[ATTR_TEMPERATURE] == 15.6
+    assert furnace.attributes[ATTR_HVAC_MODES] == [HVACMode.HEAT]
+    assert (
+        furnace.attributes[ATTR_SUPPORTED_FEATURES]
+        == ClimateEntityFeature.TARGET_TEMPERATURE
+    )
+
+    client.async_send_command_no_wait.reset_mock()
+
+    # Test setting temperature of heating setpoint
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_TEMPERATURE,
+        {
+            ATTR_ENTITY_ID: heating_entity_id,
+            ATTR_TEMPERATURE: 20.0,
+        },
+        blocking=True,
+    )
+
+    # Test setting temperature of furnace setpoint
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_TEMPERATURE,
+        {
+            ATTR_ENTITY_ID: furnace_entity_id,
+            ATTR_TEMPERATURE: 2.0,
+        },
+        blocking=True,
+    )
+
+    # Test setting illegal mode raises an error
+    with pytest.raises(ValueError):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {
+                ATTR_ENTITY_ID: heating_entity_id,
+                ATTR_HVAC_MODE: HVACMode.COOL,
+            },
+            blocking=True,
+        )
+
+    with pytest.raises(ValueError):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {
+                ATTR_ENTITY_ID: furnace_entity_id,
+                ATTR_HVAC_MODE: HVACMode.COOL,
+            },
+            blocking=True,
+        )
+
+    # this is a no-op since there's no mode
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {
+            ATTR_ENTITY_ID: heating_entity_id,
+            ATTR_HVAC_MODE: HVACMode.HEAT,
+        },
+        blocking=True,
+    )
+
+    # this is a no-op since there's no mode
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {
+            ATTR_ENTITY_ID: furnace_entity_id,
+            ATTR_HVAC_MODE: HVACMode.HEAT,
+        },
+        blocking=True,
+    )
+
+    assert len(client.async_send_command.call_args_list) == 2
+    args = client.async_send_command.call_args_list[0][0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == 19
+    assert args["valueId"] == {
+        "endpoint": 1,
+        "commandClass": 67,
+        "property": "setpoint",
+        "propertyKey": 1,
+    }
+    assert args["value"] == 68.0
+
+    args = client.async_send_command.call_args_list[1][0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == 19
+    assert args["valueId"] == {
+        "endpoint": 0,
+        "commandClass": 67,
+        "property": "setpoint",
+        "propertyKey": 7,
+    }
+    assert args["value"] == 35.6
+
+    client.async_send_command.reset_mock()
+
+    # Test heating setpoint value update from value updated event
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": 19,
+            "args": {
+                "commandClassName": "Thermostat Setpoint",
+                "commandClass": 67,
+                "endpoint": 1,
+                "property": "setpoint",
+                "propertyKey": 1,
+                "propertyKeyName": "Heating",
+                "propertyName": "setpoint",
+                "newValue": 23,
+                "prevValue": 21.5,
+            },
+        },
+    )
+    node.receive_event(event)
+
+    state = hass.states.get(heating_entity_id)
+    assert state
+    assert state.state == HVACMode.HEAT
+    assert state.attributes[ATTR_TEMPERATURE] == -5
+
+    # furnace not changed
+    state = hass.states.get(furnace_entity_id)
+    assert state
+    assert state.state == HVACMode.HEAT
+    assert state.attributes[ATTR_TEMPERATURE] == 15.6
+
+    client.async_send_command.reset_mock()
+
+    # Test furnace setpoint value update from value updated event
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": 19,
+            "args": {
+                "commandClassName": "Thermostat Setpoint",
+                "commandClass": 67,
+                "endpoint": 0,
+                "property": "setpoint",
+                "propertyKey": 7,
+                "propertyKeyName": "Furnace",
+                "propertyName": "setpoint",
+                "newValue": 68,
+                "prevValue": 21.5,
+            },
+        },
+    )
+    node.receive_event(event)
+
+    # heating not changed
+    state = hass.states.get(heating_entity_id)
+    assert state
+    assert state.state == HVACMode.HEAT
+    assert state.attributes[ATTR_TEMPERATURE] == -5
+
+    state = hass.states.get(furnace_entity_id)
+    assert state
+    assert state.state == HVACMode.HEAT
+    assert state.attributes[ATTR_TEMPERATURE] == 20
+
+    client.async_send_command.reset_mock()


### PR DESCRIPTION
- Fix Spotify media position update value ([@Archomeda] - [#100044]) ([spotify docs])
- Fix error handling on subscribe when mqtt is not initialized ([@jbouwh] - [#101832]) ([mqtt docs])
- Bump aioesphomeapi to 17.1.4 ([@bdraco] - [#101897]) ([esphome docs]) (dependency)
- Bump aioesphomeapi to 17.1.5 ([@bdraco] - [#101916]) ([esphome docs]) (dependency)
- Fix Setpoint in Matter climate platform ([@goloveychuk] - [#101929]) ([matter docs])
- Update zwave issue repair strings ([@raman325] - [#101940]) ([zwave_js docs])
- Bump screenlogicpy to v0.9.3 ([@dieselrabbit] - [#101957]) ([screenlogic docs]) (dependency)
- Bump pynina to 0.3.3 ([@DeerMaximum] - [#101960]) ([nina docs]) (dependency)
- Fix google_maps same last_seen bug ([@pnbruckner] - [#101971]) ([google_maps docs])
- Bump aioesphomeapi to 17.2.0 ([@bdraco] - [#101981]) ([esphome docs]) (dependency)
- Bump aioesphomeapi to 18.0.1 ([@bdraco] - [#102028]) ([esphome docs]) (dependency) (noteworthy)
- Fix bug in calendar state transitions ([@allenporter] - [#102083]) ([calendar docs])
- Call disconnected callbacks from BT ESPHome client ([@abmantis] - [#102084]) ([esphome docs])
- Bump aioesphomeapi to 18.0.3 ([@bdraco] - [#102085]) ([esphome docs]) (dependency)
- Correct sensor state attribute and device class in Velbus sensors ([@Cereal2nd] - [#102099]) ([velbus docs])
- Bump velbusaio to 2023.10.0 ([@Cereal2nd] - [#102100]) ([velbus docs]) (dependency)
- Bump zha-quirks to 0.0.105 ([@TheJulianJES] - [#102113]) ([zha docs]) (dependency)
- Fix UniFi client tracker entities being unavailable when away on restart ([@Kane610] - [#102125]) ([unifi docs])
- Send events for tts stream start/end ([@jesserockz] - [#102139]) ([esphome docs])
- Bump opower to 0.0.36 ([@tronikos] - [#102150]) ([opower docs]) (dependency)
- Explicitly set entity name for VenstarSensor ([@dseven] - [#102158]) ([venstar docs])
- Don't warn about unknown pipeline events in ESPHome ([@synesthesiam] - [#102174]) ([esphome docs])
- Bump velbusaio to 2023.10.1 ([@Cereal2nd] - [#102178]) ([velbus docs]) (dependency)
- Bump aiowaqi to 2.1.0 ([@joostlek] - [#102209]) ([waqi docs]) (dependency)
- Handle timeouts on AEMET init ([@Noltari] - [#102289]) ([aemet docs])
- Bump pyduotecno to 2023.10.1 ([@Cereal2nd] - [#102344]) ([duotecno docs]) (dependency)
- Bump ZHA dependencies ([@puddly] - [#102358]) ([zha docs]) (dependency)
- Bump vehicle to 2.0.0 ([@joostlek] - [#102379]) ([rdw docs])
- Update aioairzone to v0.6.9 ([@Noltari] - [#102383]) ([airzone docs]) (dependency)
- Bump aioesphomeapi to 18.0.6 ([@bdraco] - [#102195]) ([esphome docs]) (dependency)
- Bump dbus-fast to 2.12.0 ([@bdraco] - [#102206]) ([bluetooth docs]) (dependency)
- Bump bluetooth-data-tools to 1.13.0 ([@bdraco] - [#102208]) ([esphome docs]) ([bluetooth docs]) ([led_ble docs]) ([ld2410_ble docs]) ([private_ble_device docs]) (dependency)
- Fix temperature setting for multi-setpoint z-wave device ([@kpine] - [#102395]) ([zwave_js docs])
- Bump aioesphomeapi to 18.0.7 ([@bdraco] - [#102399]) ([esphome docs]) (dependency)

[#100044]: https://github.com/home-assistant/core/pull/100044
[#101386]: https://github.com/home-assistant/core/pull/101386
[#101547]: https://github.com/home-assistant/core/pull/101547
[#101832]: https://github.com/home-assistant/core/pull/101832
[#101871]: https://github.com/home-assistant/core/pull/101871
[#101897]: https://github.com/home-assistant/core/pull/101897
[#101916]: https://github.com/home-assistant/core/pull/101916
[#101929]: https://github.com/home-assistant/core/pull/101929
[#101930]: https://github.com/home-assistant/core/pull/101930
[#101940]: https://github.com/home-assistant/core/pull/101940
[#101957]: https://github.com/home-assistant/core/pull/101957
[#101960]: https://github.com/home-assistant/core/pull/101960
[#101971]: https://github.com/home-assistant/core/pull/101971
[#101981]: https://github.com/home-assistant/core/pull/101981
[#102028]: https://github.com/home-assistant/core/pull/102028
[#102083]: https://github.com/home-assistant/core/pull/102083
[#102084]: https://github.com/home-assistant/core/pull/102084
[#102085]: https://github.com/home-assistant/core/pull/102085
[#102099]: https://github.com/home-assistant/core/pull/102099
[#102100]: https://github.com/home-assistant/core/pull/102100
[#102113]: https://github.com/home-assistant/core/pull/102113
[#102125]: https://github.com/home-assistant/core/pull/102125
[#102139]: https://github.com/home-assistant/core/pull/102139
[#102150]: https://github.com/home-assistant/core/pull/102150
[#102158]: https://github.com/home-assistant/core/pull/102158
[#102174]: https://github.com/home-assistant/core/pull/102174
[#102178]: https://github.com/home-assistant/core/pull/102178
[#102195]: https://github.com/home-assistant/core/pull/102195
[#102206]: https://github.com/home-assistant/core/pull/102206
[#102208]: https://github.com/home-assistant/core/pull/102208
[#102209]: https://github.com/home-assistant/core/pull/102209
[#102289]: https://github.com/home-assistant/core/pull/102289
[#102344]: https://github.com/home-assistant/core/pull/102344
[#102358]: https://github.com/home-assistant/core/pull/102358
[#102379]: https://github.com/home-assistant/core/pull/102379
[#102383]: https://github.com/home-assistant/core/pull/102383
[#102395]: https://github.com/home-assistant/core/pull/102395
[#102399]: https://github.com/home-assistant/core/pull/102399
[@Archomeda]: https://github.com/Archomeda
[@Cereal2nd]: https://github.com/Cereal2nd
[@DeerMaximum]: https://github.com/DeerMaximum
[@Kane610]: https://github.com/Kane610
[@Noltari]: https://github.com/Noltari
[@TheJulianJES]: https://github.com/TheJulianJES
[@abmantis]: https://github.com/abmantis
[@allenporter]: https://github.com/allenporter
[@bdraco]: https://github.com/bdraco
[@dieselrabbit]: https://github.com/dieselrabbit
[@dseven]: https://github.com/dseven
[@frenck]: https://github.com/frenck
[@goloveychuk]: https://github.com/goloveychuk
[@jbouwh]: https://github.com/jbouwh
[@jesserockz]: https://github.com/jesserockz
[@joostlek]: https://github.com/joostlek
[@kpine]: https://github.com/kpine
[@pnbruckner]: https://github.com/pnbruckner
[@puddly]: https://github.com/puddly
[@raman325]: https://github.com/raman325
[@synesthesiam]: https://github.com/synesthesiam
[@tronikos]: https://github.com/tronikos
[advantage_air docs]: https://www.home-assistant.io/integrations/advantage_air/
[aemet docs]: https://www.home-assistant.io/integrations/aemet/
[aftership docs]: https://www.home-assistant.io/integrations/aftership/
[airly docs]: https://www.home-assistant.io/integrations/airly/
[airzone docs]: https://www.home-assistant.io/integrations/airzone/
[bluetooth docs]: https://www.home-assistant.io/integrations/bluetooth/
[calendar docs]: https://www.home-assistant.io/integrations/calendar/
[duotecno docs]: https://www.home-assistant.io/integrations/duotecno/
[esphome docs]: https://www.home-assistant.io/integrations/esphome/
[google_maps docs]: https://www.home-assistant.io/integrations/google_maps/
[ld2410_ble docs]: https://www.home-assistant.io/integrations/ld2410_ble/
[led_ble docs]: https://www.home-assistant.io/integrations/led_ble/
[matter docs]: https://www.home-assistant.io/integrations/matter/
[mqtt docs]: https://www.home-assistant.io/integrations/mqtt/
[nina docs]: https://www.home-assistant.io/integrations/nina/
[opower docs]: https://www.home-assistant.io/integrations/opower/
[private_ble_device docs]: https://www.home-assistant.io/integrations/private_ble_device/
[rdw docs]: https://www.home-assistant.io/integrations/rdw/
[reolink docs]: https://www.home-assistant.io/integrations/reolink/
[screenlogic docs]: https://www.home-assistant.io/integrations/screenlogic/
[sensibo docs]: https://www.home-assistant.io/integrations/sensibo/
[spotify docs]: https://www.home-assistant.io/integrations/spotify/
[unifi docs]: https://www.home-assistant.io/integrations/unifi/
[velbus docs]: https://www.home-assistant.io/integrations/velbus/
[venstar docs]: https://www.home-assistant.io/integrations/venstar/
[waqi docs]: https://www.home-assistant.io/integrations/waqi/
[wiz docs]: https://www.home-assistant.io/integrations/wiz/
[zha docs]: https://www.home-assistant.io/integrations/zha/
[zwave_js docs]: https://www.home-assistant.io/integrations/zwave_js/

Docs PR: <https://github.com/home-assistant/home-assistant.io/pull/29453>