### PR TITLE
Add zwave_js thermostat operating state sensor

### DIFF
--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -38,6 +38,7 @@ from zwave_js_server.const.command_class.thermostat import (
     THERMOSTAT_FAN_MODE_PROPERTY,
     THERMOSTAT_MODE_PROPERTY,
     THERMOSTAT_SETPOINT_PROPERTY,
+    THERMOSTAT_OPERATING_STATE_PROPERTY,
 )
 from zwave_js_server.exceptions import UnknownValueData
 from zwave_js_server.model.device_class import DeviceClassItem
@@ -733,6 +734,16 @@ DISCOVERY_SCHEMAS = [
                 type={ValueType.NUMBER},
             ),
         ],
+    ),
+    # thermostat operating state
+    ZWaveDiscoverySchema(
+        platform=Platform.SENSOR,
+        hint="thermostat_opertating_state",
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.THERMOSTAT_OPERATING_STATE},
+            property={THERMOSTAT_OPERATING_STATE_PROPERTY},
+            type={ValueType.NUMBER},
+        ),
     ),
     # binary sensors
     # When CC is Sensor Binary and device class generic is Binary Sensor, entity should

--- a/tests/components/zwave_js/test_discovery.py
+++ b/tests/components/zwave_js/test_discovery.py
@@ -307,3 +307,4 @@ async def test_thermostat_operating_state(
 
     state = hass.states.get("sensor.adc_t3000_operating_state")
     assert state
+    assert state.state == "Idle"

--- a/tests/components/zwave_js/test_discovery.py
+++ b/tests/components/zwave_js/test_discovery.py
@@ -297,3 +297,13 @@ async def test_indicator_test(
         "propertyKey": "Switch",
     }
     assert args["value"] is False
+
+
+async def test_thermostat_operating_state(
+    hass: HomeAssistant, client, climate_adc_t3000, integration
+) -> None:
+    """Test that Thermostat Operating State sensor is discovered for climate_adc_t3000"""
+    node = climate_adc_t3000
+
+    state = hass.states.get("sensor.adc_t3000_operating_state")
+    assert state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The `Thermostat Operating State` Command Class reports the current operating state of the thermostat. This value is currently used to populate the `hvac_action` attribute of the `Platform.CLIMATE` entity created for the thermostats, but this translation is not one-to-one and discards some of the details found in the original value. Specifically, the `hvac_action` attribute does not distinguish between the different stages of heating and cooling on multi-stage hvac systems.

This PR adds discovery of a basic sensor with the original value of the `ThermostatOperatingState.Report`.

It was suggested on Discord that the new sensor should be made disabled by default. The code currently doesn't include this, but that's fine if the majority would prefer it that way.

I set the hint to "thermostat_operating_state", because I didn't know what a good name for it would be. The sensors.py file does not check for this value, because the desired result is for it to fall through to the base `ZwaveSensor`. @raman325 suggested that the sensor should be a `ZwaveListSensor`, but I don't think that's correct here. That class seems to be intended for the weird keyed values like the legacy `Alarm` Command class.

The code is currently NOT tested beyond the unit test I added. I don't have a setup for testing yet and wanted to get feedback on the "hint" and default enabled/disabled status.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
