### PR TITLE
Generic Hygrostat: Do not log warning if the hygrostat is already not active

### DIFF
--- a/homeassistant/components/generic_hygrostat/humidifier.py
+++ b/homeassistant/components/generic_hygrostat/humidifier.py
@@ -384,9 +384,12 @@ class GenericHygrostat(HumidifierEntity, RestoreEntity):
         try:
             self._cur_humidity = float(humidity)
         except ValueError as ex:
-            _LOGGER.warning("Unable to update from sensor: %s", ex)
+            if self._active:
+                _LOGGER.warning("Unable to update from sensor: %s", ex)
+                self._active = False
+            else:
+                _LOGGER.debug("Unable to update from sensor: %s", ex)
             self._cur_humidity = None
-            self._active = False
             if self._is_device_active:
                 await self._async_device_turn_off()
 

--- a/tests/components/generic_hygrostat/test_humidifier.py
+++ b/tests/components/generic_hygrostat/test_humidifier.py
@@ -468,6 +468,35 @@ async def test_sensor_bad_value(hass: HomeAssistant, setup_comp_2) -> None:
     assert hass.states.get(ENTITY).state == STATE_UNAVAILABLE
 
 
+async def test_sensor_bad_value_twice(
+    hass: HomeAssistant, setup_comp_2, caplog
+) -> None:
+    """Test sensor that the second bad value is not logged as warning."""
+    assert hass.states.get(ENTITY).state == STATE_ON
+
+    _setup_sensor(hass, "forty")
+    await hass.async_block_till_done()
+
+    assert hass.states.get(ENTITY).state == STATE_UNAVAILABLE
+    assert [
+        rec.levelname
+        for rec in caplog.records
+        if "Unable to update from sensor" in rec.message
+    ] == ["WARNING"]
+
+    caplog.clear()
+
+    _setup_sensor(hass, "fifty")
+    await hass.async_block_till_done()
+
+    assert hass.states.get(ENTITY).state == STATE_UNAVAILABLE
+    assert [
+        rec.levelname
+        for rec in caplog.records
+        if "Unable to update from sensor" in rec.message
+    ] == ["DEBUG"]
+
+
 async def test_set_target_humidity_humidifier_on(
     hass: HomeAssistant, setup_comp_2
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Only log warning if the sensor update failed when the hygrostat is already active. When it is not active, only log a debug message. This helps preventing polluting the log with warnings.
One common use case is that the warning is emitted when the generic_hygrostat component is loaded before the platform that provides the sensor.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #102053
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
