### PR TITLE
2023.10.5

### DIFF
--- a/homeassistant/components/dlna_dmr/manifest.json
+++ b/homeassistant/components/dlna_dmr/manifest.json
@@ -8,7 +8,7 @@
   "documentation": "https://www.home-assistant.io/integrations/dlna_dmr",
   "iot_class": "local_push",
   "loggers": ["async_upnp_client"],
-  "requirements": ["async-upnp-client==0.36.1", "getmac==0.8.2"],
+  "requirements": ["async-upnp-client==0.36.2", "getmac==0.8.2"],
   "ssdp": [
     {
       "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:1",

--- a/homeassistant/components/dlna_dms/manifest.json
+++ b/homeassistant/components/dlna_dms/manifest.json
@@ -8,7 +8,7 @@
   "documentation": "https://www.home-assistant.io/integrations/dlna_dms",
   "iot_class": "local_polling",
   "quality_scale": "platinum",
-  "requirements": ["async-upnp-client==0.36.1"],
+  "requirements": ["async-upnp-client==0.36.2"],
   "ssdp": [
     {
       "deviceType": "urn:schemas-upnp-org:device:MediaServer:1",

--- a/homeassistant/components/samsungtv/manifest.json
+++ b/homeassistant/components/samsungtv/manifest.json
@@ -39,7 +39,7 @@
     "samsungctl[websocket]==0.7.1",
     "samsungtvws[async,encrypted]==2.6.0",
     "wakeonlan==2.1.0",
-    "async-upnp-client==0.36.1"
+    "async-upnp-client==0.36.2"
   ],
   "ssdp": [
     {

--- a/homeassistant/components/ssdp/manifest.json
+++ b/homeassistant/components/ssdp/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "loggers": ["async_upnp_client"],
   "quality_scale": "internal",
-  "requirements": ["async-upnp-client==0.36.1"]
+  "requirements": ["async-upnp-client==0.36.2"]
 }

--- a/homeassistant/components/upnp/manifest.json
+++ b/homeassistant/components/upnp/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["async_upnp_client"],
-  "requirements": ["async-upnp-client==0.36.1", "getmac==0.8.2"],
+  "requirements": ["async-upnp-client==0.36.2", "getmac==0.8.2"],
   "ssdp": [
     {
       "st": "urn:schemas-upnp-org:device:InternetGatewayDevice:1"

--- a/homeassistant/components/yeelight/manifest.json
+++ b/homeassistant/components/yeelight/manifest.json
@@ -17,7 +17,7 @@
   "iot_class": "local_push",
   "loggers": ["async_upnp_client", "yeelight"],
   "quality_scale": "platinum",
-  "requirements": ["yeelight==0.7.13", "async-upnp-client==0.36.1"],
+  "requirements": ["yeelight==0.7.13", "async-upnp-client==0.36.2"],
   "zeroconf": [
     {
       "type": "_miio._udp.local.",

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,7 +21,7 @@
     "universal_silabs_flasher"
   ],
   "requirements": [
-    "bellows==0.36.7",
+    "bellows==0.36.5",
     "pyserial==3.5",
     "pyserial-asyncio==0.6",
     "zha-quirks==0.0.105",

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -7,7 +7,7 @@ from typing import Final
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2023
 MINOR_VERSION: Final = 10
-PATCH_VERSION: Final = "4"
+PATCH_VERSION: Final = "5"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 11, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -2,7 +2,7 @@ aiodiscover==1.5.1
 aiohttp==3.8.5
 aiohttp_cors==0.7.0
 astral==2.2
-async-upnp-client==0.36.1
+async-upnp-client==0.36.2
 atomicwrites-homeassistant==1.4.1
 attrs==23.1.0
 awesomeversion==23.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2023.10.4"
+version     = "2023.10.5"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -512,7 +512,7 @@ beautifulsoup4==4.12.2
 # beewi-smartclim==0.0.10
 
 # homeassistant.components.zha
-bellows==0.36.7
+bellows==0.36.5
 
 # homeassistant.components.bmw_connected_drive
 bimmer-connected==0.14.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -458,7 +458,7 @@ async-interrupt==1.1.1
 # homeassistant.components.ssdp
 # homeassistant.components.upnp
 # homeassistant.components.yeelight
-async-upnp-client==0.36.1
+async-upnp-client==0.36.2
 
 # homeassistant.components.keyboard_remote
 asyncinotify==4.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -436,7 +436,7 @@ base36==0.1.1
 beautifulsoup4==4.12.2
 
 # homeassistant.components.zha
-bellows==0.36.7
+bellows==0.36.5
 
 # homeassistant.components.bmw_connected_drive
 bimmer-connected==0.14.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -412,7 +412,7 @@ async-interrupt==1.1.1
 # homeassistant.components.ssdp
 # homeassistant.components.upnp
 # homeassistant.components.yeelight
-async-upnp-client==0.36.1
+async-upnp-client==0.36.2
 
 # homeassistant.components.sleepiq
 asyncsleepiq==1.3.7


### PR DESCRIPTION
- Downgrade ZHA dependency bellows ([@puddly] - [#102471]) ([zha docs])
- Bump async-upnp-client to 0.36.2 ([@StevenLooman] - [#102472]) ([upnp docs]) ([yeelight docs]) ([dlna_dmr docs]) ([samsungtv docs]) ([ssdp docs]) ([dlna_dms docs]) (dependency)

[#101386]: https://github.com/home-assistant/core/pull/101386
[#101547]: https://github.com/home-assistant/core/pull/101547
[#101871]: https://github.com/home-assistant/core/pull/101871
[#101930]: https://github.com/home-assistant/core/pull/101930
[#102397]: https://github.com/home-assistant/core/pull/102397
[#102471]: https://github.com/home-assistant/core/pull/102471
[#102472]: https://github.com/home-assistant/core/pull/102472
[@StevenLooman]: https://github.com/StevenLooman
[@frenck]: https://github.com/frenck
[@puddly]: https://github.com/puddly
[advantage_air docs]: https://www.home-assistant.io/integrations/advantage_air/
[aemet docs]: https://www.home-assistant.io/integrations/aemet/
[aftership docs]: https://www.home-assistant.io/integrations/aftership/
[airly docs]: https://www.home-assistant.io/integrations/airly/
[dlna_dmr docs]: https://www.home-assistant.io/integrations/dlna_dmr/
[dlna_dms docs]: https://www.home-assistant.io/integrations/dlna_dms/
[reolink docs]: https://www.home-assistant.io/integrations/reolink/
[samsungtv docs]: https://www.home-assistant.io/integrations/samsungtv/
[sensibo docs]: https://www.home-assistant.io/integrations/sensibo/
[ssdp docs]: https://www.home-assistant.io/integrations/ssdp/
[upnp docs]: https://www.home-assistant.io/integrations/upnp/
[wiz docs]: https://www.home-assistant.io/integrations/wiz/
[yeelight docs]: https://www.home-assistant.io/integrations/yeelight/
[zha docs]: https://www.home-assistant.io/integrations/zha/

Docs PR: <https://github.com/home-assistant/home-assistant.io/pull/29467>