### PR TITLE
Add HassClimateGetTemperature intent

### DIFF
--- a/homeassistant/components/climate/intent.py
+++ b/homeassistant/components/climate/intent.py
@@ -1,0 +1,64 @@
+"""Intents for the client integration."""
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers import intent
+from homeassistant.helpers.entity_component import EntityComponent
+
+from . import DOMAIN, ClimateEntity
+
+INTENT_GET_TEMPERATURE = "HassClimateGetTemperature"
+
+
+async def async_setup_intents(hass: HomeAssistant) -> None:
+    """Set up the climate intents."""
+    intent.async_register(hass, GetTemperatureIntent())
+
+
+class GetTemperatureIntent(intent.IntentHandler):
+    """Handle GetTemperature intents."""
+
+    intent_type = INTENT_GET_TEMPERATURE
+    slot_schema = {vol.Optional("area"): str}
+
+    async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
+        """Handle the intent."""
+        hass = intent_obj.hass
+        slots = self.async_validate_slots(intent_obj.slots)
+
+        component: EntityComponent[ClimateEntity] = hass.data[DOMAIN]
+        entities: list[ClimateEntity] = list(component.entities)
+        climate_state: State | None = None
+
+        if not entities:
+            raise intent.IntentHandleError("No climate entities")
+
+        if "area" in slots:
+            # Filter by area
+            area_name = slots["area"]["value"]
+            for maybe_climate in intent.async_match_states(
+                hass, area_name=area_name, domains=[DOMAIN]
+            ):
+                climate_state = maybe_climate
+                break
+
+            if climate_state is None:
+                raise intent.IntentHandleError(f"No climate entity in area {area_name}")
+        else:
+            # First entity
+            climate_entity = entities[0]
+            climate_state = hass.states.get(climate_entity.entity_id)
+
+            if climate_state is None:
+                raise intent.IntentHandleError(
+                    f"No state for climate entity {climate_entity.entity_id}"
+                )
+
+        assert climate_state is not None
+
+        response = intent_obj.create_response()
+        response.response_type = intent.IntentResponseType.QUERY_ANSWER
+        response.async_set_states(matched_states=[climate_state])
+        return response

--- a/homeassistant/components/climate/intent.py
+++ b/homeassistant/components/climate/intent.py
@@ -57,11 +57,6 @@ class GetTemperatureIntent(intent.IntentHandler):
 
         assert climate_entity is not None
 
-        if climate_entity.current_temperature is None:
-            raise intent.IntentHandleError(
-                f"No temperature for entity: {climate_entity.entity_id}"
-            )
-
         if climate_state is None:
             raise intent.IntentHandleError(f"No state for {climate_entity.name}")
 

