### PR TITLE
Deprecate calendar.list_events

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -263,8 +263,8 @@ CALENDAR_EVENT_SCHEMA = vol.Schema(
 
 LEGACY_SERVICE_LIST_EVENTS: Final = "list_events"
 """Deprecated: please use SERVICE_LIST_EVENTS."""
-SERVICE_LIST_EVENTS: Final = "events"
-SERVICE_LIST_EVENTS_SCHEMA: Final = vol.All(
+SERVICE_GET_EVENTS: Final = "get_events"
+SERVICE_GET_EVENTS_SCHEMA: Final = vol.All(
     cv.has_at_least_one_key(EVENT_END_DATETIME, EVENT_DURATION),
     cv.has_at_most_one_key(EVENT_END_DATETIME, EVENT_DURATION),
     cv.make_entity_service_schema(
@@ -304,14 +304,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     )
     component.async_register_legacy_entity_service(
         LEGACY_SERVICE_LIST_EVENTS,
-        SERVICE_LIST_EVENTS_SCHEMA,
+        SERVICE_GET_EVENTS_SCHEMA,
         async_list_events_service,
         supports_response=SupportsResponse.ONLY,
     )
     component.async_register_entity_service(
-        SERVICE_LIST_EVENTS,
-        SERVICE_LIST_EVENTS_SCHEMA,
-        async_events_service,
+        SERVICE_GET_EVENTS,
+        SERVICE_GET_EVENTS_SCHEMA,
+        async_get_events_service,
         supports_response=SupportsResponse.ONLY,
     )
     await component.async_setup(config)
@@ -861,18 +861,17 @@ async def async_list_events_service(
 ) -> ServiceResponse:
     """List events on a calendar during a time range.
 
-    Deprecated: please use async_events_service.
+    Deprecated: please use async_get_events_service.
     """
     _LOGGER.warning(
         "Detected use of service 'calendar.list_events'. "
         "This is deprecated and will stop working in Home Assistant 2024.6. "
-        "Use calendar.events instead which supports multiple entities",
+        "Use calendar.get_events instead which supports multiple entities",
     )
+    return await async_get_events_service(calendar, service_call)
 
-    return await async_events_service(calendar, service_call)
 
-
-async def async_events_service(
+async def async_get_events_service(
     calendar: CalendarEntity, service_call: ServiceCall
 ) -> ServiceResponse:
     """List events on a calendar during a time range."""

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -874,7 +874,7 @@ async def async_list_events_service(
         DOMAIN,
         "deprecated_service_calendar_list_events",
         breaks_in_ha_version="2024.6.0",
-        is_fixable=False,
+        is_fixable=True,
         is_persistent=False,
         issue_domain=calendar.platform.platform_name,
         severity=IssueSeverity.WARNING,

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -37,6 +37,7 @@ from homeassistant.helpers.config_validation import (  # noqa: F401
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.event import async_track_point_in_time
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.template import DATE_STR_FORMAT
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import dt as dt_util
@@ -866,7 +867,18 @@ async def async_list_events_service(
     _LOGGER.warning(
         "Detected use of service 'calendar.list_events'. "
         "This is deprecated and will stop working in Home Assistant 2024.6. "
-        "Use calendar.get_events instead which supports multiple entities",
+        "Use 'calendar.get_events' instead which supports multiple entities",
+    )
+    async_create_issue(
+        calendar.hass,
+        DOMAIN,
+        "deprecated_service_calendar_list_events",
+        breaks_in_ha_version="2024.6.0",
+        is_fixable=False,
+        is_persistent=False,
+        issue_domain=calendar.platform.platform_name,
+        severity=IssueSeverity.WARNING,
+        translation_key="deprecated_service_calendar_list_events",
     )
     return await async_get_events_service(calendar, service_call)
 

--- a/homeassistant/components/calendar/services.yaml
+++ b/homeassistant/components/calendar/services.yaml
@@ -52,3 +52,19 @@ list_events:
     duration:
       selector:
         duration:
+get_events:
+  target:
+    entity:
+      domain: calendar
+  fields:
+    start_date_time:
+      example: "2022-03-22 20:00:00"
+      selector:
+        datetime:
+    end_date_time:
+      example: "2022-03-22 22:00:00"
+      selector:
+        datetime:
+    duration:
+      selector:
+        duration:

--- a/homeassistant/components/calendar/strings.json
+++ b/homeassistant/components/calendar/strings.json
@@ -94,7 +94,14 @@
   "issues": {
     "deprecated_service_calendar_list_events": {
       "title": "Detected use of deprecated service `calendar.list_events`",
-      "description": "Use `calendar.get_events` instead which supports multiple entities."
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "[%key:component::calendar::issues::deprecated_service_calendar_list_events::title%]",
+            "description": "Use `calendar.get_events` instead which supports multiple entities.\n\nPlease replace this service and adjust your automations and scripts and select **submit** to close this issue."
+          }
+        }
+      }
     }
   }
 }

--- a/homeassistant/components/calendar/strings.json
+++ b/homeassistant/components/calendar/strings.json
@@ -90,5 +90,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "deprecated_service_calendar_list_events": {
+      "title": "Detected use of deprecated service `calendar.list_events`",
+      "description": "Use `calendar.get_events` instead which supports multiple entities."
+    }
   }
 }

--- a/homeassistant/components/calendar/strings.json
+++ b/homeassistant/components/calendar/strings.json
@@ -72,9 +72,9 @@
         }
       }
     },
