### PR TITLE
Add connections to PassiveBluetoothProcessorEntity

### DIFF
--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Generic, TypedDict, TypeVar, cast
 
 from homeassistant import config_entries
 from homeassistant.const import (
+    ATTR_CONNECTIONS,
     ATTR_IDENTIFIERS,
     ATTR_NAME,
     CONF_ENTITY_CATEGORY,
@@ -16,7 +17,7 @@ from homeassistant.const import (
     EntityCategory,
 )
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_platform import async_get_current_platform
 from homeassistant.helpers.event import async_track_time_interval
@@ -644,6 +645,7 @@ class PassiveBluetoothProcessorEntity(Entity, Generic[_PassiveBluetoothDataProce
             self._attr_unique_id = f"{address}-{key}"
         if ATTR_NAME not in self._attr_device_info:
             self._attr_device_info[ATTR_NAME] = self.processor.coordinator.name
+        self._attr_device_info[ATTR_CONNECTIONS] = {(CONNECTION_BLUETOOTH, address)}
         self._attr_name = processor.entity_names.get(entity_key)
 
     @property

--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -645,7 +645,8 @@ class PassiveBluetoothProcessorEntity(Entity, Generic[_PassiveBluetoothDataProce
             self._attr_unique_id = f"{address}-{key}"
         if ATTR_NAME not in self._attr_device_info:
             self._attr_device_info[ATTR_NAME] = self.processor.coordinator.name
-        self._attr_device_info[ATTR_CONNECTIONS] = {(CONNECTION_BLUETOOTH, address)}
+        if device_id is None:
+            self._attr_device_info[ATTR_CONNECTIONS] = {(CONNECTION_BLUETOOTH, address)}
         self._attr_name = processor.entity_names.get(entity_key)
 
     @property

--- a/tests/components/bluetooth/test_passive_update_processor.py
+++ b/tests/components/bluetooth/test_passive_update_processor.py
@@ -1093,6 +1093,7 @@ async def test_integration_with_entity(
     assert entity_one.unique_id == "aa:bb:cc:dd:ee:ff-temperature-remote"
     assert entity_one.device_info == {
         "identifiers": {("bluetooth", "aa:bb:cc:dd:ee:ff-remote")},
+        "connections": {("bluetooth", "aa:bb:cc:dd:ee:ff")},
         "manufacturer": "Govee",
         "model": "H5178-REMOTE",
         "name": "B5178D6FB Remote",
@@ -1208,6 +1209,7 @@ async def test_integration_with_entity_without_a_device(
     assert entity_one.unique_id == "aa:bb:cc:dd:ee:ff-temperature"
     assert entity_one.device_info == {
         "identifiers": {("bluetooth", "aa:bb:cc:dd:ee:ff")},
+        "connections": {("bluetooth", "aa:bb:cc:dd:ee:ff")},
         "name": "Generic",
     }
     assert entity_one.entity_key == PassiveBluetoothEntityKey(
@@ -1396,6 +1398,7 @@ async def test_integration_multiple_entity_platforms(
     assert sensor_entity_one.unique_id == "aa:bb:cc:dd:ee:ff-pressure"
     assert sensor_entity_one.device_info == {
         "identifiers": {("bluetooth", "aa:bb:cc:dd:ee:ff")},
+        "connections": {("bluetooth", "aa:bb:cc:dd:ee:ff")},
         "manufacturer": "Test Manufacturer",
         "model": "Test Model",
         "name": "Test Device",
@@ -1412,6 +1415,7 @@ async def test_integration_multiple_entity_platforms(
     assert binary_sensor_entity_one.unique_id == "aa:bb:cc:dd:ee:ff-motion"
     assert binary_sensor_entity_one.device_info == {
         "identifiers": {("bluetooth", "aa:bb:cc:dd:ee:ff")},
+        "connections": {("bluetooth", "aa:bb:cc:dd:ee:ff")},
         "manufacturer": "Test Manufacturer",
         "model": "Test Model",
         "name": "Test Device",
@@ -1556,6 +1560,7 @@ async def test_integration_multiple_entity_platforms_with_reload_and_restart(
     assert sensor_entity_one.unique_id == "aa:bb:cc:dd:ee:ff-pressure"
     assert sensor_entity_one.device_info == {
         "identifiers": {("bluetooth", "aa:bb:cc:dd:ee:ff")},
+        "connections": {("bluetooth", "aa:bb:cc:dd:ee:ff")},
         "manufacturer": "Test Manufacturer",
         "model": "Test Model",
         "name": "Test Device",
@@ -1572,6 +1577,7 @@ async def test_integration_multiple_entity_platforms_with_reload_and_restart(
     assert binary_sensor_entity_one.unique_id == "aa:bb:cc:dd:ee:ff-motion"
     assert binary_sensor_entity_one.device_info == {
         "identifiers": {("bluetooth", "aa:bb:cc:dd:ee:ff")},
+        "connections": {("bluetooth", "aa:bb:cc:dd:ee:ff")},
         "manufacturer": "Test Manufacturer",
         "model": "Test Model",
         "name": "Test Device",
@@ -1636,6 +1642,7 @@ async def test_integration_multiple_entity_platforms_with_reload_and_restart(
     assert sensor_entity_one.unique_id == "aa:bb:cc:dd:ee:ff-pressure"
     assert sensor_entity_one.device_info == {
         "identifiers": {("bluetooth", "aa:bb:cc:dd:ee:ff")},
+        "connections": {("bluetooth", "aa:bb:cc:dd:ee:ff")},
         "manufacturer": "Test Manufacturer",
         "model": "Test Model",
         "name": "Test Device",
@@ -1652,6 +1659,7 @@ async def test_integration_multiple_entity_platforms_with_reload_and_restart(
     assert binary_sensor_entity_one.unique_id == "aa:bb:cc:dd:ee:ff-motion"
     assert binary_sensor_entity_one.device_info == {
         "identifiers": {("bluetooth", "aa:bb:cc:dd:ee:ff")},
+        "connections": {("bluetooth", "aa:bb:cc:dd:ee:ff")},
         "manufacturer": "Test Manufacturer",
         "model": "Test Model",
         "name": "Test Device",
@@ -1730,6 +1738,7 @@ async def test_integration_multiple_entity_platforms_with_reload_and_restart(
     assert sensor_entity_one.unique_id == "aa:bb:cc:dd:ee:ff-pressure"
     assert sensor_entity_one.device_info == {
         "identifiers": {("bluetooth", "aa:bb:cc:dd:ee:ff")},
+        "connections": {("bluetooth", "aa:bb:cc:dd:ee:ff")},
         "manufacturer": "Test Manufacturer",
         "model": "Test Model",
         "name": "Test Device",
@@ -1746,6 +1755,7 @@ async def test_integration_multiple_entity_platforms_with_reload_and_restart(
     assert binary_sensor_entity_one.unique_id == "aa:bb:cc:dd:ee:ff-motion"
     assert binary_sensor_entity_one.device_info == {
         "identifiers": {("bluetooth", "aa:bb:cc:dd:ee:ff")},
+        "connections": {("bluetooth", "aa:bb:cc:dd:ee:ff")},
         "manufacturer": "Test Manufacturer",
         "model": "Test Model",
         "name": "Test Device",

--- a/tests/components/bluetooth/test_passive_update_processor.py
+++ b/tests/components/bluetooth/test_passive_update_processor.py
@@ -1093,7 +1093,6 @@ async def test_integration_with_entity(
     assert entity_one.unique_id == "aa:bb:cc:dd:ee:ff-temperature-remote"
     assert entity_one.device_info == {
         "identifiers": {("bluetooth", "aa:bb:cc:dd:ee:ff-remote")},
-        "connections": {("bluetooth", "aa:bb:cc:dd:ee:ff")},
         "manufacturer": "Govee",
         "model": "H5178-REMOTE",
         "name": "B5178D6FB Remote",


### PR DESCRIPTION
## Proposed change
Currently, the BTHome and Xiaomi BLE device entries still lack the `connections` entry. https://github.com/home-assistant/core/pull/102773 has tried to resolve this, but the entry is only updated when an event occurs.

This PR adds the `connections` attribute to the device info in the base class `PassiveBluetoothProcessorEntity` so that every passive entity benefits from it.

Ideally, this could be included in the next beta release.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/102858
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
