### PR TITLE
Extend HassShoppingListAddItem intent to multiple lists

### DIFF
--- a/homeassistant/components/shopping_list/intent.py
+++ b/homeassistant/components/shopping_list/intent.py
@@ -1,36 +1,18 @@
 """Intents for the Shopping List integration."""
 from __future__ import annotations
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import intent
 import homeassistant.helpers.config_validation as cv
 
-from . import DOMAIN, EVENT_SHOPPING_LIST_UPDATED
+from . import DOMAIN
 
-INTENT_ADD_ITEM = "HassShoppingListAddItem"
 INTENT_LAST_ITEMS = "HassShoppingListLastItems"
 
 
-async def async_setup_intents(hass):
+async def async_setup_intents(hass: HomeAssistant) -> None:
     """Set up the Shopping List intents."""
-    intent.async_register(hass, AddItemIntent())
     intent.async_register(hass, ListTopItemsIntent())
-
-
-class AddItemIntent(intent.IntentHandler):
-    """Handle AddItem intents."""
-
-    intent_type = INTENT_ADD_ITEM
-    slot_schema = {"item": cv.string}
-
-    async def async_handle(self, intent_obj: intent.Intent):
-        """Handle the intent."""
-        slots = self.async_validate_slots(intent_obj.slots)
-        item = slots["item"]["value"]
-        await intent_obj.hass.data[DOMAIN].async_add(item)
-
-        response = intent_obj.create_response()
-        intent_obj.hass.bus.async_fire(EVENT_SHOPPING_LIST_UPDATED)
-        return response
 
 
 class ListTopItemsIntent(intent.IntentHandler):

--- a/homeassistant/components/shopping_list/manifest.json
+++ b/homeassistant/components/shopping_list/manifest.json
@@ -3,7 +3,7 @@
   "name": "Shopping List",
   "codeowners": [],
   "config_flow": true,
-  "dependencies": ["http"],
+  "dependencies": ["http", "intent", "todo"],
   "documentation": "https://www.home-assistant.io/integrations/shopping_list",
   "iot_class": "local_push",
   "quality_scale": "internal"

--- a/homeassistant/components/todo/intent.py
+++ b/homeassistant/components/todo/intent.py
@@ -1,0 +1,78 @@
+"""Intents for the todo integration."""
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_component import EntityComponent
+
+from . import DOMAIN, TodoItem, TodoListEntity
+
+INTENT_ADD_ITEM = "HassListAddItem"
+
+
+async def async_setup_intents(hass: HomeAssistant) -> None:
+    """Set up the todo intents."""
+    intent.async_register(hass, AddItemIntent())
+
+
+class AddItemIntent(intent.IntentHandler):
+    """Handle AddItem intents."""
+
+    intent_type = INTENT_ADD_ITEM
+    slot_schema = {"item": cv.string, vol.Optional("list"): cv.string}
+
+    async def async_handle(self, intent_obj: intent.Intent):
+        """Handle the intent."""
+        hass = intent_obj.hass
+
+        slots = self.async_validate_slots(intent_obj.slots)
+        item = slots["item"]["value"]
+
+        component: EntityComponent[TodoListEntity] = hass.data[DOMAIN]
+        list_entities: list[TodoListEntity] = list(component.entities)
+        if not list_entities:
+            raise intent.IntentHandleError("No list entities")
+
+        target_list: TodoListEntity | None = None
+
+        if "list" in slots:
+            # Add to a list by name
+            list_name = slots["list"]["value"]
+
+            # Try literal name match first
+            for maybe_list in list_entities:
+                if not isinstance(maybe_list.name, str):
+                    continue
+
+                if list_name == maybe_list.name:
+                    target_list = maybe_list
+                    break
+
+            if target_list is None:
+                list_name_norm = list_name.strip().lower()
+                for maybe_list in list_entities:
+                    if not isinstance(maybe_list.name, str):
+                        continue
+
+                    maybe_name_norm = maybe_list.name.strip().lower()
+                    if list_name_norm == maybe_name_norm:
+                        target_list = maybe_list
+                        break
+
+            if target_list is None:
+                raise intent.IntentHandleError(f"No list named {list_name}")
+        else:
+            # Add to the first list
+            target_list = list_entities[0]
+
+        assert target_list is not None
+
+        # Add to list
+        await target_list.async_create_todo_item(TodoItem(item))
+
+        response = intent_obj.create_response()
+        response.response_type = intent.IntentResponseType.ACTION_DONE
+        return response

--- a/tests/components/shopping_list/conftest.py
+++ b/tests/components/shopping_list/conftest.py
@@ -21,7 +21,7 @@ def mock_shopping_list_io():
 @pytest.fixture
 def mock_config_entry() -> MockConfigEntry:
     """Config Entry fixture."""
-    return MockConfigEntry(domain="shopping_list")
+    return MockConfigEntry(domain="shopping_list", entry_id="1234")
 
 
 @pytest.fixture

--- a/tests/components/shopping_list/conftest.py
+++ b/tests/components/shopping_list/conftest.py
@@ -27,7 +27,6 @@ def mock_config_entry() -> MockConfigEntry:
 @pytest.fixture
 async def sl_setup(hass: HomeAssistant, mock_config_entry: MockConfigEntry):
     """Set up the shopping list."""
-
     mock_config_entry.add_to_hass(hass)
 
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)

--- a/tests/components/shopping_list/test_intent.py
+++ b/tests/components/shopping_list/test_intent.py
@@ -1,14 +1,10 @@
 """Test Shopping List intents."""
