### PR TITLE
Add Switch platform for motion detection in Blink

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -123,6 +123,7 @@ omit =
     homeassistant/components/blink/binary_sensor.py
     homeassistant/components/blink/camera.py
     homeassistant/components/blink/sensor.py
+    homeassistant/components/blink/switch.py
     homeassistant/components/blinksticklight/light.py
     homeassistant/components/blockchain/sensor.py
     homeassistant/components/bloomsky/*

--- a/homeassistant/components/blink/binary_sensor.py
+++ b/homeassistant/components/blink/binary_sensor.py
@@ -15,13 +15,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    DEFAULT_BRAND,
-    DOMAIN,
-    TYPE_BATTERY,
-    TYPE_CAMERA_ARMED,
-    TYPE_MOTION_DETECTED,
-)
+from .const import DEFAULT_BRAND, DOMAIN, TYPE_BATTERY, TYPE_MOTION_DETECTED
 from .coordinator import BlinkUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,10 +25,6 @@ BINARY_SENSORS_TYPES: tuple[BinarySensorEntityDescription, ...] = (
         key=TYPE_BATTERY,
         device_class=BinarySensorDeviceClass.BATTERY,
         entity_category=EntityCategory.DIAGNOSTIC,
-    ),
-    BinarySensorEntityDescription(
-        key=TYPE_CAMERA_ARMED,
-        translation_key="camera_armed",
     ),
     BinarySensorEntityDescription(
         key=TYPE_MOTION_DETECTED,

--- a/homeassistant/components/blink/binary_sensor.py
+++ b/homeassistant/components/blink/binary_sensor.py
@@ -32,9 +32,11 @@ BINARY_SENSORS_TYPES: tuple[BinarySensorEntityDescription, ...] = (
         device_class=BinarySensorDeviceClass.BATTERY,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # Camera Armed sensor is depreciated covered by switch and will be removed in the future.
     BinarySensorEntityDescription(
         key=TYPE_CAMERA_ARMED,
         translation_key="camera_armed",
+        entity_registry_enabled_default=False,
     ),
     BinarySensorEntityDescription(
         key=TYPE_MOTION_DETECTED,

--- a/homeassistant/components/blink/binary_sensor.py
+++ b/homeassistant/components/blink/binary_sensor.py
@@ -15,7 +15,13 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DEFAULT_BRAND, DOMAIN, TYPE_BATTERY, TYPE_MOTION_DETECTED
+from .const import (
+    DEFAULT_BRAND,
+    DOMAIN,
+    TYPE_BATTERY,
+    TYPE_CAMERA_ARMED,
+    TYPE_MOTION_DETECTED,
+)
 from .coordinator import BlinkUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,6 +31,10 @@ BINARY_SENSORS_TYPES: tuple[BinarySensorEntityDescription, ...] = (
         key=TYPE_BATTERY,
         device_class=BinarySensorDeviceClass.BATTERY,
         entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BinarySensorEntityDescription(
+        key=TYPE_CAMERA_ARMED,
+        translation_key="camera_armed",
     ),
     BinarySensorEntityDescription(
         key=TYPE_MOTION_DETECTED,

--- a/homeassistant/components/blink/binary_sensor.py
+++ b/homeassistant/components/blink/binary_sensor.py
@@ -32,7 +32,7 @@ BINARY_SENSORS_TYPES: tuple[BinarySensorEntityDescription, ...] = (
         device_class=BinarySensorDeviceClass.BATTERY,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    # Camera Armed sensor is depreciated covered by switch and will be removed in the future.
+    # Camera Armed sensor is depreciated covered by switch and will be removed in 2023.6.
     BinarySensorEntityDescription(
         key=TYPE_CAMERA_ARMED,
         translation_key="camera_armed",

--- a/homeassistant/components/blink/const.py
+++ b/homeassistant/components/blink/const.py
@@ -30,4 +30,5 @@ PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.CAMERA,
     Platform.SENSOR,
+    Platform.SWITCH,
 ]

--- a/homeassistant/components/blink/strings.json
+++ b/homeassistant/components/blink/strings.json
@@ -47,6 +47,11 @@
       "camera_armed": {
         "name": "Camera armed"
       }
+    },
+    "switch": {
+      "camera_motion": {
+        "name": "Camera motion detection"
+      }
     }
   },
   "services": {

--- a/homeassistant/components/blink/strings.json
+++ b/homeassistant/components/blink/strings.json
@@ -43,11 +43,6 @@
         "name": "Wi-Fi RSSI"
       }
     },
-    "binary_sensor": {
-      "camera_armed": {
-        "name": "Camera armed"
-      }
-    },
     "switch": {
       "camera_motion": {
         "name": "Camera motion detection"

--- a/homeassistant/components/blink/strings.json
+++ b/homeassistant/components/blink/strings.json
@@ -43,6 +43,11 @@
         "name": "Wi-Fi RSSI"
       }
     },
+    "binary_sensor": {
+      "camera_armed": {
+        "name": "Camera armed"
+      }
+    },
     "switch": {
       "camera_motion": {
         "name": "Camera motion detection"

--- a/homeassistant/components/blink/switch.py
+++ b/homeassistant/components/blink/switch.py
@@ -48,6 +48,7 @@ class BlinkSwitch(CoordinatorEntity[BlinkUpdateCoordinator], SwitchEntity):
     """Representation of a Blink Motion Switch."""
 
     _attr_has_entity_name = True
+    _attr_name = None
 
     def __init__(
         self,
@@ -79,7 +80,9 @@ class BlinkSwitch(CoordinatorEntity[BlinkUpdateCoordinator], SwitchEntity):
 
         except asyncio.TimeoutError as er:
             raise HomeAssistantError("Blink failed to arm camera") from er
-        self._attr_is_on = True
+
+        self._camera.motion_enabled = True
+        await self._coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
@@ -88,8 +91,9 @@ class BlinkSwitch(CoordinatorEntity[BlinkUpdateCoordinator], SwitchEntity):
 
         except asyncio.TimeoutError as er:
             raise HomeAssistantError("Blink failed to dis-arm camera") from er
-        self._attr_is_on = False
-        # self.async_write_ha_state()
+
+        self._camera.motion_enabled = False
+        await self._coordinator.async_refresh()
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/homeassistant/components/blink/switch.py
+++ b/homeassistant/components/blink/switch.py
@@ -1,4 +1,4 @@
-"""Support for Blink Motion switches."""
+"""Support for Blink Motion detection switches."""
 from __future__ import annotations
 
 import asyncio
@@ -46,7 +46,7 @@ async def async_setup_entry(
 
 
 class BlinkSwitch(CoordinatorEntity[BlinkUpdateCoordinator], SwitchEntity):
-    """Representation of a Blink Motion Switch."""
+    """Representation of a Blink motion detection switch."""
 
     _attr_has_entity_name = True
     _attr_name = None

--- a/homeassistant/components/blink/switch.py
+++ b/homeassistant/components/blink/switch.py
@@ -22,7 +22,8 @@ from .coordinator import BlinkUpdateCoordinator
 SWITCH_TYPES: tuple[SwitchEntityDescription, ...] = (
     SwitchEntityDescription(
         key=TYPE_CAMERA_ARMED,
-        translation_key="camera_armed",
+        icon="mdi:motion-sensor",
+        translation_key="camera_motion",
         device_class=SwitchDeviceClass.SWITCH,
     ),
 )

--- a/homeassistant/components/blink/switch.py
+++ b/homeassistant/components/blink/switch.py
@@ -75,7 +75,9 @@ class BlinkSwitch(CoordinatorEntity[BlinkUpdateCoordinator], SwitchEntity):
             await self._camera.async_arm(True)
 
         except asyncio.TimeoutError as er:
-            raise HomeAssistantError("Blink failed to arm camera") from er
+            raise HomeAssistantError(
+                "Blink failed to arm camera motion detection"
+            ) from er
 
         await self.coordinator.async_refresh()
 
@@ -85,7 +87,9 @@ class BlinkSwitch(CoordinatorEntity[BlinkUpdateCoordinator], SwitchEntity):
             await self._camera.async_arm(False)
 
         except asyncio.TimeoutError as er:
-            raise HomeAssistantError("Blink failed to dis-arm camera") from er
+            raise HomeAssistantError(
+                "Blink failed to dis-arm camera motion detection"
+            ) from er
 
         await self.coordinator.async_refresh()
 

--- a/homeassistant/components/blink/switch.py
+++ b/homeassistant/components/blink/switch.py
@@ -82,7 +82,6 @@ class BlinkSwitch(CoordinatorEntity[BlinkUpdateCoordinator], SwitchEntity):
         except asyncio.TimeoutError as er:
             raise HomeAssistantError("Blink failed to arm camera") from er
 
-        self._camera.motion_enabled = True
         await self._coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
@@ -93,7 +92,6 @@ class BlinkSwitch(CoordinatorEntity[BlinkUpdateCoordinator], SwitchEntity):
         except asyncio.TimeoutError as er:
             raise HomeAssistantError("Blink failed to dis-arm camera") from er
 
-        self._camera.motion_enabled = False
         await self._coordinator.async_refresh()
 
     @callback

--- a/homeassistant/components/blink/switch.py
+++ b/homeassistant/components/blink/switch.py
@@ -1,0 +1,103 @@
+"""Support for Blink Motion switches."""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from homeassistant.components.switch import (
+    SwitchDeviceClass,
+    SwitchEntity,
+    SwitchEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DEFAULT_BRAND, DOMAIN, TYPE_CAMERA_ARMED
+from .coordinator import BlinkUpdateCoordinator
+
+SWITCH_TYPES: tuple[SwitchEntityDescription, ...] = (
+    SwitchEntityDescription(
+        key=TYPE_CAMERA_ARMED,
+        translation_key="camera_armed",
+        device_class=SwitchDeviceClass.SWITCH,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Blink switches."""
+    coordinator: BlinkUpdateCoordinator = hass.data[DOMAIN][config.entry_id]
+
+    entities = [
+        BlinkSwitch(coordinator, camera, description)
+        for camera in coordinator.api.cameras
+        for description in SWITCH_TYPES
+    ]
+    async_add_entities(entities)
+
+
+class BlinkSwitch(CoordinatorEntity[BlinkUpdateCoordinator], SwitchEntity):
+    """Representation of a Blink Motion Switch."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: BlinkUpdateCoordinator,
+        camera,
+        description: SwitchEntityDescription,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator)
+        self._coordinator = coordinator
+        self._prev_state = None
+        self._camera = coordinator.api.cameras[camera]
+        self.entity_description = description
+        serial = self._camera.serial
+        self._attr_unique_id = f"{serial}-{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, serial)},
+            serial_number=serial,
+            name=camera,
+            manufacturer=DEFAULT_BRAND,
+            model=self._camera.camera_type,
+        )
+        self._update_attrs()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on."""
+        try:
+            await self._camera.async_arm(True)
+
+        except asyncio.TimeoutError as er:
+            raise HomeAssistantError("Blink failed to arm camera") from er
+        self._attr_is_on = True
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off."""
+        try:
+            await self._camera.async_arm(False)
+
+        except asyncio.TimeoutError as er:
+            raise HomeAssistantError("Blink failed to dis-arm camera") from er
+        self._attr_is_on = False
+        # self.async_write_ha_state()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle update from data coordinator."""
+        self._update_attrs()
+        super()._handle_coordinator_update()
+
+    @callback
+    def _update_attrs(self) -> None:
+        """Update attributes for binary sensor."""
+        self._attr_is_on = self._camera.motion_enabled


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The binary_sensor Camera Armed will be removed in the future, status can be found in the new switch Camera Motion Detection.  This change allows for individual camera enable/disable of the motion detection feature. 

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add switch platform for camera motion detection switch - allowing for enable/disable of the motion detection feature.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]: https://github.com/home-assistant/home-assistant.io/pull/29534

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
