### PR TITLE
Suppress log warnings when a sensor group has non numeric members

### DIFF
--- a/homeassistant/components/group/sensor.py
+++ b/homeassistant/components/group/sensor.py
@@ -319,7 +319,7 @@ class SensorGroup(GroupEntity, SensorEntity):
         self._attr_extra_state_attributes = {ATTR_ENTITY_ID: entity_ids}
         self._attr_unique_id = unique_id
         self._ignore_non_numeric = ignore_non_numeric
-        self._mode = all if ignore_non_numeric is False else any
+        self.mode = all if ignore_non_numeric is False else any
         self._state_calc: Callable[
             [list[tuple[str, float, State]]],
             tuple[dict[str, str | None], float | None],
@@ -398,13 +398,10 @@ class SensorGroup(GroupEntity, SensorEntity):
         # Set group as unavailable if all members do not have numeric values
         self._attr_available = any(numeric_state for numeric_state in valid_states)
 
-        valid_state = self._mode(
+        valid_state = self.mode(
             state not in (STATE_UNKNOWN, STATE_UNAVAILABLE) for state in states
         )
-
-        valid_state_numeric = self._mode(
-            numeric_state for numeric_state in valid_states
-        )
+        valid_state_numeric = self.mode(numeric_state for numeric_state in valid_states)
 
         if not valid_state or not valid_state_numeric:
             self._attr_native_value = None

--- a/homeassistant/components/group/sensor.py
+++ b/homeassistant/components/group/sensor.py
@@ -319,6 +319,7 @@ class SensorGroup(GroupEntity, SensorEntity):
         self._attr_extra_state_attributes = {ATTR_ENTITY_ID: entity_ids}
         self._attr_unique_id = unique_id
         self._ignore_non_numeric = ignore_non_numeric
+        self._mode = all if ignore_non_numeric is False else any
         self._state_calc: Callable[
             [list[tuple[str, float, State]]],
             tuple[dict[str, str | None], float | None],
@@ -397,13 +398,13 @@ class SensorGroup(GroupEntity, SensorEntity):
         # Set group as unavailable if all members do not have numeric values
         self._attr_available = any(numeric_state for numeric_state in valid_states)
 
-        # Get validation function
-        validate = any if self._ignore_non_numeric else all
-
-        valid_state = validate(
+        valid_state = self._mode(
             state not in (STATE_UNKNOWN, STATE_UNAVAILABLE) for state in states
         )
-        valid_state_numeric = validate(numeric_state for numeric_state in valid_states)
+
+        valid_state_numeric = self._mode(
+            numeric_state for numeric_state in valid_states
+        )
 
         if not valid_state or not valid_state_numeric:
             self._attr_native_value = None

--- a/homeassistant/components/group/sensor.py
+++ b/homeassistant/components/group/sensor.py
@@ -299,7 +299,7 @@ class SensorGroup(GroupEntity, SensorEntity):
         unique_id: str | None,
         name: str,
         entity_ids: list[str],
-        mode: bool,
+        ignore_non_numeric: bool,
         sensor_type: str,
         unit_of_measurement: str | None,
         state_class: SensorStateClass | None,
@@ -318,7 +318,7 @@ class SensorGroup(GroupEntity, SensorEntity):
             self._attr_name = f"{DEFAULT_NAME} {sensor_type}".capitalize()
         self._attr_extra_state_attributes = {ATTR_ENTITY_ID: entity_ids}
         self._attr_unique_id = unique_id
-        self.mode = all if mode is False else any
+        self._ignore_non_numeric = ignore_non_numeric
         self._state_calc: Callable[
             [list[tuple[str, float, State]]],
             tuple[dict[str, str | None], float | None],
@@ -358,9 +358,14 @@ class SensorGroup(GroupEntity, SensorEntity):
                     sensor_values.append((entity_id, numeric_state, state))
                     if entity_id in self._state_incorrect:
                         self._state_incorrect.remove(entity_id)
+                    valid_states.append(True)
                 except ValueError:
                     valid_states.append(False)
-                    if entity_id not in self._state_incorrect:
+                    # Log invalid states unless ignoring non numeric values
+                    if (
+                        not self._ignore_non_numeric
+                        and entity_id not in self._state_incorrect
+                    ):
                         self._state_incorrect.add(entity_id)
                         _LOGGER.warning(
                             "Unable to use state. Only numerical states are supported,"
@@ -388,16 +393,17 @@ class SensorGroup(GroupEntity, SensorEntity):
                             state.attributes.get("unit_of_measurement"),
                             self.entity_id,
                         )
-                    continue
-                valid_states.append(True)
 
         # Set group as unavailable if all members do not have numeric values
         self._attr_available = any(numeric_state for numeric_state in valid_states)
 
-        valid_state = self.mode(
+        # Get validation function
+        validate = any if self._ignore_non_numeric else all
+
+        valid_state = validate(
             state not in (STATE_UNKNOWN, STATE_UNAVAILABLE) for state in states
         )
-        valid_state_numeric = self.mode(numeric_state for numeric_state in valid_states)
+        valid_state_numeric = validate(numeric_state for numeric_state in valid_states)
 
         if not valid_state or not valid_state_numeric:
             self._attr_native_value = None

--- a/tests/components/group/test_sensor.py
+++ b/tests/components/group/test_sensor.py
@@ -274,8 +274,7 @@ async def test_sensor_incorrect_state_with_ignore_non_numeric(
     state = hass.states.get("sensor.test_ignore_non_numeric")
     assert state.state == "17.0"
     assert (
-        "Unable to use state. Only numerical states are supported,"
-        not in caplog.text
+        "Unable to use state. Only numerical states are supported," not in caplog.text
     )
 
     # Check that the final sensor value with all numeric inputs
@@ -315,10 +314,7 @@ async def test_sensor_incorrect_state_with_not_ignore_non_numeric(
 
     state = hass.states.get("sensor.test_failure")
     assert state.state == "unknown"
-    assert (
-        "Unable to use state. Only numerical states are supported"
-        in caplog.text
-    )
+    assert "Unable to use state. Only numerical states are supported" in caplog.text
 
     # Check that the final sensor value is correct with all numeric inputs
     for entity_id, value in dict(zip(entity_ids, VALUES)).items():

--- a/tests/components/group/test_sensor.py
+++ b/tests/components/group/test_sensor.py
@@ -286,7 +286,7 @@ async def test_sensor_ignore_non_numeric(
 async def test_sensor_non_numeric(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test that non numeric values are caused a group to be unknown."""
+    """Test that non numeric values cause a group to be unknown."""
     config = {
         SENSOR_DOMAIN: {
             "platform": GROUP_DOMAIN,

--- a/tests/components/group/test_sensor.py
+++ b/tests/components/group/test_sensor.py
@@ -245,15 +245,15 @@ async def test_reload(hass: HomeAssistant) -> None:
     assert hass.states.get("sensor.second_test")
 
 
-async def test_sensor_incorrect_state(
+async def test_sensor_ignore_non_numeric(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test the min sensor."""
+    """Test that non numeric values are ignored in a group."""
     config = {
         SENSOR_DOMAIN: {
             "platform": GROUP_DOMAIN,
             "name": "test_failure",
-            "type": "min",
+            "type": "max",
             "ignore_non_numeric": True,
             "entities": ["sensor.test_1", "sensor.test_2", "sensor.test_3"],
             "unique_id": "very_unique_id",
@@ -266,24 +266,63 @@ async def test_sensor_incorrect_state(
 
     entity_ids = config["sensor"]["entities"]
 
+    # Check that the final sensor value ignores the non numeric input
     for entity_id, value in dict(zip(entity_ids, VALUES_ERROR)).items():
         hass.states.async_set(entity_id, value)
         await hass.async_block_till_done()
 
     state = hass.states.get("sensor.test_failure")
+    assert state.state == "17.0"
 
-    assert state.state == "15.3"
-    assert (
-        "Unable to use state. Only numerical states are supported, entity sensor.test_2 with value string excluded from calculation"
-        in caplog.text
-    )
-
+    # Check that the final sensor value with all numeric inputs
     for entity_id, value in dict(zip(entity_ids, VALUES)).items():
         hass.states.async_set(entity_id, value)
         await hass.async_block_till_done()
 
     state = hass.states.get("sensor.test_failure")
-    assert state.state == "15.3"
+    assert state.state == "20.0"
+
+
+async def test_sensor_non_numeric(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that non numeric values are caused a group to be unknown."""
+    config = {
+        SENSOR_DOMAIN: {
+            "platform": GROUP_DOMAIN,
+            "name": "test_failure",
+            "type": "max",
+            "ignore_non_numeric": False,
+            "entities": ["sensor.test_1", "sensor.test_2", "sensor.test_3"],
+            "unique_id": "very_unique_id",
+            "state_class": SensorStateClass.MEASUREMENT,
+        }
+    }
+
+    assert await async_setup_component(hass, "sensor", config)
+    await hass.async_block_till_done()
+
+    entity_ids = config["sensor"]["entities"]
+
+    # Check that the final sensor value is unavailable if a non numeric input exists
+    for entity_id, value in dict(zip(entity_ids, VALUES_ERROR)).items():
+        hass.states.async_set(entity_id, value)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.test_failure")
+    assert state.state == "unknown"
+    assert (
+        "Unable to use state. Only numerical states are supported, entity sensor.test_2 with value string excluded from calculation"
+        in caplog.text
+    )
+
+    # Check that the final sensor value is correct with all numeric inputs
+    for entity_id, value in dict(zip(entity_ids, VALUES)).items():
+        hass.states.async_set(entity_id, value)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.test_failure")
+    assert state.state == "20.0"
 
 
 async def test_sensor_require_all_states(hass: HomeAssistant) -> None:

--- a/tests/components/group/test_sensor.py
+++ b/tests/components/group/test_sensor.py
@@ -274,7 +274,7 @@ async def test_sensor_incorrect_state_with_ignore_non_numeric(
     state = hass.states.get("sensor.test_ignore_non_numeric")
     assert state.state == "17.0"
     assert (
-        "Unable to use state. Only numerical states are supported, entity sensor.test_2 with value string excluded from calculation"
+        "Unable to use state. Only numerical states are supported,"
         not in caplog.text
     )
 
@@ -287,7 +287,7 @@ async def test_sensor_incorrect_state_with_ignore_non_numeric(
     assert state.state == "20.0"
 
 
-async def test_sensor_incorrect_state(
+async def test_sensor_incorrect_state_with_not_ignore_non_numeric(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test that non numeric values cause a group to be unknown."""
@@ -316,7 +316,7 @@ async def test_sensor_incorrect_state(
     state = hass.states.get("sensor.test_failure")
     assert state.state == "unknown"
     assert (
-        "Unable to use state. Only numerical states are supported, entity sensor.test_2 with value string excluded from calculation"
+        "Unable to use state. Only numerical states are supported"
         in caplog.text
     )
 

--- a/tests/components/group/test_sensor.py
+++ b/tests/components/group/test_sensor.py
@@ -245,7 +245,7 @@ async def test_reload(hass: HomeAssistant) -> None:
     assert hass.states.get("sensor.second_test")
 
 
-async def test_sensor_ignore_non_numeric(
+async def test_sensor_incorrect_state_with_ignore_non_numeric(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test that non numeric values are ignored in a group."""

--- a/tests/components/group/test_sensor.py
+++ b/tests/components/group/test_sensor.py
@@ -252,7 +252,7 @@ async def test_sensor_incorrect_state_with_ignore_non_numeric(
     config = {
         SENSOR_DOMAIN: {
             "platform": GROUP_DOMAIN,
-            "name": "test_failure",
+            "name": "test_ignore_non_numeric",
             "type": "max",
             "ignore_non_numeric": True,
             "entities": ["sensor.test_1", "sensor.test_2", "sensor.test_3"],
@@ -271,19 +271,23 @@ async def test_sensor_incorrect_state_with_ignore_non_numeric(
         hass.states.async_set(entity_id, value)
         await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.test_failure")
+    state = hass.states.get("sensor.test_ignore_non_numeric")
     assert state.state == "17.0"
+    assert (
+        "Unable to use state. Only numerical states are supported, entity sensor.test_2 with value string excluded from calculation"
+        not in caplog.text
+    )
 
     # Check that the final sensor value with all numeric inputs
     for entity_id, value in dict(zip(entity_ids, VALUES)).items():
         hass.states.async_set(entity_id, value)
         await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.test_failure")
+    state = hass.states.get("sensor.test_ignore_non_numeric")
     assert state.state == "20.0"
 
 
-async def test_sensor_non_numeric(
+async def test_sensor_incorrect_state(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test that non numeric values cause a group to be unknown."""


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Suppress log warnings from sensor groups that have non-numeric members and have been configured to ignore said non-numeric values

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #87924

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
