### PR TITLE
Fix ZHA covering mode for Aqara E1 curtain driver not initialized

### DIFF
--- a/homeassistant/components/zha/core/cluster_handlers/closures.py
+++ b/homeassistant/components/zha/core/cluster_handlers/closures.py
@@ -1,6 +1,9 @@
 """Closures cluster handlers module for Zigbee Home Automation."""
-from typing import Any
+from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
+
+import zigpy.zcl
 from zigpy.zcl.clusters import closures
 
 from homeassistant.core import callback
@@ -8,6 +11,9 @@ from homeassistant.core import callback
 from .. import registries
 from ..const import REPORT_CONFIG_IMMEDIATE, SIGNAL_ATTR_UPDATED
 from . import AttrReportConfig, ClientClusterHandler, ClusterHandler
+
+if TYPE_CHECKING:
+    from ..endpoint import Endpoint
 
 
 @registries.ZIGBEE_CLUSTER_HANDLER_REGISTRY.register(closures.DoorLock.cluster_id)
@@ -138,6 +144,14 @@ class WindowCovering(ClusterHandler):
             attr="current_position_tilt_percentage", config=REPORT_CONFIG_IMMEDIATE
         ),
     )
+
+    def __init__(self, cluster: zigpy.zcl.Cluster, endpoint: Endpoint) -> None:
+        """Initialize WindowCovering cluster handler."""
+        super().__init__(cluster, endpoint)
+
+        if self.cluster.endpoint.model == "lumi.curtain.agl001":
+            self.ZCL_INIT_ATTRS = self.ZCL_INIT_ATTRS.copy()
+            self.ZCL_INIT_ATTRS["window_covering_mode"] = True
 
     async def async_update(self):
         """Retrieve latest state."""


### PR DESCRIPTION
## Proposed change
This fixes the configuration entity introduced in the linked PR below by actually initializing the attribute.
- https://github.com/home-assistant/core/pull/75132

Whilst working on the quirk for this device, multiple users reported that the entity wasn't showning up until the attribute was read once (and HA then restarted).
It seems like that attribute is never initialized, so this PR actually initializes the `window_covering_mode` attribute for the Aqara E1 curtain driver. This is done in the same way as in other cluster handlers.

### Note:

The mentioned PR with the configuration entity was merged over a year ago, but the underlying quirk was never actually merged:
- https://github.com/zigpy/zha-device-handlers/pull/1648

It's now added with:
- https://github.com/zigpy/zha-device-handlers/pull/2629
- https://github.com/home-assistant/core/pull/102741 

Also, `window_covering_mode` is a standard ZCL attribute, so that's why the previous PR never caused any issues/warnings.

In the future, we should see if more devices require changing the `window_covering_mode`.
The config entity added with the previous PR only allows to change the "reverse bit" though. So that might need to be updated for other devices in the future.

(And yes, this PR doesn't match by a quirk ID. I've only been able to update the [Tuya plugs so far](https://github.com/home-assistant/core/pull/102489) (where it was badly needed. I'll try to update other devices in future PRs. Not for 2023.11.x though)

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
