### PR TITLE
Change ZHA Tuya plugs to use quirk IDs

### DIFF
--- a/homeassistant/components/zha/core/cluster_handlers/general.py
+++ b/homeassistant/components/zha/core/cluster_handlers/general.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections.abc import Coroutine
 from typing import TYPE_CHECKING, Any
 
+from zhaquirks.quirk_ids import TUYA_PLUG_ONOFF
 import zigpy.exceptions
 import zigpy.types as t
 import zigpy.zcl
@@ -347,26 +348,10 @@ class OnOffClusterHandler(ClusterHandler):
         super().__init__(cluster, endpoint)
         self._off_listener = None
 
-        if self.cluster.endpoint.model not in (
-            "TS011F",
-            "TS0121",
-            "TS0001",
-            "TS0002",
-            "TS0003",
-            "TS0004",
-        ):
-            return
-
-        try:
-            self.cluster.find_attribute("backlight_mode")
-        except KeyError:
-            return
-
-        self.ZCL_INIT_ATTRS = self.ZCL_INIT_ATTRS.copy()
-        self.ZCL_INIT_ATTRS["backlight_mode"] = True
-        self.ZCL_INIT_ATTRS["power_on_state"] = True
-
-        if self.cluster.endpoint.model == "TS011F":
+        if endpoint.device.quirk_id == TUYA_PLUG_ONOFF:
+            self.ZCL_INIT_ATTRS = self.ZCL_INIT_ATTRS.copy()
+            self.ZCL_INIT_ATTRS["backlight_mode"] = True
+            self.ZCL_INIT_ATTRS["power_on_state"] = True
             self.ZCL_INIT_ATTRS["child_lock"] = True
 
     @classmethod

--- a/homeassistant/components/zha/core/cluster_handlers/manufacturerspecific.py
+++ b/homeassistant/components/zha/core/cluster_handlers/manufacturerspecific.py
@@ -5,6 +5,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from zhaquirks.inovelli.types import AllLEDEffectType, SingleLEDEffectType
+from zhaquirks.quirk_ids import TUYA_PLUG_MANUFACTURER
 import zigpy.zcl
 
 from homeassistant.core import callback
@@ -72,25 +73,7 @@ class TuyaClusterHandler(ClusterHandler):
     def __init__(self, cluster: zigpy.zcl.Cluster, endpoint: Endpoint) -> None:
         """Initialize TuyaClusterHandler."""
         super().__init__(cluster, endpoint)
-
-        if self.cluster.endpoint.manufacturer in (
-            "_TZE200_7tdtqgwv",
-            "_TZE200_amp6tsvy",
-            "_TZE200_oisqyl4o",
-            "_TZE200_vhy3iakz",
-            "_TZ3000_uim07oem",
-            "_TZE200_wfxuhoea",
-            "_TZE200_tviaymwx",
-            "_TZE200_g1ib5ldv",
-            "_TZE200_wunufsil",
-            "_TZE200_7deq70b8",
-            "_TZE200_tz32mtza",
-            "_TZE200_2hf7x9n3",
-            "_TZE200_aqnazj70",
-            "_TZE200_1ozguk6x",
-            "_TZE200_k6jhsr0q",
-            "_TZE200_9mahtqtg",
-        ):
+        if endpoint.device.quirk_id == TUYA_PLUG_MANUFACTURER:
             self.ZCL_INIT_ATTRS = {
                 "backlight_mode": True,
                 "power_on_state": True,

--- a/homeassistant/components/zha/select.py
+++ b/homeassistant/components/zha/select.py
@@ -6,6 +6,7 @@ import functools
 import logging
 from typing import TYPE_CHECKING, Any, Self
 
+from zhaquirks.quirk_ids import TUYA_PLUG_MANUFACTURER, TUYA_PLUG_ONOFF
 from zigpy import types
 from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.clusters.security import IasWd
@@ -246,29 +247,10 @@ class TuyaPowerOnState(types.enum8):
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
-    cluster_handler_names=CLUSTER_HANDLER_ON_OFF,
-    models={"TS011F", "TS0121", "TS0001", "TS0002", "TS0003", "TS0004"},
+    cluster_handler_names=CLUSTER_HANDLER_ON_OFF, quirk_ids=TUYA_PLUG_ONOFF
 )
 @CONFIG_DIAGNOSTIC_MATCH(
-    cluster_handler_names="tuya_manufacturer",
-    manufacturers={
-        "_TZE200_7tdtqgwv",
-        "_TZE200_amp6tsvy",
-        "_TZE200_oisqyl4o",
-        "_TZE200_vhy3iakz",
-        "_TZ3000_uim07oem",
-        "_TZE200_wfxuhoea",
-        "_TZE200_tviaymwx",
-        "_TZE200_g1ib5ldv",
-        "_TZE200_wunufsil",
-        "_TZE200_7deq70b8",
-        "_TZE200_tz32mtza",
-        "_TZE200_2hf7x9n3",
-        "_TZE200_aqnazj70",
-        "_TZE200_1ozguk6x",
-        "_TZE200_k6jhsr0q",
-        "_TZE200_9mahtqtg",
-    },
+    cluster_handler_names="tuya_manufacturer", quirk_ids=TUYA_PLUG_MANUFACTURER
 )
 class TuyaPowerOnStateSelectEntity(ZCLEnumSelectEntity):
     """Representation of a ZHA power on state select entity."""
