### PR TITLE
Delay import of webrtc to avoid blocking start up if package is missing

### DIFF
--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -12,11 +12,13 @@ from pathlib import Path
 from queue import Queue
 from threading import Thread
 import time
-from typing import Any, Final, cast
+from typing import TYPE_CHECKING, Any, Final, cast
 import wave
 
 import voluptuous as vol
-from webrtc_noise_gain import AudioProcessor
+
+if TYPE_CHECKING:
+    from webrtc_noise_gain import AudioProcessor
 
 from homeassistant.components import (
     conversation,
@@ -522,6 +524,12 @@ class PipelineRun:
         # Initialize with audio settings
         self.audio_processor_buffer = AudioBuffer(AUDIO_PROCESSOR_BYTES)
         if self.audio_settings.needs_processor:
+            # Delay import of webrtc so HA start up is not affected if package
+            # is missing.
+            #
+            # pylint: disable=import-outside-toplevel
+            from webrtc_noise_gain import AudioProcessor
+
             self.audio_processor = AudioProcessor(
                 self.audio_settings.auto_gain_dbfs,
                 self.audio_settings.noise_suppression_level,

--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -524,8 +524,8 @@ class PipelineRun:
         # Initialize with audio settings
         self.audio_processor_buffer = AudioBuffer(AUDIO_PROCESSOR_BYTES)
         if self.audio_settings.needs_processor:
-            # Delay import of webrtc so HA start up is not affected if package
-            # is missing.
+            # Delay import of webrtc so HA start up is not crashing
+            # on older architectures (armhf).
             #
             # pylint: disable=import-outside-toplevel
             from webrtc_noise_gain import AudioProcessor

--- a/homeassistant/components/assist_pipeline/vad.py
+++ b/homeassistant/components/assist_pipeline/vad.py
@@ -49,8 +49,8 @@ class WebRtcVad(VoiceActivityDetector):
 
     def __init__(self) -> None:
         """Initialize webrtcvad."""
-        # Delay import of webrtc so HA start up is not affected if package is
-        # missing.
+        # Delay import of webrtc so HA start up is not crashing
+        # on older architectures (armhf).
         #
         # pylint: disable=import-outside-toplevel
         from webrtc_noise_gain import AudioProcessor

--- a/homeassistant/components/assist_pipeline/vad.py
+++ b/homeassistant/components/assist_pipeline/vad.py
@@ -7,8 +7,6 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Final, cast
 
-from webrtc_noise_gain import AudioProcessor
-
 _SAMPLE_RATE: Final = 16000  # Hz
 _SAMPLE_WIDTH: Final = 2  # bytes
 
@@ -51,6 +49,12 @@ class WebRtcVad(VoiceActivityDetector):
 
     def __init__(self) -> None:
         """Initialize webrtcvad."""
+        # Delay import of webrtc so HA start up is not affected if package is
+        # missing.
+        #
+        # pylint: disable=import-outside-toplevel
+        from webrtc_noise_gain import AudioProcessor
+
         # Just VAD: no noise suppression or auto gain
         self._audio_processor = AudioProcessor(0, 0)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Delay the import of webrtc so HA can still start even if the `webrtc_noise_gain` package is missing from the install.
Using any of the Assist audio pipeline features will still cause errors, but this is optional.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
