### PR TITLE
Add custom template functions for jewish_calendar

### DIFF
--- a/homeassistant/components/jewish_calendar/__init__.py
+++ b/homeassistant/components/jewish_calendar/__init__.py
@@ -10,6 +10,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.typing import ConfigType
 
+from .template_functions import JewishCalendarTemplates
+
 DOMAIN = "jewish_calendar"
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR]
 
@@ -103,5 +105,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     for platform in PLATFORMS:
         hass.async_create_task(async_load_platform(hass, platform, DOMAIN, {}, config))
+    JewishCalendarTemplates(hass, config)
 
     return True

--- a/homeassistant/components/jewish_calendar/template_functions.py
+++ b/homeassistant/components/jewish_calendar/template_functions.py
@@ -1,0 +1,85 @@
+"""Template functions to return HDate instances & other information."""
+
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from typing import cast
+
+from hdate import HDate, Zmanim
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import template
+from homeassistant.helpers.typing import ConfigType
+import homeassistant.util.dt as dt_util
+
+DOMAIN = "jewish_calendar"
+
+LOGGER = logging.getLogger(__name__)
+
+
+class JewishCalendarTemplates:
+    """Registers services for the jewish_calendar integration."""
+
+    def __init__(self, hass: HomeAssistant, config: ConfigType) -> None:
+        """Register the services."""
+        data = hass.data[DOMAIN]
+
+        self._location = data["location"]
+        self._hebrew = data["language"] == "hebrew"
+        self._candle_lighting_offset = data["candle_lighting_offset"]
+        self._havdalah_offset = data["havdalah_offset"]
+        self._diaspora = data["diaspora"]
+
+        template.register_function(
+            hass,
+            "get_hebrew_date",
+            self.get_hebrew_date,
+        )
+        template.register_filter(
+            hass,
+            "get_hebrew_date",
+            self.get_hebrew_date,
+        )
+
+        template.register_function(
+            hass,
+            "get_zmanim",
+            self.get_zmanim,
+        )
+        template.register_filter(
+            hass,
+            "get_zmanim",
+            self.get_zmanim,
+        )
+
+    def get_hebrew_date(self, val: str | int | float | dt.datetime, /) -> HDate:
+        """Template function that returns an HDate object."""
+        return HDate(
+            parse_date_param(val), diaspora=self._diaspora, hebrew=self._hebrew
+        )
+
+    def get_zmanim(self, val: str | int | float | dt.datetime, /) -> HDate:
+        """Template function that returns a Zmanim object."""
+        return Zmanim(
+            parse_date_param(val),
+            location=self._location,
+            hebrew=self._hebrew,
+            candle_lighting_offset=self._candle_lighting_offset,
+            havdalah_offset=self._havdalah_offset,
+        )
+
+
+def parse_date_param(val: str | int | float | dt.datetime) -> dt.datetime:
+    """Parse a date-like parameter into a date object."""
+
+    if isinstance(val, dt.datetime):
+        return val
+    if isinstance(val, HDate):
+        return cast(dt.datetime, val.gdate)
+    if isinstance(val, str):
+        return cast(dt.datetime, dt_util.parse_datetime(val))
+    if isinstance(val, float | int):
+        return dt_util.utc_from_timestamp(val)
+    raise ValueError("Unknown datetime value {val}")

--- a/tests/components/jewish_calendar/test_template_functions.py
+++ b/tests/components/jewish_calendar/test_template_functions.py
@@ -1,0 +1,65 @@
+"""Unit tests for template functions."""
+
+from homeassistant.components import jewish_calendar
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.template import Template
+from homeassistant.setup import async_setup_component
+
+
+async def test_get_hebrew_date_string_date(hass: HomeAssistant) -> None:
+    """Tests get_hebrew_date."""
+    assert await async_setup_component(
+        hass, jewish_calendar.DOMAIN, {"jewish_calendar": {"language": "hebrew"}}
+    )
+    await hass.async_block_till_done()
+
+    assert (
+        Template("{{ get_hebrew_date('2020-02-02').daf_yomi }}", hass).async_render()
+        == "ברכות ל"
+    )
+
+
+async def test_get_hebrew_date_timestamp(hass: HomeAssistant) -> None:
+    """Tests get_hebrew_date."""
+    assert await async_setup_component(
+        hass, jewish_calendar.DOMAIN, {"jewish_calendar": {"language": "english"}}
+    )
+    await hass.async_block_till_done()
+
+    assert (
+        Template("{{ get_hebrew_date(9876543210) | string }}", hass).async_render()
+        == "Friday 20 Kislev 6043"
+    )
+
+
+async def test_get_hebrew_date_date(hass: HomeAssistant) -> None:
+    """Tests get_hebrew_date."""
+    assert await async_setup_component(
+        hass, jewish_calendar.DOMAIN, {"jewish_calendar": {"language": "english"}}
+    )
+    await hass.async_block_till_done()
+
+    assert (
+        Template(
+            "{{ '2020-02-02' | as_datetime | get_hebrew_date | string }}", hass
+        ).async_render()
+        == "Sunday 7 Sh'vat 5780"
+    )
+
+
+async def test_get_zmanim(hass: HomeAssistant) -> None:
+    """Tests get_zmanim."""
+    assert await async_setup_component(
+        hass,
+        jewish_calendar.DOMAIN,
+        {"jewish_calendar": {"language": "english", "diaspora": "true"}},
+    )
+    await hass.async_block_till_done()
+
+    assert (
+        Template(
+            "{{ get_zmanim('2023-10-01').havdalah | as_timestamp | timestamp_utc }}",
+            hass,
+        ).async_render()
+        == "2023-10-02T02:10:00+00:00"
+    )

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -4588,3 +4588,33 @@ async def test_lru_increases_with_many_entities(hass: HomeAssistant) -> None:
     assert template.CACHED_TEMPLATE_NO_COLLECT_LRU.get_size() == int(
         round(mock_entity_count * template.ENTITY_COUNT_GROWTH_FACTOR)
     )
+
+
+def test_register_filter(hass: HomeAssistant) -> None:
+    """Test register_filter."""
+
+    def double(n: int) -> int:
+        return n * 2
+
+    template.register_filter(hass, "double", double)
+    assert template.Template("{{ 2 | double }}", hass).async_render() == 4
+
+
+def test_register_function(hass: HomeAssistant) -> None:
+    """Test register_function."""
+
+    def double(n: int) -> int:
+        return n * 2
+
+    template.register_function(hass, "double", double)
+    assert template.Template("{{ double(2) }}", hass).async_render() == 4
+
+
+def test_register_test(hass: HomeAssistant) -> None:
+    """Test register_test."""
+
+    def is_even(n: int) -> bool:
+        return n % 2 == 0
+
+    template.register_test(hass, "even", is_even)
+    assert template.Template("{{ 2 is even }}", hass).async_render() is True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

[Feature Request](https://community.home-assistant.io/t/add-services-for-jewish-calendar/612741)

This makes it possible for templates to read information about arbitrary dates on the Jewish Calendar.  This unlocks advanced scenarios.  I may send a separate PR to add equivalent service calls (this is mostly done; are you interested?), but exposing these as template functions is much more useful (especially since I want to expose actual Python class instances).

As part of this feature, this PR also adds a generic API for integrations to register custom template functions, filters, and tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: TODO

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
