### PR TITLE
Increase logging level for Netatmo API connection issues

### DIFF
--- a/homeassistant/components/netatmo/data_handler.py
+++ b/homeassistant/components/netatmo/data_handler.py
@@ -235,12 +235,16 @@ class NetatmoDataHandler:
                 **self.publisher[signal_name].kwargs
             )
 
-        except (pyatmo.NoDevice, pyatmo.ApiError) as err:
-            _LOGGER.debug(err)
+        except pyatmo.NoDevice as err:
+            _LOGGER.warning(err)
             has_error = True
 
-        except (asyncio.TimeoutError, aiohttp.ClientConnectorError) as err:
-            _LOGGER.debug(err)
+        except (
+            aiohttp.ClientConnectorError,
+            asyncio.TimeoutError,
+            pyatmo.ApiError,
+        ) as err:
+            _LOGGER.error(err)
             return True
 
         for update_callback in self.publisher[signal_name].subscriptions:


### PR DESCRIPTION
## Proposed change
API errors would only typically be shown in debugging mode, so show as error state instead.

There was previously a comment why we would not put an error if there was no devices. This is because this integration _can_ work without devices (albeit it would be uncommon) because it can function as a Weather integration also.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes Issue #67560
- Link to documentation pull request: previously closed (by accident!) PR #89267

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.