-from homeassistant.components.todo import intent as todo_intent
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import intent
 
 
 async def test_recent_items_intent(hass: HomeAssistant, sl_setup) -> None:
     """Test recent items."""
-    # HassShoppingListAddItem is in todo now
-    await todo_intent.async_setup_intents(hass)
-
     await intent.async_handle(
         hass, "test", "HassShoppingListAddItem", {"item": {"value": "beer"}}
     )

--- a/tests/components/shopping_list/test_intent.py
+++ b/tests/components/shopping_list/test_intent.py
@@ -1,10 +1,14 @@
 """Test Shopping List intents."""
+from homeassistant.components.todo import intent as todo_intent
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import intent
 
 
 async def test_recent_items_intent(hass: HomeAssistant, sl_setup) -> None:
     """Test recent items."""
+    # HassShoppingListAddItem is in todo now
+    await todo_intent.async_setup_intents(hass)
+
     await intent.async_handle(
         hass, "test", "HassShoppingListAddItem", {"item": {"value": "beer"}}
     )

--- a/tests/components/shopping_list/test_todo.py
+++ b/tests/components/shopping_list/test_todo.py
@@ -11,7 +11,8 @@ from homeassistant.exceptions import HomeAssistantError
 
 from tests.typing import WebSocketGenerator
 
-TEST_ENTITY = "todo.shopping_list"
+# NOTE: This depends on the config entry_id in sl_setup
+TEST_ENTITY = "todo.shopping_list_1234"
 
 
 @pytest.fixture

--- a/tests/components/todo/test_init.py
+++ b/tests/components/todo/test_init.py
@@ -13,11 +13,13 @@ from homeassistant.components.todo import (
     TodoItemStatus,
     TodoListEntity,
     TodoListEntityFeature,
+    intent as todo_intent,
 )
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState, ConfigFlow
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import intent
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from tests.common import (
@@ -35,6 +37,18 @@ TEST_DOMAIN = "test"
 
 class MockFlow(ConfigFlow):
     """Test flow."""
+
+
+class MockTodoListEntity(TodoListEntity):
+    """Test todo list entity."""
+
+    def __init__(self) -> None:
+        """Initialize entity."""
+        self.items: list[TodoItem] = []
+
+    async def async_create_todo_item(self, item: TodoItem) -> None:
+        """Add an item to the To-do list."""
+        self.items.append(item)
 
 
 @pytest.fixture(autouse=True)
@@ -728,3 +742,58 @@ async def test_move_item_unsupported(
     resp = await client.receive_json()
     assert resp.get("id") == 1
     assert resp.get("error", {}).get("code") == "not_supported"
+
+
+async def test_add_item_intent(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test adding items to lists using an intent."""
+    await todo_intent.async_setup_intents(hass)
+
+    entity1 = MockTodoListEntity()
+    entity1._attr_name = "List 1"
+    entity1.entity_id = "todo.list_1"
+
+    entity2 = MockTodoListEntity()
+    entity2._attr_name = "List 2"
+    entity2.entity_id = "todo.list_2"
+
+    await create_mock_platform(hass, [entity1, entity2])
+
+    # Add to first list
+    response = await intent.async_handle(
+        hass, "test", "HassListAddItem", {"item": {"value": "beer"}}
+    )
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+
+    assert len(entity1.items) == 1
+    assert len(entity2.items) == 0
+    assert entity1.items[0].summary == "beer"
+    entity1.items.clear()
+
+    # Add to list by name
+    response = await intent.async_handle(
+        hass,
+        "test",
+        "HassListAddItem",
+        {"item": {"value": "cheese"}, "list": {"value": "List 2"}},
+    )
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+
+    assert len(entity1.items) == 0
+    assert len(entity2.items) == 1
+    assert entity2.items[0].summary == "cheese"
+
+    # List name is case insensitive
+    response = await intent.async_handle(
+        hass,
+        "test",
+        "HassListAddItem",
+        {"item": {"value": "wine"}, "list": {"value": "lIST 2"}},
+    )
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+
+    assert len(entity1.items) == 0
+    assert len(entity2.items) == 2
+    assert entity2.items[1].summary == "wine"

--- a/tests/components/todo/test_init.py
+++ b/tests/components/todo/test_init.py
@@ -763,7 +763,7 @@ async def test_add_item_intent(
 
     # Add to first list
     response = await intent.async_handle(
-        hass, "test", "HassListAddItem", {"item": {"value": "beer"}}
+        hass, "test", todo_intent.INTENT_ADD_ITEM, {"item": {"value": "beer"}}
     )
     assert response.response_type == intent.IntentResponseType.ACTION_DONE
 
@@ -776,7 +776,7 @@ async def test_add_item_intent(
     response = await intent.async_handle(
         hass,
         "test",
-        "HassListAddItem",
+        todo_intent.INTENT_ADD_ITEM,
         {"item": {"value": "cheese"}, "list": {"value": "List 2"}},
     )
     assert response.response_type == intent.IntentResponseType.ACTION_DONE
@@ -789,7 +789,7 @@ async def test_add_item_intent(
     response = await intent.async_handle(
         hass,
         "test",
-        "HassListAddItem",
+        todo_intent.INTENT_ADD_ITEM,
         {"item": {"value": "wine"}, "list": {"value": "lIST 2"}},
     )
     assert response.response_type == intent.IntentResponseType.ACTION_DONE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrates `HassShoppingListAddItem` to the `todo` integration, and adds an optional list name slot.
If a list name is provided, the item will be added to that list. Otherwise, the first list found is used.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
