### PR TITLE
Correct range for nibe_heatpump numbers

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -827,7 +827,6 @@ omit =
     homeassistant/components/nibe_heatpump/__init__.py
     homeassistant/components/nibe_heatpump/climate.py
     homeassistant/components/nibe_heatpump/binary_sensor.py
-    homeassistant/components/nibe_heatpump/number.py
     homeassistant/components/nibe_heatpump/select.py
     homeassistant/components/nibe_heatpump/sensor.py
     homeassistant/components/nibe_heatpump/switch.py

--- a/homeassistant/components/nibe_heatpump/number.py
+++ b/homeassistant/components/nibe_heatpump/number.py
@@ -50,6 +50,8 @@ class Number(CoilEntity, NumberEntity):
                 self._attr_native_min_value,
                 self._attr_native_max_value,
             ) = _get_numeric_limits(coil.size)
+            self._attr_native_min_value /= coil.factor
+            self._attr_native_max_value /= coil.factor
         else:
             self._attr_native_min_value = float(coil.min)
             self._attr_native_max_value = float(coil.max)

--- a/tests/components/nibe_heatpump/__init__.py
+++ b/tests/components/nibe_heatpump/__init__.py
@@ -2,11 +2,23 @@
 
 from typing import Any
 
+from nibe.heatpump import Model
+
 from homeassistant.components.nibe_heatpump import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
+
+MOCK_ENTRY_DATA = {
+    "model": None,
+    "ip_address": "127.0.0.1",
+    "listening_port": 9999,
+    "remote_read_port": 10000,
+    "remote_write_port": 10001,
+    "word_swap": True,
+    "connection_type": "nibegw",
+}
 
 
 async def async_add_entry(hass: HomeAssistant, data: dict[str, Any]) -> None:
@@ -17,3 +29,8 @@ async def async_add_entry(hass: HomeAssistant, data: dict[str, Any]) -> None:
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
     assert entry.state == ConfigEntryState.LOADED
+
+
+async def async_add_model(hass: HomeAssistant, model: Model):
+    """Add entry of specific model."""
+    await async_add_entry(hass, {**MOCK_ENTRY_DATA, "model": model.name})

--- a/tests/components/nibe_heatpump/conftest.py
+++ b/tests/components/nibe_heatpump/conftest.py
@@ -62,4 +62,15 @@ async def fixture_coils(mock_connection):
 
     mock_connection.read_coil = read_coil
     mock_connection.read_coils = read_coils
-    return coils
+
+    # pylint: disable-next=import-outside-toplevel
+    from homeassistant.components.nibe_heatpump import HeatPump
+
+    get_coils_original = HeatPump.get_coils
+
+    def get_coils(x):
+        coils_data = get_coils_original(x)
+        return [coil for coil in coils_data if coil.address in coils]
+
+    with patch.object(HeatPump, "get_coils", new=get_coils):
+        yield coils

--- a/tests/components/nibe_heatpump/snapshots/test_number.ambr
+++ b/tests/components/nibe_heatpump/snapshots/test_number.ambr
@@ -1,0 +1,135 @@
+# serializer version: 1
+# name: test_update[Model.F1155-47011-number.heat_offset_s1_47011--10]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'F1155 Heat Offset S1',
+      'max': 10.0,
+      'min': -10.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.heat_offset_s1_47011',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-10.0',
+  })
+# ---
+# name: test_update[Model.F1155-47011-number.heat_offset_s1_47011-10]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'F1155 Heat Offset S1',
+      'max': 10.0,
+      'min': -10.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.heat_offset_s1_47011',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10.0',
+  })
+# ---
+# name: test_update[Model.F1155-47062-number.heat_offset_s1_47011-None]
+  None
+# ---
+# name: test_update[Model.F750-47062-number.hw_charge_offset_47062--10]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'F750 HW charge offset',
+      'max': 12.7,
+      'min': -12.8,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 0.1,
+      'unit_of_measurement': '°C',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.hw_charge_offset_47062',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-10.0',
+  })
+# ---
+# name: test_update[Model.F750-47062-number.hw_charge_offset_47062-10]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'F750 HW charge offset',
+      'max': 12.7,
+      'min': -12.8,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 0.1,
+      'unit_of_measurement': '°C',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.hw_charge_offset_47062',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10.0',
+  })
+# ---
+# name: test_update[Model.F750-47062-number.hw_charge_offset_47062-None]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'F750 HW charge offset',
+      'max': 12.7,
+      'min': -12.8,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 0.1,
+      'unit_of_measurement': '°C',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.hw_charge_offset_47062',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update[Model.S320-40031-number.heating_offset_climate_system_1_40031--10]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'S320 Heating offset climate system 1',
+      'max': 10.0,
+      'min': -10.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.heating_offset_climate_system_1_40031',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-10.0',
+  })
+# ---
+# name: test_update[Model.S320-40031-number.heating_offset_climate_system_1_40031-10]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'S320 Heating offset climate system 1',
+      'max': 10.0,
+      'min': -10.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.heating_offset_climate_system_1_40031',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10.0',
+  })
+# ---
+# name: test_update[Model.S320-40031-number.heating_offset_climate_system_1_40031-None]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'S320 Heating offset climate system 1',
+      'max': 10.0,
+      'min': -10.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.heating_offset_climate_system_1_40031',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---

