### PR TITLE
ESPHome Text entities

### DIFF
--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -29,6 +29,7 @@ from aioesphomeapi import (
     SensorInfo,
     SensorState,
     SwitchInfo,
+    TextInfo,
     TextSensorInfo,
     UserService,
     build_unique_id,
@@ -68,6 +69,7 @@ INFO_TYPE_TO_PLATFORM: dict[type[EntityInfo], Platform] = {
     SelectInfo: Platform.SELECT,
     SensorInfo: Platform.SENSOR,
     SwitchInfo: Platform.SWITCH,
+    TextInfo: Platform.TEXT,
     TextSensorInfo: Platform.SENSOR,
 }
 

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -16,7 +16,7 @@
   "loggers": ["aioesphomeapi", "noiseprotocol"],
   "requirements": [
     "async-interrupt==1.1.1",
-    "aioesphomeapi==18.0.12",
+    "aioesphomeapi==18.1.0",
     "bluetooth-data-tools==1.13.0",
     "esphome-dashboard-api==1.2.3"
   ],

--- a/homeassistant/components/esphome/text.py
+++ b/homeassistant/components/esphome/text.py
@@ -1,12 +1,7 @@
 """Support for esphome texts."""
 from __future__ import annotations
 
-from aioesphomeapi import (
-    EntityInfo,
-    TextInfo,
-    TextMode as EsphomeTextMode,
-    TextState,
-)
+from aioesphomeapi import EntityInfo, TextInfo, TextMode as EsphomeTextMode, TextState
 
 from homeassistant.components.text import TextEntity, TextMode
 from homeassistant.config_entries import ConfigEntry
@@ -52,7 +47,7 @@ class EsphomeText(EsphomeEntity[TextInfo, TextState], TextEntity):
         self._attr_native_min = static_info.min_length
         self._attr_native_max = static_info.max_length
         self._attr_pattern = static_info.pattern
-        self._attr_mode = TEXT_MODES.from_esphome(static_info.mode)
+        self._attr_mode = TEXT_MODES.from_esphome(static_info.mode) or TextMode.TEXT
 
     @property
     @esphome_state_property

--- a/homeassistant/components/esphome/text.py
+++ b/homeassistant/components/esphome/text.py
@@ -1,0 +1,68 @@
+"""Support for esphome texts."""
+from __future__ import annotations
+
+from aioesphomeapi import (
+    EntityInfo,
+    TextInfo,
+    TextMode as EsphomeTextMode,
+    TextState,
+)
+
+from homeassistant.components.text import TextEntity, TextMode
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .entity import EsphomeEntity, esphome_state_property, platform_async_setup_entry
+from .enum_mapper import EsphomeEnumMapper
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up esphome texts based on a config entry."""
+    await platform_async_setup_entry(
+        hass,
+        entry,
+        async_add_entities,
+        info_type=TextInfo,
+        entity_type=EsphomeText,
+        state_type=TextState,
+    )
+
+
+TEXT_MODES: EsphomeEnumMapper[EsphomeTextMode, TextMode] = EsphomeEnumMapper(
+    {
+        EsphomeTextMode.TEXT: TextMode.TEXT,
+        EsphomeTextMode.PASSWORD: TextMode.PASSWORD,
+    }
+)
+
+
+class EsphomeText(EsphomeEntity[TextInfo, TextState], TextEntity):
+    """A text implementation for esphome."""
+
+    @callback
+    def _on_static_info_update(self, static_info: EntityInfo) -> None:
+        """Set attrs from static info."""
+        super()._on_static_info_update(static_info)
+        static_info = self._static_info
+        self._attr_native_min = static_info.min_length
+        self._attr_native_max = static_info.max_length
+        self._attr_pattern = static_info.pattern
+        self._attr_mode = TEXT_MODES.from_esphome(static_info.mode)
+
+    @property
+    @esphome_state_property
+    def native_value(self) -> str | None:
+        """Return the state of the entity."""
+        state = self._state
+        if state.missing_state:
+            return None
+        return state.state
+
+    async def async_set_value(self, value: str) -> None:
+        """Update the current value."""
+        await self._client.text_command(self._key, value)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -237,7 +237,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==18.0.12
+aioesphomeapi==18.1.0
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -218,7 +218,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==18.0.12
+aioesphomeapi==18.1.0
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/tests/components/esphome/test_text.py
+++ b/tests/components/esphome/test_text.py
@@ -1,0 +1,121 @@
+"""Test ESPHome texts."""
+
+import math
+from unittest.mock import call
+
+from aioesphomeapi import (
+    APIClient,
+    TextInfo,
+    TextMode as ESPHomeTextMode,
+    TextState,
+)
+
+from homeassistant.components.text import (
+    ATTR_VALUE,
+    DOMAIN as TEXT_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+
+
+async def test_generic_text_entity(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_generic_device_entry,
+) -> None:
+    """Test a generic text entity."""
+    entity_info = [
+        TextInfo(
+            object_id="mytext",
+            key=1,
+            name="my text",
+            unique_id="my_text",
+            max_length=100,
+            min_length=0,
+            pattern=None,
+            mode=ESPHomeTextMode.TEXT,
+        )
+    ]
+    states = [TextState(key=1, state="hello world")]
+    user_service = []
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    state = hass.states.get("text.test_mytext")
+    assert state is not None
+    assert state.state == "hello world"
+
+    await hass.services.async_call(
+        TEXT_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: "text.test_mytext", ATTR_VALUE: "goodbye"},
+        blocking=True,
+    )
+    mock_client.text_command.assert_has_calls([call(1, "goodbye")])
+    mock_client.text_command.reset_mock()
+
+
+async def test_generic_text_entity_no_state(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_generic_device_entry,
+) -> None:
+    """Test a generic text entity that has no state."""
+    entity_info = [
+        TextInfo(
+            object_id="mytext",
+            key=1,
+            name="my text",
+            unique_id="my_text",
+            max_length=100,
+            min_length=0,
+            pattern=None,
+            mode=ESPHomeTextMode.TEXT,
+        )
+    ]
+    states = []
+    user_service = []
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    state = hass.states.get("text.test_mytext")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+
+async def test_generic_text_entity_missing_state(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_generic_device_entry,
+) -> None:
+    """Test a generic text entity that has no state."""
+    entity_info = [
+        TextInfo(
+            object_id="mytext",
+            key=1,
+            name="my text",
+            unique_id="my_text",
+            max_length=100,
+            min_length=0,
+            pattern=None,
+            mode=ESPHomeTextMode.TEXT,
+        )
+    ]
+    states = [TextState(key=1, state="", missing_state=True)]
+    user_service = []
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    state = hass.states.get("text.test_mytext")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN

--- a/tests/components/esphome/test_text.py
+++ b/tests/components/esphome/test_text.py
@@ -1,14 +1,8 @@
 """Test ESPHome texts."""
 
-import math
 from unittest.mock import call
 
-from aioesphomeapi import (
-    APIClient,
-    TextInfo,
-    TextMode as ESPHomeTextMode,
-    TextState,
-)
+from aioesphomeapi import APIClient, TextInfo, TextMode as ESPHomeTextMode, TextState
 
 from homeassistant.components.text import (
     ATTR_VALUE,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Implements `text` entities for ESPHome devices.

Related PRs:
- https://github.com/esphome/esphome/pull/5336
- https://github.com/esphome/aioesphomeapi/pull/532 https://github.com/esphome/aioesphomeapi/compare/v18.0.12...v18.1.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29518

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
