### PR TITLE
Change todo move API to reference previous uid

### DIFF
--- a/homeassistant/components/local_todo/todo.py
+++ b/homeassistant/components/local_todo/todo.py
@@ -139,20 +139,28 @@ class LocalTodoListEntity(TodoListEntity):
         await self._async_save()
         await self.async_update_ha_state(force_refresh=True)
 
-    async def async_move_todo_item(self, uid: str, pos: int) -> None:
+    async def async_move_todo_item(
+        self, uid: str, previous_uid: str | None = None
+    ) -> None:
         """Re-order an item to the To-do list."""
+        if uid == previous_uid:
+            return
         todos = self._calendar.todos
-        found_item: Todo | None = None
-        for idx, itm in enumerate(todos):
-            if itm.uid == uid:
-                found_item = itm
-                todos.pop(idx)
-                break
-        if found_item is None:
+        item_idx: dict[str, int] = {itm.uid: idx for idx, itm in enumerate(todos)}
+        if uid not in item_idx:
             raise HomeAssistantError(
-                f"Item '{uid}' not found in todo list {self.entity_id}"
+                "Item '{uid}' not found in todo list {self.entity_id}"
             )
-        todos.insert(pos, found_item)
+        if previous_uid and previous_uid not in item_idx:
+            raise HomeAssistantError(
+                "Item '{previous_uid}' not found in todo list {self.entity_id}"
+            )
+        dst_idx = item_idx[previous_uid] + 1 if previous_uid else 0
+        src_idx = item_idx[uid]
+        src_item = todos.pop(src_idx)
+        if dst_idx > src_idx:
+            dst_idx -= 1
+        todos.insert(dst_idx, src_item)
         await self._async_save()
         await self.async_update_ha_state(force_refresh=True)
 

--- a/homeassistant/components/shopping_list/__init__.py
+++ b/homeassistant/components/shopping_list/__init__.py
@@ -322,17 +322,23 @@ class ShoppingData:
             context=context,
         )
 
-    async def async_move_item(self, uid: str, pos: int) -> None:
+    async def async_move_item(self, uid: str, previous: str | None = None) -> None:
         """Re-order a shopping list item."""
-        found_item: dict[str, Any] | None = None
-        for idx, itm in enumerate(self.items):
-            if cast(str, itm["id"]) == uid:
-                found_item = itm
-                self.items.pop(idx)
-                break
-        if not found_item:
+        if uid == previous:
+            return
+        item_idx = {cast(str, itm["id"]): idx for idx, itm in enumerate(self.items)}
+        if uid not in item_idx:
             raise NoMatchingShoppingListItem(f"Item '{uid}' not found in shopping list")
-        self.items.insert(pos, found_item)
+        if previous and previous not in item_idx:
+            raise NoMatchingShoppingListItem(
+                f"Item '{previous}' not found in shopping list"
+            )
+        dst_idx = item_idx[previous] + 1 if previous else 0
+        src_idx = item_idx[uid]
+        src_item = self.items.pop(src_idx)
+        if dst_idx > src_idx:
+            dst_idx -= 1
+        self.items.insert(dst_idx, src_item)
         await self.hass.async_add_executor_job(self.save)
         self._async_notify()
         self.hass.bus.async_fire(

--- a/homeassistant/components/shopping_list/todo.py
+++ b/homeassistant/components/shopping_list/todo.py
@@ -71,11 +71,13 @@ class ShoppingTodoListEntity(TodoListEntity):
         """Add an item to the To-do list."""
         await self._data.async_remove_items(set(uids))
 
-    async def async_move_todo_item(self, uid: str, pos: int) -> None:
+    async def async_move_todo_item(
+        self, uid: str, previous_uid: str | None = None
+    ) -> None:
         """Re-order an item to the To-do list."""
 
         try:
-            await self._data.async_move_item(uid, pos)
+            await self._data.async_move_item(uid, previous_uid)
         except NoMatchingShoppingListItem as err:
             raise HomeAssistantError(
                 f"Shopping list item '{uid}' could not be re-ordered"

--- a/homeassistant/components/todo/__init__.py
+++ b/homeassistant/components/todo/__init__.py
@@ -152,7 +152,7 @@ class TodoListEntity(Entity):
         """Delete an item in the To-do list."""
         raise NotImplementedError()
 
-    async def async_move_todo_item(self, uid: str, pos: int) -> None:
+    async def async_move_todo_item(self, uid: str, previous_uid: str | None) -> None:
         """Move an item in the To-do list."""
         raise NotImplementedError()
 
@@ -190,7 +190,7 @@ async def websocket_handle_todo_item_list(
         vol.Required("type"): "todo/item/move",
         vol.Required("entity_id"): cv.entity_id,
         vol.Required("uid"): cv.string,
-        vol.Optional("pos", default=0): cv.positive_int,
+        vol.Optional("previous_uid"): cv.string,
     }
 )
 @websocket_api.async_response
@@ -215,9 +215,10 @@ async def websocket_handle_todo_item_move(
             )
         )
         return