--- a/tests/components/climate/test_intent.py
+++ b/tests/components/climate/test_intent.py
@@ -1,0 +1,165 @@
+"""Test climate intents."""
+from collections.abc import Generator
+
+import pytest
+
+from homeassistant.components.climate import (
+    DOMAIN,
+    ClimateEntity,
+    HVACMode,
+    intent as climate_intent,
+)
+from homeassistant.config_entries import ConfigEntry, ConfigFlow
+from homeassistant.const import Platform, UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import area_registry as ar, entity_registry as er, intent
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from tests.common import (
+    MockConfigEntry,
+    MockModule,
+    MockPlatform,
+    mock_config_flow,
+    mock_integration,
+    mock_platform,
+)
+
+TEST_DOMAIN = "test"
+
+
+class MockFlow(ConfigFlow):
+    """Test flow."""
+
+
+@pytest.fixture(autouse=True)
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+    """Mock config flow."""
+    mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
+
+    with mock_config_flow(TEST_DOMAIN, MockFlow):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def mock_setup_integration(hass: HomeAssistant) -> None:
+    """Fixture to set up a mock integration."""
+
+    async def async_setup_entry_init(
+        hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> bool:
+        """Set up test config entry."""
+        await hass.config_entries.async_forward_entry_setup(config_entry, DOMAIN)
+        return True
+
+    async def async_unload_entry_init(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+    ) -> bool:
+        await hass.config_entries.async_unload_platforms(config_entry, [Platform.TODO])
+        return True
+
+    mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
+    mock_integration(
+        hass,
+        MockModule(
+            TEST_DOMAIN,
+            async_setup_entry=async_setup_entry_init,
+            async_unload_entry=async_unload_entry_init,
+        ),
+    )
+
+
+async def create_mock_platform(
+    hass: HomeAssistant,
+    entities: list[ClimateEntity],
+) -> MockConfigEntry:
+    """Create a todo platform with the specified entities."""
+
+    async def async_setup_entry_platform(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddEntitiesCallback,
+    ) -> None:
+        """Set up test event platform via config entry."""
+        async_add_entities(entities)
+
+    mock_platform(
+        hass,
+        f"{TEST_DOMAIN}.{DOMAIN}",
+        MockPlatform(async_setup_entry=async_setup_entry_platform),
+    )
+
+    config_entry = MockConfigEntry(domain=TEST_DOMAIN)
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    return config_entry
+
+
+class MockClimateEntity(ClimateEntity):
+    """Mock Climate device to use in tests."""
+
+    _attr_temperature_unit = UnitOfTemperature.FAHRENHEIT
+    _attr_hvac_mode = HVACMode.OFF
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT]
+
+
+async def test_get_temperature(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test HassClimateGetTemperature intent."""
+    await climate_intent.async_setup_intents(hass)
+
+    climate_1 = MockClimateEntity()
+    climate_1._attr_name = "Climate 1"
+    climate_1._attr_unique_id = "1234"
+    entity_registry.async_get_or_create(
+        DOMAIN, "test", "1234", suggested_object_id="climate_1"
+    )
+
+    climate_2 = MockClimateEntity()
+    climate_2._attr_name = "Climate 2"
+    climate_2._attr_unique_id = "5678"
+    entity_registry.async_get_or_create(
+        DOMAIN, "test", "5678", suggested_object_id="climate_2"
+    )
+
+    await create_mock_platform(hass, [climate_1, climate_2])
+
+    # Add climate entities to different areas:
+    # climate_1 => living room
+    # climate_2 => bedroom
+    living_room_area = area_registry.async_create(name="Living Room")
+    bedroom_area = area_registry.async_create(name="Bedroom")
+
+    entity_registry.async_update_entity(
+        climate_1.entity_id, area_id=living_room_area.id
+    )
+    entity_registry.async_update_entity(climate_2.entity_id, area_id=bedroom_area.id)
+
+    hass.states.async_set(climate_1.entity_id, "30")
+    hass.states.async_set(climate_2.entity_id, "55")
+
+    # First climate entity will be selected (no area)
+    response = await intent.async_handle(
+        hass, "test", climate_intent.INTENT_GET_TEMPERATURE, {}
+    )
+    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert len(response.matched_states) == 1
+    assert response.matched_states[0].entity_id == climate_1.entity_id
+    assert response.matched_states[0].state == "30"
+
+    # Select by area instead (climate_2)
+    response = await intent.async_handle(
+        hass,
+        "test",
+        climate_intent.INTENT_GET_TEMPERATURE,
+        {"area": {"value": "Bedroom"}},
+    )
+    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert len(response.matched_states) == 1
+    assert response.matched_states[0].entity_id == climate_2.entity_id
+    assert response.matched_states[0].state == "55"

--- a/tests/components/climate/test_intent.py
+++ b/tests/components/climate/test_intent.py
@@ -150,7 +150,8 @@ async def test_get_temperature(
     assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_1.entity_id
-    assert float(response.matched_states[0].state) == 10.0
+    state = response.matched_states[0]
+    assert state.attributes["current_temperature"] == 10.0
 
     # Select by area instead (climate_2)
     response = await intent.async_handle(
@@ -162,7 +163,8 @@ async def test_get_temperature(
     assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_2.entity_id
-    assert float(response.matched_states[0].state) == 22.0
+    state = response.matched_states[0]
+    assert state.attributes["current_temperature"] == 22.0
 
 
 async def test_get_temperature_no_entities(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a new intent: `HassClimateGetTemperature`, whose sentences are in the [intents repo](https://github.com/home-assistant/intents/).

This intent gets the state of the first climate entity. An optional area name can be provided, narrowing the selection to just that area.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
