### PR TITLE
Avoid dispatching same state to passive bluetooth entities

### DIFF
--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -136,8 +136,12 @@ class PassiveBluetoothDataUpdate(Generic[_T]):
 
     def update(
         self, new_data: PassiveBluetoothDataUpdate[_T]
-    ) -> set[PassiveBluetoothEntityKey]:
-        """Update the data and returned changed PassiveBluetoothEntityKey."""
+    ) -> set[PassiveBluetoothEntityKey] | None:
+        """Update the data and returned changed PassiveBluetoothEntityKey or None on device change.
+
+        The changed PassiveBluetoothEntityKey can be used to filter
+        which listeners are called.
+        """
         device_change = False
         changed_entity_keys: set[PassiveBluetoothEntityKey] = set()
         for key, device_info in new_data.devices.items():
@@ -151,10 +155,12 @@ class PassiveBluetoothDataUpdate(Generic[_T]):
         ):
             # mypy can't seem to work this out
             for key, data in incoming.items():  # type: ignore[attr-defined]
-                if device_change or current.get(key) != data:  # type: ignore[attr-defined]
+                if current.get(key) != data:  # type: ignore[attr-defined]
                     changed_entity_keys.add(key)  # type: ignore[arg-type]
                 current[key] = data  # type: ignore[index]
-        return changed_entity_keys
+        # If the device changed we don't need to return the changed
+        # entity keys as all entities will be updated
+        return None if device_change else changed_entity_keys
 
     def async_get_restore_data(self) -> RestoredPassiveBluetoothDataUpdate:
         """Serialize restore data to storage."""

--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -147,7 +147,7 @@ class PassiveBluetoothDataUpdate(Generic[_T]):
         for key, device_info in new_data.devices.items():
             if device_change or self.devices.get(key) != device_info:
                 device_change = True
-            self.devices[key] = device_info
+                self.devices[key] = device_info
         for incoming, current in (
             (new_data.entity_descriptions, self.entity_descriptions),
             (new_data.entity_names, self.entity_names),
@@ -157,7 +157,7 @@ class PassiveBluetoothDataUpdate(Generic[_T]):
             for key, data in incoming.items():  # type: ignore[attr-defined]
                 if current.get(key) != data:  # type: ignore[attr-defined]
                     changed_entity_keys.add(key)  # type: ignore[arg-type]
-                current[key] = data  # type: ignore[index]
+                    current[key] = data  # type: ignore[index]
         # If the device changed we don't need to return the changed
         # entity keys as all entities will be updated
         return None if device_change else changed_entity_keys

--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -21,6 +21,7 @@ from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_platform import async_get_current_platform
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.storage import Store
+from homeassistant.helpers.typing import UNDEFINED
 from homeassistant.util.enum import try_parse_enum
 
 from .const import DOMAIN
@@ -145,7 +146,7 @@ class PassiveBluetoothDataUpdate(Generic[_T]):
         device_change = False
         changed_entity_keys: set[PassiveBluetoothEntityKey] = set()
         for key, device_info in new_data.devices.items():
-            if device_change or self.devices.get(key) != device_info:
+            if device_change or self.devices.get(key, UNDEFINED) != device_info:
                 device_change = True
                 self.devices[key] = device_info
         for incoming, current in (
@@ -155,7 +156,7 @@ class PassiveBluetoothDataUpdate(Generic[_T]):
         ):
             # mypy can't seem to work this out
             for key, data in incoming.items():  # type: ignore[attr-defined]
-                if current.get(key) != data:  # type: ignore[attr-defined]
+                if current.get(key, UNDEFINED) != data:  # type: ignore[attr-defined]
                     changed_entity_keys.add(key)  # type: ignore[arg-type]
                     current[key] = data  # type: ignore[index]
         # If the device changed we don't need to return the changed

--- a/tests/components/bluetooth/test_passive_update_processor.py
+++ b/tests/components/bluetooth/test_passive_update_processor.py
@@ -112,6 +112,34 @@ GENERIC_PASSIVE_BLUETOOTH_DATA_UPDATE = PassiveBluetoothDataUpdate(
     },
 )
 