--- a/tests/components/nibe_heatpump/test_button.py
+++ b/tests/components/nibe_heatpump/test_button.py
@@ -17,19 +17,9 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from . import async_add_entry
+from . import async_add_model
 
 from tests.common import async_fire_time_changed
-
-MOCK_ENTRY_DATA = {
-    "model": None,
-    "ip_address": "127.0.0.1",
-    "listening_port": 9999,
-    "remote_read_port": 10000,
-    "remote_write_port": 10001,
-    "word_swap": True,
-    "connection_type": "nibegw",
-}
 
 
 @pytest.fixture(autouse=True)
@@ -62,7 +52,7 @@ async def test_reset_button(
     coils[unit.alarm_reset] = 0
     coils[unit.alarm] = 0
 
-    await async_add_entry(hass, {**MOCK_ENTRY_DATA, "model": model.name})
+    await async_add_model(hass, model)
 
     state = hass.states.get(entity_id)
     assert state

--- a/tests/components/nibe_heatpump/test_number.py
+++ b/tests/components/nibe_heatpump/test_number.py
@@ -1,0 +1,109 @@
+"""Test the Nibe Heat Pump config flow."""
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from nibe.coil import CoilData
+from nibe.heatpump import Model
+import pytest
+from syrupy import SnapshotAssertion
+
+from homeassistant.components.number import (
+    ATTR_VALUE,
+    DOMAIN as PLATFORM_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+
+from . import async_add_model
+
+
+@pytest.fixture(autouse=True)
+async def fixture_single_platform():
+    """Only allow this platform to load."""
+    with patch("homeassistant.components.nibe_heatpump.PLATFORMS", [Platform.NUMBER]):
+        yield
+
+
+@pytest.mark.parametrize(
+    ("model", "address", "entity_id", "value"),
+    [
+        # Tests for S series coils with min/max
+        (Model.S320, 40031, "number.heating_offset_climate_system_1_40031", 10),
+        (Model.S320, 40031, "number.heating_offset_climate_system_1_40031", -10),
+        (Model.S320, 40031, "number.heating_offset_climate_system_1_40031", None),
+        # Tests for F series coils with min/max
+        (Model.F1155, 47011, "number.heat_offset_s1_47011", 10),
+        (Model.F1155, 47011, "number.heat_offset_s1_47011", -10),
+        (Model.F1155, 47062, "number.heat_offset_s1_47011", None),
+        # Tests for F series coils without min/max
+        (Model.F750, 47062, "number.hw_charge_offset_47062", 10),
+        (Model.F750, 47062, "number.hw_charge_offset_47062", -10),
+        (Model.F750, 47062, "number.hw_charge_offset_47062", None),
+    ],
+)
+async def test_update(
+    hass: HomeAssistant,
+    model: Model,
+    entity_id: str,
+    address: int,
+    value: Any,
+    coils: dict[int, Any],
+    entity_registry_enabled_by_default: None,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test setting of value."""
+    coils[address] = value
+
+    await async_add_model(hass, model)
+
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state == snapshot
+
+
+@pytest.mark.parametrize(
+    ("model", "address", "entity_id", "value"),
+    [
+        (Model.S320, 40031, "number.heating_offset_climate_system_1_40031", 10),
+        (Model.S320, 40031, "number.heating_offset_climate_system_1_40031", -10),
+        (Model.F1155, 47011, "number.heat_offset_s1_47011", 10),
+        (Model.F1155, 47011, "number.heat_offset_s1_47011", -10),
+        (Model.F750, 47062, "number.hw_charge_offset_47062", 10),
+    ],
+)
+async def test_set_value(
+    hass: HomeAssistant,
+    mock_connection: AsyncMock,
+    model: Model,
+    entity_id: str,
+    address: int,
+    value: Any,
+    coils: dict[int, Any],
+    entity_registry_enabled_by_default: None,
+) -> None:
+    """Test setting of value."""
+    coils[address] = 0
+
+    await async_add_model(hass, model)
+
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id)
+
+    # Write value
+    await hass.services.async_call(
+        PLATFORM_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: value},
+        blocking=True,
+    )
+
+    await hass.async_block_till_done()
+
+    # Verify written
+    args = mock_connection.write_coil.call_args
+    assert args
+    coil = args.args[0]
+    assert isinstance(coil, CoilData)
+    assert coil.coil.address == address
+    assert coil.value == value


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
* Correct invalid range values for nibe numbers for coils without min/max values
* Add tests number entities

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