@@ -288,8 +270,7 @@ class TuyaBacklightMode(types.enum8):
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
-    cluster_handler_names=CLUSTER_HANDLER_ON_OFF,
-    models={"TS011F", "TS0121", "TS0001", "TS0002", "TS0003", "TS0004"},
+    cluster_handler_names=CLUSTER_HANDLER_ON_OFF, quirk_ids=TUYA_PLUG_ONOFF
 )
 class TuyaBacklightModeSelectEntity(ZCLEnumSelectEntity):
     """Representation of a ZHA backlight mode select entity."""
@@ -310,25 +291,7 @@ class MoesBacklightMode(types.enum8):
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
-    cluster_handler_names="tuya_manufacturer",
-    manufacturers={
-        "_TZE200_7tdtqgwv",
-        "_TZE200_amp6tsvy",
-        "_TZE200_oisqyl4o",
-        "_TZE200_vhy3iakz",
-        "_TZ3000_uim07oem",
-        "_TZE200_wfxuhoea",
-        "_TZE200_tviaymwx",
-        "_TZE200_g1ib5ldv",
-        "_TZE200_wunufsil",
-        "_TZE200_7deq70b8",
-        "_TZE200_tz32mtza",
-        "_TZE200_2hf7x9n3",
-        "_TZE200_aqnazj70",
-        "_TZE200_1ozguk6x",
-        "_TZE200_k6jhsr0q",
-        "_TZE200_9mahtqtg",
-    },
+    cluster_handler_names="tuya_manufacturer", quirk_ids=TUYA_PLUG_MANUFACTURER
 )
 class MoesBacklightModeSelectEntity(ZCLEnumSelectEntity):
     """Moes devices have a different backlight mode select options."""

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -5,6 +5,7 @@ import functools
 import logging
 from typing import TYPE_CHECKING, Any, Self
 
+from zhaquirks.quirk_ids import TUYA_PLUG_ONOFF
 from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.foundation import Status
 
@@ -488,8 +489,7 @@ class AqaraPetFeederChildLock(ZHASwitchConfigurationEntity):
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
-    cluster_handler_names=CLUSTER_HANDLER_ON_OFF,
-    models={"TS011F"},
+    cluster_handler_names=CLUSTER_HANDLER_ON_OFF, quirk_ids=TUYA_PLUG_ONOFF
 )
 class TuyaChildLockSwitch(ZHASwitchConfigurationEntity):
     """Representation of a child lock configuration entity."""


### PR DESCRIPTION
## Proposed change
This implements using quirk IDs for configurable Tuya plugs.

The main purpose is to not duplicate manufacturer/model names in both ZHA and zha-quirks.
For example, there are many different versions of the Tuya TS011F plug. Each version requires a (slightly new) quirk.
With this PR, it'll be enough to create a new quirk in zha-quirks with the same quirk ID.

This fixes issues like: https://github.com/home-assistant/core/issues/82108 (and others that aren't listed here where plugs don't have a quirk yet, but ZHA still tries to initialize the custom attributes which don't exist).
So this PR is both a bug-fix and an improvement to code quality.

(In the future, more existing "devices" can be switched to using quirk IDs.)

## Tested

Tested these changes with a BlitzWolf SHP-13 (`_TZ3000_g5xawfcq` / `TS0121`) plug and they seem to be working as expected.
The `child_lock` entity isn't created for this plug, as the devices report that it's an "unsupported attribute" upon initialization of the plug (expected/good).
(That plug model uses the configuration attributes on the `OnOff` cluster.)

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue) (fixes issues from previous implementation)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests (<- original goal)

## Additional information
- This PR fixes or closes issue: fixes #82108
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