-    "list_events": {
-      "name": "List event",
-      "description": "Lists events on a calendar within a time range.",
+    "get_events": {
+      "name": "Get event",
+      "description": "Get events on a calendar within a time range.",
       "fields": {
         "start_date_time": {
           "name": "Start time",
@@ -87,6 +87,24 @@
         "duration": {
           "name": "Duration",
           "description": "Returns active events from start_date_time until the specified duration."
+        }
+      }
+    },
+    "list_events": {
+      "name": "List event",
+      "description": "Lists events on a calendar within a time range.",
+      "fields": {
+        "start_date_time": {
+          "name": "[%key:component::calendar::services::get_events::fields::start_date_time::name%]",
+          "description": "[%key:component::calendar::services::get_events::fields::start_date_time::description%]"
+        },
+        "end_date_time": {
+          "name": "[%key:component::calendar::services::get_events::fields::end_date_time::name%]",
+          "description": "[%key:component::calendar::services::get_events::fields::end_date_time::description%]"
+        },
+        "duration": {
+          "name": "[%key:component::calendar::services::get_events::fields::duration::name%]",
+          "description": "[%key:component::calendar::services::get_events::fields::duration::description%]"
         }
       }
     }

--- a/tests/components/calendar/snapshots/test_init.ambr
+++ b/tests/components/calendar/snapshots/test_init.ambr
@@ -1,7 +1,49 @@
 # serializer version: 1
+# name: test_list_events_service_duration[calendar.calendar_1-00:15:00-events]
+  dict({
+    'calendar.calendar_1': dict({
+      'events': list([
+      ]),
+    }),
+  })
+# ---
+# name: test_list_events_service_duration[calendar.calendar_1-00:15:00-list_events]
+  dict({
+    'events': list([
+    ]),
+  })
+# ---
 # name: test_list_events_service_duration[calendar.calendar_1-00:15:00]
   dict({
     'events': list([
+    ]),
+  })
+# ---
+# name: test_list_events_service_duration[calendar.calendar_1-01:00:00-events]
+  dict({
+    'calendar.calendar_1': dict({
+      'events': list([
+        dict({
+          'description': 'Future Description',
+          'end': '2023-10-19T08:20:05-07:00',
+          'location': 'Future Location',
+          'start': '2023-10-19T07:20:05-07:00',
+          'summary': 'Future Event',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_list_events_service_duration[calendar.calendar_1-01:00:00-list_events]
+  dict({
+    'events': list([
+      dict({
+        'description': 'Future Description',
+        'end': '2023-10-19T08:20:05-07:00',
+        'location': 'Future Location',
+        'start': '2023-10-19T07:20:05-07:00',
+        'summary': 'Future Event',
+      }),
     ]),
   })
 # ---
@@ -14,6 +56,30 @@
         'location': 'Future Location',
         'start': '2023-10-19T07:20:05-07:00',
         'summary': 'Future Event',
+      }),
+    ]),
+  })
+# ---
+# name: test_list_events_service_duration[calendar.calendar_2-00:15:00-events]
+  dict({
+    'calendar.calendar_2': dict({
+      'events': list([
+        dict({
+          'end': '2023-10-19T07:20:05-07:00',
+          'start': '2023-10-19T06:20:05-07:00',
+          'summary': 'Current Event',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_list_events_service_duration[calendar.calendar_2-00:15:00-list_events]
+  dict({
+    'events': list([
+      dict({
+        'end': '2023-10-19T07:20:05-07:00',
+        'start': '2023-10-19T06:20:05-07:00',
+        'summary': 'Current Event',
       }),
     ]),
   })

--- a/tests/components/calendar/snapshots/test_init.ambr
+++ b/tests/components/calendar/snapshots/test_init.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_list_events_service_duration[calendar.calendar_1-00:15:00-events]
+# name: test_list_events_service_duration[calendar.calendar_1-00:15:00-get_events]
   dict({
     'calendar.calendar_1': dict({
       'events': list([
@@ -13,13 +13,7 @@
     ]),
   })
 # ---
-# name: test_list_events_service_duration[calendar.calendar_1-00:15:00]
-  dict({
-    'events': list([
-    ]),
-  })
-# ---
-# name: test_list_events_service_duration[calendar.calendar_1-01:00:00-events]
+# name: test_list_events_service_duration[calendar.calendar_1-01:00:00-get_events]
   dict({
     'calendar.calendar_1': dict({
       'events': list([
@@ -47,20 +41,7 @@
     ]),
   })
 # ---
-# name: test_list_events_service_duration[calendar.calendar_1-01:00:00]
-  dict({
-    'events': list([
-      dict({
-        'description': 'Future Description',
-        'end': '2023-10-19T08:20:05-07:00',
-        'location': 'Future Location',
-        'start': '2023-10-19T07:20:05-07:00',
-        'summary': 'Future Event',
-      }),
-    ]),
-  })
-# ---
-# name: test_list_events_service_duration[calendar.calendar_2-00:15:00-events]
+# name: test_list_events_service_duration[calendar.calendar_2-00:15:00-get_events]
   dict({
     'calendar.calendar_2': dict({
       'events': list([
@@ -74,17 +55,6 @@
   })
 # ---
 # name: test_list_events_service_duration[calendar.calendar_2-00:15:00-list_events]
-  dict({
-    'events': list([
-      dict({
-        'end': '2023-10-19T07:20:05-07:00',
-        'start': '2023-10-19T06:20:05-07:00',
-        'summary': 'Current Event',
-      }),
-    ]),
-  })
-# ---
-# name: test_list_events_service_duration[calendar.calendar_2-00:15:00]
   dict({
     'events': list([
       dict({

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -15,7 +15,7 @@ from homeassistant.bootstrap import async_setup_component
 from homeassistant.components.calendar import (
     DOMAIN,
     LEGACY_SERVICE_LIST_EVENTS,
-    SERVICE_LIST_EVENTS,
+    SERVICE_GET_EVENTS,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -411,7 +411,7 @@ async def test_create_event_service_invalid_params(
             },
         ),
         (
-            SERVICE_LIST_EVENTS,
+            SERVICE_GET_EVENTS,
             {
                 "calendar.calendar_1": {
                     "events": [
@@ -472,7 +472,7 @@ async def test_list_events_service(
     ("service"),
     [
         (LEGACY_SERVICE_LIST_EVENTS),
-        (SERVICE_LIST_EVENTS),
+        SERVICE_GET_EVENTS,
     ],
 )
 @pytest.mark.parametrize(
@@ -519,7 +519,7 @@ async def test_list_events_positive_duration(hass: HomeAssistant) -> None:
     with pytest.raises(vol.Invalid, match="should be positive"):
         await hass.services.async_call(
             DOMAIN,
-            SERVICE_LIST_EVENTS,
+            SERVICE_GET_EVENTS,
             {
                 "entity_id": "calendar.calendar_1",
                 "duration": "-01:00:00",
@@ -539,7 +539,7 @@ async def test_list_events_exclusive_fields(hass: HomeAssistant) -> None:
     with pytest.raises(vol.Invalid, match="at most one of"):
         await hass.services.async_call(
             DOMAIN,
-            SERVICE_LIST_EVENTS,
+            SERVICE_GET_EVENTS,
             {
                 "entity_id": "calendar.calendar_1",
                 "end_date_time": end,
@@ -558,7 +558,7 @@ async def test_list_events_missing_fields(hass: HomeAssistant) -> None:
     with pytest.raises(vol.Invalid, match="at least one of"):
         await hass.services.async_call(
             DOMAIN,
-            SERVICE_LIST_EVENTS,
+            SERVICE_GET_EVENTS,
             {
                 "entity_id": "calendar.calendar_1",
             },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
`calendar.list_events` uses an outdated response data format It is deprecated and will be removed in 2024.6.
Please use `calendar.get_events` which supports multiple entities instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As discussed in https://github.com/home-assistant/architecture/discussions/948.

Deprecates `calendar.list_events` and introduces new service `calendar.get_events` with the new response format instead.

Depends on: #96370

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
