### PR TITLE
Add `number` state to prometheus metrics

### DIFF
--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -353,7 +353,7 @@ class PrometheusMetrics:
         value = self.state_as_number(state)
         metric.labels(**self._labels(state)).set(value)
 
-    def _numereric_handler(self, state, domain, title):
+    def _numeric_handler(self, state, domain, title):
         if unit := self._unit_string(state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)):
             metric = self._metric(
                 f"{domain}_state_{unit}",
@@ -379,10 +379,10 @@ class PrometheusMetrics:
             metric.labels(**self._labels(state)).set(value)
 
     def _handle_input_number(self, state):
-        self._numereric_handler(state, "input_number", "input number")
+        self._numeric_handler(state, "input_number", "input number")
 
     def _handle_number(self, state):
-        self._numereric_handler(state, "number", "number")
+        self._numeric_handler(state, "number", "number")
 
     def _handle_device_tracker(self, state):
         metric = self._metric(

--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -378,6 +378,31 @@ class PrometheusMetrics:
                 )
             metric.labels(**self._labels(state)).set(value)
 
+    def _handle_number(self, state):
+        if unit := self._unit_string(state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)):
+            metric = self._metric(
+                f"number_state_{unit}",
+                self.prometheus_cli.Gauge,
+                f"State of the number measured in {unit}",
+            )
+        else:
+            metric = self._metric(
+                "number_state",
+                self.prometheus_cli.Gauge,
+                "State of the number",
+            )
+
+        with suppress(ValueError):
+            value = self.state_as_number(state)
+            if (
+                state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+                == UnitOfTemperature.FAHRENHEIT
+            ):
+                value = TemperatureConverter.convert(
+                    value, UnitOfTemperature.FAHRENHEIT, UnitOfTemperature.CELSIUS
+                )
+            metric.labels(**self._labels(state)).set(value)
+
     def _handle_device_tracker(self, state):
         metric = self._metric(
             "device_tracker_state",

--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -353,18 +353,18 @@ class PrometheusMetrics:
         value = self.state_as_number(state)
         metric.labels(**self._labels(state)).set(value)
 
-    def _handle_input_number(self, state):
+    def _numereric_handler(self, state, domain, title):
         if unit := self._unit_string(state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)):
             metric = self._metric(
-                f"input_number_state_{unit}",
+                f"{domain}_state_{unit}",
                 self.prometheus_cli.Gauge,
-                f"State of the input number measured in {unit}",
+                f"State of the {title} measured in {unit}",
             )
         else:
             metric = self._metric(
-                "input_number_state",
+                f"{domain}_state",
                 self.prometheus_cli.Gauge,
-                "State of the input number",
+                f"State of the {title}",
             )
 
         with suppress(ValueError):
@@ -377,31 +377,12 @@ class PrometheusMetrics:
                     value, UnitOfTemperature.FAHRENHEIT, UnitOfTemperature.CELSIUS
                 )
             metric.labels(**self._labels(state)).set(value)
+
+    def _handle_input_number(self, state):
+        self._numereric_handler(state, "input_number", "input number")
 
     def _handle_number(self, state):
-        if unit := self._unit_string(state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)):
-            metric = self._metric(
-                f"number_state_{unit}",
-                self.prometheus_cli.Gauge,
-                f"State of the number measured in {unit}",
-            )
-        else:
-            metric = self._metric(
-                "number_state",
-                self.prometheus_cli.Gauge,
-                "State of the number",
-            )
-
-        with suppress(ValueError):
-            value = self.state_as_number(state)
-            if (
-                state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-                == UnitOfTemperature.FAHRENHEIT
-            ):
-                value = TemperatureConverter.convert(
-                    value, UnitOfTemperature.FAHRENHEIT, UnitOfTemperature.CELSIUS
-                )
-            metric.labels(**self._labels(state)).set(value)
+        self._numereric_handler(state, "number", "number")
 
     def _handle_device_tracker(self, state):
         metric = self._metric(

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -18,6 +18,7 @@ from homeassistant.components import (
     humidifier,
     input_boolean,
     input_number,
+    number,
     light,
     lock,
     person,
@@ -288,6 +289,30 @@ async def test_input_number(client, input_number_entities) -> None:
     assert (
         'input_number_state_celsius{domain="input_number",'
         'entity="input_number.target_temperature",'
+        'friendly_name="Target temperature"} 22.7' in body
+    )
+
+
+@pytest.mark.parametrize("namespace", [""])
+async def test_number(client, number_entities) -> None:
+    """Test prometheus metrics for number."""
+    body = await generate_latest_metrics(client)
+
+    assert (
+        'number_state{domain="number",'
+        'entity="number.threshold",'
+        'friendly_name="Threshold"} 5.2' in body
+    )
+
+    assert (
+        'number_state{domain="number",'
+        'entity="number.brightness",'
+        'friendly_name="None"} 60.0' in body
+    )
+
+    assert (
+        'number_state_celsius{domain="number",'
+        'entity="number.target_temperature",'
         'friendly_name="Target temperature"} 22.7' in body
     )
 

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -18,9 +18,9 @@ from homeassistant.components import (
     humidifier,
     input_boolean,
     input_number,
-    number,
     light,
     lock,
+    number,
     person,
     prometheus,
     sensor,
@@ -1402,6 +1402,46 @@ async def input_number_fixture(
     )
     set_state_with_entry(hass, input_number_3, 22.7)
     data["input_number_3"] = input_number_3
+
+    await hass.async_block_till_done()
+    return data
+
+
+@pytest.fixture(name="number_entities")
+async def number_fixture(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> dict[str, er.RegistryEntry]:
+    """Simulate number entities."""
+    data = {}
+    number_1 = entity_registry.async_get_or_create(
+        domain=number.DOMAIN,
+        platform="test",
+        unique_id="number_1",
+        suggested_object_id="threshold",
+        original_name="Threshold",
+    )
+    set_state_with_entry(hass, number_1, 5.2)
+    data["number_1"] = number_1
+
+    number_2 = entity_registry.async_get_or_create(
+        domain=number.DOMAIN,
+        platform="test",
+        unique_id="number_2",
+        suggested_object_id="brightness",
+    )
+    set_state_with_entry(hass, number_2, 60)
+    data["number_2"] = number_2
+
+    number_3 = entity_registry.async_get_or_create(
+        domain=number.DOMAIN,
+        platform="test",
+        unique_id="number_3",
+        suggested_object_id="target_temperature",
+        original_name="Target temperature",
+        unit_of_measurement=UnitOfTemperature.CELSIUS,
+    )
+    set_state_with_entry(hass, number_3, 22.7)
+    data["number_3"] = number_3
 
     await hass.async_block_till_done()
     return data


### PR DESCRIPTION
## Proposed change
The prometheus integration exposes `input_number` but not `number`.
This pull request adds the state of `number` entities to the prometheus metrics.
The new metric can be found under `<namespace>_number_state`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #102276 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