+GENERIC_PASSIVE_BLUETOOTH_DATA_UPDATE_WITH_TEMP_CHANGE = PassiveBluetoothDataUpdate(
+    devices={
+        None: DeviceInfo(
+            name="Test Device", model="Test Model", manufacturer="Test Manufacturer"
+        ),
+    },
+    entity_data={
+        PassiveBluetoothEntityKey("temperature", None): 15.5,
+        PassiveBluetoothEntityKey("pressure", None): 1234,
+    },
+    entity_names={
+        PassiveBluetoothEntityKey("temperature", None): "Temperature",
+        PassiveBluetoothEntityKey("pressure", None): "Pressure",
+    },
+    entity_descriptions={
+        PassiveBluetoothEntityKey("temperature", None): SensorEntityDescription(
+            key="temperature",
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+            device_class=SensorDeviceClass.TEMPERATURE,
+        ),
+        PassiveBluetoothEntityKey("pressure", None): SensorEntityDescription(
+            key="pressure",
+            native_unit_of_measurement="hPa",
+            device_class=SensorDeviceClass.PRESSURE,
+        ),
+    },
+)
+
 
 async def test_basic_usage(
     hass: HomeAssistant,
@@ -189,8 +217,115 @@ async def test_basic_usage(
 
     inject_bluetooth_service_info(hass, GENERIC_BLUETOOTH_SERVICE_INFO_2)
 
+    # Only the all listener should receive the new data
+    # since temperature is not in the new data
+    assert len(entity_key_events) == 1
+    assert len(all_events) == 2
+
+    # On the second, the entities should already be created
+    # so the mock should not be called again
+    assert len(mock_entity.mock_calls) == 2
+
+    cancel_async_add_entity_key_listener()
+    cancel_listener()
+    cancel_async_add_entities_listener()
+
+    inject_bluetooth_service_info(hass, GENERIC_BLUETOOTH_SERVICE_INFO)
+
+    # Each listener should not trigger any more now
+    # that they were cancelled
+    assert len(entity_key_events) == 1
+    assert len(all_events) == 2
+    assert len(mock_entity.mock_calls) == 2
+    assert coordinator.available is True
+
+    unregister_processor()
+    cancel_coordinator()
+
+
+async def test_entity_key_is_dispatched_on_entity_key_change(
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
+    """Test entity key listeners are only dispatched on change."""
+    await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+    update_count = 0
+
+    @callback
+    def _mock_update_method(
+        service_info: BluetoothServiceInfo,
+    ) -> dict[str, str]:
+        return {"test": "data"}
+
+    @callback
+    def _async_generate_mock_data(
+        data: dict[str, str],
+    ) -> PassiveBluetoothDataUpdate:
+        """Generate mock data."""
+        assert data == {"test": "data"}
+        nonlocal update_count
+        update_count += 1
+        if update_count > 1:
+            return GENERIC_PASSIVE_BLUETOOTH_DATA_UPDATE_WITH_TEMP_CHANGE
+        return GENERIC_PASSIVE_BLUETOOTH_DATA_UPDATE
+
+    coordinator = PassiveBluetoothProcessorCoordinator(
+        hass,
+        _LOGGER,
+        "aa:bb:cc:dd:ee:ff",
+        BluetoothScanningMode.ACTIVE,
+        _mock_update_method,
+    )
+    assert coordinator.available is False  # no data yet
+
+    processor = PassiveBluetoothDataProcessor(_async_generate_mock_data)
+
+    unregister_processor = coordinator.async_register_processor(processor)
+    cancel_coordinator = coordinator.async_start()
+
+    entity_key = PassiveBluetoothEntityKey("temperature", None)
+    entity_key_events = []
+    all_events = []
+    mock_entity = MagicMock()
+    mock_add_entities = MagicMock()
+
+    def _async_entity_key_listener(data: PassiveBluetoothDataUpdate | None) -> None:
+        """Mock entity key listener."""
+        entity_key_events.append(data)
+
+    cancel_async_add_entity_key_listener = processor.async_add_entity_key_listener(
+        _async_entity_key_listener,
+        entity_key,
+    )
+
+    def _all_listener(data: PassiveBluetoothDataUpdate | None) -> None:
+        """Mock an all listener."""
+        all_events.append(data)
+
+    cancel_listener = processor.async_add_listener(
+        _all_listener,
+    )
+
+    cancel_async_add_entities_listener = processor.async_add_entities_listener(
+        mock_entity,
+        mock_add_entities,
+    )
+
+    inject_bluetooth_service_info(hass, GENERIC_BLUETOOTH_SERVICE_INFO)
+
     # Each listener should receive the same data
     # since both match
+    assert len(entity_key_events) == 1
+    assert len(all_events) == 1
+
+    # There should be 4 calls to create entities
+    assert len(mock_entity.mock_calls) == 2
+
+    inject_bluetooth_service_info(hass, GENERIC_BLUETOOTH_SERVICE_INFO_2)
+
+    # Both listeners should receive the new data
+    # since temperature IS in the new data
     assert len(entity_key_events) == 2
     assert len(all_events) == 2
 
@@ -897,9 +1032,9 @@ async def test_integration_with_entity(
     # Forth call with both primary and remote sensor entities does not add them again
     assert len(mock_add_entities.mock_calls) == 2
 
-    # should not have triggered the entity key listener since there
-    # there is an update with the entity key
-    assert len(entity_key_events) == 3
+    # should not have triggered the entity key listener humidity
+    # is not in the update
+    assert len(entity_key_events) == 2
 
     entities = [
         *mock_add_entities.mock_calls[0][1][0],


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We had a check to avoid dispatching to passive bluetooth entities when the entire advertisement had the same data, but since RSSI changes result in a change it was not very effective and resulted in far too many updates that had to be discarded. We now avoid dispatching to the specific entity key if the data for that entity key is the same between updates


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