-
     try:
-        await entity.async_move_todo_item(uid=msg["uid"], pos=msg["pos"])
+        await entity.async_move_todo_item(
+            uid=msg["uid"], previous_uid=msg.get("previous_uid")
+        )
     except HomeAssistantError as ex:
         connection.send_error(msg["id"], "failed", str(ex))
     else:

--- a/homeassistant/components/todo/__init__.py
+++ b/homeassistant/components/todo/__init__.py
@@ -152,8 +152,15 @@ class TodoListEntity(Entity):
         """Delete an item in the To-do list."""
         raise NotImplementedError()
 
-    async def async_move_todo_item(self, uid: str, previous_uid: str | None) -> None:
-        """Move an item in the To-do list."""
+    async def async_move_todo_item(
+        self, uid: str, previous_uid: str | None = None
+    ) -> None:
+        """Move an item in the To-do list.
+
+        The To-do item with the specified `uid` should be moved to the position
+        in the list after the specified by `previous_uid` or `None` for the first
+        position in the To-do list.
+        """
         raise NotImplementedError()
 
 

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -2469,7 +2469,7 @@ _INHERITANCE_MATCH: dict[str, list[ClassTypeHintMatch]] = {
                     function_name="async_move_todo_item",
                     arg_types={
                         1: "str",
-                        2: "int",
+                        2: "str | None",
                     },
                     return_type="None",
                 ),

--- a/tests/components/todo/test_init.py
+++ b/tests/components/todo/test_init.py
@@ -571,7 +571,7 @@ async def test_move_todo_item_service_by_id(
             "type": "todo/item/move",
             "entity_id": "todo.entity1",
             "uid": "item-1",
-            "pos": "1",
+            "previous_uid": "item-2",
         }
     )
     resp = await client.receive_json()
@@ -581,7 +581,7 @@ async def test_move_todo_item_service_by_id(
     args = test_entity.async_move_todo_item.call_args
     assert args
     assert args.kwargs.get("uid") == "item-1"
-    assert args.kwargs.get("pos") == 1
+    assert args.kwargs.get("previous_uid") == "item-2"
 
 
 async def test_move_todo_item_service_raises(
@@ -601,7 +601,7 @@ async def test_move_todo_item_service_raises(
             "type": "todo/item/move",
             "entity_id": "todo.entity1",
             "uid": "item-1",
-            "pos": "1",
+            "previous_uid": "item-2",
         }
     )
     resp = await client.receive_json()
@@ -620,14 +620,9 @@ async def test_move_todo_item_service_raises(
         ),
         ({"entity_id": "todo.entity1"}, "invalid_format", "required key not provided"),
         (
-            {"entity_id": "todo.entity1", "pos": "2"},
+            {"entity_id": "todo.entity1", "previous_uid": "item-2"},
             "invalid_format",
             "required key not provided",
-        ),
-        (
-            {"entity_id": "todo.entity1", "uid": "item-1", "pos": "-2"},
-            "invalid_format",
-            "value must be at least 0",
         ),
     ],
 )
@@ -722,7 +717,7 @@ async def test_move_item_unsupported(
             "type": "todo/item/move",
             "entity_id": "todo.entity1",
             "uid": "item-1",
-            "pos": "1",
+            "previous_uid": "item-2",
         }
     )
     resp = await client.receive_json()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change todo move API to reference previous uid so that the frontend can sort items without worrying about the ordering for complete vs needs-action items.

This is a partial revert to the original API in #100019 and #102627 with some additional simplifications, so it should be re-reviewed.

This is a breaking change for the todo api, but should be save since it has not been released yet.

This PR needs a frontend PR approved before merge: https://github.com/home-assistant/frontend/pull/18410

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1958
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/18410

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
