### PR TITLE
Improve validation of device automations

### DIFF
--- a/homeassistant/components/device_automation/helpers.py
+++ b/homeassistant/components/device_automation/helpers.py
@@ -75,8 +75,9 @@ async def async_validate_device_automation_config(
             ConfigType, getattr(platform, STATIC_VALIDATOR[automation_type])(config)
         )
 
-    # The entity platforms have dynamic validators for actions, bypass the checks below
-    # for the correct config entry
+    # Devices are not linked to config entries from entity platform domains, skip
+    # the checks below which look for a config entry matching the device automation
+    # domain
     if (
         automation_type == DeviceAutomationType.ACTION
         and validated_config[CONF_DOMAIN] in ENTITY_PLATFORMS
@@ -87,8 +88,7 @@ async def async_validate_device_automation_config(
             await getattr(platform, DYNAMIC_VALIDATOR[automation_type])(hass, config),
         )
 
-    # Only call the dynamic validator if the referenced is tied to a config entry from
-    # the right domain and the relevant config entry is loaded
+    # Find a config entry with the same domain as the device automation
     device_config_entry = None
     for entry_id in device.config_entries:
         if (
@@ -100,7 +100,7 @@ async def async_validate_device_automation_config(
         break
 
     if not device_config_entry:
-        # The config entry referenced by the device automation does not exist
+        # There's no config entry with the same domain as the device automation
         raise InvalidDeviceAutomationConfig(
             f"Device '{validated_config[CONF_DEVICE_ID]}' has no config entry from "
             f"domain '{validated_config[CONF_DOMAIN]}'"

--- a/homeassistant/components/device_automation/helpers.py
+++ b/homeassistant/components/device_automation/helpers.py
@@ -5,9 +5,9 @@ from typing import cast
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, Platform
+from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.typing import ConfigType
 
 from . import DeviceAutomationType, async_get_device_automation_platform
@@ -55,31 +55,40 @@ async def async_validate_device_automation_config(
     platform = await async_get_device_automation_platform(
         hass, validated_config[CONF_DOMAIN], automation_type
     )
+
+    # Make sure the referenced device and optional entity exist
+    device_registry = dr.async_get(hass)
+    if not (device := device_registry.async_get(validated_config[CONF_DEVICE_ID])):
+        # The device referenced by the device automation does not exist
+        raise InvalidDeviceAutomationConfig(
+            f"Unknown device '{validated_config[CONF_DEVICE_ID]}'"
+        )
+    if entity := validated_config.get(CONF_ENTITY_ID):
+        try:
+            er.async_validate_entity_id(er.async_get(hass), entity)
+        except vol.Invalid as err:
+            raise InvalidDeviceAutomationConfig(f"Unknown entity '{entity}'") from err
+
     if not hasattr(platform, DYNAMIC_VALIDATOR[automation_type]):
         # Pass the unvalidated config to avoid mutating the raw config twice
         return cast(
             ConfigType, getattr(platform, STATIC_VALIDATOR[automation_type])(config)
         )
 
-    # Bypass checks for entity platforms
+    # The entity platforms have dynamic validators for actions, bypass the checks below
+    # for the correct config entry
     if (
         automation_type == DeviceAutomationType.ACTION
         and validated_config[CONF_DOMAIN] in ENTITY_PLATFORMS
     ):
+        # Pass the unvalidated config to avoid mutating the raw config twice
         return cast(
             ConfigType,
             await getattr(platform, DYNAMIC_VALIDATOR[automation_type])(hass, config),
         )
 
-    # Only call the dynamic validator if the referenced device exists and the relevant
-    # config entry is loaded
-    registry = dr.async_get(hass)
-    if not (device := registry.async_get(validated_config[CONF_DEVICE_ID])):
-        # The device referenced by the device automation does not exist
-        raise InvalidDeviceAutomationConfig(
-            f"Unknown device '{validated_config[CONF_DEVICE_ID]}'"
-        )
-
+    # Only call the dynamic validator if the referenced is tied to a config entry from
+    # the right domain and the relevant config entry is loaded
     device_config_entry = None
     for entry_id in device.config_entries:
         if (

--- a/homeassistant/components/device_automation/helpers.py
+++ b/homeassistant/components/device_automation/helpers.py
@@ -63,11 +63,13 @@ async def async_validate_device_automation_config(
         raise InvalidDeviceAutomationConfig(
             f"Unknown device '{validated_config[CONF_DEVICE_ID]}'"
         )
-    if entity := validated_config.get(CONF_ENTITY_ID):
+    if entity_id := validated_config.get(CONF_ENTITY_ID):
         try:
-            er.async_validate_entity_id(er.async_get(hass), entity)
+            er.async_validate_entity_id(er.async_get(hass), entity_id)
         except vol.Invalid as err:
-            raise InvalidDeviceAutomationConfig(f"Unknown entity '{entity}'") from err
+            raise InvalidDeviceAutomationConfig(
+                f"Unknown entity '{entity_id}'"
+            ) from err
 
     if not hasattr(platform, DYNAMIC_VALIDATOR[automation_type]):
         # Pass the unvalidated config to avoid mutating the raw config twice

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -1,6 +1,7 @@
 """The test for light device automation."""
 from unittest.mock import AsyncMock, Mock, patch
 
+import attr
 import pytest
 from pytest_unordered import unordered
 import voluptuous as vol
@@ -29,6 +30,13 @@ from tests.common import (
     mock_platform,
 )
 from tests.typing import WebSocketGenerator
+
+
+@attr.s(frozen=True)
+class MockDeviceEntry(dr.DeviceEntry):
+    """Device Registry Entry with fixed UUID."""
+
+    id: str = attr.ib(default="very_unique")
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
@@ -1240,17 +1248,56 @@ async def test_automation_with_integration_without_device_trigger(
     )
 
 
+BAD_AUTOMATIONS = [
+    (
+        {"device_id": "very_unique", "domain": "light"},
+        "required key not provided @ data['entity_id']",
+    ),
+    (
+        {"device_id": "wrong", "domain": "light"},
+        "Unknown device 'wrong'",
+    ),
+    (
+        {"device_id": "wrong"},
+        "required key not provided @ data{path}['domain']",
+    ),
+    (
+        {"device_id": "wrong", "domain": "light"},
+        "Unknown device 'wrong'",
+    ),
+    (
+        {"device_id": "very_unique", "domain": "light"},
+        "required key not provided @ data['entity_id']",
+    ),
+    (
+        {"device_id": "very_unique", "domain": "light", "entity_id": "wrong"},
+        "Unknown entity 'wrong'",
+    ),
+]
+
+BAD_TRIGGERS = BAD_CONDITIONS = BAD_AUTOMATIONS + [
+    (
+        {"domain": "light"},
+        "required key not provided @ data{path}['device_id']",
+    )
+]
+
+
+@patch("homeassistant.helpers.device_registry.DeviceEntry", MockDeviceEntry)
+@pytest.mark.parametrize(("action", "expected_error"), BAD_AUTOMATIONS)
 async def test_automation_with_bad_action(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
+    action: dict[str, str],
+    expected_error: str,
 ) -> None:
     """Test automation with bad device action."""
     config_entry = MockConfigEntry(domain="fake_integration", data={})
     config_entry.state = config_entries.ConfigEntryState.LOADED
     config_entry.add_to_hass(hass)
-    device_entry = device_registry.async_get_or_create(
+    device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
@@ -1262,25 +1309,29 @@ async def test_automation_with_bad_action(
             automation.DOMAIN: {
                 "alias": "hello",
                 "trigger": {"platform": "event", "event_type": "test_event1"},
-                "action": {"device_id": device_entry.id, "domain": "light"},
+                "action": action,
             }
         },
     )
 
-    assert "required key not provided" in caplog.text
+    assert expected_error.format(path="['action'][0]") in caplog.text
 
 
+@patch("homeassistant.helpers.device_registry.DeviceEntry", MockDeviceEntry)
+@pytest.mark.parametrize(("condition", "expected_error"), BAD_CONDITIONS)
 async def test_automation_with_bad_condition_action(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
+    condition: dict[str, str],
+    expected_error: str,
 ) -> None:
     """Test automation with bad device action."""
     config_entry = MockConfigEntry(domain="fake_integration", data={})
     config_entry.state = config_entries.ConfigEntryState.LOADED
     config_entry.add_to_hass(hass)
-    device_entry = device_registry.async_get_or_create(
+    device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
@@ -1292,42 +1343,32 @@ async def test_automation_with_bad_condition_action(
             automation.DOMAIN: {
                 "alias": "hello",
                 "trigger": {"platform": "event", "event_type": "test_event1"},
-                "action": {
-                    "condition": "device",
-                    "device_id": device_entry.id,
-                    "domain": "light",
-                },
+                "action": {"condition": "device"} | condition,
             }
         },
     )
 
-    assert "required key not provided" in caplog.text
+    assert expected_error.format(path="['action'][0]") in caplog.text
 
 
-async def test_automation_with_bad_condition_missing_domain(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Test automation with bad device condition."""
-    assert await async_setup_component(
-        hass,
-        automation.DOMAIN,
-        {
-            automation.DOMAIN: {
-                "alias": "hello",
-                "trigger": {"platform": "event", "event_type": "test_event1"},
-                "condition": {"condition": "device", "device_id": "hello.device"},
-                "action": {"service": "test.automation", "entity_id": "hello.world"},
-            }
-        },
-    )
-
-    assert "required key not provided @ data['condition'][0]['domain']" in caplog.text
-
-
+@patch("homeassistant.helpers.device_registry.DeviceEntry", MockDeviceEntry)
+@pytest.mark.parametrize(("condition", "expected_error"), BAD_CONDITIONS)
 async def test_automation_with_bad_condition(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    device_registry: dr.DeviceRegistry,
+    condition: dict[str, str],
+    expected_error: str,
 ) -> None:
     """Test automation with bad device condition."""
+    config_entry = MockConfigEntry(domain="fake_integration", data={})
+    config_entry.state = config_entries.ConfigEntryState.LOADED
+    config_entry.add_to_hass(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -1335,13 +1376,13 @@ async def test_automation_with_bad_condition(
             automation.DOMAIN: {
                 "alias": "hello",
                 "trigger": {"platform": "event", "event_type": "test_event1"},
-                "condition": {"condition": "device", "domain": "light"},
+                "condition": {"condition": "device"} | condition,
                 "action": {"service": "test.automation", "entity_id": "hello.world"},
             }
         },
     )
 
-    assert "required key not provided" in caplog.text
+    assert expected_error.format(path="['condition'][0]") in caplog.text
 
 
 @pytest.fixture
@@ -1475,10 +1516,24 @@ async def test_automation_with_sub_condition(
     )
 
 
+@patch("homeassistant.helpers.device_registry.DeviceEntry", MockDeviceEntry)
+@pytest.mark.parametrize(("condition", "expected_error"), BAD_CONDITIONS)
 async def test_automation_with_bad_sub_condition(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    device_registry: dr.DeviceRegistry,
+    condition: dict[str, str],
+    expected_error: str,
 ) -> None:
     """Test automation with bad device condition under and/or conditions."""
+    config_entry = MockConfigEntry(domain="fake_integration", data={})
+    config_entry.state = config_entries.ConfigEntryState.LOADED
+    config_entry.add_to_hass(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -1488,33 +1543,48 @@ async def test_automation_with_bad_sub_condition(
                 "trigger": {"platform": "event", "event_type": "test_event1"},
                 "condition": {
                     "condition": "and",
-                    "conditions": [{"condition": "device", "domain": "light"}],
+                    "conditions": [{"condition": "device"} | condition],
                 },
                 "action": {"service": "test.automation", "entity_id": "hello.world"},
             }
         },
     )
 
-    assert "required key not provided" in caplog.text
+    path = "['condition'][0]['conditions'][0]"
+    assert expected_error.format(path=path) in caplog.text
 
 
+@patch("homeassistant.helpers.device_registry.DeviceEntry", MockDeviceEntry)
+@pytest.mark.parametrize(("trigger", "expected_error"), BAD_TRIGGERS)
 async def test_automation_with_bad_trigger(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    device_registry: dr.DeviceRegistry,
+    trigger: dict[str, str],
+    expected_error: str,
 ) -> None:
     """Test automation with bad device trigger."""
+    config_entry = MockConfigEntry(domain="fake_integration", data={})
+    config_entry.state = config_entries.ConfigEntryState.LOADED
+    config_entry.add_to_hass(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
         {
             automation.DOMAIN: {
                 "alias": "hello",
-                "trigger": {"platform": "device", "domain": "light"},
+                "trigger": {"platform": "device"} | trigger,
                 "action": {"service": "test.automation", "entity_id": "hello.world"},
             }
         },
     )
 
-    assert "required key not provided" in caplog.text
+    assert expected_error.format(path="") in caplog.text
 
 
 async def test_websocket_device_not_found(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve validation of device automations:
- Fail validation if a device automation references a device which does not exist
- Fail validation if a device automation references an entity registry id which does not exist

This fixes the error seen in https://gist.github.com/woutf/1e51a566817aaf9f4865b72189ac1877

Needs https://github.com/home-assistant/core/pull/102692 + https://github.com/home-assistant/core/pull/102785 + https://github.com/home-assistant/core/pull/102824 for tests to pass

#### Startup log with this PR
```
2023-10-25 11:03:53.537 ERROR (MainThread) [homeassistant.components.automation] Automation with alias 'Test automation' failed to setup conditions and has been disabled: Unknown entity '7d18a157b7c00adbf2982ea7de0d0362'
```

#### UI feedback when attempting to save an automation with this PR
![image](https://github.com/home-assistant/core/assets/14281572/968a265a-298f-4f53-82cb-29b68ed93526)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
