### PR TITLE
Add support for options to airq integration

### DIFF
--- a/homeassistant/components/airq/__init__.py
+++ b/homeassistant/components/airq/__init__.py
@@ -18,6 +18,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Query the device for the first time and initialise coordinator.data
     await coordinator.async_config_entry_first_refresh()
+    entry.async_on_unload(entry.add_update_listener(coordinator.async_set_options))
 
     # Record the coordinator in a global store
     hass.data.setdefault(DOMAIN, {})

--- a/homeassistant/components/airq/const.py
+++ b/homeassistant/components/airq/const.py
@@ -1,9 +1,10 @@
 """Constants for the air-Q integration."""
 from typing import Final
 
+CONF_RETURN_AVERAGE: Final = "return_average"
+CONF_CLIP_NEGATIVE: Final = "clip_negatives"
 DOMAIN: Final = "airq"
 MANUFACTURER: Final = "CorantGmbH"
-TARGET_ROUTE: Final = "average"
 CONCENTRATION_GRAMS_PER_CUBIC_METER: Final = "g/m³"
 ACTIVITY_BECQUEREL_PER_CUBIC_METER: Final = "Bq/m³"
 UPDATE_INTERVAL: float = 10.0

--- a/homeassistant/components/airq/coordinator.py
+++ b/homeassistant/components/airq/coordinator.py
@@ -7,15 +7,27 @@ import logging
 from aioairq import AirQ
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
+from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD, CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN, MANUFACTURER, TARGET_ROUTE, UPDATE_INTERVAL
+from .const import (
+    CONF_CLIP_NEGATIVE,
+    CONF_RETURN_AVERAGE,
+    DOMAIN,
+    MANUFACTURER,
+    UPDATE_INTERVAL,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+DEFAULT_OPTIONS = {
+    CONF_SCAN_INTERVAL: UPDATE_INTERVAL,
+    CONF_CLIP_NEGATIVE: True,
+    CONF_RETURN_AVERAGE: True,
+}
 
 
 class AirQCoordinator(DataUpdateCoordinator):
@@ -27,11 +39,12 @@ class AirQCoordinator(DataUpdateCoordinator):
         entry: ConfigEntry,
     ) -> None:
         """Initialise a custom coordinator."""
+        self.options = DEFAULT_OPTIONS | entry.options
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(seconds=UPDATE_INTERVAL),
+            update_interval=timedelta(seconds=self.options[CONF_SCAN_INTERVAL]),
         )
         session = async_get_clientsession(hass)
         self.airq = AirQ(
@@ -56,6 +69,21 @@ class AirQCoordinator(DataUpdateCoordinator):
                     hw_version=info["hw_version"],
                 )
             )
+        return await self.airq.get_latest_data(
+            return_average=self.options[CONF_RETURN_AVERAGE],
+            clip_negative_values=self.options[CONF_CLIP_NEGATIVE],
+        )
 
-        data = await self.airq.get(TARGET_ROUTE)
-        return self.airq.drop_uncertainties_from_data(data)
+    async def async_set_options(
+        self, hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> None:
+        """Update the configuration options for the device."""
+        options = self.options | config_entry.options
+        _LOGGER.debug(
+            "%s.async_set_options: from %s to %s",
+            self.__class__.__name__,
+            repr(self.options),
+            repr(options),
+        )
+        self.options = options
+        self.update_interval = timedelta(seconds=self.options[CONF_SCAN_INTERVAL])

--- a/homeassistant/components/airq/manifest.json
+++ b/homeassistant/components/airq/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["aioairq"],
-  "requirements": ["aioairq==0.2.4"]
+  "requirements": ["aioairq==0.3.1"]
 }

--- a/homeassistant/components/airq/strings.json
+++ b/homeassistant/components/airq/strings.json
@@ -19,6 +19,23 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Configure air-Q integration",
+        "data": {
+          "scan_interval": "Polling interval in seconds",
+          "return_average": "Show values averaged by the device",
+          "clip_negatives": "Clip negative values"
+        },
+        "data_description": {
+          "scan_interval": "Setting the polling interval to low values (less than 2 seconds) is discouraged, as frequent polling can slow down the air-Q smartphone app",
+          "return_average": "air-Q allows to control the strength of sensor value averaging performed on the device. To poll noisy sensor readings from the device, switch this feature off",
+          "clip_negatives": "For baseline calibration purposes, certain sensor values may briefly become negative. The default behaviour is to clip such values to 0"
+        }
+      }
+    }
+  },
   "entity": {
     "sensor": {
       "acetaldehyde": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -185,7 +185,7 @@ aio-geojson-usgs-earthquakes==0.2
 aio-georss-gdacs==0.8
 
 # homeassistant.components.airq
-aioairq==0.2.4
+aioairq==0.3.1
 
 # homeassistant.components.airzone_cloud
 aioairzone-cloud==0.3.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -164,7 +164,7 @@ aio-geojson-usgs-earthquakes==0.2
 aio-georss-gdacs==0.8
 
 # homeassistant.components.airq
-aioairq==0.2.4
+aioairq==0.3.1
 
 # homeassistant.components.airzone_cloud
 aioairzone-cloud==0.3.6


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Expose to the user the following configuration:
1. The polling interval (previously hard coded at 10s)
2. A choice between fetching the averaged (old behavior) vs. noisy sensor reading from the device
3. A toggle to clip (spuriously) negative sensor values (new and now default functionality)

To those ends:
- Bump aioairq version to [0.3.1](https://github.com/CorantGmbH/aioairq/commit/b8a0d0a47337ac0ded025b2b4c0a9bfbe676dfe6) which allows clipping of negative sensor values. This also makes `AirQCoordinator` use a slightly different API to fetch the data
- Introduce an `OptionsFlowHandler` alongside with a listener `AirQCoordinator.async_set_options`
- Introduce constants to handle represent options
- Add tests and strings


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29538

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
