### PR TITLE
Override the `async_update()` method for Shelly sleeping devices

### DIFF
--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -618,6 +618,13 @@ class ShellySleepingBlockAttributeEntity(ShellyBlockAttributeEntity):
                 super()._update_callback()
                 return
 
+    async def async_update(self) -> None:
+        """Update the entity."""
+        LOGGER.warning(
+            "Entity %s comes from a sleeping device, update is not possible",
+            self.entity_id,
+        )
+
 
 class ShellySleepingRpcAttributeEntity(ShellyRpcAttributeEntity):
     """Helper class to represent a sleeping rpc attribute."""
@@ -654,3 +661,10 @@ class ShellySleepingRpcAttributeEntity(ShellyRpcAttributeEntity):
             )
         elif entry is not None:
             self._attr_name = cast(str, entry.original_name)
+
+    async def async_update(self) -> None:
+        """Update the entity."""
+        LOGGER.warning(
+            "Entity %s comes from a sleeping device, update is not possible",
+            self.entity_id,
+        )

--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -620,7 +620,7 @@ class ShellySleepingBlockAttributeEntity(ShellyBlockAttributeEntity):
 
     async def async_update(self) -> None:
         """Update the entity."""
-        LOGGER.warning(
+        LOGGER.info(
             "Entity %s comes from a sleeping device, update is not possible",
             self.entity_id,
         )
@@ -664,7 +664,7 @@ class ShellySleepingRpcAttributeEntity(ShellyRpcAttributeEntity):
 
     async def async_update(self) -> None:
         """Update the entity."""
-        LOGGER.warning(
+        LOGGER.info(
             "Entity %s comes from a sleeping device, update is not possible",
             self.entity_id,
         )

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -1,9 +1,15 @@
 """Tests for Shelly sensor platform."""
 from freezegun.api import FrozenDateTimeFactory
+import pytest
 
+from homeassistant.components.homeassistant import (
+    DOMAIN as HA_DOMAIN,
+    SERVICE_UPDATE_ENTITY,
+)
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.shelly.const import DOMAIN
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     ATTR_UNIT_OF_MEASUREMENT,
     PERCENTAGE,
     STATE_UNAVAILABLE,
@@ -12,6 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.entity_registry import async_get
+from homeassistant.setup import async_setup_component
 
 from . import (
     init_integration,
@@ -448,3 +455,76 @@ async def test_rpc_em1_sensors(
     entry = registry.async_get("sensor.test_name_em1_total_active_energy")
     assert entry
     assert entry.unique_id == "123456789ABC-em1data:1-total_act_energy"
+
+
+async def test_rpc_sleeping_update_entity_service(
+    hass: HomeAssistant, mock_rpc_device, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test RPC sleeping device when the update_entity service is used."""
+    await async_setup_component(hass, "homeassistant", {})
+
+    entity_id = f"{SENSOR_DOMAIN}.test_name_temperature"
+    await init_integration(hass, 2, sleep_period=1000)
+
+    # Entity should be created when device is online
+    assert hass.states.get(entity_id) is None
+
+    # Make device online
+    mock_rpc_device.mock_update()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == "22.9"
+
+    await hass.services.async_call(
+        HA_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        service_data={ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    # Entity should be available after update_entity service call
+    state = hass.states.get(entity_id)
+    assert state.state == "22.9"
+
+    assert (
+        "Entity sensor.test_name_temperature comes from a sleeping device"
+        in caplog.text
+    )
+
+
+async def test_block_sleeping_update_entity_service(
+    hass: HomeAssistant, mock_block_device, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test block sleeping device when the update_entity service is used."""
+    await async_setup_component(hass, "homeassistant", {})
+
+    entity_id = f"{SENSOR_DOMAIN}.test_name_temperature"
+    await init_integration(hass, 1, sleep_period=1000)
+
+    # Sensor should be created when device is online
+    assert hass.states.get(entity_id) is None
+
+    # Make device online
+    mock_block_device.mock_update()
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == "22.1"
+
+    await hass.services.async_call(
+        HA_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        service_data={ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    # Entity should be available after update_entity service call
+    state = hass.states.get(entity_id)
+    assert state.state == "22.1"
+
+    assert (
+        "Entity sensor.test_name_temperature comes from a sleeping device"
+        in caplog.text
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, if you use the `homeassistant.update_entity` method for an entity of a sleeping device (which cannot respond) it ends with `UpdateFailed` and all entities of this device are marked as unavailable.

With this change, the device entities will remain available, and information will be sent to the log that an update is not possible for this entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #101570
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29526

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
