### PR TITLE
Fix hassio delaying startup to fetch container stats

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -757,7 +757,8 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
             name=DOMAIN,
             update_interval=HASSIO_UPDATE_INTERVAL,
             # We don't want an immediate refresh since we want to avoid
-            # hammering the Supervisor API on startup
+            # fetching the container stats right away and avoid hammering
+            # the Supervisor API on startup
             request_refresh_debouncer=Debouncer(
                 hass, _LOGGER, cooldown=REQUEST_REFRESH_DELAY, immediate=False
             ),

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -34,6 +34,7 @@ from homeassistant.core import (
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.storage import Store
@@ -74,6 +75,7 @@ from .const import (
     DATA_KEY_SUPERVISOR,
     DATA_KEY_SUPERVISOR_ISSUES,
     DOMAIN,
+    REQUEST_REFRESH_DELAY,
     SUPERVISOR_CONTAINER,
     SupervisorEntityModel,
 )
@@ -334,7 +336,7 @@ def get_addons_stats(hass):
 
     Async friendly.
     """
-    return hass.data.get(DATA_ADDONS_STATS)
+    return hass.data.get(DATA_ADDONS_STATS) or {}
 
 
 @callback
@@ -344,7 +346,7 @@ def get_core_stats(hass):
 
     Async friendly.
     """
-    return hass.data.get(DATA_CORE_STATS)
+    return hass.data.get(DATA_CORE_STATS) or {}
 
 
 @callback
@@ -354,7 +356,7 @@ def get_supervisor_stats(hass):
 
     Async friendly.
     """
-    return hass.data.get(DATA_SUPERVISOR_STATS)
+    return hass.data.get(DATA_SUPERVISOR_STATS) or {}
 
 
 @callback
@@ -754,6 +756,11 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER,
             name=DOMAIN,
             update_interval=HASSIO_UPDATE_INTERVAL,
+            # We don't want an immediate refresh since we want to avoid
+            # hammering the Supervisor API on startup
+            request_refresh_debouncer=Debouncer(
+                hass, _LOGGER, cooldown=REQUEST_REFRESH_DELAY, immediate=False
+            ),
         )
         self.hassio: HassIO = hass.data[DOMAIN]
         self.data = {}
@@ -875,9 +882,9 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
             DATA_SUPERVISOR_INFO: hassio.get_supervisor_info(),
             DATA_OS_INFO: hassio.get_os_info(),
         }
-        if first_update or CONTAINER_STATS in container_updates[CORE_CONTAINER]:
+        if CONTAINER_STATS in container_updates[CORE_CONTAINER]:
             updates[DATA_CORE_STATS] = hassio.get_core_stats()
-        if first_update or CONTAINER_STATS in container_updates[SUPERVISOR_CONTAINER]:
+        if CONTAINER_STATS in container_updates[SUPERVISOR_CONTAINER]:
             updates[DATA_SUPERVISOR_STATS] = hassio.get_supervisor_stats()
 
         results = await asyncio.gather(*updates.values())
@@ -903,20 +910,28 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
         # API calls since otherwise we would fetch stats for all containers
         # and throw them away.
         #
-        for data_key, update_func, enabled_key, wanted_addons in (
+        for data_key, update_func, enabled_key, wanted_addons, needs_first_update in (
             (
                 DATA_ADDONS_STATS,
                 self._update_addon_stats,
                 CONTAINER_STATS,
                 started_addons,
+                False,
             ),
             (
                 DATA_ADDONS_CHANGELOGS,
                 self._update_addon_changelog,
                 CONTAINER_CHANGELOG,
                 all_addons,
+                True,
             ),
-            (DATA_ADDONS_INFO, self._update_addon_info, CONTAINER_INFO, all_addons),
+            (
+                DATA_ADDONS_INFO,
+                self._update_addon_info,
+                CONTAINER_INFO,
+                all_addons,
+                True,
+            ),
         ):
             container_data: dict[str, Any] = data.setdefault(data_key, {})
             container_data.update(
@@ -925,7 +940,8 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
                         *[
                             update_func(slug)
                             for slug in wanted_addons
-                            if first_update or enabled_key in container_updates[slug]
+                            if (first_update and needs_first_update)
+                            or enabled_key in container_updates[slug]
                         ]
                     )
                 )

--- a/homeassistant/components/hassio/const.py
+++ b/homeassistant/components/hassio/const.py
@@ -90,6 +90,8 @@ CONTAINER_STATS = "stats"
 CONTAINER_CHANGELOG = "changelog"
 CONTAINER_INFO = "info"
 
+NEEDS_FIRST_UPDATE = {CONTAINER_INFO}
+
 # This is a mapping of which endpoint the key in the addon data
 # is obtained from so we know which endpoint to update when the
 # coordinator polls for updates.
@@ -100,6 +102,8 @@ KEY_TO_UPDATE_TYPES: dict[str, set[str]] = {
     ATTR_VERSION: {CONTAINER_INFO},
     ATTR_STATE: {CONTAINER_INFO},
 }
+
+REQUEST_REFRESH_DELAY = 10
 
 
 class SupervisorEntityModel(StrEnum):

--- a/homeassistant/components/hassio/const.py
+++ b/homeassistant/components/hassio/const.py
@@ -90,8 +90,6 @@ CONTAINER_STATS = "stats"
 CONTAINER_CHANGELOG = "changelog"
 CONTAINER_INFO = "info"
 
-NEEDS_FIRST_UPDATE = {CONTAINER_INFO}
-
 # This is a mapping of which endpoint the key in the addon data
 # is obtained from so we know which endpoint to update when the
 # coordinator polls for updates.

--- a/homeassistant/components/hassio/entity.py
+++ b/homeassistant/components/hassio/entity.py
@@ -58,6 +58,7 @@ class HassioAddonEntity(CoordinatorEntity[HassioDataUpdateCoordinator]):
                 self._addon_slug, self.entity_id, update_types
             )
         )
+        await self.coordinator.async_request_refresh()
 
 
 class HassioOSEntity(CoordinatorEntity[HassioDataUpdateCoordinator]):
@@ -147,6 +148,7 @@ class HassioSupervisorEntity(CoordinatorEntity[HassioDataUpdateCoordinator]):
                 SUPERVISOR_CONTAINER, self.entity_id, update_types
             )
         )
+        await self.coordinator.async_request_refresh()
 
 
 class HassioCoreEntity(CoordinatorEntity[HassioDataUpdateCoordinator]):
@@ -183,3 +185,4 @@ class HassioCoreEntity(CoordinatorEntity[HassioDataUpdateCoordinator]):
                 CORE_CONTAINER, self.entity_id, update_types
             )
         )
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/hassio/entity.py
+++ b/homeassistant/components/hassio/entity.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from . import DOMAIN, HassioDataUpdateCoordinator
 from .const import (
     ATTR_SLUG,
+    CONTAINER_STATS,
     CORE_CONTAINER,
     DATA_KEY_ADDONS,
     DATA_KEY_CORE,
@@ -58,7 +59,8 @@ class HassioAddonEntity(CoordinatorEntity[HassioDataUpdateCoordinator]):
                 self._addon_slug, self.entity_id, update_types
             )
         )
-        await self.coordinator.async_request_refresh()
+        if CONTAINER_STATS in update_types:
+            await self.coordinator.async_request_refresh()
 
 
 class HassioOSEntity(CoordinatorEntity[HassioDataUpdateCoordinator]):
@@ -148,7 +150,8 @@ class HassioSupervisorEntity(CoordinatorEntity[HassioDataUpdateCoordinator]):
                 SUPERVISOR_CONTAINER, self.entity_id, update_types
             )
         )
-        await self.coordinator.async_request_refresh()
+        if CONTAINER_STATS in update_types:
+            await self.coordinator.async_request_refresh()
 
 
 class HassioCoreEntity(CoordinatorEntity[HassioDataUpdateCoordinator]):
@@ -185,4 +188,5 @@ class HassioCoreEntity(CoordinatorEntity[HassioDataUpdateCoordinator]):
                 CORE_CONTAINER, self.entity_id, update_types
             )
         )
-        await self.coordinator.async_request_refresh()
+        if CONTAINER_STATS in update_types:
+            await self.coordinator.async_request_refresh()

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -17,6 +17,7 @@ from homeassistant.components.hassio import (
     async_get_addon_store_info,
     hostname_from_addon_slug,
 )
+from homeassistant.components.hassio.const import REQUEST_REFRESH_DELAY
 from homeassistant.components.hassio.handler import HassioAPIError
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.core import HomeAssistant
@@ -244,7 +245,7 @@ async def test_setup_api_ping(
         await hass.async_block_till_done()
 
     assert result
-    assert aioclient_mock.call_count == 22
+    assert aioclient_mock.call_count == 20
     assert hass.components.hassio.get_core_info()["version_latest"] == "1.0.0"
     assert hass.components.hassio.is_hassio()
 
@@ -289,7 +290,7 @@ async def test_setup_api_push_api_data(
         await hass.async_block_till_done()
 
     assert result
-    assert aioclient_mock.call_count == 22
+    assert aioclient_mock.call_count == 20
     assert not aioclient_mock.mock_calls[1][2]["ssl"]
     assert aioclient_mock.mock_calls[1][2]["port"] == 9999
     assert aioclient_mock.mock_calls[1][2]["watchdog"]
@@ -308,7 +309,7 @@ async def test_setup_api_push_api_data_server_host(
         await hass.async_block_till_done()
 
     assert result
-    assert aioclient_mock.call_count == 22
+    assert aioclient_mock.call_count == 20
     assert not aioclient_mock.mock_calls[1][2]["ssl"]
     assert aioclient_mock.mock_calls[1][2]["port"] == 9999
     assert not aioclient_mock.mock_calls[1][2]["watchdog"]
@@ -325,7 +326,7 @@ async def test_setup_api_push_api_data_default(
         await hass.async_block_till_done()
 
     assert result
-    assert aioclient_mock.call_count == 22
+    assert aioclient_mock.call_count == 20
     assert not aioclient_mock.mock_calls[1][2]["ssl"]
     assert aioclient_mock.mock_calls[1][2]["port"] == 8123
     refresh_token = aioclient_mock.mock_calls[1][2]["refresh_token"]
@@ -405,7 +406,7 @@ async def test_setup_api_existing_hassio_user(
         await hass.async_block_till_done()
 
     assert result
-    assert aioclient_mock.call_count == 22
+    assert aioclient_mock.call_count == 20
     assert not aioclient_mock.mock_calls[1][2]["ssl"]
     assert aioclient_mock.mock_calls[1][2]["port"] == 8123
     assert aioclient_mock.mock_calls[1][2]["refresh_token"] == token.token
@@ -422,7 +423,7 @@ async def test_setup_core_push_timezone(
         await hass.async_block_till_done()
 
     assert result
-    assert aioclient_mock.call_count == 22
+    assert aioclient_mock.call_count == 20
     assert aioclient_mock.mock_calls[2][2]["timezone"] == "testzone"
 
     with patch("homeassistant.util.dt.set_default_time_zone"):
@@ -442,7 +443,7 @@ async def test_setup_hassio_no_additional_data(
         await hass.async_block_till_done()
 
     assert result
-    assert aioclient_mock.call_count == 22
+    assert aioclient_mock.call_count == 20
     assert aioclient_mock.mock_calls[-1][3]["Authorization"] == "Bearer 123456"
 
 
@@ -524,14 +525,14 @@ async def test_service_calls(
     )
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 26
+    assert aioclient_mock.call_count == 24
     assert aioclient_mock.mock_calls[-1][2] == "test"
 
     await hass.services.async_call("hassio", "host_shutdown", {})
     await hass.services.async_call("hassio", "host_reboot", {})
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 28
+    assert aioclient_mock.call_count == 26
 
     await hass.services.async_call("hassio", "backup_full", {})
     await hass.services.async_call(
@@ -546,7 +547,7 @@ async def test_service_calls(
     )
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 30
+    assert aioclient_mock.call_count == 28
     assert aioclient_mock.mock_calls[-1][2] == {
         "name": "2021-11-13 03:48:00",
         "homeassistant": True,
@@ -571,7 +572,7 @@ async def test_service_calls(
     )
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 32
+    assert aioclient_mock.call_count == 30
     assert aioclient_mock.mock_calls[-1][2] == {
         "addons": ["test"],
         "folders": ["ssl"],
@@ -590,7 +591,7 @@ async def test_service_calls(
     )
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 33
+    assert aioclient_mock.call_count == 31
     assert aioclient_mock.mock_calls[-1][2] == {
         "name": "backup_name",
         "location": "backup_share",
@@ -606,7 +607,7 @@ async def test_service_calls(
     )
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 34
+    assert aioclient_mock.call_count == 32
     assert aioclient_mock.mock_calls[-1][2] == {
         "name": "2021-11-13 03:48:00",
         "location": None,
@@ -624,7 +625,7 @@ async def test_service_calls(
     )
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 36
+    assert aioclient_mock.call_count == 34
     assert aioclient_mock.mock_calls[-1][2] == {
         "name": "2021-11-13 11:48:00",
         "location": None,
@@ -896,7 +897,15 @@ async def test_coordinator_updates(
         config_entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
+        # Initial refresh without stats
         assert refresh_updates_mock.call_count == 1
+
+        # Refresh with stats once we know which ones are needed
+        async_fire_time_changed(
+            hass, dt_util.now() + timedelta(seconds=REQUEST_REFRESH_DELAY)
+        )
+        await hass.async_block_till_done()
+        assert refresh_updates_mock.call_count == 2
 
     with patch(
         "homeassistant.components.hassio.HassIO.refresh_updates",
@@ -919,10 +928,12 @@ async def test_coordinator_updates(
             },
             blocking=True,
         )
-        assert refresh_updates_mock.call_count == 1
+        assert refresh_updates_mock.call_count == 0
 
-    # There is a 10s cooldown on the debouncer
-    async_fire_time_changed(hass, dt_util.now() + timedelta(seconds=10))
+    # There is a REQUEST_REFRESH_DELAYs cooldown on the debouncer
+    async_fire_time_changed(
+        hass, dt_util.now() + timedelta(seconds=REQUEST_REFRESH_DELAY)
+    )
     await hass.async_block_till_done()
 
     with patch(
@@ -940,6 +951,11 @@ async def test_coordinator_updates(
             },
             blocking=True,
         )
+        # There is a REQUEST_REFRESH_DELAYs cooldown on the debouncer
+        async_fire_time_changed(
+            hass, dt_util.now() + timedelta(seconds=REQUEST_REFRESH_DELAY)
+        )
+        await hass.async_block_till_done()
         assert refresh_updates_mock.call_count == 1
         assert "Error on Supervisor API: Unknown" in caplog.text
 
@@ -973,7 +989,7 @@ async def test_setup_hardware_integration(
         await hass.async_block_till_done()
 
     assert result
-    assert aioclient_mock.call_count == 22
+    assert aioclient_mock.call_count == 20
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/hassio/test_sensor.py
+++ b/tests/components/hassio/test_sensor.py
@@ -10,6 +10,7 @@ from homeassistant.components.hassio import (
     HASSIO_UPDATE_INTERVAL,
     HassioAPIError,
 )
+from homeassistant.components.hassio.const import REQUEST_REFRESH_DELAY
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -245,6 +246,12 @@ async def test_sensor(
     await hass.config_entries.async_reload(config_entry.entry_id)
     await hass.async_block_till_done()
 
+    # There is a REQUEST_REFRESH_DELAYs cooldown on the debouncer
+    async_fire_time_changed(
+        hass, dt_util.now() + timedelta(seconds=REQUEST_REFRESH_DELAY)
+    )
+    await hass.async_block_till_done()
+
     # Verify that the entity have the expected state.
     state = hass.states.get(entity_id)
     assert state.state == expected
@@ -304,6 +311,12 @@ async def test_stats_addon_sensor(
     # Enable the entity.
     entity_registry.async_update_entity(entity_id, disabled_by=None)
     await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # There is a REQUEST_REFRESH_DELAYs cooldown on the debouncer
+    async_fire_time_changed(
+        hass, dt_util.now() + timedelta(seconds=REQUEST_REFRESH_DELAY)
+    )
     await hass.async_block_till_done()
 
     # Verify that the entity have the expected state.


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently startup waits for hassio to get container stats for all containers because we always request them on first update. For slower installs or installs with many containers this can delay startup by up to 90s (or more). We now request an update of the stats only after the entities have been added to avoid delaying startup since everything has to wait for hassio to finish before proceeding to stage 2.

We now update everything needed to get hassio going except the container stats, and when the stats entities are added they request refresh which will happen after the 10s cooldown, which allows startup to proceed while the cooldown is happening.

Startup is much faster now when the user has not enabled any stats entities:
<img width="435" alt="Screenshot 2023-10-25 at 6 00 19 AM" src="https://github.com/home-assistant/core/assets/663432/4dd5f295-148e-4934-8347-5b79dad9e9a4">

If they have, we now are able to move to stage 2 before the cooldown happens and stats update which allows other things to start.  Since we are now only updating stats they ask for, this is much faster (except for the cases where the user has manually enabled stats entities for every container)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
