### PR TITLE
Make google assistant entity expose setting always override expose_by_default

### DIFF
--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -135,6 +135,9 @@ class GoogleConfig(AbstractConfig):
 
         explicit_expose = self.entity_config.get(state.entity_id, {}).get(CONF_EXPOSE)
 
+        if isinstance(explicit_expose, bool):
+            return explicit_expose
+
         domain_exposed_by_default = (
             expose_by_default and state.domain in exposed_domains
         )
@@ -143,12 +146,7 @@ class GoogleConfig(AbstractConfig):
         # and the entity is not a config or diagnostic entity
         entity_exposed_by_default = domain_exposed_by_default and not auxiliary_entity
 
-        # Expose an entity if the entity's is exposed by default and
-        # the configuration doesn't explicitly exclude it from being
-        # exposed, or if the entity is explicitly exposed
-        is_default_exposed = entity_exposed_by_default and explicit_expose is not False
-
-        return is_default_exposed or explicit_expose
+        return entity_exposed_by_default
 
     def get_agent_user_id(self, context):
         """Get agent user ID making request."""

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -9,6 +9,9 @@ import pytest
 
 from homeassistant.components.google_assistant import GOOGLE_ASSISTANT_SCHEMA
 from homeassistant.components.google_assistant.const import (
+    CONF_ENTITY_CONFIG,
+    CONF_EXPOSE,
+    CONF_EXPOSE_BY_DEFAULT,
     DOMAIN,
     EVENT_COMMAND_RECEIVED,
     HOMEGRAPH_TOKEN_URL,
@@ -299,6 +302,23 @@ async def test_should_expose(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert config.should_expose(State(CLOUD_NEVER_EXPOSED_ENTITIES[0], "mock")) is False
+
+    # Test expose by default
+    config._config[CONF_EXPOSE_BY_DEFAULT] = True
+    assert config.should_expose(State("light.mock", "mock")) is True
+
+    config._config[CONF_EXPOSE_BY_DEFAULT] = False
+    assert config.should_expose(State("light.mock", "mock")) is False
+
+    # Test that it overrides true
+    config._config[CONF_EXPOSE_BY_DEFAULT] = True
+    config._config[CONF_ENTITY_CONFIG] = {"light.mock": {CONF_EXPOSE: False}}
+    assert config.should_expose(State("light.mock", "mock")) is False
+
+    # Test that it overrides false
+    config._config[CONF_EXPOSE_BY_DEFAULT] = False
+    config._config[CONF_ENTITY_CONFIG] = {"light.mock": {CONF_EXPOSE: True}}
+    assert config.should_expose(State("light.mock", "mock")) is True
 
 
 async def test_missing_service_account(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This has the possibility of breaking change for some users if they have `expose_by_default: true` and set some entity to `expose: false`. Before this was a noop but now it will not expose that entity which has explicit `expose: false`. According to the language from the docs

> ***expose*** _boolean (Optional, default: true)_
> Force an entity to be exposed/excluded.

this may actually be expected behavior :wink:.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When setting up Google Assistant, there is to me and at least [one other](https://community.home-assistant.io/t/google-home-hide-devices/126999) a use case where one might want to hide devices from the assistant but keep everything else exposed. This change will allow this by having the [`expose`](https://www.home-assistant.io/integrations/google_assistant/#expose) option in `entity_config`. I have also updated the test to properly test this but some feedback on the testing methodology is appreciated.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A, can open an issue if needed
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
