### PR TITLE
Use onkyo domain for select_hdmi_output service, add service description

### DIFF
--- a/homeassistant/components/onkyo/media_player.py
+++ b/homeassistant/components/onkyo/media_player.py
@@ -9,7 +9,6 @@ from eiscp import eISCP
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
-    DOMAIN,
     PLATFORM_SCHEMA,
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
@@ -23,6 +22,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 _LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "onkyo"
 
 CONF_SOURCES = "sources"
 CONF_MAX_VOLUME = "max_volume"
@@ -106,7 +107,7 @@ ONKYO_SELECT_OUTPUT_SCHEMA = vol.Schema(
     }
 )
 
-SERVICE_SELECT_HDMI_OUTPUT = "onkyo_select_hdmi_output"
+SERVICE_SELECT_HDMI_OUTPUT = "select_hdmi_output"
 
 
 def _parse_onkyo_payload(payload):

--- a/homeassistant/components/onkyo/services.yaml
+++ b/homeassistant/components/onkyo/services.yaml
@@ -1,0 +1,24 @@
+# Describes the format for selecting HDMI output
+select_hdmi_output:
+  target:
+    entity:
+      integration: onkyo
+      domain: media_player
+  fields:
+    hdmi_output:
+      required: true
+      default: out
+      example: out
+      selector:
+        select:
+          translation_key: "hdmi_output"
+          options:
+            - "no"
+            - "analog"
+            - "yes"
+            - "out"
+            - "out-sub"
+            - "sub"
+            - "hdbaset"
+            - "both"
+            - "up"

--- a/homeassistant/components/onkyo/strings.json
+++ b/homeassistant/components/onkyo/strings.json
@@ -1,0 +1,29 @@
+{
+  "services": {
+    "select_hdmi_output": {
+      "name": "Select HDMI output",
+      "description": "Changes the HDMI output of your receiver.",
+      "fields": {
+        "hdmi_output": {
+          "name": "HDMI Output",
+          "description": "The desired output code. Which one to use seems to vary depending on model so you will have to try them out (for model TX-NR676E it seems to be ‘out’ for main, ‘out-sub’ for sub, and ‘sub’ for both )."
+        }
+      }
+    }
+  },
+  "selector": {
+    "hdmi_output": {
+      "options": {
+        "no": "no",
+        "analog": "analog",
+        "yes": "yes",
+        "out": "out",
+        "out-sub": "out-sub",
+        "sub": "sub",
+        "hdbaset": "hdbaset",
+        "both": "both",
+        "up": "up"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This moves the current `media_player.onkyo_select_hdmi_source` service to `onkyo.select_hdmi_source` to be consistent with the recommendation in the dev docs (https://developers.home-assistant.io/docs/dev_101_services). It also adds descriptions for this service in `services.yaml` with translatable `strings.json`.

One possible issue - I don't know why the word "onkyo" in the service select is not capitalized?

Before (Developer Tools > Services tab):
<img width="796" alt="Screenshot 2023-10-20 at 9 54 30 AM" src="https://github.com/home-assistant/core/assets/1522068/645bc76f-fb72-41fe-811f-c4ac5a404230">


After:
<img width="774" alt="Screenshot 2023-10-20 at 9 55 41 AM" src="https://github.com/home-assistant/core/assets/1522068/a0e8ea3a-46ec-430d-8330-95a9c8295193">



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
