### PR TITLE
Add HassGetWeather intent

### DIFF
--- a/homeassistant/components/weather/intent.py
+++ b/homeassistant/components/weather/intent.py
@@ -42,11 +42,7 @@ class GetWeatherIntent(intent.IntentHandler):
                 hass, name=weather_name, domains=[DOMAIN]
             )
             for weather_state in matching_states:
-                for maybe_weather in entities:
-                    if maybe_weather.name == weather_state.name:
-                        weather = maybe_weather
-                        break
-
+                weather = component.get_entity(weather_state.entity_id)
                 if weather is not None:
                     break
 

--- a/homeassistant/components/weather/intent.py
+++ b/homeassistant/components/weather/intent.py
@@ -1,0 +1,78 @@
+"""Intents for the weather integration."""
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_component import EntityComponent
+
+from . import DOMAIN, WeatherEntity
+
+INTENT_GET_WEATHER = "HassGetWeather"
+
+
+async def async_setup_intents(hass: HomeAssistant) -> None:
+    """Set up the weather intents."""
+    intent.async_register(hass, GetWeatherIntent())
+
+
+class GetWeatherIntent(intent.IntentHandler):
+    """Handle GetWeather intents."""
+
+    intent_type = INTENT_GET_WEATHER
+    slot_schema = {vol.Optional("name"): cv.string}
+
+    async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
+        """Handle the intent."""
+        slots = self.async_validate_slots(intent_obj.slots)
+
+        weather: WeatherEntity | None = None
+        component: EntityComponent[WeatherEntity] = intent_obj.hass.data[DOMAIN]
+        entities = list(component.entities)
+
+        if "name" in slots:
+            # Named weather entity
+            name = str(slots["name"]["value"]).strip().casefold()
+            for maybe_weather in entities:
+                if not isinstance(maybe_weather.name, str):
+                    continue
+
+                if maybe_weather.name.strip().casefold() == name:
+                    weather = maybe_weather
+                    break
+
+            if weather is None:
+                raise intent.IntentHandleError(f"No weather entity named {name}")
+
+        if (weather is None) and entities:
+            # First weather entity
+            weather = entities[0]
+
+        if weather is None:
+            raise intent.IntentHandleError("No weather entity")
+
+        assert weather is not None
+
+        # Create response
+        response = intent_obj.create_response()
+        response.response_type = intent.IntentResponseType.QUERY_ANSWER
+        response.async_set_results(
+            success_results=[
+                intent.IntentResponseTarget(
+                    type=intent.IntentResponseTargetType.ENTITY,
+                    name=weather.name if isinstance(weather.name, str) else "",
+                    id=weather.entity_id,
+                )
+            ]
+        )
+
+        state = intent_obj.hass.states.get(weather.entity_id)
+        if state is None:
+            raise intent.IntentHandleError(f"No state for {weather.entity_id}")
+
+        assert state is not None
+        response.async_set_states(matched_states=[state])
+
+        return response

--- a/homeassistant/components/weather/intent.py
+++ b/homeassistant/components/weather/intent.py
@@ -73,11 +73,6 @@ class GetWeatherIntent(intent.IntentHandler):
             ]
         )
 
-        state = hass.states.get(weather.entity_id)
-        if state is None:
-            raise intent.IntentHandleError(f"No state for {weather.entity_id}")
-
-        assert state is not None
-        response.async_set_states(matched_states=[state])
+        response.async_set_states(matched_states=[weather])
 
         return response

--- a/tests/components/weather/test_intent.py
+++ b/tests/components/weather/test_intent.py
@@ -11,35 +11,28 @@ from homeassistant.helpers import intent
 from homeassistant.setup import async_setup_component
 
 
-class MockWeatherEntity1(WeatherEntity):
-    """Mock a Weather Entity."""
-
-    name = "Weather 1"
-    entity_id = "weather.test_1"
-
-
-class MockWeatherEntity2(WeatherEntity):
-    """Mock a Weather Entity."""
-
-    name = "Weather 2"
-    entity_id = "weather.test_2"
-
-
 async def test_get_weather(hass: HomeAssistant) -> None:
     """Test get weather for first entity."""
     assert await async_setup_component(
         hass, "weather", {"weather": {"platform": "test"}}
     )
 
-    entity1 = MockWeatherEntity1()
-    entity2 = MockWeatherEntity2()
+    entity1 = WeatherEntity()
+    entity1._attr_name = "Weather 1"
+    entity1.entity_id = "weather.test_1"
+
+    entity2 = WeatherEntity()
+    entity2._attr_name = "Weather 2"
+    entity2.entity_id = "weather.test_2"
 
     await hass.data[DOMAIN].async_add_entities([entity1, entity2])
 
     await weather_intent.async_setup_intents(hass)
 
     # First entity will be chosen
-    response = await intent.async_handle(hass, "test", "HassGetWeather", {})
+    response = await intent.async_handle(
+        hass, "test", weather_intent.INTENT_GET_WEATHER, {}
+    )
     assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     state = response.matched_states[0]
