### PR TITLE
Handle invalid thermostat setpoint types

### DIFF
--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -147,7 +147,7 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
         for enum in ThermostatSetpointType:
             # when this is a setpoint thermostat, be sure not to pollute this entity's
             # setpoints with any other entities' setpoints
-            if self._current_mode or enum == self.info.primary_value.property_key:
+            if self._current_mode or enum.value == self.info.primary_value.property_key:
                 self._setpoint_values[enum] = self.get_zwave_value(
                     THERMOSTAT_SETPOINT_PROPERTY,
                     command_class=CommandClass.THERMOSTAT_SETPOINT,

--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -1,7 +1,6 @@
 """Representation of Z-Wave thermostats."""
 from __future__ import annotations
 
-import contextlib
 from typing import Any, cast
 
 from zwave_js_server.client import Client as ZwaveClient
@@ -146,12 +145,18 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
         )
         self._setpoint_values: dict[ThermostatSetpointType, ZwaveValue | None] = {}
         for enum in ThermostatSetpointType:
-            self._setpoint_values[enum] = self.get_zwave_value(
-                THERMOSTAT_SETPOINT_PROPERTY,
-                command_class=CommandClass.THERMOSTAT_SETPOINT,
-                value_property_key=enum.value,
-                add_to_watched_value_ids=True,
-            )
+            # when this is a setpoint thermostat, be sure not to pollute this entity's
+            # setpoints with any other entities' setpoints
+            if self._current_mode or enum == self.info.primary_value.property_key:
+                self._setpoint_values[enum] = self.get_zwave_value(
+                    THERMOSTAT_SETPOINT_PROPERTY,
+                    command_class=CommandClass.THERMOSTAT_SETPOINT,
+                    value_property_key=enum.value,
+                    add_to_watched_value_ids=True,
+                )
+            else:
+                self._setpoint_values[enum] = None
+
             # Use the first found non N/A setpoint value to always determine the
             # temperature unit
             if (
@@ -259,25 +264,16 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
     @property
     def _current_mode_setpoint_enums(self) -> list[ThermostatSetpointType]:
         """Return the list of enums that are relevant to the current thermostat mode."""
-        if self._current_mode is None or self._current_mode.value is None:
-            # Thermostat with no support for setting a mode is just a setpoint.
+        if self._current_mode and self._current_mode.value is not None:
+            return THERMOSTAT_MODE_SETPOINT_MAP.get(int(self._current_mode.value), [])
 
-            # Some devices have missing or invalid setpoint types. For backwards
-            # compatibility we unconditionally map these to the Heating setpoint
-            # (including the actual NA setpoint).
-            setpoint_type = ThermostatSetpointType.NA
-            if self.info.primary_value.property_key is not None:
-                with contextlib.suppress(ValueError):
-                    setpoint_type = ThermostatSetpointType(
-                        int(self.info.primary_value.property_key)
-                    )
+        # This should be a setpoint thermostat, with only a single setpoint
+        for setpoint, value in self._setpoint_values.items():
+            if value is not None:
+                return [setpoint]
 
-            if setpoint_type == ThermostatSetpointType.NA:
-                return [ThermostatSetpointType.HEATING]
-
-            return [setpoint_type]
-
-        return THERMOSTAT_MODE_SETPOINT_MAP.get(int(self._current_mode.value), [])
+        # Some thermostats have unknown setpoints, but we don't catch those at discovery time.
+        return []
 
     @property
     def temperature_unit(self) -> str:

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -674,6 +674,12 @@ def central_scene_node_state_fixture():
     return json.loads(load_fixture("zwave_js/central_scene_node_state.json"))
 
 
+@pytest.fixture(name="climate_danfoss_bad_setpoint_state", scope="session")
+def climate_danfoss_bad_setpoint_state_fixture():
+    """Load Danfoss (LC-13) electronic radiator thermostat with bad setpoints node state fixture data."""
+    return json.loads(load_fixture("zwave_js/climate_danfoss_bad_setpoint_state.json"))
+
+
 # model fixtures
 
 
@@ -1316,5 +1322,13 @@ def climate_intermatic_pe653_fixture(client, climate_intermatic_pe653_state):
 def central_scene_node_fixture(client, central_scene_node_state):
     """Mock a node with the Central Scene CC."""
     node = Node(client, copy.deepcopy(central_scene_node_state))
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="climate_danfoss_bad_setpoint")
+def climate_danfoss_bad_setpoint_fixture(client, climate_danfoss_bad_setpoint_state):
+    """Mock a Danfoss thermostat with bad setpoint values node."""
+    node = Node(client, copy.deepcopy(climate_danfoss_bad_setpoint_state))
     client.driver.controller.nodes[node.node_id] = node
     return node

--- a/tests/components/zwave_js/fixtures/climate_danfoss_bad_setpoint_state.json
+++ b/tests/components/zwave_js/fixtures/climate_danfoss_bad_setpoint_state.json
@@ -1,0 +1,496 @@
+{
+  "nodeId": 5,
+  "index": 0,
+  "status": 1,
+  "ready": true,
+  "deviceClass": {
+    "basic": {
+      "key": 4,
+      "label": "Routing Slave"
+    },
+    "generic": {
+      "key": 8,
+      "label": "Thermostat"
+    },
+    "specific": {
+      "key": 4,
+      "label": "Setpoint Thermostat"
+    },
+    "mandatorySupportedCCs": [114, 143, 67, 134],
+    "mandatoryControlledCCs": []
+  },
+  "isListening": false,
+  "isFrequentListening": false,
+  "isRouting": true,
+  "maxBaudRate": 40000,
+  "isSecure": false,
+  "version": 4,
+  "isBeaming": true,
+  "manufacturerId": 2,
+  "productId": 4,
+  "productType": 5,
+  "firmwareVersion": "1.1",
+  "deviceConfig": {
+    "filename": "/usr/src/app/node_modules/@zwave-js/config/config/devices/0x0002/lc-13.json",
+    "manufacturerId": 2,
+    "manufacturer": "Danfoss",
+    "label": "LC-13",
+    "description": "Living Connect Z Thermostat",
+    "devices": [
+      {
+        "productType": "0x0005",
+        "productId": "0x0004"
+      },
+      {
+        "productType": "0x8005",
+        "productId": "0x0001"
+      },
+      {
+        "productType": "0x8005",
+        "productId": "0x0002"
+      }
+    ],
+    "firmwareVersion": {
+      "min": "0.0",
+      "max": "255.255"
+    },
+    "associations": {},
+    "compat": {
+      "valueIdRegex": {},
+      "queryOnWakeup": [
+        ["Battery", "get"],
+        ["Thermostat Setpoint", "get", 1]
+      ]
+    }
+  },
+  "label": "LC-13",
+  "neighbors": [1, 14],
+  "interviewAttempts": 1,
+  "interviewStage": 7,
+  "endpoints": [
+    {
+      "nodeId": 5,
+      "index": 0,
+      "commandClasses": [
+        {
+          "id": 49,
+          "name": "Multilevel Sensor",
+          "version": 6,
+          "isSecure": false
+        },
+        {
+          "id": 67,
+          "name": "Thermostat Setpoint",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 70,
+          "name": "Climate Control Schedule",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 114,
+          "name": "Manufacturer Specific",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 117,
+          "name": "Protection",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 128,
+          "name": "Battery",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 129,
+          "name": "Clock",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 132,
+          "name": "Wake Up",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 134,
+          "name": "Version",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 143,
+          "name": "Multi Command",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    }
+  ],
+  "values": [
+    {
+      "endpoint": 0,
+      "commandClass": 49,
+      "commandClassName": "Multilevel Sensor",
+      "property": "Air temperature",
+      "propertyName": "Air temperature",
+      "ccVersion": 6,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Air temperature",
+        "ccSpecific": {
+          "sensorType": 1,
+          "scale": 0
+        },
+        "unit": "\u00b0C",
+        "stateful": true,
+        "secret": false
+      },
+      "value": 18
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 67,
+      "commandClassName": "Thermostat Setpoint",
+      "property": "setpoint",
+      "propertyKey": 1,
+      "propertyName": "setpoint",
+      "propertyKeyName": "Heating",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "ccSpecific": {
+          "setpointType": 1
+        },
+        "unit": "\u00b0C",
+        "stateful": true,
+        "secret": false
+      },
+      "value": 11
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 67,
+      "commandClassName": "Thermostat Setpoint",
+      "property": "setpoint",
+      "propertyKey": 3,
+      "propertyName": "setpoint",
+      "propertyKeyName": "unknown (0x03)",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Setpoint (unknown (0x03))",
+        "ccSpecific": {
+          "setpointType": 3
+        },
+        "unit": "\u00b0C",
+        "stateful": true,
+        "secret": false
+      },
+      "value": 13
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 67,
+      "commandClassName": "Thermostat Setpoint",
+      "property": "setpoint",
+      "propertyKey": 5,
+      "propertyName": "setpoint",
+      "propertyKeyName": "unknown (0x05)",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Setpoint (unknown (0x05))",
+        "ccSpecific": {
+          "setpointType": 5
+        },
+        "unit": "\u00b0C",
+        "stateful": true,
+        "secret": false
+      },
+      "value": 15
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 70,
+      "commandClassName": "Climate Control Schedule",
+      "property": "changeCounter",
+      "propertyName": "changeCounter",
+      "ccVersion": 0,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": true
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 70,
+      "commandClassName": "Climate Control Schedule",
+      "property": "overrideType",
+      "propertyName": "overrideType",
+      "ccVersion": 0,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": true
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 70,
+      "commandClassName": "Climate Control Schedule",
+      "property": "overrideState",
+      "propertyName": "overrideState",
+      "ccVersion": 0,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": true
+      },
+      "value": "Unused"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "manufacturerId",
+      "propertyName": "manufacturerId",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "min": 0,
+        "max": 65535,
+        "label": "Manufacturer ID"
+      },
+      "value": 2
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "productType",
+      "propertyName": "productType",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "min": 0,
+        "max": 65535,
+        "label": "Product type"
+      },
+      "value": 5
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "productId",
+      "propertyName": "productId",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "min": 0,
+        "max": 65535,
+        "label": "Product ID"
+      },
+      "value": 4
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 117,
+      "commandClassName": "Protection",
+      "property": "local",
+      "propertyName": "local",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Local protection state",
+        "states": {
+          "0": "Unprotected",
+          "2": "NoOperationPossible"
+        }
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 117,
+      "commandClassName": "Protection",
+      "property": "rf",
+      "propertyName": "rf",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "RF protection state",
+        "states": {}
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 117,
+      "commandClassName": "Protection",
+      "property": "exclusiveControlNodeId",
+      "propertyName": "exclusiveControlNodeId",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": true
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 117,
+      "commandClassName": "Protection",
+      "property": "timeout",
+      "propertyName": "timeout",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": true
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 128,
+      "commandClassName": "Battery",
+      "property": "level",
+      "propertyName": "level",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "min": 0,
+        "max": 100,
+        "unit": "%",
+        "label": "Battery level"
+      },
+      "value": 49
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 128,
+      "commandClassName": "Battery",
+      "property": "isLow",
+      "propertyName": "isLow",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Low battery level"
+      },
+      "value": false
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 132,
+      "commandClassName": "Wake Up",
+      "property": "wakeUpInterval",
+      "propertyName": "wakeUpInterval",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": false,
+        "writeable": true,
+        "min": 60,
+        "max": 1800,
+        "label": "Wake Up interval",
+        "steps": 60,
+        "default": 300
+      },
+      "value": 300
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 132,
+      "commandClassName": "Wake Up",
+      "property": "controllerNodeId",
+      "propertyName": "controllerNodeId",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": false,
+        "label": "Node ID of the controller"
+      },
+      "value": 1
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "libraryType",
+      "propertyName": "libraryType",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": false,
+        "label": "Library type"
+      },
+      "value": 6
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "protocolVersion",
+      "propertyName": "protocolVersion",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave protocol version"
+      },
+      "value": "3.67"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "firmwareVersions",
+      "propertyName": "firmwareVersions",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave chip firmware versions"
+      },
+      "value": ["1.1"]
+    }
+  ],
+  "isControllerNode": false
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

PR #102395 fixed one issue, but revealed another hidden issue. For some unknown reason, some Z-Wave thermostat devices have unknown setpoint types. Previously these unknown setpoints would have just been hardcoded to heating. With #102395 the unknown types are casted to an enum which raises a ValueError (as they are invalid).

I also noticed another bug related to multi-setpoint devices. The setpoint entity's list of setpoints (`self._setpoint_values`) was being polluted with unrelated setpoints. I've addressed that by filtering out the non-relevant setpoints. Now when unknown setpoints are discovered, they will report that they don't support target temperature, and the set_temperature service call will not allow their usage. This is an alternative to detecting no valid set points in the service call and returning HomeAssistantError.

I think this can be considered a breaking change now. The entities mapped to these unknown setpoints will no longer control the heating setpoint. The devices will need to be re-interviewed.

Alternatives:

- Revert the original PR and restore the incorrect, but working behavior. If there are any upcoming patch releases this might be preferable.
- Ignore values that have unknown setpoints in discovery using the property_key matcher

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #102637
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