@@ -47,7 +40,10 @@ async def test_get_weather(hass: HomeAssistant) -> None:
 
     # Named entity will be chosen
     response = await intent.async_handle(
-        hass, "test", "HassGetWeather", {"name": {"value": "Weather 2"}}
+        hass,
+        "test",
+        weather_intent.INTENT_GET_WEATHER,
+        {"name": {"value": "Weather 2"}},
     )
     assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1

--- a/tests/components/weather/test_intent.py
+++ b/tests/components/weather/test_intent.py
@@ -1,5 +1,7 @@
 """Test weather intents."""
+from unittest.mock import patch
 
+import pytest
 
 from homeassistant.components.weather import (
     DOMAIN,
@@ -12,10 +14,8 @@ from homeassistant.setup import async_setup_component
 
 
 async def test_get_weather(hass: HomeAssistant) -> None:
-    """Test get weather for first entity."""
-    assert await async_setup_component(
-        hass, "weather", {"weather": {"platform": "test"}}
-    )
+    """Test get weather for first entity and by name."""
+    assert await async_setup_component(hass, "weather", {"weather": {}})
 
     entity1 = WeatherEntity()
     entity1._attr_name = "Weather 1"
@@ -49,3 +49,60 @@ async def test_get_weather(hass: HomeAssistant) -> None:
     assert len(response.matched_states) == 1
     state = response.matched_states[0]
     assert state.entity_id == entity2.entity_id
+
+
+async def test_get_weather_wrong_name(hass: HomeAssistant) -> None:
+    """Test get weather with the wrong name."""
+    assert await async_setup_component(hass, "weather", {"weather": {}})
+
+    entity1 = WeatherEntity()
+    entity1._attr_name = "Weather 1"
+    entity1.entity_id = "weather.test_1"
+
+    await hass.data[DOMAIN].async_add_entities([entity1])
+
+    await weather_intent.async_setup_intents(hass)
+
+    # Incorrect name
+    with pytest.raises(intent.IntentHandleError):
+        await intent.async_handle(
+            hass,
+            "test",
+            weather_intent.INTENT_GET_WEATHER,
+            {"name": {"value": "not the right name"}},
+        )
+
+
+async def test_get_weather_no_entities(hass: HomeAssistant) -> None:
+    """Test get weather with no weather entities."""
+    assert await async_setup_component(hass, "weather", {"weather": {}})
+    await weather_intent.async_setup_intents(hass)
+
+    # No weather entities
+    with pytest.raises(intent.IntentHandleError):
+        await intent.async_handle(hass, "test", weather_intent.INTENT_GET_WEATHER, {})
+
+
+async def test_get_weather_no_state(hass: HomeAssistant) -> None:
+    """Test get weather when state is not returned."""
+    assert await async_setup_component(hass, "weather", {"weather": {}})
+
+    entity1 = WeatherEntity()
+    entity1._attr_name = "Weather 1"
+    entity1.entity_id = "weather.test_1"
+
+    await hass.data[DOMAIN].async_add_entities([entity1])
+
+    await weather_intent.async_setup_intents(hass)
+
+    # Success with state
+    response = await intent.async_handle(
+        hass, "test", weather_intent.INTENT_GET_WEATHER, {}
+    )
+    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+
+    # Failure without state
+    with patch("homeassistant.core.StateMachine.get", return_value=None), pytest.raises(
+        intent.IntentHandleError
+    ):
+        await intent.async_handle(hass, "test", weather_intent.INTENT_GET_WEATHER, {})

--- a/tests/components/weather/test_intent.py
+++ b/tests/components/weather/test_intent.py
@@ -1,0 +1,55 @@
+"""Test weather intents."""
+
+
+from homeassistant.components.weather import (
+    DOMAIN,
+    WeatherEntity,
+    intent as weather_intent,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
+from homeassistant.setup import async_setup_component
+
+
+class MockWeatherEntity1(WeatherEntity):
+    """Mock a Weather Entity."""
+
+    name = "Weather 1"
+    entity_id = "weather.test_1"
+
+
+class MockWeatherEntity2(WeatherEntity):
+    """Mock a Weather Entity."""
+
+    name = "Weather 2"
+    entity_id = "weather.test_2"
+
+
+async def test_get_weather(hass: HomeAssistant) -> None:
+    """Test get weather for first entity."""
+    assert await async_setup_component(
+        hass, "weather", {"weather": {"platform": "test"}}
+    )
+
+    entity1 = MockWeatherEntity1()
+    entity2 = MockWeatherEntity2()
+
+    await hass.data[DOMAIN].async_add_entities([entity1, entity2])
+
+    await weather_intent.async_setup_intents(hass)
+
+    # First entity will be chosen
+    response = await intent.async_handle(hass, "test", "HassGetWeather", {})
+    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert len(response.matched_states) == 1
+    state = response.matched_states[0]
+    assert state.entity_id == entity1.entity_id
+
+    # Named entity will be chosen
+    response = await intent.async_handle(
+        hass, "test", "HassGetWeather", {"name": {"value": "Weather 2"}}
+    )
+    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert len(response.matched_states) == 1
+    state = response.matched_states[0]
+    assert state.entity_id == entity2.entity_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a new intent: `HassGetWeather`
This intent will provide the current state of a weather entity, either by name or the first weather entity found.
Related to intents PR: https://github.com/home-assistant/intents/pull/1627

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
