### PR TITLE
Switch formatting from black to ruff-format

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "ms-python.black-formatter",
+        "charliermarsh.ruff",
         "ms-python.pylint",
         "ms-python.vscode-pylance",
         "visualstudioexptteam.vscodeintellicode",
@@ -39,7 +39,10 @@
           "!include_dir_list scalar",
           "!include_dir_merge_list scalar",
           "!include_dir_merge_named scalar"
-        ]
+        ],
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff"
+        }
       }
     }
   }

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -60,7 +60,7 @@
 - [ ] There is no commented out code in this PR.
 - [ ] I have followed the [development checklist][dev-checklist]
 - [ ] I have followed the [perfect PR recommendations][perfect-pr]
-- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
+- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
 - [ ] Tests have been added to verify that the new code works.
 
 If user exposed functionality or configuration variables are added/changed:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,6 @@ env:
   CACHE_VERSION: 5
   PIP_CACHE_VERSION: 4
   MYPY_CACHE_VERSION: 6
-  BLACK_CACHE_VERSION: 1
   HA_SHORT_VERSION: "2023.12"
   DEFAULT_PYTHON: "3.11"
   ALL_PYTHON_VERSIONS: "['3.11', '3.12']"
@@ -58,7 +57,6 @@ env:
   POSTGRESQL_VERSIONS: "['postgres:12.14','postgres:15.2']"
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
   PIP_CACHE: /tmp/pip-cache
-  BLACK_CACHE: /tmp/black-cache
   SQLALCHEMY_WARN_20: 1
   PYTHONASYNCIODEBUG: 1
   HASS_CI: 1
@@ -261,8 +259,8 @@ jobs:
           . venv/bin/activate
           pre-commit install-hooks
 
-  lint-black:
-    name: Check black
+  lint-ruff-format:
+    name: Check ruff-format
     runs-on: ubuntu-22.04
     needs:
       - info
@@ -276,13 +274,6 @@ jobs:
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           check-latest: true
-      - name: Generate partial black restore key
-        id: generate-black-key
-        run: |
-          black_version=$(cat requirements_test_pre_commit.txt | grep black | cut -d '=' -f 3)
-          echo "version=$black_version" >> $GITHUB_OUTPUT
-          echo "key=black-${{ env.BLACK_CACHE_VERSION }}-$black_version-${{
-            env.HA_SHORT_VERSION }}-$(date -u '+%Y-%m-%dT%H:%M:%s')" >> $GITHUB_OUTPUT
       - name: Restore base Python virtual environment
         id: cache-venv
         uses: actions/cache/restore@v3.3.2
@@ -301,33 +292,17 @@ jobs:
           key: >-
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
               needs.info.outputs.pre-commit_cache_key }}
-      - name: Restore black cache
-        uses: actions/cache@v3.3.2
-        with:
-          path: ${{ env.BLACK_CACHE }}
-          key: >-
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
-            steps.generate-black-key.outputs.key }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-black-${{
-            env.BLACK_CACHE_VERSION }}-${{ steps.generate-black-key.outputs.version }}-${{
-            env.HA_SHORT_VERSION }}-
-      - name: Run black (fully)
-        if: needs.info.outputs.test_full_suite == 'true'
-        env:
-          BLACK_CACHE_DIR: ${{ env.BLACK_CACHE }}
+      - name: Run ruff-format (fully)
         run: |
           . venv/bin/activate
-          pre-commit run --hook-stage manual black --all-files --show-diff-on-failure
-      - name: Run black (partially)
+          pre-commit run --hook-stage manual ruff-format --all-files --show-diff-on-failure
+      - name: Run ruff-format (partially)
         if: needs.info.outputs.test_full_suite == 'false'
         shell: bash
-        env:
-          BLACK_CACHE_DIR: ${{ env.BLACK_CACHE }}
         run: |
           . venv/bin/activate
           shopt -s globstar
-          pre-commit run --hook-stage manual black --files {homeassistant,tests}/components/${{ needs.info.outputs.integrations_glob }}/{*,**/*} --show-diff-on-failure
+          pre-commit run --hook-stage manual ruff-format --files {homeassistant,tests}/components/${{ needs.info.outputs.integrations_glob }}/{*,**/*} --show-diff-on-failure
 
   lint-ruff:
     name: Check ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,11 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.1
+    rev: v0.1.6
     hooks:
       - id: ruff
         args:
           - --fix
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.11.0
-    hooks:
-      - id: black
-        args:
-          - --quiet
+      - id: ruff-format
         files: ^((homeassistant|pylint|script|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.2

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["esbenp.prettier-vscode", "ms-python.python"]
+  "recommendations": [
+    "charliermarsh.ruff",
+    "esbenp.prettier-vscode",
+    "ms-python.python"
+  ]
 }

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,8 +5,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Uninstall pre-installed formatting and linting tools
 # They would conflict with our pinned versions
 RUN \
-    pipx uninstall black \
-    && pipx uninstall pydocstyle \
+    pipx uninstall pydocstyle \
     && pipx uninstall pycodestyle \
     && pipx uninstall mypy \
     && pipx uninstall pylint

--- a/homeassistant/auth/permissions/types.py
+++ b/homeassistant/auth/permissions/types.py
@@ -5,9 +5,7 @@ from collections.abc import Mapping
 
 ValueType = (
     # Example: entities.all = { read: true, control: true }
-    Mapping[str, bool]
-    | bool
-    | None
+    Mapping[str, bool] | bool | None
 )
 
 # Example: entities.domains = { light: … }

--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -1315,9 +1315,9 @@ class PipelineInput:
                 if stt_audio_buffer:
                     # Send audio in the buffer first to speech-to-text, then move on to stt_stream.
                     # This is basically an async itertools.chain.
-                    async def buffer_then_audio_stream() -> AsyncGenerator[
-                        ProcessedAudioChunk, None
-                    ]:
+                    async def buffer_then_audio_stream() -> (
+                        AsyncGenerator[ProcessedAudioChunk, None]
+                    ):
                         # Buffered audio
                         for chunk in stt_audio_buffer:
                             yield chunk

--- a/homeassistant/components/assist_pipeline/websocket_api.py
+++ b/homeassistant/components/assist_pipeline/websocket_api.py
@@ -417,8 +417,7 @@ async def websocket_device_capture(
     # single sample (16 bits) per queue item.
     max_queue_items = (
         # +1 for None to signal end
-        int(math.ceil(timeout_seconds * CAPTURE_RATE))
-        + 1
+        int(math.ceil(timeout_seconds * CAPTURE_RATE)) + 1
     )
 
     audio_queue = DeviceAudioQueue(queue=asyncio.Queue(maxsize=max_queue_items))

--- a/homeassistant/components/bmw_connected_drive/select.py
+++ b/homeassistant/components/bmw_connected_drive/select.py
@@ -44,7 +44,8 @@ SELECT_TYPES: dict[str, BMWSelectEntityDescription] = {
         translation_key="ac_limit",
         is_available=lambda v: v.is_remote_set_ac_limit_enabled,
         dynamic_options=lambda v: [
-            str(lim) for lim in v.charging_profile.ac_available_limits  # type: ignore[union-attr]
+            str(lim)
+            for lim in v.charging_profile.ac_available_limits  # type: ignore[union-attr]
         ],
         current_option=lambda v: str(v.charging_profile.ac_current_limit),  # type: ignore[union-attr]
         remote_service=lambda v, o: v.remote_services.trigger_charging_settings_update(

--- a/homeassistant/components/cloud/http_api.py
+++ b/homeassistant/components/cloud/http_api.py
@@ -140,7 +140,7 @@ def _ws_handle_cloud_errors(
     handler: Callable[
         [HomeAssistant, websocket_api.ActiveConnection, dict[str, Any]],
         Coroutine[None, None, None],
-    ]
+    ],
 ) -> Callable[
     [HomeAssistant, websocket_api.ActiveConnection, dict[str, Any]],
     Coroutine[None, None, None],
@@ -362,8 +362,11 @@ def _require_cloud_login(
     handler: Callable[
         [HomeAssistant, websocket_api.ActiveConnection, dict[str, Any]],
         None,
-    ]
-) -> Callable[[HomeAssistant, websocket_api.ActiveConnection, dict[str, Any]], None,]:
+    ],
+) -> Callable[
+    [HomeAssistant, websocket_api.ActiveConnection, dict[str, Any]],
+    None,
+]:
     """Websocket decorator that requires cloud to be logged in."""
 
     @wraps(handler)

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -129,9 +129,8 @@ class DeconzDevice(DeconzBase[_DeviceT], Entity):
         if self.gateway.ignore_state_updates:
             return
 
-        if (
-            self._update_keys is not None
-            and not self._device.changed_keys.intersection(self._update_keys)
+        if self._update_keys is not None and not self._device.changed_keys.intersection(
+            self._update_keys
         ):
             return
 

--- a/homeassistant/components/devolo_home_network/__init__.py
+++ b/homeassistant/components/devolo_home_network/__init__.py
@@ -63,7 +63,8 @@ async def async_setup_entry(  # noqa: C901
         )
         await device.async_connect(session_instance=async_client)
         device.password = entry.data.get(
-            CONF_PASSWORD, ""  # This key was added in HA Core 2022.6
+            CONF_PASSWORD,
+            "",  # This key was added in HA Core 2022.6
         )
     except DeviceNotFound as err:
         raise ConfigEntryNotReady(

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -453,10 +453,9 @@ class DlnaDmrEntity(MediaPlayerEntity):
             for state_variable in state_variables:
                 # Force a state refresh when player begins or pauses playback
                 # to update the position info.
-                if (
-                    state_variable.name == "TransportState"
-                    and state_variable.value
-                    in (TransportState.PLAYING, TransportState.PAUSED_PLAYBACK)
+                if state_variable.name == "TransportState" and state_variable.value in (
+                    TransportState.PLAYING,
+                    TransportState.PAUSED_PLAYBACK,
                 ):
                     force_refresh = True
 

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -441,9 +441,7 @@ async def async_setup_entry(
                     description,
                     entry,
                     telegram,
-                    *device_class_and_uom(
-                        telegram, description
-                    ),  # type: ignore[arg-type]
+                    *device_class_and_uom(telegram, description),  # type: ignore[arg-type]
                 )
                 for description in all_sensors
                 if (

--- a/homeassistant/components/elmax/cover.py
+++ b/homeassistant/components/elmax/cover.py
@@ -18,13 +18,11 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-_COMMAND_BY_MOTION_STATUS = (
-    {  # Maps the stop command to use for every cover motion status
-        CoverStatus.DOWN: CoverCommand.DOWN,
-        CoverStatus.UP: CoverCommand.UP,
-        CoverStatus.IDLE: None,
-    }
-)
+_COMMAND_BY_MOTION_STATUS = {  # Maps the stop command to use for every cover motion status
+    CoverStatus.DOWN: CoverCommand.DOWN,
+    CoverStatus.UP: CoverCommand.UP,
+    CoverStatus.IDLE: None,
+}
 
 
 async def async_setup_entry(

--- a/homeassistant/components/esphome/enum_mapper.py
+++ b/homeassistant/components/esphome/enum_mapper.py
@@ -14,9 +14,7 @@ class EsphomeEnumMapper(Generic[_EnumT, _ValT]):
     def __init__(self, mapping: dict[_EnumT, _ValT]) -> None:
         """Construct a EsphomeEnumMapper."""
         # Add none mapping
-        augmented_mapping: dict[
-            _EnumT | None, _ValT | None
-        ] = mapping  # type: ignore[assignment]
+        augmented_mapping: dict[_EnumT | None, _ValT | None] = mapping  # type: ignore[assignment]
         augmented_mapping[None] = None
 
         self._mapping = augmented_mapping

--- a/homeassistant/components/esphome/fan.py
+++ b/homeassistant/components/esphome/fan.py
@@ -117,7 +117,8 @@ class EsphomeFan(EsphomeEntity[FanInfo, FanState], FanEntity):
         """Return the current speed percentage."""
         if not self._supports_speed_levels:
             return ordered_list_item_to_percentage(
-                ORDERED_NAMED_FAN_SPEEDS, self._state.speed  # type: ignore[misc]
+                ORDERED_NAMED_FAN_SPEEDS,
+                self._state.speed,  # type: ignore[misc]
             )
 
         return ranged_value_to_percentage(

--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -124,10 +124,13 @@ def convert_dict(dictionary: dict[str, Any]) -> dict[str, Any]:
     def convert_key(key: str) -> str:
         """Convert a string to snake_case."""
         string = re.sub(r"[\-\.\s]", "_", str(key))
-        return (string[0]).lower() + re.sub(
-            r"[A-Z]",
-            lambda matched: f"_{matched.group(0).lower()}",  # type:ignore[str-bytes-safe]
-            string[1:],
+        return (
+            (string[0]).lower()
+            + re.sub(
+                r"[A-Z]",
+                lambda matched: f"_{matched.group(0).lower()}",  # type:ignore[str-bytes-safe]
+                string[1:],
+            )
         )
 
     return {

--- a/homeassistant/components/goodwe/sensor.py
+++ b/homeassistant/components/goodwe/sensor.py
@@ -79,12 +79,12 @@ _ICONS: dict[SensorKind, str] = {
 class GoodweSensorEntityDescription(SensorEntityDescription):
     """Class describing Goodwe sensor entities."""
 
-    value: Callable[
-        [GoodweUpdateCoordinator, str], Any
-    ] = lambda coordinator, sensor: coordinator.sensor_value(sensor)
-    available: Callable[
-        [GoodweUpdateCoordinator], bool
-    ] = lambda coordinator: coordinator.last_update_success
+    value: Callable[[GoodweUpdateCoordinator, str], Any] = (
+        lambda coordinator, sensor: coordinator.sensor_value(sensor)
+    )
+    available: Callable[[GoodweUpdateCoordinator], bool] = (
+        lambda coordinator: coordinator.last_update_success
+    )
 
 
 _DESCRIPTIONS: dict[str, GoodweSensorEntityDescription] = {

--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -59,7 +59,11 @@ LOCAL_SDK_MIN_VERSION = AwesomeVersion("2.1.5")
 @callback
 def _get_registry_entries(
     hass: HomeAssistant, entity_id: str
-) -> tuple[er.RegistryEntry | None, dr.DeviceEntry | None, ar.AreaEntry | None,]:
+) -> tuple[
+    er.RegistryEntry | None,
+    dr.DeviceEntry | None,
+    ar.AreaEntry | None,
+]:
     """Get registry entries."""
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)

--- a/homeassistant/components/google_tasks/todo.py
+++ b/homeassistant/components/google_tasks/todo.py
@@ -93,7 +93,8 @@ class GoogleTaskTodoListEntity(
                 summary=item["title"],
                 uid=item["id"],
                 status=TODO_STATUS_MAP.get(
-                    item.get("status"), TodoItemStatus.NEEDS_ACTION  # type: ignore[arg-type]
+                    item.get("status"),
+                    TodoItemStatus.NEEDS_ACTION,  # type: ignore[arg-type]
                 ),
             )
             for item in _order_tasks(self.coordinator.data)

--- a/homeassistant/components/google_tasks/todo.py
+++ b/homeassistant/components/google_tasks/todo.py
@@ -93,8 +93,8 @@ class GoogleTaskTodoListEntity(
                 summary=item["title"],
                 uid=item["id"],
                 status=TODO_STATUS_MAP.get(
-                    item.get("status"),
-                    TodoItemStatus.NEEDS_ACTION,  # type: ignore[arg-type]
+                    item.get("status"),  # type: ignore[arg-type]
+                    TodoItemStatus.NEEDS_ACTION,
                 ),
             )
             for item in _order_tasks(self.coordinator.data)

--- a/homeassistant/components/hdmi_cec/__init__.py
+++ b/homeassistant/components/hdmi_cec/__init__.py
@@ -195,9 +195,7 @@ def setup(hass: HomeAssistant, base_config: ConfigType) -> bool:  # noqa: C901
 
     loop = (
         # Create own thread if more than 1 CPU
-        hass.loop
-        if multiprocessing.cpu_count() < 2
-        else None
+        hass.loop if multiprocessing.cpu_count() < 2 else None
     )
     host = base_config[DOMAIN].get(CONF_HOST)
     display_name = base_config[DOMAIN].get(CONF_DISPLAY_NAME, DEFAULT_DISPLAY_NAME)

--- a/homeassistant/components/homekit/type_fans.py
+++ b/homeassistant/components/homekit/type_fans.py
@@ -127,9 +127,8 @@ class Fan(HomeAccessory):
                 self.preset_mode_chars[preset_mode] = preset_serv.configure_char(
                     CHAR_ON,
                     value=False,
-                    setter_callback=lambda value, preset_mode=preset_mode: self.set_preset_mode(
-                        value, preset_mode
-                    ),
+                    setter_callback=lambda value,
+                    preset_mode=preset_mode: self.set_preset_mode(value, preset_mode),
                 )
 
         if CHAR_SWING_MODE in self.chars:

--- a/homeassistant/components/homekit/type_fans.py
+++ b/homeassistant/components/homekit/type_fans.py
@@ -124,11 +124,15 @@ class Fan(HomeAccessory):
                     ),
                 )
 
+                setter_callback = (
+                    lambda value, preset_mode=preset_mode: self.set_preset_mode(
+                        value, preset_mode
+                    )
+                )
                 self.preset_mode_chars[preset_mode] = preset_serv.configure_char(
                     CHAR_ON,
                     value=False,
-                    setter_callback=lambda value,
-                    preset_mode=preset_mode: self.set_preset_mode(value, preset_mode),
+                    setter_callback=setter_callback,
                 )
 
         if CHAR_SWING_MODE in self.chars:

--- a/homeassistant/components/hunterdouglas_powerview/select.py
+++ b/homeassistant/components/hunterdouglas_powerview/select.py
@@ -116,7 +116,6 @@ class PowerViewSelect(ShadeEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self.entity_description.select_fn(self._shade, option)
-        await (
-            self._shade.refresh()
-        )  # force update data to ensure new info is in coordinator
+        # force update data to ensure new info is in coordinator
+        await self._shade.refresh()
         self.async_write_ha_state()

--- a/homeassistant/components/hunterdouglas_powerview/select.py
+++ b/homeassistant/components/hunterdouglas_powerview/select.py
@@ -116,5 +116,7 @@ class PowerViewSelect(ShadeEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self.entity_description.select_fn(self._shade, option)
-        await self._shade.refresh()  # force update data to ensure new info is in coordinator
+        await (
+            self._shade.refresh()
+        )  # force update data to ensure new info is in coordinator
         self.async_write_ha_state()

--- a/homeassistant/components/imap/__init__.py
+++ b/homeassistant/components/imap/__init__.py
@@ -66,8 +66,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         coordinator: ImapPushDataUpdateCoordinator | ImapPollingDataUpdateCoordinator = hass.data[
             DOMAIN
-        ].pop(
-            entry.entry_id
-        )
+        ].pop(entry.entry_id)
         await coordinator.shutdown()
     return unload_ok

--- a/homeassistant/components/kraken/sensor.py
+++ b/homeassistant/components/kraken/sensor.py
@@ -259,7 +259,8 @@ class KrakenSensor(
             return
         try:
             self._attr_native_value = self.entity_description.value_fn(
-                self.coordinator, self.tracked_asset_pair_wsname  # type: ignore[arg-type]
+                self.coordinator,
+                self.tracked_asset_pair_wsname,  # type: ignore[arg-type]
             )
             self._received_data_at_least_once = True
         except KeyError:

--- a/homeassistant/components/kraken/sensor.py
+++ b/homeassistant/components/kraken/sensor.py
@@ -259,8 +259,8 @@ class KrakenSensor(
             return
         try:
             self._attr_native_value = self.entity_description.value_fn(
-                self.coordinator,
-                self.tracked_asset_pair_wsname,  # type: ignore[arg-type]
+                self.coordinator,  # type: ignore[arg-type]
+                self.tracked_asset_pair_wsname,
             )
             self._received_data_at_least_once = True
         except KeyError:

--- a/homeassistant/components/landisgyr_heat_meter/sensor.py
+++ b/homeassistant/components/landisgyr_heat_meter/sensor.py
@@ -316,7 +316,9 @@ class HeatMeterSensor(
         """Set up the sensor with the initial values."""
         super().__init__(coordinator)
         self.key = description.key
-        self._attr_unique_id = f"{coordinator.config_entry.data['device_number']}_{description.key}"  # type: ignore[union-attr]
+        self._attr_unique_id = (
+            f"{coordinator.config_entry.data['device_number']}_{description.key}"  # type: ignore[union-attr]
+        )
         self._attr_name = f"Heat Meter {description.name}"
         self.entity_description = description
         self._attr_device_info = device

--- a/homeassistant/components/lookin/__init__.py
+++ b/homeassistant/components/lookin/__init__.py
@@ -118,7 +118,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     push_coordinator = LookinPushCoordinator(entry.title)
 
     if lookin_device.model >= 2:
-        meteo_coordinator = LookinDataUpdateCoordinator[MeteoSensor](
+        meteo_coordinator = LookinDataUpdateCoordinator[
+            MeteoSensor
+        ](
             hass,
             push_coordinator,
             name=entry.title,

--- a/homeassistant/components/lookin/__init__.py
+++ b/homeassistant/components/lookin/__init__.py
@@ -118,9 +118,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     push_coordinator = LookinPushCoordinator(entry.title)
 
     if lookin_device.model >= 2:
-        meteo_coordinator = LookinDataUpdateCoordinator[
-            MeteoSensor
-        ](
+        coordinator_class = LookinDataUpdateCoordinator[MeteoSensor]
+        meteo_coordinator = coordinator_class(
             hass,
             push_coordinator,
             name=entry.title,

--- a/homeassistant/components/matrix/__init__.py
+++ b/homeassistant/components/matrix/__init__.py
@@ -348,7 +348,10 @@ class MatrixBot:
         self._access_tokens[self._mx_id] = token
 
         await self.hass.async_add_executor_job(
-            save_json, self._session_filepath, self._access_tokens, True  # private=True
+            save_json,
+            self._session_filepath,
+            self._access_tokens,
+            True,  # private=True
         )
 
     async def _login(self) -> None:

--- a/homeassistant/components/matter/event.py
+++ b/homeassistant/components/matter/event.py
@@ -104,7 +104,11 @@ class MatterEventEntity(MatterEntity, EventEntity):
         """Call when Node attribute(s) changed."""
 
     @callback
-    def _on_matter_node_event(self, event: EventType, data: MatterNodeEvent) -> None:  # noqa: F821
+    def _on_matter_node_event(  # noqa: F821
+        self,
+        event: EventType,
+        data: MatterNodeEvent,
+    ) -> None:
         """Call on NodeEvent."""
         if data.endpoint_id != self._endpoint.endpoint_id:
             return

--- a/homeassistant/components/matter/event.py
+++ b/homeassistant/components/matter/event.py
@@ -104,9 +104,7 @@ class MatterEventEntity(MatterEntity, EventEntity):
         """Call when Node attribute(s) changed."""
 
     @callback
-    def _on_matter_node_event(
-        self, event: EventType, data: MatterNodeEvent
-    ) -> None:  # noqa: F821
+    def _on_matter_node_event(self, event: EventType, data: MatterNodeEvent) -> None:  # noqa: F821
         """Call on NodeEvent."""
         if data.endpoint_id != self._endpoint.endpoint_id:
             return

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -1137,8 +1137,7 @@ class MediaPlayerImageView(HomeAssistantView):
     extra_urls = [
         # Need to modify the default regex for media_content_id as it may
         # include arbitrary characters including '/','{', or '}'
-        url
-        + "/browse_media/{media_content_type}/{media_content_id:.+}",
+        url + "/browse_media/{media_content_type}/{media_content_id:.+}",
     ]
 
     def __init__(self, component: EntityComponent[MediaPlayerEntity]) -> None:

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -470,7 +470,10 @@ class MqttTemperatureControlEntity(MqttEntity, ABC):
         except ValueError:
             _LOGGER.error("Could not parse %s from %s", template_name, payload)
 
-    def prepare_subscribe_topics(self, topics: dict[str, dict[str, Any]]) -> None:  # noqa: C901
+    def prepare_subscribe_topics(  # noqa: C901
+        self,
+        topics: dict[str, dict[str, Any]],
+    ) -> None:
         """(Re)Subscribe to topics."""
 
         @callback

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -470,9 +470,7 @@ class MqttTemperatureControlEntity(MqttEntity, ABC):
         except ValueError:
             _LOGGER.error("Could not parse %s from %s", template_name, payload)
 
-    def prepare_subscribe_topics(
-        self, topics: dict[str, dict[str, Any]]
-    ) -> None:  # noqa: C901
+    def prepare_subscribe_topics(self, topics: dict[str, dict[str, Any]]) -> None:  # noqa: C901
         """(Re)Subscribe to topics."""
 
         @callback

--- a/homeassistant/components/mqtt/util.py
+++ b/homeassistant/components/mqtt/util.py
@@ -63,9 +63,9 @@ async def async_wait_for_mqtt_client(hass: HomeAssistant) -> bool:
 
     state_reached_future: asyncio.Future[bool]
     if DATA_MQTT_AVAILABLE not in hass.data:
-        hass.data[
-            DATA_MQTT_AVAILABLE
-        ] = state_reached_future = hass.loop.create_future()
+        hass.data[DATA_MQTT_AVAILABLE] = (
+            state_reached_future
+        ) = hass.loop.create_future()
     else:
         state_reached_future = hass.data[DATA_MQTT_AVAILABLE]
         if state_reached_future.done():

--- a/homeassistant/components/mqtt/util.py
+++ b/homeassistant/components/mqtt/util.py
@@ -63,9 +63,8 @@ async def async_wait_for_mqtt_client(hass: HomeAssistant) -> bool:
 
     state_reached_future: asyncio.Future[bool]
     if DATA_MQTT_AVAILABLE not in hass.data:
-        hass.data[DATA_MQTT_AVAILABLE] = (
-            state_reached_future
-        ) = hass.loop.create_future()
+        state_reached_future = hass.loop.create_future()
+        hass.data[DATA_MQTT_AVAILABLE] = state_reached_future
     else:
         state_reached_future = hass.data[DATA_MQTT_AVAILABLE]
         if state_reached_future.done():

--- a/homeassistant/components/nextcloud/sensor.py
+++ b/homeassistant/components/nextcloud/sensor.py
@@ -34,9 +34,9 @@ UNIT_OF_LOAD: Final[str] = "load"
 class NextcloudSensorEntityDescription(SensorEntityDescription):
     """Describes Nextcloud sensor entity."""
 
-    value_fn: Callable[
-        [str | int | float], str | int | float | datetime
-    ] = lambda value: value
+    value_fn: Callable[[str | int | float], str | int | float | datetime] = (
+        lambda value: value
+    )
 
 
 SENSORS: Final[list[NextcloudSensorEntityDescription]] = [

--- a/homeassistant/components/onvif/base.py
+++ b/homeassistant/components/onvif/base.py
@@ -32,8 +32,7 @@ class ONVIFBaseEntity(Entity):
         See: https://github.com/home-assistant/core/issues/35883
         """
         return (
-            self.device.info.mac
-            or self.device.info.serial_number  # type:ignore[return-value]
+            self.device.info.mac or self.device.info.serial_number  # type:ignore[return-value]
         )
 
     @property

--- a/homeassistant/components/overkiz/climate_entities/hitachi_air_to_air_heat_pump_hlrrwifi.py
+++ b/homeassistant/components/overkiz/climate_entities/hitachi_air_to_air_heat_pump_hlrrwifi.py
@@ -245,12 +245,13 @@ class HitachiAirToAirHeatPumpHLRRWIFI(OverkizEntity, ClimateEntity):
             MODE_CHANGE_STATE,
             OverkizCommandParam.AUTO,
         ).lower()  # Overkiz can return states that have uppercase characters which are not accepted back as commands
-        if hvac_mode.replace(
-            " ", ""
-        ) in [  # Overkiz can return states like 'auto cooling' or 'autoHeating' that are not valid commands and need to be converted to 'auto'
-            OverkizCommandParam.AUTOCOOLING,
-            OverkizCommandParam.AUTOHEATING,
-        ]:
+        if (
+            hvac_mode.replace(" ", "")
+            in [  # Overkiz can return states like 'auto cooling' or 'autoHeating' that are not valid commands and need to be converted to 'auto'
+                OverkizCommandParam.AUTOCOOLING,
+                OverkizCommandParam.AUTOHEATING,
+            ]
+        ):
             hvac_mode = OverkizCommandParam.AUTO
 
         swing_mode = self._control_backfill(

--- a/homeassistant/components/private_ble_device/sensor.py
+++ b/homeassistant/components/private_ble_device/sensor.py
@@ -83,14 +83,17 @@ SENSOR_DESCRIPTIONS = (
         native_unit_of_measurement=UnitOfTime.SECONDS,
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda hass,
-        service_info: bluetooth.async_get_learned_advertising_interval(
-            hass, service_info.address
-        )
-        or bluetooth.async_get_fallback_availability_interval(
-            hass, service_info.address
-        )
-        or bluetooth.FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
+        value_fn=(
+            lambda hass, service_info: (
+                bluetooth.async_get_learned_advertising_interval(
+                    hass, service_info.address
+                )
+                or bluetooth.async_get_fallback_availability_interval(
+                    hass, service_info.address
+                )
+                or bluetooth.FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS
+            )
+        ),
         suggested_display_precision=1,
     ),
 )

--- a/homeassistant/components/private_ble_device/sensor.py
+++ b/homeassistant/components/private_ble_device/sensor.py
@@ -83,7 +83,8 @@ SENSOR_DESCRIPTIONS = (
         native_unit_of_measurement=UnitOfTime.SECONDS,
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda hass, service_info: bluetooth.async_get_learned_advertising_interval(
+        value_fn=lambda hass,
+        service_info: bluetooth.async_get_learned_advertising_interval(
             hass, service_info.address
         )
         or bluetooth.async_get_fallback_availability_interval(

--- a/homeassistant/components/recorder/auto_repairs/schema.py
+++ b/homeassistant/components/recorder/auto_repairs/schema.py
@@ -101,9 +101,7 @@ def _validate_table_schema_has_correct_collation(
 
         collate = (
             dialect_kwargs.get("mysql_collate")
-            or dialect_kwargs.get(
-                "mariadb_collate"
-            )  # pylint: disable-next=protected-access
+            or dialect_kwargs.get("mariadb_collate")  # pylint: disable-next=protected-access
             or connection.dialect._fetch_setting(connection, "collation_server")  # type: ignore[attr-defined]
         )
         if collate and collate != "utf8mb4_unicode_ci":

--- a/homeassistant/components/recorder/auto_repairs/schema.py
+++ b/homeassistant/components/recorder/auto_repairs/schema.py
@@ -101,7 +101,8 @@ def _validate_table_schema_has_correct_collation(
 
         collate = (
             dialect_kwargs.get("mysql_collate")
-            or dialect_kwargs.get("mariadb_collate")  # pylint: disable-next=protected-access
+            or dialect_kwargs.get("mariadb_collate")
+            # pylint: disable-next=protected-access
             or connection.dialect._fetch_setting(connection, "collation_server")  # type: ignore[attr-defined]
         )
         if collate and collate != "utf8mb4_unicode_ci":

--- a/homeassistant/components/recorder/db_schema.py
+++ b/homeassistant/components/recorder/db_schema.py
@@ -176,17 +176,17 @@ class NativeLargeBinary(LargeBinary):
 # For MariaDB and MySQL we can use an unsigned integer type since it will fit 2**32
 # for sqlite and postgresql we use a bigint
 UINT_32_TYPE = BigInteger().with_variant(
-    mysql.INTEGER(unsigned=True),
+    mysql.INTEGER(unsigned=True),  # type: ignore[no-untyped-call]
     "mysql",
-    "mariadb",  # type: ignore[no-untyped-call]
+    "mariadb",
 )
 JSON_VARIANT_CAST = Text().with_variant(
-    postgresql.JSON(none_as_null=True),
-    "postgresql",  # type: ignore[no-untyped-call]
+    postgresql.JSON(none_as_null=True),  # type: ignore[no-untyped-call]
+    "postgresql",
 )
 JSONB_VARIANT_CAST = Text().with_variant(
-    postgresql.JSONB(none_as_null=True),
-    "postgresql",  # type: ignore[no-untyped-call]
+    postgresql.JSONB(none_as_null=True),  # type: ignore[no-untyped-call]
+    "postgresql",
 )
 DATETIME_TYPE = (
     DateTime(timezone=True)

--- a/homeassistant/components/recorder/db_schema.py
+++ b/homeassistant/components/recorder/db_schema.py
@@ -176,13 +176,17 @@ class NativeLargeBinary(LargeBinary):
 # For MariaDB and MySQL we can use an unsigned integer type since it will fit 2**32
 # for sqlite and postgresql we use a bigint
 UINT_32_TYPE = BigInteger().with_variant(
-    mysql.INTEGER(unsigned=True), "mysql", "mariadb"  # type: ignore[no-untyped-call]
+    mysql.INTEGER(unsigned=True),
+    "mysql",
+    "mariadb",  # type: ignore[no-untyped-call]
 )
 JSON_VARIANT_CAST = Text().with_variant(
-    postgresql.JSON(none_as_null=True), "postgresql"  # type: ignore[no-untyped-call]
+    postgresql.JSON(none_as_null=True),
+    "postgresql",  # type: ignore[no-untyped-call]
 )
 JSONB_VARIANT_CAST = Text().with_variant(
-    postgresql.JSONB(none_as_null=True), "postgresql"  # type: ignore[no-untyped-call]
+    postgresql.JSONB(none_as_null=True),
+    "postgresql",  # type: ignore[no-untyped-call]
 )
 DATETIME_TYPE = (
     DateTime(timezone=True)

--- a/homeassistant/components/recorder/filters.py
+++ b/homeassistant/components/recorder/filters.py
@@ -244,8 +244,8 @@ class Filters:
             ),
             # Needs https://github.com/bdraco/home-assistant/commit/bba91945006a46f3a01870008eb048e4f9cbb1ef
             self._generate_filter_for_columns(
-                (ENTITY_ID_IN_EVENT, OLD_ENTITY_ID_IN_EVENT),
-                _encoder,  # type: ignore[arg-type]
+                (ENTITY_ID_IN_EVENT, OLD_ENTITY_ID_IN_EVENT),  # type: ignore[arg-type]
+                _encoder,
             ).self_group(),
         )
 

--- a/homeassistant/components/recorder/filters.py
+++ b/homeassistant/components/recorder/filters.py
@@ -244,7 +244,8 @@ class Filters:
             ),
             # Needs https://github.com/bdraco/home-assistant/commit/bba91945006a46f3a01870008eb048e4f9cbb1ef
             self._generate_filter_for_columns(
-                (ENTITY_ID_IN_EVENT, OLD_ENTITY_ID_IN_EVENT), _encoder  # type: ignore[arg-type]
+                (ENTITY_ID_IN_EVENT, OLD_ENTITY_ID_IN_EVENT),
+                _encoder,  # type: ignore[arg-type]
             ).self_group(),
         )
 

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -532,7 +532,9 @@ def _update_states_table_with_foreign_key_options(
 
     states_key_constraints = Base.metadata.tables[TABLE_STATES].foreign_key_constraints
     old_states_table = Table(  # noqa: F841
-        TABLE_STATES, MetaData(), *(alter["old_fk"] for alter in alters)  # type: ignore[arg-type]
+        TABLE_STATES,
+        MetaData(),
+        *(alter["old_fk"] for alter in alters),  # type: ignore[arg-type]
     )
 
     for alter in alters:

--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -89,9 +89,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         async with asyncio.timeout(host.api.timeout * (RETRY_ATTEMPTS + 2)):
             await host.renew()
 
-    async def async_check_firmware_update() -> str | Literal[
-        False
-    ] | NewSoftwareVersion:
+    async def async_check_firmware_update() -> (
+        str | Literal[False] | NewSoftwareVersion
+    ):
         """Check for firmware updates."""
         if not host.api.supported(None, "update"):
             return False

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -566,10 +566,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         ports = await self.hass.async_add_executor_job(serial.tools.list_ports.comports)
         list_of_ports = {}
         for port in ports:
-            list_of_ports[
-                port.device
-            ] = f"{port}, s/n: {port.serial_number or 'n/a'}" + (
-                f" - {port.manufacturer}" if port.manufacturer else ""
+            list_of_ports[port.device] = (
+                f"{port}, s/n: {port.serial_number or 'n/a'}"
+                + (f" - {port.manufacturer}" if port.manufacturer else "")
             )
         list_of_ports[CONF_MANUAL_PATH] = CONF_MANUAL_PATH
 

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -280,9 +280,9 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
 
     async def _async_fallback_poll(self) -> None:
         """Retrieve latest state by polling."""
-        await self.hass.data[DATA_SONOS].favorites[
-            self.speaker.household_id
-        ].async_poll()
+        await (
+            self.hass.data[DATA_SONOS].favorites[self.speaker.household_id].async_poll()
+        )
         await self.hass.async_add_executor_job(self._update)
 
     def _update(self) -> None:

--- a/homeassistant/components/stream/recorder.py
+++ b/homeassistant/components/stream/recorder.py
@@ -78,7 +78,13 @@ class RecorderOutput(StreamOutput):
 
         def write_segment(segment: Segment) -> None:
             """Write a segment to output."""
-            nonlocal output, output_v, output_a, last_stream_id, running_duration, last_sequence
+            nonlocal \
+                output, \
+                output_v, \
+                output_a, \
+                last_stream_id, \
+                running_duration, \
+                last_sequence
             # Because the stream_worker is in a different thread from the record service,
             # the lookback segments may still have some overlap with the recorder segments
             if segment.sequence <= last_sequence:

--- a/homeassistant/components/stream/recorder.py
+++ b/homeassistant/components/stream/recorder.py
@@ -78,13 +78,9 @@ class RecorderOutput(StreamOutput):
 
         def write_segment(segment: Segment) -> None:
             """Write a segment to output."""
-            nonlocal \
-                output, \
-                output_v, \
-                output_a, \
-                last_stream_id, \
-                running_duration, \
-                last_sequence
+            # fmt: off
+            nonlocal output, output_v, output_a, last_stream_id, running_duration, last_sequence
+            # fmt: on
             # Because the stream_worker is in a different thread from the record service,
             # the lookback segments may still have some overlap with the recorder segments
             if segment.sequence <= last_sequence:

--- a/homeassistant/components/synology_dsm/camera.py
+++ b/homeassistant/components/synology_dsm/camera.py
@@ -153,7 +153,9 @@ class SynoDSMCamera(SynologyDSMBaseEntity[SynologyDSMCameraUpdateCoordinator], C
         if not self.available:
             return None
         try:
-            return await self._api.surveillance_station.get_camera_image(self.entity_description.key, self.snapshot_quality)  # type: ignore[no-any-return]
+            return await self._api.surveillance_station.get_camera_image(
+                self.entity_description.key, self.snapshot_quality
+            )  # type: ignore[no-any-return]
         except (
             SynologyDSMAPIErrorException,
             SynologyDSMRequestException,

--- a/homeassistant/components/synology_dsm/camera.py
+++ b/homeassistant/components/synology_dsm/camera.py
@@ -153,9 +153,9 @@ class SynoDSMCamera(SynologyDSMBaseEntity[SynologyDSMCameraUpdateCoordinator], C
         if not self.available:
             return None
         try:
-            return await self._api.surveillance_station.get_camera_image(
+            return await self._api.surveillance_station.get_camera_image(  # type: ignore[no-any-return]
                 self.entity_description.key, self.snapshot_quality
-            )  # type: ignore[no-any-return]
+            )
         except (
             SynologyDSMAPIErrorException,
             SynologyDSMRequestException,

--- a/homeassistant/components/template/weather.py
+++ b/homeassistant/components/template/weather.py
@@ -57,7 +57,8 @@ from .template_entity import TemplateEntity, rewrite_common_legacy_to_modern_con
 from .trigger_entity import TriggerEntity
 
 CHECK_FORECAST_KEYS = (
-    set().union(Forecast.__annotations__.keys())
+    set()
+    .union(Forecast.__annotations__.keys())
     # Manually add the forecast resulting attributes that only exists
     #  as native_* in the Forecast definition
     .union(("apparent_temperature", "wind_gust_speed", "dew_point"))

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -119,9 +119,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Handle Memo Text service call."""
         memo_text = call.data[CONF_MEMO_TEXT]
         memo_text.hass = hass
-        await hass.data[DOMAIN][call.data[CONF_INTERFACE]]["cntrl"].get_module(
-            call.data[CONF_ADDRESS]
-        ).set_memo_text(memo_text.async_render())
+        await (
+            hass.data[DOMAIN][call.data[CONF_INTERFACE]]["cntrl"]
+            .get_module(call.data[CONF_ADDRESS])
+            .set_memo_text(memo_text.async_render())
+        )
 
     hass.services.async_register(
         DOMAIN,

--- a/homeassistant/components/vesync/sensor.py
+++ b/homeassistant/components/vesync/sensor.py
@@ -48,12 +48,12 @@ class VeSyncSensorEntityDescription(
 ):
     """Describe VeSync sensor entity."""
 
-    exists_fn: Callable[
-        [VeSyncAirBypass | VeSyncOutlet | VeSyncSwitch], bool
-    ] = lambda _: True
-    update_fn: Callable[
-        [VeSyncAirBypass | VeSyncOutlet | VeSyncSwitch], None
-    ] = lambda _: None
+    exists_fn: Callable[[VeSyncAirBypass | VeSyncOutlet | VeSyncSwitch], bool] = (
+        lambda _: True
+    )
+    update_fn: Callable[[VeSyncAirBypass | VeSyncOutlet | VeSyncSwitch], None] = (
+        lambda _: None
+    )
 
 
 def update_energy(device):

--- a/homeassistant/components/vodafone_station/sensor.py
+++ b/homeassistant/components/vodafone_station/sensor.py
@@ -28,9 +28,9 @@ NOT_AVAILABLE: list = ["", "N/A", "0.0.0.0"]
 class VodafoneStationBaseEntityDescription:
     """Vodafone Station entity base description."""
 
-    value: Callable[
-        [Any, Any], Any
-    ] = lambda coordinator, key: coordinator.data.sensors[key]
+    value: Callable[[Any, Any], Any] = (
+        lambda coordinator, key: coordinator.data.sensors[key]
+    )
     is_suitable: Callable[[dict], bool] = lambda val: True
 
 

--- a/homeassistant/components/voip/voip.py
+++ b/homeassistant/components/voip/voip.py
@@ -111,7 +111,8 @@ class HassVoipDatagramProtocol(VoipDatagramProtocol):
             valid_protocol_factory=lambda call_info, rtcp_state: make_protocol(
                 hass, devices, call_info, rtcp_state
             ),
-            invalid_protocol_factory=lambda call_info, rtcp_state: PreRecordMessageProtocol(
+            invalid_protocol_factory=lambda call_info,
+            rtcp_state: PreRecordMessageProtocol(
                 hass,
                 "not_configured.pcm",
                 opus_payload_type=call_info.opus_payload_type,

--- a/homeassistant/components/voip/voip.py
+++ b/homeassistant/components/voip/voip.py
@@ -111,12 +111,13 @@ class HassVoipDatagramProtocol(VoipDatagramProtocol):
             valid_protocol_factory=lambda call_info, rtcp_state: make_protocol(
                 hass, devices, call_info, rtcp_state
             ),
-            invalid_protocol_factory=lambda call_info,
-            rtcp_state: PreRecordMessageProtocol(
-                hass,
-                "not_configured.pcm",
-                opus_payload_type=call_info.opus_payload_type,
-                rtcp_state=rtcp_state,
+            invalid_protocol_factory=(
+                lambda call_info, rtcp_state: PreRecordMessageProtocol(
+                    hass,
+                    "not_configured.pcm",
+                    opus_payload_type=call_info.opus_payload_type,
+                    rtcp_state=rtcp_state,
+                )
             ),
         )
         self.hass = hass

--- a/homeassistant/components/yamaha_musiccast/config_flow.py
+++ b/homeassistant/components/yamaha_musiccast/config_flow.py
@@ -95,9 +95,7 @@ class MusicCastFlowHandler(ConfigFlow, domain=DOMAIN):
         self.upnp_description = discovery_info.ssdp_location
 
         # ssdp_location and hostname have been checked in check_yamaha_ssdp so it is safe to ignore type assignment
-        self.host = urlparse(
-            discovery_info.ssdp_location
-        ).hostname  # type: ignore[assignment]
+        self.host = urlparse(discovery_info.ssdp_location).hostname  # type: ignore[assignment]
 
         await self.async_set_unique_id(self.serial_number)
         self._abort_if_unique_id_configured(

--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -276,9 +276,7 @@ async def async_setup_entry(
                 if state_key == "0":
                     continue
 
-                notification_description: NotificationZWaveJSEntityDescription | None = (
-                    None
-                )
+                notification_description: NotificationZWaveJSEntityDescription | None = None
 
                 for description in NOTIFICATION_SENSOR_MAPPINGS:
                     if (

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -344,7 +344,8 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
             is not None
             and (extra_data := await self.async_get_last_extra_data())
             and (
-                latest_version_firmware := ZWaveNodeFirmwareUpdateExtraStoredData.from_dict(
+                latest_version_firmware
+                := ZWaveNodeFirmwareUpdateExtraStoredData.from_dict(
                     extra_data.as_dict()
                 ).latest_version_firmware
             )

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -252,7 +252,7 @@ def async_track_state_change(
 
     return hass.bus.async_listen(
         EVENT_STATE_CHANGED,
-        state_change_dispatcher,
+        state_change_dispatcher,  # type: ignore[arg-type]
         event_filter=state_change_filter,  # type: ignore[arg-type]
     )
 

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -251,7 +251,9 @@ def async_track_state_change(
         return async_track_state_change_event(hass, entity_ids, state_change_listener)
 
     return hass.bus.async_listen(
-        EVENT_STATE_CHANGED, state_change_dispatcher, event_filter=state_change_filter  # type: ignore[arg-type]
+        EVENT_STATE_CHANGED,
+        state_change_dispatcher,
+        event_filter=state_change_filter,  # type: ignore[arg-type]
     )
 
 
@@ -761,7 +763,8 @@ class _TrackStateChangeFiltered:
     @callback
     def _setup_all_listener(self) -> None:
         self._listeners[_ALL_LISTENER] = self.hass.bus.async_listen(
-            EVENT_STATE_CHANGED, self._action  # type: ignore[arg-type]
+            EVENT_STATE_CHANGED,
+            self._action,  # type: ignore[arg-type]
         )
 
 
@@ -1335,7 +1338,8 @@ def async_track_same_state(
 
     if entity_ids == MATCH_ALL:
         async_remove_state_for_cancel = hass.bus.async_listen(
-            EVENT_STATE_CHANGED, state_for_cancel_listener  # type: ignore[arg-type]
+            EVENT_STATE_CHANGED,
+            state_for_cancel_listener,  # type: ignore[arg-type]
         )
     else:
         async_remove_state_for_cancel = async_track_state_change_event(

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -190,7 +190,8 @@ class RestoreStateData:
                 state, self.entities[state.entity_id].extra_restore_state_data, now
             )
             for state in all_states
-            if state.entity_id in self.entities and
+            if state.entity_id in self.entities
+            and
             # Ignore all states that are entity registry placeholders
             not state.attributes.get(ATTR_RESTORED)
         ]

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -99,8 +99,7 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
         # Pick a random microsecond in range 0.05..0.50 to stagger the refreshes
         # and avoid a thundering herd.
         self._microsecond = (
-            randint(event.RANDOM_MICROSECOND_MIN, event.RANDOM_MICROSECOND_MAX)
-            / 10**6
+            randint(event.RANDOM_MICROSECOND_MIN, event.RANDOM_MICROSECOND_MAX) / 10**6
         )
 
         self._listeners: dict[CALLBACK_TYPE, tuple[CALLBACK_TYPE, object | None]] = {}

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -403,9 +403,7 @@ async def async_get_zeroconf(
     hass: HomeAssistant,
 ) -> dict[str, list[dict[str, str | dict[str, str]]]]:
     """Return cached list of zeroconf types."""
-    zeroconf: dict[
-        str, list[dict[str, str | dict[str, str]]]
-    ] = ZEROCONF.copy()  # type: ignore[assignment]
+    zeroconf: dict[str, list[dict[str, str | dict[str, str]]]] = ZEROCONF.copy()  # type: ignore[assignment]
 
     integrations = await async_get_custom_components(hass)
     for integration in integrations.values():
@@ -1013,9 +1011,7 @@ def _load_file(
     Async friendly.
     """
     with suppress(KeyError):
-        return hass.data[DATA_COMPONENTS][  # type: ignore[no-any-return]
-            comp_or_platform
-        ]
+        return hass.data[DATA_COMPONENTS][comp_or_platform]  # type: ignore[no-any-return]
 
     cache = hass.data[DATA_COMPONENTS]
 

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -57,7 +57,8 @@ def json_loads_object(__obj: bytes | bytearray | memoryview | str) -> JsonObject
 
 
 def load_json(
-    filename: str | PathLike, default: JsonValueType = _SENTINEL  # type: ignore[assignment]
+    filename: str | PathLike,
+    default: JsonValueType = _SENTINEL,  # type: ignore[assignment]
 ) -> JsonValueType:
     """Load JSON data from a file.
 
@@ -79,7 +80,8 @@ def load_json(
 
 
 def load_json_array(
-    filename: str | PathLike, default: JsonArrayType = _SENTINEL  # type: ignore[assignment]
+    filename: str | PathLike,
+    default: JsonArrayType = _SENTINEL,  # type: ignore[assignment]
 ) -> JsonArrayType:
     """Load JSON data from a file and return as list.
 
@@ -98,7 +100,8 @@ def load_json_array(
 
 
 def load_json_object(
-    filename: str | PathLike, default: JsonObjectType = _SENTINEL  # type: ignore[assignment]
+    filename: str | PathLike,
+    default: JsonObjectType = _SENTINEL,  # type: ignore[assignment]
 ) -> JsonObjectType:
     """Load JSON data from a file and return as dict.
 

--- a/homeassistant/util/location.py
+++ b/homeassistant/util/location.py
@@ -138,11 +138,7 @@ def vincenty(
             / 4
             * (
                 cosSigma * (-1 + 2 * cos2SigmaM**2)
-                - B
-                / 6
-                * cos2SigmaM
-                * (-3 + 4 * sinSigma**2)
-                * (-3 + 4 * cos2SigmaM**2)
+                - B / 6 * cos2SigmaM * (-3 + 4 * sinSigma**2) * (-3 + 4 * cos2SigmaM**2)
             )
         )
     )

--- a/homeassistant/util/location.py
+++ b/homeassistant/util/location.py
@@ -129,6 +129,7 @@ def vincenty(
     uSq = cosSqAlpha * (AXIS_A**2 - AXIS_B**2) / (AXIS_B**2)
     A = 1 + uSq / 16384 * (4096 + uSq * (-768 + uSq * (320 - 175 * uSq)))
     B = uSq / 1024 * (256 + uSq * (-128 + uSq * (74 - 47 * uSq)))
+    # fmt: off
     deltaSigma = (
         B
         * sinSigma
@@ -138,10 +139,15 @@ def vincenty(
             / 4
             * (
                 cosSigma * (-1 + 2 * cos2SigmaM**2)
-                - B / 6 * cos2SigmaM * (-3 + 4 * sinSigma**2) * (-3 + 4 * cos2SigmaM**2)
+                - B
+                / 6
+                * cos2SigmaM
+                * (-3 + 4 * sinSigma ** 2)
+                * (-3 + 4 * cos2SigmaM ** 2)
             )
         )
     )
+    # fmt: on
     s = AXIS_B * A * (sigma - deltaSigma)
 
     s /= 1000  # Conversion of meters to kilometers

--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -340,7 +340,12 @@ def _handle_mapping_tag(
             raise yaml.MarkedYAMLError(
                 context=f'invalid key: "{key}"',
                 context_mark=yaml.Mark(
-                    fname, 0, line, -1, None, None  # type: ignore[arg-type]
+                    fname,
+                    0,
+                    line,
+                    -1,
+                    None,
+                    None,  # type: ignore[arg-type]
                 ),
             ) from exc
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,9 +79,6 @@ include-package-data = true
 [tool.setuptools.packages.find]
 include = ["homeassistant*"]
 
-[tool.black]
-extend-exclude = "/generated/"
-
 [tool.pylint.MAIN]
 py-version = "3.11"
 ignore = [

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,6 +1,5 @@
 # Automatically generated from .pre-commit-config.yaml by gen_requirements_all.py, do not edit
 
-black==23.11.0
 codespell==2.2.2
-ruff==0.1.1
+ruff==0.1.6
 yamllint==1.32.0

--- a/script/check_format
+++ b/script/check_format
@@ -1,10 +1,10 @@
 #!/bin/sh
-# Format code with black.
+# Format code with ruff-format.
 
 cd "$(dirname "$0")/.."
 
-black \
+ruff \
+  format \
   --check \
-  --fast \
   --quiet \
   homeassistant tests script *.py

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -192,6 +192,7 @@ IGNORE_PRE_COMMIT_HOOK_ID = (
     "no-commit-to-branch",
     "prettier",
     "python-typing-update",
+    "ruff-format",  # it's just ruff
 )
 
 PACKAGE_REGEX = re.compile(r"^(?:--.+\s)?([-_\.\w\d]+).*==.+$")

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -395,7 +395,8 @@ def requirements_test_all_output(reqs: dict[str, list[str]]) -> str:
         for requirement, modules in reqs.items()
         if any(
             # Always install requirements that are not part of integrations
-            not mdl.startswith("homeassistant.components.") or
+            not mdl.startswith("homeassistant.components.")
+            or
             # Install tests for integrations that have tests
             has_tests(mdl)
             for mdl in modules

--- a/script/hassfest/serializer.py
+++ b/script/hassfest/serializer.py
@@ -2,10 +2,9 @@
 from __future__ import annotations
 
 from collections.abc import Collection, Iterable, Mapping
+import shutil
+import subprocess
 from typing import Any
-
-import black
-from black.mode import Mode
 
 DEFAULT_GENERATOR = "script.hassfest"
 
@@ -72,7 +71,14 @@ To update, run python3 -m {generator}
 
 {content}
 """
-    return black.format_str(content.strip(), mode=Mode())
+    ruff = shutil.which("ruff")
+    if not ruff:
+        raise RuntimeError("ruff not found")
+    return subprocess.check_output(
+        [ruff, "format", "-"],
+        input=content.strip(),
+        encoding="utf-8",
+    )
 
 
 def format_python_namespace(

--- a/tests/common.py
+++ b/tests/common.py
@@ -266,9 +266,7 @@ async def async_test_home_assistant(event_loop, load_registries=True):
         ), patch(
             "homeassistant.helpers.restore_state.RestoreStateData.async_setup_dump",
             return_value=None,
-        ), patch(
-            "homeassistant.helpers.restore_state.start.async_at_start"
-        ):
+        ), patch("homeassistant.helpers.restore_state.start.async_at_start"):
             await asyncio.gather(
                 ar.async_load(hass),
                 dr.async_load(hass),

--- a/tests/common.py
+++ b/tests/common.py
@@ -266,7 +266,9 @@ async def async_test_home_assistant(event_loop, load_registries=True):
         ), patch(
             "homeassistant.helpers.restore_state.RestoreStateData.async_setup_dump",
             return_value=None,
-        ), patch("homeassistant.helpers.restore_state.start.async_at_start"):
+        ), patch(
+            "homeassistant.helpers.restore_state.start.async_at_start",
+        ):
             await asyncio.gather(
                 ar.async_load(hass),
                 dr.async_load(hass),

--- a/tests/components/airvisual_pro/conftest.py
+++ b/tests/components/airvisual_pro/conftest.py
@@ -78,9 +78,7 @@ async def setup_airvisual_pro_fixture(hass, config, pro):
         "homeassistant.components.airvisual_pro.config_flow.NodeSamba", return_value=pro
     ), patch(
         "homeassistant.components.airvisual_pro.NodeSamba", return_value=pro
-    ), patch(
-        "homeassistant.components.airvisual.PLATFORMS", []
-    ):
+    ), patch("homeassistant.components.airvisual.PLATFORMS", []):
         assert await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()
         yield

--- a/tests/components/analytics/test_analytics.py
+++ b/tests/components/analytics/test_analytics.py
@@ -179,8 +179,12 @@ async def test_send_base_with_supervisor(
     ), patch(
         "homeassistant.components.hassio.is_hassio",
         side_effect=Mock(return_value=True),
-    ), patch("uuid.UUID.hex", new_callable=PropertyMock) as hex, patch(
-        "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION
+    ), patch(
+        "uuid.UUID.hex",
+        new_callable=PropertyMock,
+    ) as hex, patch(
+        "homeassistant.components.analytics.analytics.HA_VERSION",
+        MOCK_VERSION,
     ):
         hex.return_value = MOCK_UUID
         await analytics.load()
@@ -286,7 +290,10 @@ async def test_send_usage_with_supervisor(
     ), patch(
         "homeassistant.components.hassio.is_hassio",
         side_effect=Mock(return_value=True),
-    ), patch("homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION):
+    ), patch(
+        "homeassistant.components.analytics.analytics.HA_VERSION",
+        MOCK_VERSION,
+    ):
         await analytics.send_analytics()
     assert (
         "'addons': [{'slug': 'test_addon', 'protected': True, 'version': '1',"
@@ -487,7 +494,10 @@ async def test_send_statistics_with_supervisor(
     ), patch(
         "homeassistant.components.hassio.is_hassio",
         side_effect=Mock(return_value=True),
-    ), patch("homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION):
+    ), patch(
+        "homeassistant.components.analytics.analytics.HA_VERSION",
+        MOCK_VERSION,
+    ):
         await analytics.send_analytics()
     assert "'addon_count': 1" in caplog.text
     assert "'integrations':" not in caplog.text

--- a/tests/components/analytics/test_analytics.py
+++ b/tests/components/analytics/test_analytics.py
@@ -179,9 +179,7 @@ async def test_send_base_with_supervisor(
     ), patch(
         "homeassistant.components.hassio.is_hassio",
         side_effect=Mock(return_value=True),
-    ), patch(
-        "uuid.UUID.hex", new_callable=PropertyMock
-    ) as hex, patch(
+    ), patch("uuid.UUID.hex", new_callable=PropertyMock) as hex, patch(
         "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION
     ):
         hex.return_value = MOCK_UUID
@@ -288,9 +286,7 @@ async def test_send_usage_with_supervisor(
     ), patch(
         "homeassistant.components.hassio.is_hassio",
         side_effect=Mock(return_value=True),
-    ), patch(
-        "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION
-    ):
+    ), patch("homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION):
         await analytics.send_analytics()
     assert (
         "'addons': [{'slug': 'test_addon', 'protected': True, 'version': '1',"
@@ -491,9 +487,7 @@ async def test_send_statistics_with_supervisor(
     ), patch(
         "homeassistant.components.hassio.is_hassio",
         side_effect=Mock(return_value=True),
-    ), patch(
-        "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION
-    ):
+    ), patch("homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION):
         await analytics.send_analytics()
     assert "'addon_count': 1" in caplog.text
     assert "'integrations':" not in caplog.text

--- a/tests/components/anova/__init__.py
+++ b/tests/components/anova/__init__.py
@@ -50,9 +50,7 @@ async def async_init_integration(
         "homeassistant.components.anova.coordinator.AnovaPrecisionCooker.update"
     ) as update_patch, patch(
         "homeassistant.components.anova.AnovaApi.authenticate"
-    ), patch(
-        "homeassistant.components.anova.AnovaApi.get_devices"
-    ) as device_patch:
+    ), patch("homeassistant.components.anova.AnovaApi.get_devices") as device_patch:
         update_patch.return_value = ONLINE_UPDATE
         device_patch.return_value = [
             AnovaPrecisionCooker(None, DEVICE_UNIQUE_ID, "type_sample", None)

--- a/tests/components/anova/__init__.py
+++ b/tests/components/anova/__init__.py
@@ -50,7 +50,9 @@ async def async_init_integration(
         "homeassistant.components.anova.coordinator.AnovaPrecisionCooker.update"
     ) as update_patch, patch(
         "homeassistant.components.anova.AnovaApi.authenticate"
-    ), patch("homeassistant.components.anova.AnovaApi.get_devices") as device_patch:
+    ), patch(
+        "homeassistant.components.anova.AnovaApi.get_devices",
+    ) as device_patch:
         update_patch.return_value = ONLINE_UPDATE
         device_patch.return_value = [
             AnovaPrecisionCooker(None, DEVICE_UNIQUE_ID, "type_sample", None)

--- a/tests/components/backup/test_manager.py
+++ b/tests/components/backup/test_manager.py
@@ -91,7 +91,10 @@ async def test_load_backups(hass: HomeAssistant) -> None:
             "name": TEST_BACKUP.name,
             "date": TEST_BACKUP.date,
         },
-    ), patch("pathlib.Path.stat", return_value=MagicMock(st_size=TEST_BACKUP.size)):
+    ), patch(
+        "pathlib.Path.stat",
+        return_value=MagicMock(st_size=TEST_BACKUP.size),
+    ):
         await manager.load_backups()
     backups = await manager.get_backups()
     assert backups == {TEST_BACKUP.slug: TEST_BACKUP}

--- a/tests/components/backup/test_manager.py
+++ b/tests/components/backup/test_manager.py
@@ -91,9 +91,7 @@ async def test_load_backups(hass: HomeAssistant) -> None:
             "name": TEST_BACKUP.name,
             "date": TEST_BACKUP.date,
         },
-    ), patch(
-        "pathlib.Path.stat", return_value=MagicMock(st_size=TEST_BACKUP.size)
-    ):
+    ), patch("pathlib.Path.stat", return_value=MagicMock(st_size=TEST_BACKUP.size)):
         await manager.load_backups()
     backups = await manager.get_backups()
     assert backups == {TEST_BACKUP.slug: TEST_BACKUP}

--- a/tests/components/blink/test_config_flow.py
+++ b/tests/components/blink/test_config_flow.py
@@ -119,7 +119,10 @@ async def test_form_2fa_connect_error(hass: HomeAssistant) -> None:
     ), patch(
         "homeassistant.components.blink.config_flow.Blink.setup_urls",
         side_effect=BlinkSetupError,
-    ), patch("homeassistant.components.blink.async_setup_entry", return_value=True):
+    ), patch(
+        "homeassistant.components.blink.async_setup_entry",
+        return_value=True,
+    ):
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"], {"pin": "1234"}
         )
@@ -158,7 +161,10 @@ async def test_form_2fa_invalid_key(hass: HomeAssistant) -> None:
     ), patch(
         "homeassistant.components.blink.config_flow.Blink.setup_urls",
         return_value=True,
-    ), patch("homeassistant.components.blink.async_setup_entry", return_value=True):
+    ), patch(
+        "homeassistant.components.blink.async_setup_entry",
+        return_value=True,
+    ):
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"], {"pin": "1234"}
         )
@@ -195,7 +201,10 @@ async def test_form_2fa_unknown_error(hass: HomeAssistant) -> None:
     ), patch(
         "homeassistant.components.blink.config_flow.Blink.setup_urls",
         side_effect=KeyError,
-    ), patch("homeassistant.components.blink.async_setup_entry", return_value=True):
+    ), patch(
+        "homeassistant.components.blink.async_setup_entry",
+        return_value=True,
+    ):
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"], {"pin": "1234"}
         )

--- a/tests/components/blink/test_config_flow.py
+++ b/tests/components/blink/test_config_flow.py
@@ -119,9 +119,7 @@ async def test_form_2fa_connect_error(hass: HomeAssistant) -> None:
     ), patch(
         "homeassistant.components.blink.config_flow.Blink.setup_urls",
         side_effect=BlinkSetupError,
-    ), patch(
-        "homeassistant.components.blink.async_setup_entry", return_value=True
-    ):
+    ), patch("homeassistant.components.blink.async_setup_entry", return_value=True):
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"], {"pin": "1234"}
         )
@@ -160,9 +158,7 @@ async def test_form_2fa_invalid_key(hass: HomeAssistant) -> None:
     ), patch(
         "homeassistant.components.blink.config_flow.Blink.setup_urls",
         return_value=True,
-    ), patch(
-        "homeassistant.components.blink.async_setup_entry", return_value=True
-    ):
+    ), patch("homeassistant.components.blink.async_setup_entry", return_value=True):
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"], {"pin": "1234"}
         )
@@ -199,9 +195,7 @@ async def test_form_2fa_unknown_error(hass: HomeAssistant) -> None:
     ), patch(
         "homeassistant.components.blink.config_flow.Blink.setup_urls",
         side_effect=KeyError,
-    ), patch(
-        "homeassistant.components.blink.async_setup_entry", return_value=True
-    ):
+    ), patch("homeassistant.components.blink.async_setup_entry", return_value=True):
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"], {"pin": "1234"}
         )

--- a/tests/components/bluetooth/conftest.py
+++ b/tests/components/bluetooth/conftest.py
@@ -47,11 +47,15 @@ def mock_operating_system_90():
 def macos_adapter():
     """Fixture that mocks the macos adapter."""
     with patch("bleak.get_platform_scanner_backend_type"), patch(
-        "homeassistant.components.bluetooth.platform.system", return_value="Darwin"
+        "homeassistant.components.bluetooth.platform.system",
+        return_value="Darwin",
     ), patch(
         "homeassistant.components.bluetooth.scanner.platform.system",
         return_value="Darwin",
-    ), patch("bluetooth_adapters.systems.platform.system", return_value="Darwin"):
+    ), patch(
+        "bluetooth_adapters.systems.platform.system",
+        return_value="Darwin",
+    ):
         yield
 
 
@@ -69,12 +73,16 @@ def windows_adapter():
 def no_adapter_fixture():
     """Fixture that mocks no adapters on Linux."""
     with patch(
-        "homeassistant.components.bluetooth.platform.system", return_value="Linux"
+        "homeassistant.components.bluetooth.platform.system",
+        return_value="Linux",
     ), patch(
         "homeassistant.components.bluetooth.scanner.platform.system",
         return_value="Linux",
-    ), patch("bluetooth_adapters.systems.platform.system", return_value="Linux"), patch(
-        "bluetooth_adapters.systems.linux.LinuxAdapters.refresh"
+    ), patch(
+        "bluetooth_adapters.systems.platform.system",
+        return_value="Linux",
+    ), patch(
+        "bluetooth_adapters.systems.linux.LinuxAdapters.refresh",
     ), patch(
         "bluetooth_adapters.systems.linux.LinuxAdapters.adapters",
         {},
@@ -86,12 +94,16 @@ def no_adapter_fixture():
 def one_adapter_fixture():
     """Fixture that mocks one adapter on Linux."""
     with patch(
-        "homeassistant.components.bluetooth.platform.system", return_value="Linux"
+        "homeassistant.components.bluetooth.platform.system",
+        return_value="Linux",
     ), patch(
         "homeassistant.components.bluetooth.scanner.platform.system",
         return_value="Linux",
-    ), patch("bluetooth_adapters.systems.platform.system", return_value="Linux"), patch(
-        "bluetooth_adapters.systems.linux.LinuxAdapters.refresh"
+    ), patch(
+        "bluetooth_adapters.systems.platform.system",
+        return_value="Linux",
+    ), patch(
+        "bluetooth_adapters.systems.linux.LinuxAdapters.refresh",
     ), patch(
         "bluetooth_adapters.systems.linux.LinuxAdapters.adapters",
         {

--- a/tests/components/bluetooth/conftest.py
+++ b/tests/components/bluetooth/conftest.py
@@ -51,9 +51,7 @@ def macos_adapter():
     ), patch(
         "homeassistant.components.bluetooth.scanner.platform.system",
         return_value="Darwin",
-    ), patch(
-        "bluetooth_adapters.systems.platform.system", return_value="Darwin"
-    ):
+    ), patch("bluetooth_adapters.systems.platform.system", return_value="Darwin"):
         yield
 
 
@@ -75,9 +73,7 @@ def no_adapter_fixture():
     ), patch(
         "homeassistant.components.bluetooth.scanner.platform.system",
         return_value="Linux",
-    ), patch(
-        "bluetooth_adapters.systems.platform.system", return_value="Linux"
-    ), patch(
+    ), patch("bluetooth_adapters.systems.platform.system", return_value="Linux"), patch(
         "bluetooth_adapters.systems.linux.LinuxAdapters.refresh"
     ), patch(
         "bluetooth_adapters.systems.linux.LinuxAdapters.adapters",
@@ -94,9 +90,7 @@ def one_adapter_fixture():
     ), patch(
         "homeassistant.components.bluetooth.scanner.platform.system",
         return_value="Linux",
-    ), patch(
-        "bluetooth_adapters.systems.platform.system", return_value="Linux"
-    ), patch(
+    ), patch("bluetooth_adapters.systems.platform.system", return_value="Linux"), patch(
         "bluetooth_adapters.systems.linux.LinuxAdapters.refresh"
     ), patch(
         "bluetooth_adapters.systems.linux.LinuxAdapters.adapters",
@@ -124,9 +118,7 @@ def two_adapters_fixture():
     ), patch(
         "homeassistant.components.bluetooth.scanner.platform.system",
         return_value="Linux",
-    ), patch(
-        "bluetooth_adapters.systems.platform.system", return_value="Linux"
-    ), patch(
+    ), patch("bluetooth_adapters.systems.platform.system", return_value="Linux"), patch(
         "bluetooth_adapters.systems.linux.LinuxAdapters.refresh"
     ), patch(
         "bluetooth_adapters.systems.linux.LinuxAdapters.adapters",
@@ -166,9 +158,7 @@ def one_adapter_old_bluez():
     ), patch(
         "homeassistant.components.bluetooth.scanner.platform.system",
         return_value="Linux",
-    ), patch(
-        "bluetooth_adapters.systems.platform.system", return_value="Linux"
-    ), patch(
+    ), patch("bluetooth_adapters.systems.platform.system", return_value="Linux"), patch(
         "bluetooth_adapters.systems.linux.LinuxAdapters.refresh"
     ), patch(
         "bluetooth_adapters.systems.linux.LinuxAdapters.adapters",

--- a/tests/components/bond/common.py
+++ b/tests/components/bond/common.py
@@ -67,13 +67,9 @@ async def setup_bond_entity(
         enabled=patch_token
     ), patch_bond_version(enabled=patch_version), patch_bond_device_ids(
         enabled=patch_device_ids
-    ), patch_setup_entry(
-        "cover", enabled=patch_platforms
-    ), patch_setup_entry(
+    ), patch_setup_entry("cover", enabled=patch_platforms), patch_setup_entry(
         "fan", enabled=patch_platforms
-    ), patch_setup_entry(
-        "light", enabled=patch_platforms
-    ), patch_setup_entry(
+    ), patch_setup_entry("light", enabled=patch_platforms), patch_setup_entry(
         "switch", enabled=patch_platforms
     ):
         return await hass.config_entries.async_setup(config_entry.entry_id)
@@ -102,15 +98,11 @@ async def setup_platform(
         "homeassistant.components.bond.PLATFORMS", [platform]
     ), patch_bond_version(return_value=bond_version), patch_bond_bridge(
         return_value=bridge
-    ), patch_bond_token(
-        return_value=token
-    ), patch_bond_device_ids(
+    ), patch_bond_token(return_value=token), patch_bond_device_ids(
         return_value=[bond_device_id]
     ), patch_start_bpup(), patch_bond_device(
         return_value=discovered_device
-    ), patch_bond_device_properties(
-        return_value=props
-    ), patch_bond_device_state(
+    ), patch_bond_device_properties(return_value=props), patch_bond_device_state(
         return_value=state
     ):
         assert await async_setup_component(hass, BOND_DOMAIN, {})

--- a/tests/components/bond/test_init.py
+++ b/tests/components/bond/test_init.py
@@ -184,9 +184,7 @@ async def test_old_identifiers_are_removed(
             "name": "test1",
             "type": DeviceType.GENERIC_DEVICE,
         }
-    ), patch_bond_device_properties(
-        return_value={}
-    ), patch_bond_device_state(
+    ), patch_bond_device_properties(return_value={}), patch_bond_device_state(
         return_value={}
     ):
         assert await hass.config_entries.async_setup(config_entry.entry_id) is True
@@ -228,9 +226,7 @@ async def test_smart_by_bond_device_suggested_area(
             "type": DeviceType.GENERIC_DEVICE,
             "location": "Den",
         }
-    ), patch_bond_device_properties(
-        return_value={}
-    ), patch_bond_device_state(
+    ), patch_bond_device_properties(return_value={}), patch_bond_device_state(
         return_value={}
     ):
         assert await hass.config_entries.async_setup(config_entry.entry_id) is True
@@ -275,9 +271,7 @@ async def test_bridge_device_suggested_area(
             "type": DeviceType.GENERIC_DEVICE,
             "location": "Bathroom",
         }
-    ), patch_bond_device_properties(
-        return_value={}
-    ), patch_bond_device_state(
+    ), patch_bond_device_properties(return_value={}), patch_bond_device_state(
         return_value={}
     ):
         assert await hass.config_entries.async_setup(config_entry.entry_id) is True

--- a/tests/components/cast/test_config_flow.py
+++ b/tests/components/cast/test_config_flow.py
@@ -18,7 +18,9 @@ async def test_creating_entry_sets_up_media_player(hass: HomeAssistant) -> None:
         return_value=True,
     ) as mock_setup, patch(
         "pychromecast.discovery.discover_chromecasts", return_value=(True, None)
-    ), patch("pychromecast.discovery.stop_discovery"):
+    ), patch(
+        "pychromecast.discovery.stop_discovery",
+    ):
         result = await hass.config_entries.flow.async_init(
             cast.DOMAIN, context={"source": config_entries.SOURCE_USER}
         )

--- a/tests/components/cast/test_config_flow.py
+++ b/tests/components/cast/test_config_flow.py
@@ -18,9 +18,7 @@ async def test_creating_entry_sets_up_media_player(hass: HomeAssistant) -> None:
         return_value=True,
     ) as mock_setup, patch(
         "pychromecast.discovery.discover_chromecasts", return_value=(True, None)
-    ), patch(
-        "pychromecast.discovery.stop_discovery"
-    ):
+    ), patch("pychromecast.discovery.stop_discovery"):
         result = await hass.config_entries.flow.async_init(
             cast.DOMAIN, context={"source": config_entries.SOURCE_USER}
         )

--- a/tests/components/comelit/test_config_flow.py
+++ b/tests/components/comelit/test_config_flow.py
@@ -23,9 +23,7 @@ async def test_user(hass: HomeAssistant) -> None:
         "aiocomelit.api.ComeliteSerialBridgeApi.logout",
     ), patch(
         "homeassistant.components.comelit.async_setup_entry"
-    ) as mock_setup_entry, patch(
-        "requests.get"
-    ) as mock_request_get:
+    ) as mock_setup_entry, patch("requests.get") as mock_request_get:
         mock_request_get.return_value.status_code = 200
 
         result = await hass.config_entries.flow.async_init(
@@ -69,9 +67,7 @@ async def test_exception_connection(hass: HomeAssistant, side_effect, error) -> 
         side_effect=side_effect,
     ), patch(
         "aiocomelit.api.ComeliteSerialBridgeApi.logout",
-    ), patch(
-        "homeassistant.components.comelit.async_setup_entry"
-    ):
+    ), patch("homeassistant.components.comelit.async_setup_entry"):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=MOCK_USER_DATA
         )
@@ -135,9 +131,7 @@ async def test_reauth_not_successful(hass: HomeAssistant, side_effect, error) ->
         "aiocomelit.api.ComeliteSerialBridgeApi.login", side_effect=side_effect
     ), patch(
         "aiocomelit.api.ComeliteSerialBridgeApi.logout",
-    ), patch(
-        "homeassistant.components.comelit.async_setup_entry"
-    ):
+    ), patch("homeassistant.components.comelit.async_setup_entry"):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_REAUTH, "entry_id": mock_config.entry_id},

--- a/tests/components/comelit/test_config_flow.py
+++ b/tests/components/comelit/test_config_flow.py
@@ -23,7 +23,9 @@ async def test_user(hass: HomeAssistant) -> None:
         "aiocomelit.api.ComeliteSerialBridgeApi.logout",
     ), patch(
         "homeassistant.components.comelit.async_setup_entry"
-    ) as mock_setup_entry, patch("requests.get") as mock_request_get:
+    ) as mock_setup_entry, patch(
+        "requests.get",
+    ) as mock_request_get:
         mock_request_get.return_value.status_code = 200
 
         result = await hass.config_entries.flow.async_init(
@@ -67,7 +69,9 @@ async def test_exception_connection(hass: HomeAssistant, side_effect, error) -> 
         side_effect=side_effect,
     ), patch(
         "aiocomelit.api.ComeliteSerialBridgeApi.logout",
-    ), patch("homeassistant.components.comelit.async_setup_entry"):
+    ), patch(
+        "homeassistant.components.comelit.async_setup_entry",
+    ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=MOCK_USER_DATA
         )

--- a/tests/components/config/test_automation.py
+++ b/tests/components/config/test_automation.py
@@ -23,7 +23,9 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 @pytest.fixture
 async def setup_automation(
-    hass, automation_config, stub_blueprint_populate  # noqa: F811
+    hass,
+    automation_config,
+    stub_blueprint_populate,  # noqa: F811
 ):
     """Set up automation integration."""
     assert await async_setup_component(

--- a/tests/components/denonavr/test_config_flow.py
+++ b/tests/components/denonavr/test_config_flow.py
@@ -64,7 +64,10 @@ def denonavr_connect_fixture():
     ), patch(
         "homeassistant.components.denonavr.receiver.DenonAVR.receiver_type",
         TEST_RECEIVER_TYPE,
-    ), patch("homeassistant.components.denonavr.async_setup_entry", return_value=True):
+    ), patch(
+        "homeassistant.components.denonavr.async_setup_entry",
+        return_value=True,
+    ):
         yield
 
 

--- a/tests/components/denonavr/test_config_flow.py
+++ b/tests/components/denonavr/test_config_flow.py
@@ -64,9 +64,7 @@ def denonavr_connect_fixture():
     ), patch(
         "homeassistant.components.denonavr.receiver.DenonAVR.receiver_type",
         TEST_RECEIVER_TYPE,
-    ), patch(
-        "homeassistant.components.denonavr.async_setup_entry", return_value=True
-    ):
+    ), patch("homeassistant.components.denonavr.async_setup_entry", return_value=True):
         yield
 
 

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -150,8 +150,11 @@ async def _async_get_handle_dhcp_packet(hass, integration_matchers):
 
     with patch(
         "homeassistant.components.dhcp._verify_l2socket_setup",
-    ), patch("scapy.arch.common.compile_filter"), patch(
-        "scapy.sendrecv.AsyncSniffer", _mock_sniffer
+    ), patch(
+        "scapy.arch.common.compile_filter",
+    ), patch(
+        "scapy.sendrecv.AsyncSniffer",
+        _mock_sniffer,
     ):
         await dhcp_watcher.async_start()
 

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -150,9 +150,9 @@ async def _async_get_handle_dhcp_packet(hass, integration_matchers):
 
     with patch(
         "homeassistant.components.dhcp._verify_l2socket_setup",
-    ), patch(
-        "scapy.arch.common.compile_filter"
-    ), patch("scapy.sendrecv.AsyncSniffer", _mock_sniffer):
+    ), patch("scapy.arch.common.compile_filter"), patch(
+        "scapy.sendrecv.AsyncSniffer", _mock_sniffer
+    ):
         await dhcp_watcher.async_start()
 
     return async_handle_dhcp_packet

--- a/tests/components/ecobee/test_config_flow.py
+++ b/tests/components/ecobee/test_config_flow.py
@@ -198,9 +198,7 @@ async def test_import_flow_triggered_with_ecobee_conf_and_valid_data_and_stale_t
         return_value=MOCK_ECOBEE_CONF,
     ), patch(
         "homeassistant.components.ecobee.config_flow.Ecobee"
-    ) as mock_ecobee, patch.object(
-        flow, "async_step_user"
-    ) as mock_async_step_user:
+    ) as mock_ecobee, patch.object(flow, "async_step_user") as mock_async_step_user:
         mock_ecobee = mock_ecobee.return_value
         mock_ecobee.refresh_tokens.return_value = False
 

--- a/tests/components/electrasmart/test_config_flow.py
+++ b/tests/components/electrasmart/test_config_flow.py
@@ -54,9 +54,7 @@ async def test_one_time_password(hass: HomeAssistant):
     ), patch(
         "electrasmart.api.ElectraAPI.validate_one_time_password",
         return_value=mock_otp_response,
-    ), patch(
-        "electrasmart.api.ElectraAPI.fetch_devices", return_value=[]
-    ):
+    ), patch("electrasmart.api.ElectraAPI.fetch_devices", return_value=[]):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_USER},

--- a/tests/components/electrasmart/test_config_flow.py
+++ b/tests/components/electrasmart/test_config_flow.py
@@ -54,7 +54,10 @@ async def test_one_time_password(hass: HomeAssistant):
     ), patch(
         "electrasmart.api.ElectraAPI.validate_one_time_password",
         return_value=mock_otp_response,
-    ), patch("electrasmart.api.ElectraAPI.fetch_devices", return_value=[]):
+    ), patch(
+        "electrasmart.api.ElectraAPI.fetch_devices",
+        return_value=[],
+    ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_USER},

--- a/tests/components/elkm1/test_config_flow.py
+++ b/tests/components/elkm1/test_config_flow.py
@@ -229,9 +229,7 @@ async def test_form_user_with_insecure_elk_times_out(hass: HomeAssistant) -> Non
         0,
     ), patch(
         "homeassistant.components.elkm1.config_flow.LOGIN_TIMEOUT", 0
-    ), _patch_discovery(), _patch_elk(
-        elk=mocked_elk
-    ):
+    ), _patch_discovery(), _patch_elk(elk=mocked_elk):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {

--- a/tests/components/enphase_envoy/conftest.py
+++ b/tests/components/enphase_envoy/conftest.py
@@ -88,9 +88,7 @@ async def setup_enphase_envoy_fixture(hass, config, mock_envoy):
     ), patch(
         "homeassistant.components.enphase_envoy.Envoy",
         return_value=mock_envoy,
-    ), patch(
-        "homeassistant.components.enphase_envoy.PLATFORMS", []
-    ):
+    ), patch("homeassistant.components.enphase_envoy.PLATFORMS", []):
         assert await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()
         yield

--- a/tests/components/enphase_envoy/conftest.py
+++ b/tests/components/enphase_envoy/conftest.py
@@ -88,7 +88,10 @@ async def setup_enphase_envoy_fixture(hass, config, mock_envoy):
     ), patch(
         "homeassistant.components.enphase_envoy.Envoy",
         return_value=mock_envoy,
-    ), patch("homeassistant.components.enphase_envoy.PLATFORMS", []):
+    ), patch(
+        "homeassistant.components.enphase_envoy.PLATFORMS",
+        [],
+    ):
         assert await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()
         yield

--- a/tests/components/epson/test_media_player.py
+++ b/tests/components/epson/test_media_player.py
@@ -38,7 +38,7 @@ async def test_set_unique_id(
     ), patch(
         "homeassistant.components.epson.Projector.get_serial_number", return_value="123"
     ), patch(
-        "homeassistant.components.epson.Projector.get_property"
+        "homeassistant.components.epson.Projector.get_property",
     ):
         freezer.tick(timedelta(seconds=30))
         async_fire_time_changed(hass)

--- a/tests/components/esphome/test_update.py
+++ b/tests/components/esphome/test_update.py
@@ -99,7 +99,10 @@ async def test_update_entity(
         "esphome_dashboard_api.ESPHomeDashboardAPI.compile", return_value=False
     ) as mock_compile, patch(
         "esphome_dashboard_api.ESPHomeDashboardAPI.upload", return_value=True
-    ) as mock_upload, pytest.raises(HomeAssistantError, match="compiling"):
+    ) as mock_upload, pytest.raises(
+        HomeAssistantError,
+        match="compiling",
+    ):
         await hass.services.async_call(
             "update",
             "install",
@@ -117,7 +120,10 @@ async def test_update_entity(
         "esphome_dashboard_api.ESPHomeDashboardAPI.compile", return_value=True
     ) as mock_compile, patch(
         "esphome_dashboard_api.ESPHomeDashboardAPI.upload", return_value=False
-    ) as mock_upload, pytest.raises(HomeAssistantError, match="OTA"):
+    ) as mock_upload, pytest.raises(
+        HomeAssistantError,
+        match="OTA",
+    ):
         await hass.services.async_call(
             "update",
             "install",

--- a/tests/components/esphome/test_update.py
+++ b/tests/components/esphome/test_update.py
@@ -99,9 +99,7 @@ async def test_update_entity(
         "esphome_dashboard_api.ESPHomeDashboardAPI.compile", return_value=False
     ) as mock_compile, patch(
         "esphome_dashboard_api.ESPHomeDashboardAPI.upload", return_value=True
-    ) as mock_upload, pytest.raises(
-        HomeAssistantError, match="compiling"
-    ):
+    ) as mock_upload, pytest.raises(HomeAssistantError, match="compiling"):
         await hass.services.async_call(
             "update",
             "install",
@@ -119,9 +117,7 @@ async def test_update_entity(
         "esphome_dashboard_api.ESPHomeDashboardAPI.compile", return_value=True
     ) as mock_compile, patch(
         "esphome_dashboard_api.ESPHomeDashboardAPI.upload", return_value=False
-    ) as mock_upload, pytest.raises(
-        HomeAssistantError, match="OTA"
-    ):
+    ) as mock_upload, pytest.raises(HomeAssistantError, match="OTA"):
         await hass.services.async_call(
             "update",
             "install",

--- a/tests/components/evil_genius_labs/conftest.py
+++ b/tests/components/evil_genius_labs/conftest.py
@@ -50,7 +50,10 @@ async def setup_evil_genius_labs(
     ), patch(
         "pyevilgenius.EvilGeniusDevice.get_product",
         return_value=product_fixture,
-    ), patch("homeassistant.components.evil_genius_labs.PLATFORMS", platforms):
+    ), patch(
+        "homeassistant.components.evil_genius_labs.PLATFORMS",
+        platforms,
+    ):
         assert await async_setup_component(hass, "evil_genius_labs", {})
         await hass.async_block_till_done()
         yield

--- a/tests/components/evil_genius_labs/conftest.py
+++ b/tests/components/evil_genius_labs/conftest.py
@@ -50,9 +50,7 @@ async def setup_evil_genius_labs(
     ), patch(
         "pyevilgenius.EvilGeniusDevice.get_product",
         return_value=product_fixture,
-    ), patch(
-        "homeassistant.components.evil_genius_labs.PLATFORMS", platforms
-    ):
+    ), patch("homeassistant.components.evil_genius_labs.PLATFORMS", platforms):
         assert await async_setup_component(hass, "evil_genius_labs", {})
         await hass.async_block_till_done()
         yield

--- a/tests/components/fritz/test_config_flow.py
+++ b/tests/components/fritz/test_config_flow.py
@@ -47,8 +47,10 @@ async def test_user(hass: HomeAssistant, fc_class_mock, mock_get_source_ip) -> N
         return_value=MOCK_FIRMWARE_INFO,
     ), patch(
         "homeassistant.components.fritz.async_setup_entry"
-    ) as mock_setup_entry, patch("requests.get") as mock_request_get, patch(
-        "requests.post"
+    ) as mock_setup_entry, patch(
+        "requests.get",
+    ) as mock_request_get, patch(
+        "requests.post",
     ) as mock_request_post, patch(
         "homeassistant.components.fritz.config_flow.socket.gethostbyname",
         return_value=MOCK_IPS["fritz.box"],
@@ -95,8 +97,10 @@ async def test_user_already_configured(
     ), patch(
         "homeassistant.components.fritz.common.FritzBoxTools._update_device_info",
         return_value=MOCK_FIRMWARE_INFO,
-    ), patch("requests.get") as mock_request_get, patch(
-        "requests.post"
+    ), patch(
+        "requests.get",
+    ) as mock_request_get, patch(
+        "requests.post",
     ) as mock_request_post, patch(
         "homeassistant.components.fritz.config_flow.socket.gethostbyname",
         return_value=MOCK_IPS["fritz.box"],
@@ -207,9 +211,11 @@ async def test_reauth_successful(
         "homeassistant.components.fritz.common.FritzBoxTools._update_device_info",
         return_value=MOCK_FIRMWARE_INFO,
     ), patch(
-        "homeassistant.components.fritz.async_setup_entry"
-    ) as mock_setup_entry, patch("requests.get") as mock_request_get, patch(
-        "requests.post"
+        "homeassistant.components.fritz.async_setup_entry",
+    ) as mock_setup_entry, patch(
+        "requests.get",
+    ) as mock_request_get, patch(
+        "requests.post",
     ) as mock_request_post:
         mock_request_get.return_value.status_code = 200
         mock_request_get.return_value.content = MOCK_REQUEST

--- a/tests/components/fritz/test_config_flow.py
+++ b/tests/components/fritz/test_config_flow.py
@@ -47,9 +47,7 @@ async def test_user(hass: HomeAssistant, fc_class_mock, mock_get_source_ip) -> N
         return_value=MOCK_FIRMWARE_INFO,
     ), patch(
         "homeassistant.components.fritz.async_setup_entry"
-    ) as mock_setup_entry, patch(
-        "requests.get"
-    ) as mock_request_get, patch(
+    ) as mock_setup_entry, patch("requests.get") as mock_request_get, patch(
         "requests.post"
     ) as mock_request_post, patch(
         "homeassistant.components.fritz.config_flow.socket.gethostbyname",
@@ -97,9 +95,7 @@ async def test_user_already_configured(
     ), patch(
         "homeassistant.components.fritz.common.FritzBoxTools._update_device_info",
         return_value=MOCK_FIRMWARE_INFO,
-    ), patch(
-        "requests.get"
-    ) as mock_request_get, patch(
+    ), patch("requests.get") as mock_request_get, patch(
         "requests.post"
     ) as mock_request_post, patch(
         "homeassistant.components.fritz.config_flow.socket.gethostbyname",
@@ -212,9 +208,7 @@ async def test_reauth_successful(
         return_value=MOCK_FIRMWARE_INFO,
     ), patch(
         "homeassistant.components.fritz.async_setup_entry"
-    ) as mock_setup_entry, patch(
-        "requests.get"
-    ) as mock_request_get, patch(
+    ) as mock_setup_entry, patch("requests.get") as mock_request_get, patch(
         "requests.post"
     ) as mock_request_post:
         mock_request_get.return_value.status_code = 200
@@ -399,9 +393,7 @@ async def test_ssdp(hass: HomeAssistant, fc_class_mock, mock_get_source_ip) -> N
         return_value=MOCK_FIRMWARE_INFO,
     ), patch(
         "homeassistant.components.fritz.async_setup_entry"
-    ) as mock_setup_entry, patch(
-        "requests.get"
-    ) as mock_request_get, patch(
+    ) as mock_setup_entry, patch("requests.get") as mock_request_get, patch(
         "requests.post"
     ) as mock_request_post:
         mock_request_get.return_value.status_code = 200

--- a/tests/components/gios/__init__.py
+++ b/tests/components/gios/__init__.py
@@ -42,7 +42,10 @@ async def init_integration(
     ), patch(
         "homeassistant.components.gios.Gios._get_all_sensors",
         return_value=sensors,
-    ), patch("homeassistant.components.gios.Gios._get_indexes", return_value=indexes):
+    ), patch(
+        "homeassistant.components.gios.Gios._get_indexes",
+        return_value=indexes,
+    ):
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/gios/__init__.py
+++ b/tests/components/gios/__init__.py
@@ -42,9 +42,7 @@ async def init_integration(
     ), patch(
         "homeassistant.components.gios.Gios._get_all_sensors",
         return_value=sensors,
-    ), patch(
-        "homeassistant.components.gios.Gios._get_indexes", return_value=indexes
-    ):
+    ), patch("homeassistant.components.gios.Gios._get_indexes", return_value=indexes):
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/gios/test_config_flow.py
+++ b/tests/components/gios/test_config_flow.py
@@ -54,9 +54,7 @@ async def test_invalid_sensor_data(hass: HomeAssistant) -> None:
     ), patch(
         "homeassistant.components.gios.Gios._get_station",
         return_value=json.loads(load_fixture("gios/station.json")),
-    ), patch(
-        "homeassistant.components.gios.Gios._get_sensor", return_value={}
-    ):
+    ), patch("homeassistant.components.gios.Gios._get_sensor", return_value={}):
         flow = config_flow.GiosFlowHandler()
         flow.hass = hass
         flow.context = {}

--- a/tests/components/gios/test_config_flow.py
+++ b/tests/components/gios/test_config_flow.py
@@ -54,7 +54,10 @@ async def test_invalid_sensor_data(hass: HomeAssistant) -> None:
     ), patch(
         "homeassistant.components.gios.Gios._get_station",
         return_value=json.loads(load_fixture("gios/station.json")),
-    ), patch("homeassistant.components.gios.Gios._get_sensor", return_value={}):
+    ), patch(
+        "homeassistant.components.gios.Gios._get_sensor",
+        return_value={},
+    ):
         flow = config_flow.GiosFlowHandler()
         flow.hass = hass
         flow.context = {}
@@ -81,7 +84,8 @@ async def test_cannot_connect(hass: HomeAssistant) -> None:
 async def test_create_entry(hass: HomeAssistant) -> None:
     """Test that the user step works."""
     with patch(
-        "homeassistant.components.gios.Gios._get_stations", return_value=STATIONS
+        "homeassistant.components.gios.Gios._get_stations",
+        return_value=STATIONS,
     ), patch(
         "homeassistant.components.gios.Gios._get_station",
         return_value=json.loads(load_fixture("gios/station.json")),

--- a/tests/components/gios/test_init.py
+++ b/tests/components/gios/test_init.py
@@ -82,9 +82,7 @@ async def test_migrate_device_and_config_entry(
     ), patch(
         "homeassistant.components.gios.Gios._get_all_sensors",
         return_value=sensors,
-    ), patch(
-        "homeassistant.components.gios.Gios._get_indexes", return_value=indexes
-    ):
+    ), patch("homeassistant.components.gios.Gios._get_indexes", return_value=indexes):
         config_entry.add_to_hass(hass)
 
         device_entry = device_registry.async_get_or_create(

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -91,9 +91,7 @@ async def test_update_access_token(hass: HomeAssistant) -> None:
         "homeassistant.components.google_assistant.http._get_homegraph_token"
     ) as mock_get_token, patch(
         "homeassistant.components.google_assistant.http._get_homegraph_jwt"
-    ) as mock_get_jwt, patch(
-        "homeassistant.core.dt_util.utcnow"
-    ) as mock_utcnow:
+    ) as mock_get_jwt, patch("homeassistant.core.dt_util.utcnow") as mock_utcnow:
         mock_utcnow.return_value = base_time
         mock_get_jwt.return_value = jwt
         mock_get_token.return_value = MOCK_TOKEN

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -91,7 +91,9 @@ async def test_update_access_token(hass: HomeAssistant) -> None:
         "homeassistant.components.google_assistant.http._get_homegraph_token"
     ) as mock_get_token, patch(
         "homeassistant.components.google_assistant.http._get_homegraph_jwt"
-    ) as mock_get_jwt, patch("homeassistant.core.dt_util.utcnow") as mock_utcnow:
+    ) as mock_get_jwt, patch(
+        "homeassistant.core.dt_util.utcnow",
+    ) as mock_utcnow:
         mock_utcnow.return_value = base_time
         mock_get_jwt.return_value = jwt
         mock_get_token.return_value = MOCK_TOKEN

--- a/tests/components/google_assistant_sdk/test_notify.py
+++ b/tests/components/google_assistant_sdk/test_notify.py
@@ -66,7 +66,12 @@ async def test_broadcast_no_targets(
             "Anuncia en el salón Es hora de hacer los deberes",
         ),
         ("ko-KR", "숙제할 시간이야", "거실", "숙제할 시간이야 라고 거실에 방송해 줘"),
-        ("ja-JP", "宿題の時間だよ", "リビング", "宿題の時間だよとリビングにブロードキャストして"),
+        (
+            "ja-JP",
+            "宿題の時間だよ",
+            "リビング",
+            "宿題の時間だよとリビングにブロードキャストして",
+        ),
     ],
     ids=["english", "spanish", "korean", "japanese"],
 )

--- a/tests/components/guardian/conftest.py
+++ b/tests/components/guardian/conftest.py
@@ -130,9 +130,7 @@ async def setup_guardian_fixture(
     ), patch(
         "aioguardian.commands.wifi.WiFiCommands.status",
         return_value=data_wifi_status,
-    ), patch(
-        "aioguardian.client.Client.disconnect"
-    ), patch(
+    ), patch("aioguardian.client.Client.disconnect"), patch(
         "homeassistant.components.guardian.PLATFORMS", []
     ):
         assert await async_setup_component(hass, DOMAIN, config)

--- a/tests/components/guardian/conftest.py
+++ b/tests/components/guardian/conftest.py
@@ -130,8 +130,11 @@ async def setup_guardian_fixture(
     ), patch(
         "aioguardian.commands.wifi.WiFiCommands.status",
         return_value=data_wifi_status,
-    ), patch("aioguardian.client.Client.disconnect"), patch(
-        "homeassistant.components.guardian.PLATFORMS", []
+    ), patch(
+        "aioguardian.client.Client.disconnect",
+    ), patch(
+        "homeassistant.components.guardian.PLATFORMS",
+        [],
     ):
         assert await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()

--- a/tests/components/hassio/conftest.py
+++ b/tests/components/hassio/conftest.py
@@ -53,9 +53,7 @@ def hassio_stubs(hassio_env, hass, hass_client, aioclient_mock):
     ), patch(
         "homeassistant.components.hassio.HassIO.get_ingress_panels",
         return_value={"panels": []},
-    ), patch(
-        "homeassistant.components.hassio.issues.SupervisorIssues.setup"
-    ), patch(
+    ), patch("homeassistant.components.hassio.issues.SupervisorIssues.setup"), patch(
         "homeassistant.components.hassio.HassIO.refresh_updates"
     ):
         hass.state = CoreState.starting

--- a/tests/components/hassio/conftest.py
+++ b/tests/components/hassio/conftest.py
@@ -53,8 +53,10 @@ def hassio_stubs(hassio_env, hass, hass_client, aioclient_mock):
     ), patch(
         "homeassistant.components.hassio.HassIO.get_ingress_panels",
         return_value={"panels": []},
-    ), patch("homeassistant.components.hassio.issues.SupervisorIssues.setup"), patch(
-        "homeassistant.components.hassio.HassIO.refresh_updates"
+    ), patch(
+        "homeassistant.components.hassio.issues.SupervisorIssues.setup",
+    ), patch(
+        "homeassistant.components.hassio.HassIO.refresh_updates",
     ):
         hass.state = CoreState.starting
         hass.loop.run_until_complete(async_setup_component(hass, "hassio", {}))

--- a/tests/components/homekit/conftest.py
+++ b/tests/components/homekit/conftest.py
@@ -30,7 +30,9 @@ def run_driver(hass, event_loop, iid_storage):
         "pyhap.accessory_driver.AccessoryEncoder"
     ), patch("pyhap.accessory_driver.HAPServer"), patch(
         "pyhap.accessory_driver.AccessoryDriver.publish"
-    ), patch("pyhap.accessory_driver.AccessoryDriver.persist"):
+    ), patch(
+        "pyhap.accessory_driver.AccessoryDriver.persist",
+    ):
         yield HomeDriver(
             hass,
             pincode=b"123-45-678",
@@ -50,8 +52,10 @@ def hk_driver(hass, event_loop, iid_storage):
         "pyhap.accessory_driver.AccessoryEncoder"
     ), patch("pyhap.accessory_driver.HAPServer.async_stop"), patch(
         "pyhap.accessory_driver.HAPServer.async_start"
-    ), patch("pyhap.accessory_driver.AccessoryDriver.publish"), patch(
-        "pyhap.accessory_driver.AccessoryDriver.persist"
+    ), patch(
+        "pyhap.accessory_driver.AccessoryDriver.publish",
+    ), patch(
+        "pyhap.accessory_driver.AccessoryDriver.persist",
     ):
         yield HomeDriver(
             hass,
@@ -72,10 +76,14 @@ def mock_hap(hass, event_loop, iid_storage, mock_zeroconf):
         "pyhap.accessory_driver.AccessoryEncoder"
     ), patch("pyhap.accessory_driver.HAPServer.async_stop"), patch(
         "pyhap.accessory_driver.HAPServer.async_start"
-    ), patch("pyhap.accessory_driver.AccessoryDriver.publish"), patch(
-        "pyhap.accessory_driver.AccessoryDriver.async_start"
-    ), patch("pyhap.accessory_driver.AccessoryDriver.async_stop"), patch(
-        "pyhap.accessory_driver.AccessoryDriver.persist"
+    ), patch(
+        "pyhap.accessory_driver.AccessoryDriver.publish",
+    ), patch(
+        "pyhap.accessory_driver.AccessoryDriver.async_start",
+    ), patch(
+        "pyhap.accessory_driver.AccessoryDriver.async_stop",
+    ), patch(
+        "pyhap.accessory_driver.AccessoryDriver.persist",
     ):
         yield HomeDriver(
             hass,

--- a/tests/components/homekit/conftest.py
+++ b/tests/components/homekit/conftest.py
@@ -30,9 +30,7 @@ def run_driver(hass, event_loop, iid_storage):
         "pyhap.accessory_driver.AccessoryEncoder"
     ), patch("pyhap.accessory_driver.HAPServer"), patch(
         "pyhap.accessory_driver.AccessoryDriver.publish"
-    ), patch(
-        "pyhap.accessory_driver.AccessoryDriver.persist"
-    ):
+    ), patch("pyhap.accessory_driver.AccessoryDriver.persist"):
         yield HomeDriver(
             hass,
             pincode=b"123-45-678",
@@ -52,9 +50,7 @@ def hk_driver(hass, event_loop, iid_storage):
         "pyhap.accessory_driver.AccessoryEncoder"
     ), patch("pyhap.accessory_driver.HAPServer.async_stop"), patch(
         "pyhap.accessory_driver.HAPServer.async_start"
-    ), patch(
-        "pyhap.accessory_driver.AccessoryDriver.publish"
-    ), patch(
+    ), patch("pyhap.accessory_driver.AccessoryDriver.publish"), patch(
         "pyhap.accessory_driver.AccessoryDriver.persist"
     ):
         yield HomeDriver(
@@ -76,13 +72,9 @@ def mock_hap(hass, event_loop, iid_storage, mock_zeroconf):
         "pyhap.accessory_driver.AccessoryEncoder"
     ), patch("pyhap.accessory_driver.HAPServer.async_stop"), patch(
         "pyhap.accessory_driver.HAPServer.async_start"
-    ), patch(
-        "pyhap.accessory_driver.AccessoryDriver.publish"
-    ), patch(
+    ), patch("pyhap.accessory_driver.AccessoryDriver.publish"), patch(
         "pyhap.accessory_driver.AccessoryDriver.async_start"
-    ), patch(
-        "pyhap.accessory_driver.AccessoryDriver.async_stop"
-    ), patch(
+    ), patch("pyhap.accessory_driver.AccessoryDriver.async_stop"), patch(
         "pyhap.accessory_driver.AccessoryDriver.persist"
     ):
         yield HomeDriver(

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -1202,9 +1202,7 @@ async def test_homekit_reset_accessories_not_supported(
         "pyhap.accessory_driver.AccessoryDriver.async_update_advertisement"
     ) as hk_driver_async_update_advertisement, patch(
         "pyhap.accessory_driver.AccessoryDriver.async_start"
-    ), patch.object(
-        homekit_base, "_HOMEKIT_CONFIG_UPDATE_TIME", 0
-    ):
+    ), patch.object(homekit_base, "_HOMEKIT_CONFIG_UPDATE_TIME", 0):
         await async_init_entry(hass, entry)
 
         acc_mock = MagicMock()
@@ -1247,9 +1245,7 @@ async def test_homekit_reset_accessories_state_missing(
         "pyhap.accessory_driver.AccessoryDriver.config_changed"
     ) as hk_driver_config_changed, patch(
         "pyhap.accessory_driver.AccessoryDriver.async_start"
-    ), patch.object(
-        homekit_base, "_HOMEKIT_CONFIG_UPDATE_TIME", 0
-    ):
+    ), patch.object(homekit_base, "_HOMEKIT_CONFIG_UPDATE_TIME", 0):
         await async_init_entry(hass, entry)
 
         acc_mock = MagicMock()
@@ -1291,9 +1287,7 @@ async def test_homekit_reset_accessories_not_bridged(
         "pyhap.accessory_driver.AccessoryDriver.async_update_advertisement"
     ) as hk_driver_async_update_advertisement, patch(
         "pyhap.accessory_driver.AccessoryDriver.async_start"
-    ), patch.object(
-        homekit_base, "_HOMEKIT_CONFIG_UPDATE_TIME", 0
-    ):
+    ), patch.object(homekit_base, "_HOMEKIT_CONFIG_UPDATE_TIME", 0):
         await async_init_entry(hass, entry)
 
         assert hk_driver_async_update_advertisement.call_count == 0
@@ -1337,9 +1331,7 @@ async def test_homekit_reset_single_accessory(
         "pyhap.accessory_driver.AccessoryDriver.async_update_advertisement"
     ) as hk_driver_async_update_advertisement, patch(
         "pyhap.accessory_driver.AccessoryDriver.async_start"
-    ), patch(
-        f"{PATH_HOMEKIT}.accessories.HomeAccessory.run"
-    ) as mock_run:
+    ), patch(f"{PATH_HOMEKIT}.accessories.HomeAccessory.run") as mock_run:
         await async_init_entry(hass, entry)
         homekit.status = STATUS_RUNNING
         homekit.driver.aio_stop_event = MagicMock()
@@ -2070,9 +2062,7 @@ async def test_reload(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
         f"{PATH_HOMEKIT}.HomeKit"
     ) as mock_homekit2, patch.object(homekit.bridge, "add_accessory"), patch(
         f"{PATH_HOMEKIT}.async_show_setup_message"
-    ), patch(
-        f"{PATH_HOMEKIT}.get_accessory"
-    ), patch(
+    ), patch(f"{PATH_HOMEKIT}.get_accessory"), patch(
         "pyhap.accessory_driver.AccessoryDriver.async_start"
     ), patch(
         "homeassistant.components.network.async_get_source_ip", return_value="1.2.3.4"

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -1331,7 +1331,9 @@ async def test_homekit_reset_single_accessory(
         "pyhap.accessory_driver.AccessoryDriver.async_update_advertisement"
     ) as hk_driver_async_update_advertisement, patch(
         "pyhap.accessory_driver.AccessoryDriver.async_start"
-    ), patch(f"{PATH_HOMEKIT}.accessories.HomeAccessory.run") as mock_run:
+    ), patch(
+        f"{PATH_HOMEKIT}.accessories.HomeAccessory.run",
+    ) as mock_run:
         await async_init_entry(hass, entry)
         homekit.status = STATUS_RUNNING
         homekit.driver.aio_stop_event = MagicMock()
@@ -2062,8 +2064,10 @@ async def test_reload(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
         f"{PATH_HOMEKIT}.HomeKit"
     ) as mock_homekit2, patch.object(homekit.bridge, "add_accessory"), patch(
         f"{PATH_HOMEKIT}.async_show_setup_message"
-    ), patch(f"{PATH_HOMEKIT}.get_accessory"), patch(
-        "pyhap.accessory_driver.AccessoryDriver.async_start"
+    ), patch(
+        f"{PATH_HOMEKIT}.get_accessory",
+    ), patch(
+        "pyhap.accessory_driver.AccessoryDriver.async_start",
     ), patch(
         "homeassistant.components.network.async_get_source_ip", return_value="1.2.3.4"
     ):

--- a/tests/components/homematicip_cloud/test_device.py
+++ b/tests/components/homematicip_cloud/test_device.py
@@ -101,7 +101,9 @@ async def test_hmip_add_device(
         return_value=reloaded_hap,
     ), patch.object(reloaded_hap, "async_connect"), patch.object(
         reloaded_hap, "get_hap", return_value=mock_hap.home
-    ), patch("homeassistant.components.homematicip_cloud.hap.asyncio.sleep"):
+    ), patch(
+        "homeassistant.components.homematicip_cloud.hap.asyncio.sleep",
+    ):
         mock_hap.home.fire_create_event(event_type=EventType.DEVICE_ADDED)
         await hass.async_block_till_done()
 

--- a/tests/components/homematicip_cloud/test_device.py
+++ b/tests/components/homematicip_cloud/test_device.py
@@ -101,9 +101,7 @@ async def test_hmip_add_device(
         return_value=reloaded_hap,
     ), patch.object(reloaded_hap, "async_connect"), patch.object(
         reloaded_hap, "get_hap", return_value=mock_hap.home
-    ), patch(
-        "homeassistant.components.homematicip_cloud.hap.asyncio.sleep"
-    ):
+    ), patch("homeassistant.components.homematicip_cloud.hap.asyncio.sleep"):
         mock_hap.home.fire_create_event(event_type=EventType.DEVICE_ADDED)
         await hass.async_block_till_done()
 

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -52,9 +52,7 @@ async def test_auth_auth_check_and_register(hass: HomeAssistant) -> None:
         hmip_auth.auth, "isRequestAcknowledged", return_value=True
     ), patch.object(
         hmip_auth.auth, "requestAuthToken", return_value="ABC"
-    ), patch.object(
-        hmip_auth.auth, "confirmAuthToken"
-    ):
+    ), patch.object(hmip_auth.auth, "confirmAuthToken"):
         assert await hmip_auth.async_checkbutton()
         assert await hmip_auth.async_register() == "ABC"
 

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -52,7 +52,10 @@ async def test_auth_auth_check_and_register(hass: HomeAssistant) -> None:
         hmip_auth.auth, "isRequestAcknowledged", return_value=True
     ), patch.object(
         hmip_auth.auth, "requestAuthToken", return_value="ABC"
-    ), patch.object(hmip_auth.auth, "confirmAuthToken"):
+    ), patch.object(
+        hmip_auth.auth,
+        "confirmAuthToken",
+    ):
         assert await hmip_auth.async_checkbutton()
         assert await hmip_auth.async_register() == "ABC"
 

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -113,7 +113,10 @@ async def test_setup_devices_exception(
     ), patch(
         "homeassistant.components.iaqualink.AqualinkClient.get_systems",
         return_value=systems,
-    ), patch.object(system, "get_devices") as mock_get_devices:
+    ), patch.object(
+        system,
+        "get_devices",
+    ) as mock_get_devices:
         mock_get_devices.side_effect = AqualinkServiceException
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
@@ -139,7 +142,10 @@ async def test_setup_all_good_no_recognized_devices(
     ), patch(
         "homeassistant.components.iaqualink.AqualinkClient.get_systems",
         return_value=systems,
-    ), patch.object(system, "get_devices") as mock_get_devices:
+    ), patch.object(
+        system,
+        "get_devices",
+    ) as mock_get_devices:
         mock_get_devices.return_value = devices
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -113,9 +113,7 @@ async def test_setup_devices_exception(
     ), patch(
         "homeassistant.components.iaqualink.AqualinkClient.get_systems",
         return_value=systems,
-    ), patch.object(
-        system, "get_devices"
-    ) as mock_get_devices:
+    ), patch.object(system, "get_devices") as mock_get_devices:
         mock_get_devices.side_effect = AqualinkServiceException
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
@@ -141,9 +139,7 @@ async def test_setup_all_good_no_recognized_devices(
     ), patch(
         "homeassistant.components.iaqualink.AqualinkClient.get_systems",
         return_value=systems,
-    ), patch.object(
-        system, "get_devices"
-    ) as mock_get_devices:
+    ), patch.object(system, "get_devices") as mock_get_devices:
         mock_get_devices.return_value = devices
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/insteon/test_init.py
+++ b/tests/components/insteon/test_init.py
@@ -75,9 +75,7 @@ async def test_import_frontend_dev_url(hass: HomeAssistant) -> None:
         insteon, "async_connect", new=mock_successful_connection
     ), patch.object(insteon, "close_insteon_connection"), patch.object(
         insteon, "devices", new=MockDevices()
-    ), patch(
-        PATCH_CONNECTION, new=mock_successful_connection
-    ):
+    ), patch(PATCH_CONNECTION, new=mock_successful_connection):
         assert await async_setup_component(
             hass,
             insteon.DOMAIN,

--- a/tests/components/insteon/test_init.py
+++ b/tests/components/insteon/test_init.py
@@ -75,7 +75,10 @@ async def test_import_frontend_dev_url(hass: HomeAssistant) -> None:
         insteon, "async_connect", new=mock_successful_connection
     ), patch.object(insteon, "close_insteon_connection"), patch.object(
         insteon, "devices", new=MockDevices()
-    ), patch(PATCH_CONNECTION, new=mock_successful_connection):
+    ), patch(
+        PATCH_CONNECTION,
+        new=mock_successful_connection,
+    ):
         assert await async_setup_component(
             hass,
             insteon.DOMAIN,

--- a/tests/components/insteon/test_lock.py
+++ b/tests/components/insteon/test_lock.py
@@ -46,9 +46,7 @@ def patch_setup_and_devices():
         insteon, "async_close"
     ), patch.object(insteon, "devices", devices), patch.object(
         insteon_utils, "devices", devices
-    ), patch.object(
-        insteon_entity, "devices", devices
-    ):
+    ), patch.object(insteon_entity, "devices", devices):
         yield
 
 

--- a/tests/components/insteon/test_lock.py
+++ b/tests/components/insteon/test_lock.py
@@ -46,7 +46,11 @@ def patch_setup_and_devices():
         insteon, "async_close"
     ), patch.object(insteon, "devices", devices), patch.object(
         insteon_utils, "devices", devices
-    ), patch.object(insteon_entity, "devices", devices):
+    ), patch.object(
+        insteon_entity,
+        "devices",
+        devices,
+    ):
         yield
 
 

--- a/tests/components/iqvia/conftest.py
+++ b/tests/components/iqvia/conftest.py
@@ -94,13 +94,9 @@ async def setup_iqvia_fixture(
         "pyiqvia.allergens.Allergens.outlook", return_value=data_allergy_outlook
     ), patch(
         "pyiqvia.asthma.Asthma.extended", return_value=data_asthma_forecast
-    ), patch(
-        "pyiqvia.asthma.Asthma.current", return_value=data_asthma_index
-    ), patch(
+    ), patch("pyiqvia.asthma.Asthma.current", return_value=data_asthma_index), patch(
         "pyiqvia.disease.Disease.extended", return_value=data_disease_forecast
-    ), patch(
-        "pyiqvia.disease.Disease.current", return_value=data_disease_index
-    ), patch(
+    ), patch("pyiqvia.disease.Disease.current", return_value=data_disease_index), patch(
         "homeassistant.components.iqvia.PLATFORMS", []
     ):
         assert await async_setup_component(hass, DOMAIN, config)

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -76,8 +76,10 @@ def patch_file_upload(return_value=FIXTURE_KEYRING, side_effect=None):
         "homeassistant.components.knx.helpers.keyring.sync_load_keyring",
         return_value=return_value,
         side_effect=side_effect,
-    ), patch("pathlib.Path.mkdir") as mkdir_mock, patch(
-        "shutil.move"
+    ), patch(
+        "pathlib.Path.mkdir",
+    ) as mkdir_mock, patch(
+        "shutil.move",
     ) as shutil_move_mock:
         file_upload_mock.return_value.__enter__.return_value = Mock()
         yield return_value

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -76,9 +76,7 @@ def patch_file_upload(return_value=FIXTURE_KEYRING, side_effect=None):
         "homeassistant.components.knx.helpers.keyring.sync_load_keyring",
         return_value=return_value,
         side_effect=side_effect,
-    ), patch(
-        "pathlib.Path.mkdir"
-    ) as mkdir_mock, patch(
+    ), patch("pathlib.Path.mkdir") as mkdir_mock, patch(
         "shutil.move"
     ) as shutil_move_mock:
         file_upload_mock.return_value.__enter__.return_value = Mock()

--- a/tests/components/linear_garage_door/test_config_flow.py
+++ b/tests/components/linear_garage_door/test_config_flow.py
@@ -29,7 +29,10 @@ async def test_form(hass: HomeAssistant) -> None:
     ), patch(
         "homeassistant.components.linear_garage_door.config_flow.Linear.close",
         return_value=None,
-    ), patch("uuid.uuid4", return_value="test-uuid"):
+    ), patch(
+        "uuid.uuid4",
+        return_value="test-uuid",
+    ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
@@ -86,7 +89,10 @@ async def test_reauth(hass: HomeAssistant) -> None:
     ), patch(
         "homeassistant.components.linear_garage_door.config_flow.Linear.close",
         return_value=None,
-    ), patch("uuid.uuid4", return_value="test-uuid"):
+    ), patch(
+        "uuid.uuid4",
+        return_value="test-uuid",
+    ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {

--- a/tests/components/linear_garage_door/test_config_flow.py
+++ b/tests/components/linear_garage_door/test_config_flow.py
@@ -29,9 +29,7 @@ async def test_form(hass: HomeAssistant) -> None:
     ), patch(
         "homeassistant.components.linear_garage_door.config_flow.Linear.close",
         return_value=None,
-    ), patch(
-        "uuid.uuid4", return_value="test-uuid"
-    ):
+    ), patch("uuid.uuid4", return_value="test-uuid"):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
@@ -88,9 +86,7 @@ async def test_reauth(hass: HomeAssistant) -> None:
     ), patch(
         "homeassistant.components.linear_garage_door.config_flow.Linear.close",
         return_value=None,
-    ), patch(
-        "uuid.uuid4", return_value="test-uuid"
-    ):
+    ), patch("uuid.uuid4", return_value="test-uuid"):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -493,10 +493,13 @@ async def test_logbook_describe_event(
         hass,
         "fake_integration.logbook",
         Mock(
-            async_describe_events=lambda hass,
-            async_describe_event: async_describe_event(
-                "test_domain", "some_event", _describe
-            )
+            async_describe_events=(
+                lambda hass, async_describe_event: async_describe_event(
+                    "test_domain",
+                    "some_event",
+                    _describe,
+                )
+            ),
         ),
     )
 

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -493,7 +493,8 @@ async def test_logbook_describe_event(
         hass,
         "fake_integration.logbook",
         Mock(
-            async_describe_events=lambda hass, async_describe_event: async_describe_event(
+            async_describe_events=lambda hass,
+            async_describe_event: async_describe_event(
                 "test_domain", "some_event", _describe
             )
         ),

--- a/tests/components/lutron_caseta/test_config_flow.py
+++ b/tests/components/lutron_caseta/test_config_flow.py
@@ -59,7 +59,10 @@ async def test_bridge_import_flow(hass: HomeAssistant) -> None:
         return_value=True,
     ) as mock_setup_entry, patch(
         "homeassistant.components.lutron_caseta.async_setup", return_value=True
-    ), patch.object(Smartbridge, "create_tls") as create_tls:
+    ), patch.object(
+        Smartbridge,
+        "create_tls",
+    ) as create_tls:
         create_tls.return_value = MockBridge(can_connect=True)
 
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/lutron_caseta/test_config_flow.py
+++ b/tests/components/lutron_caseta/test_config_flow.py
@@ -59,9 +59,7 @@ async def test_bridge_import_flow(hass: HomeAssistant) -> None:
         return_value=True,
     ) as mock_setup_entry, patch(
         "homeassistant.components.lutron_caseta.async_setup", return_value=True
-    ), patch.object(
-        Smartbridge, "create_tls"
-    ) as create_tls:
+    ), patch.object(Smartbridge, "create_tls") as create_tls:
         create_tls.return_value = MockBridge(can_connect=True)
 
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/mill/test_init.py
+++ b/tests/components/mill/test_init.py
@@ -114,9 +114,7 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
         return_value=True,
     ) as unload_entry, patch(
         "mill.Mill.fetch_heater_and_sensor_data", return_value={}
-    ), patch(
-        "mill.Mill.connect", return_value=True
-    ):
+    ), patch("mill.Mill.connect", return_value=True):
         assert await async_setup_component(hass, "mill", {})
 
         assert await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/components/mill/test_init.py
+++ b/tests/components/mill/test_init.py
@@ -114,7 +114,10 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
         return_value=True,
     ) as unload_entry, patch(
         "mill.Mill.fetch_heater_and_sensor_data", return_value={}
-    ), patch("mill.Mill.connect", return_value=True):
+    ), patch(
+        "mill.Mill.connect",
+        return_value=True,
+    ):
         assert await async_setup_component(hass, "mill", {})
 
         assert await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/components/mysensors/conftest.py
+++ b/tests/components/mysensors/conftest.py
@@ -58,7 +58,10 @@ async def serial_transport_fixture(
         "mysensors.gateway_serial.AsyncTransport", autospec=True
     ) as transport_class, patch("mysensors.task.OTAFirmware", autospec=True), patch(
         "mysensors.task.load_fw", autospec=True
-    ), patch("mysensors.task.Persistence", autospec=True) as persistence_class:
+    ), patch(
+        "mysensors.task.Persistence",
+        autospec=True,
+    ) as persistence_class:
         persistence = persistence_class.return_value
 
         mock_gateway_features(persistence, transport_class, gateway_nodes)

--- a/tests/components/mysensors/conftest.py
+++ b/tests/components/mysensors/conftest.py
@@ -58,9 +58,7 @@ async def serial_transport_fixture(
         "mysensors.gateway_serial.AsyncTransport", autospec=True
     ) as transport_class, patch("mysensors.task.OTAFirmware", autospec=True), patch(
         "mysensors.task.load_fw", autospec=True
-    ), patch(
-        "mysensors.task.Persistence", autospec=True
-    ) as persistence_class:
+    ), patch("mysensors.task.Persistence", autospec=True) as persistence_class:
         persistence = persistence_class.return_value
 
         mock_gateway_features(persistence, transport_class, gateway_nodes)

--- a/tests/components/netatmo/common.py
+++ b/tests/components/netatmo/common.py
@@ -96,7 +96,5 @@ def selected_platforms(platforms):
         "homeassistant.components.netatmo.data_handler.PLATFORMS", platforms
     ), patch(
         "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
-    ), patch(
-        "homeassistant.components.netatmo.webhook_generate_url"
-    ):
+    ), patch("homeassistant.components.netatmo.webhook_generate_url"):
         yield

--- a/tests/components/netatmo/common.py
+++ b/tests/components/netatmo/common.py
@@ -96,5 +96,7 @@ def selected_platforms(platforms):
         "homeassistant.components.netatmo.data_handler.PLATFORMS", platforms
     ), patch(
         "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
-    ), patch("homeassistant.components.netatmo.webhook_generate_url"):
+    ), patch(
+        "homeassistant.components.netatmo.webhook_generate_url",
+    ):
         yield

--- a/tests/components/netatmo/test_camera.py
+++ b/tests/components/netatmo/test_camera.py
@@ -387,7 +387,9 @@ async def test_camera_reconnect_webhook(hass: HomeAssistant, config_entry) -> No
         "homeassistant.components.netatmo.data_handler.PLATFORMS", ["camera"]
     ), patch(
         "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
-    ), patch("homeassistant.components.netatmo.webhook_generate_url") as mock_webhook:
+    ), patch(
+        "homeassistant.components.netatmo.webhook_generate_url",
+    ) as mock_webhook:
         mock_auth.return_value.async_post_api_request.side_effect = fake_post
         mock_auth.return_value.async_addwebhook.side_effect = AsyncMock()
         mock_auth.return_value.async_dropwebhook.side_effect = AsyncMock()
@@ -479,7 +481,9 @@ async def test_setup_component_no_devices(hass: HomeAssistant, config_entry) -> 
         "homeassistant.components.netatmo.data_handler.PLATFORMS", ["camera"]
     ), patch(
         "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
-    ), patch("homeassistant.components.netatmo.webhook_generate_url"):
+    ), patch(
+        "homeassistant.components.netatmo.webhook_generate_url",
+    ):
         mock_auth.return_value.async_post_api_request.side_effect = fake_post_no_data
         mock_auth.return_value.async_addwebhook.side_effect = AsyncMock()
         mock_auth.return_value.async_dropwebhook.side_effect = AsyncMock()
@@ -517,7 +521,9 @@ async def test_camera_image_raises_exception(
         "homeassistant.components.netatmo.data_handler.PLATFORMS", ["camera"]
     ), patch(
         "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
-    ), patch("homeassistant.components.netatmo.webhook_generate_url"):
+    ), patch(
+        "homeassistant.components.netatmo.webhook_generate_url",
+    ):
         mock_auth.return_value.async_post_api_request.side_effect = fake_post
         mock_auth.return_value.async_get_image.side_effect = fake_post
         mock_auth.return_value.async_addwebhook.side_effect = AsyncMock()

--- a/tests/components/netatmo/test_camera.py
+++ b/tests/components/netatmo/test_camera.py
@@ -387,9 +387,7 @@ async def test_camera_reconnect_webhook(hass: HomeAssistant, config_entry) -> No
         "homeassistant.components.netatmo.data_handler.PLATFORMS", ["camera"]
     ), patch(
         "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
-    ), patch(
-        "homeassistant.components.netatmo.webhook_generate_url"
-    ) as mock_webhook:
+    ), patch("homeassistant.components.netatmo.webhook_generate_url") as mock_webhook:
         mock_auth.return_value.async_post_api_request.side_effect = fake_post
         mock_auth.return_value.async_addwebhook.side_effect = AsyncMock()
         mock_auth.return_value.async_dropwebhook.side_effect = AsyncMock()
@@ -481,9 +479,7 @@ async def test_setup_component_no_devices(hass: HomeAssistant, config_entry) -> 
         "homeassistant.components.netatmo.data_handler.PLATFORMS", ["camera"]
     ), patch(
         "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
-    ), patch(
-        "homeassistant.components.netatmo.webhook_generate_url"
-    ):
+    ), patch("homeassistant.components.netatmo.webhook_generate_url"):
         mock_auth.return_value.async_post_api_request.side_effect = fake_post_no_data
         mock_auth.return_value.async_addwebhook.side_effect = AsyncMock()
         mock_auth.return_value.async_dropwebhook.side_effect = AsyncMock()
@@ -521,9 +517,7 @@ async def test_camera_image_raises_exception(
         "homeassistant.components.netatmo.data_handler.PLATFORMS", ["camera"]
     ), patch(
         "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
-    ), patch(
-        "homeassistant.components.netatmo.webhook_generate_url"
-    ):
+    ), patch("homeassistant.components.netatmo.webhook_generate_url"):
         mock_auth.return_value.async_post_api_request.side_effect = fake_post
         mock_auth.return_value.async_get_image.side_effect = fake_post
         mock_auth.return_value.async_addwebhook.side_effect = AsyncMock()

--- a/tests/components/netatmo/test_diagnostics.py
+++ b/tests/components/netatmo/test_diagnostics.py
@@ -24,7 +24,9 @@ async def test_entry_diagnostics(
         "homeassistant.components.netatmo.api.AsyncConfigEntryNetatmoAuth",
     ) as mock_auth, patch(
         "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
-    ), patch("homeassistant.components.netatmo.webhook_generate_url"):
+    ), patch(
+        "homeassistant.components.netatmo.webhook_generate_url",
+    ):
         mock_auth.return_value.async_post_api_request.side_effect = fake_post_request
         mock_auth.return_value.async_addwebhook.side_effect = AsyncMock()
         mock_auth.return_value.async_dropwebhook.side_effect = AsyncMock()

--- a/tests/components/netatmo/test_diagnostics.py
+++ b/tests/components/netatmo/test_diagnostics.py
@@ -24,9 +24,7 @@ async def test_entry_diagnostics(
         "homeassistant.components.netatmo.api.AsyncConfigEntryNetatmoAuth",
     ) as mock_auth, patch(
         "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
-    ), patch(
-        "homeassistant.components.netatmo.webhook_generate_url"
-    ):
+    ), patch("homeassistant.components.netatmo.webhook_generate_url"):
         mock_auth.return_value.async_post_api_request.side_effect = fake_post_request
         mock_auth.return_value.async_addwebhook.side_effect = AsyncMock()
         mock_auth.return_value.async_dropwebhook.side_effect = AsyncMock()

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -204,9 +204,7 @@ async def test_setup_with_cloud(hass: HomeAssistant, config_entry) -> None:
         "homeassistant.components.netatmo.data_handler.PLATFORMS", []
     ), patch(
         "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
-    ), patch(
-        "homeassistant.components.netatmo.webhook_generate_url"
-    ):
+    ), patch("homeassistant.components.netatmo.webhook_generate_url"):
         mock_auth.return_value.async_post_api_request.side_effect = fake_post_request
         assert await async_setup_component(
             hass, "netatmo", {"netatmo": {"client_id": "123", "client_secret": "abc"}}
@@ -270,9 +268,7 @@ async def test_setup_with_cloudhook(hass: HomeAssistant) -> None:
         "homeassistant.components.netatmo.data_handler.PLATFORMS", []
     ), patch(
         "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
-    ), patch(
-        "homeassistant.components.netatmo.webhook_generate_url"
-    ):
+    ), patch("homeassistant.components.netatmo.webhook_generate_url"):
         mock_auth.return_value.async_post_api_request.side_effect = fake_post_request
         mock_auth.return_value.async_addwebhook.side_effect = AsyncMock()
         mock_auth.return_value.async_dropwebhook.side_effect = AsyncMock()

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -204,7 +204,9 @@ async def test_setup_with_cloud(hass: HomeAssistant, config_entry) -> None:
         "homeassistant.components.netatmo.data_handler.PLATFORMS", []
     ), patch(
         "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
-    ), patch("homeassistant.components.netatmo.webhook_generate_url"):
+    ), patch(
+        "homeassistant.components.netatmo.webhook_generate_url",
+    ):
         mock_auth.return_value.async_post_api_request.side_effect = fake_post_request
         assert await async_setup_component(
             hass, "netatmo", {"netatmo": {"client_id": "123", "client_secret": "abc"}}
@@ -268,7 +270,9 @@ async def test_setup_with_cloudhook(hass: HomeAssistant) -> None:
         "homeassistant.components.netatmo.data_handler.PLATFORMS", []
     ), patch(
         "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
-    ), patch("homeassistant.components.netatmo.webhook_generate_url"):
+    ), patch(
+        "homeassistant.components.netatmo.webhook_generate_url",
+    ):
         mock_auth.return_value.async_post_api_request.side_effect = fake_post_request
         mock_auth.return_value.async_addwebhook.side_effect = AsyncMock()
         mock_auth.return_value.async_dropwebhook.side_effect = AsyncMock()

--- a/tests/components/netatmo/test_light.py
+++ b/tests/components/netatmo/test_light.py
@@ -102,9 +102,7 @@ async def test_setup_component_no_devices(hass: HomeAssistant, config_entry) -> 
         "homeassistant.components.netatmo.data_handler.PLATFORMS", ["light"]
     ), patch(
         "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
-    ), patch(
-        "homeassistant.components.netatmo.webhook_generate_url"
-    ):
+    ), patch("homeassistant.components.netatmo.webhook_generate_url"):
         mock_auth.return_value.async_post_api_request.side_effect = (
             fake_post_request_no_data
         )

--- a/tests/components/netatmo/test_light.py
+++ b/tests/components/netatmo/test_light.py
@@ -102,7 +102,9 @@ async def test_setup_component_no_devices(hass: HomeAssistant, config_entry) -> 
         "homeassistant.components.netatmo.data_handler.PLATFORMS", ["light"]
     ), patch(
         "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
-    ), patch("homeassistant.components.netatmo.webhook_generate_url"):
+    ), patch(
+        "homeassistant.components.netatmo.webhook_generate_url",
+    ):
         mock_auth.return_value.async_post_api_request.side_effect = (
             fake_post_request_no_data
         )

--- a/tests/components/onboarding/test_views.py
+++ b/tests/components/onboarding/test_views.py
@@ -100,7 +100,10 @@ async def mock_supervisor_fixture(hass, aioclient_mock):
     ), patch(
         "homeassistant.components.hassio.HassIO.get_ingress_panels",
         return_value={"panels": {}},
-    ), patch.dict(os.environ, {"SUPERVISOR_TOKEN": "123456"}):
+    ), patch.dict(
+        os.environ,
+        {"SUPERVISOR_TOKEN": "123456"},
+    ):
         yield
 
 

--- a/tests/components/onboarding/test_views.py
+++ b/tests/components/onboarding/test_views.py
@@ -100,9 +100,7 @@ async def mock_supervisor_fixture(hass, aioclient_mock):
     ), patch(
         "homeassistant.components.hassio.HassIO.get_ingress_panels",
         return_value={"panels": {}},
-    ), patch.dict(
-        os.environ, {"SUPERVISOR_TOKEN": "123456"}
-    ):
+    ), patch.dict(os.environ, {"SUPERVISOR_TOKEN": "123456"}):
         yield
 
 

--- a/tests/components/opentherm_gw/test_config_flow.py
+++ b/tests/components/opentherm_gw/test_config_flow.py
@@ -211,9 +211,7 @@ async def test_options_migration(hass: HomeAssistant) -> None:
         return_value=True,
     ), patch(
         "homeassistant.components.opentherm_gw.async_setup", return_value=True
-    ), patch(
-        "pyotgw.status.StatusManager._process_updates", return_value=None
-    ):
+    ), patch("pyotgw.status.StatusManager._process_updates", return_value=None):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 

--- a/tests/components/opentherm_gw/test_config_flow.py
+++ b/tests/components/opentherm_gw/test_config_flow.py
@@ -210,8 +210,12 @@ async def test_options_migration(hass: HomeAssistant) -> None:
         "homeassistant.components.opentherm_gw.OpenThermGatewayDevice.connect_and_subscribe",
         return_value=True,
     ), patch(
-        "homeassistant.components.opentherm_gw.async_setup", return_value=True
-    ), patch("pyotgw.status.StatusManager._process_updates", return_value=None):
+        "homeassistant.components.opentherm_gw.async_setup",
+        return_value=True,
+    ), patch(
+        "pyotgw.status.StatusManager._process_updates",
+        return_value=None,
+    ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 

--- a/tests/components/otbr/test_util.py
+++ b/tests/components/otbr/test_util.py
@@ -72,9 +72,7 @@ async def test_factory_reset_error_1(
         side_effect=python_otbr_api.OTBRError,
     ) as factory_reset_mock, patch(
         "python_otbr_api.OTBR.delete_active_dataset"
-    ) as delete_active_dataset_mock, pytest.raises(
-        HomeAssistantError
-    ):
+    ) as delete_active_dataset_mock, pytest.raises(HomeAssistantError):
         await data.factory_reset()
 
     delete_active_dataset_mock.assert_not_called()
@@ -93,9 +91,7 @@ async def test_factory_reset_error_2(
     ) as factory_reset_mock, patch(
         "python_otbr_api.OTBR.delete_active_dataset",
         side_effect=python_otbr_api.OTBRError,
-    ) as delete_active_dataset_mock, pytest.raises(
-        HomeAssistantError
-    ):
+    ) as delete_active_dataset_mock, pytest.raises(HomeAssistantError):
         await data.factory_reset()
 
     delete_active_dataset_mock.assert_called_once_with()

--- a/tests/components/otbr/test_util.py
+++ b/tests/components/otbr/test_util.py
@@ -72,7 +72,9 @@ async def test_factory_reset_error_1(
         side_effect=python_otbr_api.OTBRError,
     ) as factory_reset_mock, patch(
         "python_otbr_api.OTBR.delete_active_dataset"
-    ) as delete_active_dataset_mock, pytest.raises(HomeAssistantError):
+    ) as delete_active_dataset_mock, pytest.raises(
+        HomeAssistantError,
+    ):
         await data.factory_reset()
 
     delete_active_dataset_mock.assert_not_called()
@@ -91,7 +93,9 @@ async def test_factory_reset_error_2(
     ) as factory_reset_mock, patch(
         "python_otbr_api.OTBR.delete_active_dataset",
         side_effect=python_otbr_api.OTBRError,
-    ) as delete_active_dataset_mock, pytest.raises(HomeAssistantError):
+    ) as delete_active_dataset_mock, pytest.raises(
+        HomeAssistantError,
+    ):
         await data.factory_reset()
 
     delete_active_dataset_mock.assert_called_once_with()

--- a/tests/components/otbr/test_websocket_api.py
+++ b/tests/components/otbr/test_websocket_api.py
@@ -188,7 +188,9 @@ async def test_create_network_fails_3(
         side_effect=[None, python_otbr_api.OTBRError],
     ), patch(
         "python_otbr_api.OTBR.create_active_dataset",
-    ), patch("python_otbr_api.OTBR.factory_reset"):
+    ), patch(
+        "python_otbr_api.OTBR.factory_reset",
+    ):
         await websocket_client.send_json_auto_id({"type": "otbr/create_network"})
         msg = await websocket_client.receive_json()
 
@@ -208,7 +210,9 @@ async def test_create_network_fails_4(
     ), patch(
         "python_otbr_api.OTBR.get_active_dataset_tlvs",
         side_effect=python_otbr_api.OTBRError,
-    ), patch("python_otbr_api.OTBR.factory_reset"):
+    ), patch(
+        "python_otbr_api.OTBR.factory_reset",
+    ):
         await websocket_client.send_json_auto_id({"type": "otbr/create_network"})
         msg = await websocket_client.receive_json()
 

--- a/tests/components/otbr/test_websocket_api.py
+++ b/tests/components/otbr/test_websocket_api.py
@@ -188,9 +188,7 @@ async def test_create_network_fails_3(
         side_effect=[None, python_otbr_api.OTBRError],
     ), patch(
         "python_otbr_api.OTBR.create_active_dataset",
-    ), patch(
-        "python_otbr_api.OTBR.factory_reset"
-    ):
+    ), patch("python_otbr_api.OTBR.factory_reset"):
         await websocket_client.send_json_auto_id({"type": "otbr/create_network"})
         msg = await websocket_client.receive_json()
 
@@ -210,9 +208,7 @@ async def test_create_network_fails_4(
     ), patch(
         "python_otbr_api.OTBR.get_active_dataset_tlvs",
         side_effect=python_otbr_api.OTBRError,
-    ), patch(
-        "python_otbr_api.OTBR.factory_reset"
-    ):
+    ), patch("python_otbr_api.OTBR.factory_reset"):
         await websocket_client.send_json_auto_id({"type": "otbr/create_network"})
         msg = await websocket_client.receive_json()
 

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -850,7 +850,9 @@ async def test_client_header_issues(
         "plexauth.PlexAuth.token", return_value=None
     ), patch(
         "homeassistant.components.http.current_request.get", return_value=MockRequest()
-    ), pytest.raises(RuntimeError):
+    ), pytest.raises(
+        RuntimeError,
+    ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -850,9 +850,7 @@ async def test_client_header_issues(
         "plexauth.PlexAuth.token", return_value=None
     ), patch(
         "homeassistant.components.http.current_request.get", return_value=MockRequest()
-    ), pytest.raises(
-        RuntimeError
-    ):
+    ), pytest.raises(RuntimeError):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )

--- a/tests/components/python_script/test_init.py
+++ b/tests/components/python_script/test_init.py
@@ -366,9 +366,7 @@ async def test_service_descriptions(hass: HomeAssistant) -> None:
         "homeassistant.components.python_script.glob.iglob", return_value=scripts1
     ), patch(
         "homeassistant.components.python_script.os.path.exists", return_value=True
-    ), patch_yaml_files(
-        services_yaml1
-    ):
+    ), patch_yaml_files(services_yaml1):
         await async_setup_component(hass, DOMAIN, {})
 
         descriptions = await async_get_all_descriptions(hass)
@@ -415,9 +413,7 @@ async def test_service_descriptions(hass: HomeAssistant) -> None:
         "homeassistant.components.python_script.glob.iglob", return_value=scripts2
     ), patch(
         "homeassistant.components.python_script.os.path.exists", return_value=True
-    ), patch_yaml_files(
-        services_yaml2
-    ):
+    ), patch_yaml_files(services_yaml2):
         await hass.services.async_call(DOMAIN, "reload", {}, blocking=True)
         descriptions = await async_get_all_descriptions(hass)
 

--- a/tests/components/python_script/test_init.py
+++ b/tests/components/python_script/test_init.py
@@ -366,7 +366,9 @@ async def test_service_descriptions(hass: HomeAssistant) -> None:
         "homeassistant.components.python_script.glob.iglob", return_value=scripts1
     ), patch(
         "homeassistant.components.python_script.os.path.exists", return_value=True
-    ), patch_yaml_files(services_yaml1):
+    ), patch_yaml_files(
+        services_yaml1,
+    ):
         await async_setup_component(hass, DOMAIN, {})
 
         descriptions = await async_get_all_descriptions(hass)
@@ -413,7 +415,9 @@ async def test_service_descriptions(hass: HomeAssistant) -> None:
         "homeassistant.components.python_script.glob.iglob", return_value=scripts2
     ), patch(
         "homeassistant.components.python_script.os.path.exists", return_value=True
-    ), patch_yaml_files(services_yaml2):
+    ), patch_yaml_files(
+        services_yaml2,
+    ):
         await hass.services.async_call(DOMAIN, "reload", {}, blocking=True)
         descriptions = await async_get_all_descriptions(hass)
 

--- a/tests/components/rainbird/test_calendar.py
+++ b/tests/components/rainbird/test_calendar.py
@@ -232,7 +232,8 @@ async def test_calendar_not_supported_by_device(
 
 
 @pytest.mark.parametrize(
-    "mock_insert_schedule_response", [([None])]  # Disable success responses
+    "mock_insert_schedule_response",
+    [([None])],  # Disable success responses
 )
 async def test_no_schedule(
     hass: HomeAssistant,

--- a/tests/components/rainmachine/conftest.py
+++ b/tests/components/rainmachine/conftest.py
@@ -133,9 +133,7 @@ async def setup_rainmachine_fixture(hass, client, config):
         "homeassistant.components.rainmachine.Client", return_value=client
     ), patch(
         "homeassistant.components.rainmachine.config_flow.Client", return_value=client
-    ), patch(
-        "homeassistant.components.rainmachine.PLATFORMS", []
-    ):
+    ), patch("homeassistant.components.rainmachine.PLATFORMS", []):
         assert await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()
         yield

--- a/tests/components/rainmachine/conftest.py
+++ b/tests/components/rainmachine/conftest.py
@@ -133,7 +133,10 @@ async def setup_rainmachine_fixture(hass, client, config):
         "homeassistant.components.rainmachine.Client", return_value=client
     ), patch(
         "homeassistant.components.rainmachine.config_flow.Client", return_value=client
-    ), patch("homeassistant.components.rainmachine.PLATFORMS", []):
+    ), patch(
+        "homeassistant.components.rainmachine.PLATFORMS",
+        [],
+    ):
         assert await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()
         yield

--- a/tests/components/recorder/common.py
+++ b/tests/components/recorder/common.py
@@ -412,17 +412,11 @@ def old_db_schema(schema_version_postfix: str) -> Iterator[None]:
         recorder.migration, "SCHEMA_VERSION", old_db_schema.SCHEMA_VERSION
     ), patch.object(core, "StatesMeta", old_db_schema.StatesMeta), patch.object(
         core, "EventTypes", old_db_schema.EventTypes
-    ), patch.object(
-        core, "EventData", old_db_schema.EventData
-    ), patch.object(
+    ), patch.object(core, "EventData", old_db_schema.EventData), patch.object(
         core, "States", old_db_schema.States
-    ), patch.object(
-        core, "Events", old_db_schema.Events
-    ), patch.object(
+    ), patch.object(core, "Events", old_db_schema.Events), patch.object(
         core, "StateAttributes", old_db_schema.StateAttributes
-    ), patch.object(
-        core, "EntityIDMigrationTask", core.RecorderTask
-    ), patch(
+    ), patch.object(core, "EntityIDMigrationTask", core.RecorderTask), patch(
         CREATE_ENGINE_TARGET,
         new=partial(
             create_engine_test_for_schema_version_postfix,

--- a/tests/components/recorder/test_migration_from_schema_32.py
+++ b/tests/components/recorder/test_migration_from_schema_32.py
@@ -85,17 +85,11 @@ def db_schema_32():
         recorder.migration, "SCHEMA_VERSION", old_db_schema.SCHEMA_VERSION
     ), patch.object(core, "StatesMeta", old_db_schema.StatesMeta), patch.object(
         core, "EventTypes", old_db_schema.EventTypes
-    ), patch.object(
-        core, "EventData", old_db_schema.EventData
-    ), patch.object(
+    ), patch.object(core, "EventData", old_db_schema.EventData), patch.object(
         core, "States", old_db_schema.States
-    ), patch.object(
-        core, "Events", old_db_schema.Events
-    ), patch.object(
+    ), patch.object(core, "Events", old_db_schema.Events), patch.object(
         core, "StateAttributes", old_db_schema.StateAttributes
-    ), patch.object(
-        core, "EntityIDMigrationTask", core.RecorderTask
-    ), patch(
+    ), patch.object(core, "EntityIDMigrationTask", core.RecorderTask), patch(
         CREATE_ENGINE_TARGET, new=_create_engine_test
     ):
         yield

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -244,9 +244,7 @@ async def test_purge_old_states_encounters_temporary_mysql_error(
     ) as sleep_mock, patch(
         "homeassistant.components.recorder.purge._purge_old_recorder_runs",
         side_effect=[mysql_exception, None],
-    ), patch.object(
-        instance.engine.dialect, "name", "mysql"
-    ):
+    ), patch.object(instance.engine.dialect, "name", "mysql"):
         await hass.services.async_call(recorder.DOMAIN, SERVICE_PURGE, {"keep_days": 0})
         await hass.async_block_till_done()
         await async_wait_recording_done(hass)

--- a/tests/components/recorder/test_purge_v32_schema.py
+++ b/tests/components/recorder/test_purge_v32_schema.py
@@ -212,9 +212,7 @@ async def test_purge_old_states_encounters_temporary_mysql_error(
     ) as sleep_mock, patch(
         "homeassistant.components.recorder.purge._purge_old_recorder_runs",
         side_effect=[mysql_exception, None],
-    ), patch.object(
-        instance.engine.dialect, "name", "mysql"
-    ):
+    ), patch.object(instance.engine.dialect, "name", "mysql"):
         await hass.services.async_call(recorder.DOMAIN, SERVICE_PURGE, {"keep_days": 0})
         await hass.async_block_till_done()
         await async_wait_recording_done(hass)

--- a/tests/components/recorder/test_v32_migration.py
+++ b/tests/components/recorder/test_v32_migration.py
@@ -98,13 +98,9 @@ async def test_migrate_times(caplog: pytest.LogCaptureFixture, tmp_path: Path) -
         recorder.migration, "SCHEMA_VERSION", old_db_schema.SCHEMA_VERSION
     ), patch.object(core, "StatesMeta", old_db_schema.StatesMeta), patch.object(
         core, "EventTypes", old_db_schema.EventTypes
-    ), patch.object(
-        core, "EventData", old_db_schema.EventData
-    ), patch.object(
+    ), patch.object(core, "EventData", old_db_schema.EventData), patch.object(
         core, "States", old_db_schema.States
-    ), patch.object(
-        core, "Events", old_db_schema.Events
-    ), patch(
+    ), patch.object(core, "Events", old_db_schema.Events), patch(
         CREATE_ENGINE_TARGET, new=_create_engine_test
     ), patch(
         "homeassistant.components.recorder.Recorder._migrate_events_context_ids",
@@ -269,13 +265,9 @@ async def test_migrate_can_resume_entity_id_post_migration(
         recorder.migration, "SCHEMA_VERSION", old_db_schema.SCHEMA_VERSION
     ), patch.object(core, "StatesMeta", old_db_schema.StatesMeta), patch.object(
         core, "EventTypes", old_db_schema.EventTypes
-    ), patch.object(
-        core, "EventData", old_db_schema.EventData
-    ), patch.object(
+    ), patch.object(core, "EventData", old_db_schema.EventData), patch.object(
         core, "States", old_db_schema.States
-    ), patch.object(
-        core, "Events", old_db_schema.Events
-    ), patch(
+    ), patch.object(core, "Events", old_db_schema.Events), patch(
         CREATE_ENGINE_TARGET, new=_create_engine_test
     ), patch(
         "homeassistant.components.recorder.Recorder._migrate_events_context_ids",

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -2227,9 +2227,7 @@ async def test_recorder_info_migration_queue_exhausted(
     ), patch(
         "homeassistant.components.recorder.core.create_engine",
         new=create_engine_test,
-    ), patch.object(
-        recorder.core, "MAX_QUEUE_BACKLOG_MIN_VALUE", 1
-    ), patch.object(
+    ), patch.object(recorder.core, "MAX_QUEUE_BACKLOG_MIN_VALUE", 1), patch.object(
         recorder.core, "QUEUE_PERCENTAGE_ALLOWED_AVAILABLE_MEMORY", 0
     ), patch(
         "homeassistant.components.recorder.migration._apply_update",

--- a/tests/components/risco/conftest.py
+++ b/tests/components/risco/conftest.py
@@ -139,9 +139,7 @@ async def setup_risco_cloud(hass, cloud_config_entry, events):
     ), patch(
         "homeassistant.components.risco.RiscoCloud.site_name",
         new_callable=PropertyMock(return_value=TEST_SITE_NAME),
-    ), patch(
-        "homeassistant.components.risco.RiscoCloud.close"
-    ), patch(
+    ), patch("homeassistant.components.risco.RiscoCloud.close"), patch(
         "homeassistant.components.risco.RiscoCloud.get_events",
         return_value=events,
     ):
@@ -190,9 +188,7 @@ async def setup_risco_local(hass, local_config_entry):
     ), patch(
         "homeassistant.components.risco.RiscoLocal.id",
         new_callable=PropertyMock(return_value=TEST_SITE_UUID),
-    ), patch(
-        "homeassistant.components.risco.RiscoLocal.disconnect"
-    ):
+    ), patch("homeassistant.components.risco.RiscoLocal.disconnect"):
         await hass.config_entries.async_setup(local_config_entry.entry_id)
         await hass.async_block_till_done()
 

--- a/tests/components/risco/conftest.py
+++ b/tests/components/risco/conftest.py
@@ -139,7 +139,9 @@ async def setup_risco_cloud(hass, cloud_config_entry, events):
     ), patch(
         "homeassistant.components.risco.RiscoCloud.site_name",
         new_callable=PropertyMock(return_value=TEST_SITE_NAME),
-    ), patch("homeassistant.components.risco.RiscoCloud.close"), patch(
+    ), patch(
+        "homeassistant.components.risco.RiscoCloud.close",
+    ), patch(
         "homeassistant.components.risco.RiscoCloud.get_events",
         return_value=events,
     ):
@@ -188,7 +190,9 @@ async def setup_risco_local(hass, local_config_entry):
     ), patch(
         "homeassistant.components.risco.RiscoLocal.id",
         new_callable=PropertyMock(return_value=TEST_SITE_UUID),
-    ), patch("homeassistant.components.risco.RiscoLocal.disconnect"):
+    ), patch(
+        "homeassistant.components.risco.RiscoLocal.disconnect",
+    ):
         await hass.config_entries.async_setup(local_config_entry.entry_id)
         await hass.async_block_till_done()
 

--- a/tests/components/risco/test_config_flow.py
+++ b/tests/components/risco/test_config_flow.py
@@ -161,7 +161,9 @@ async def test_form_reauth(hass: HomeAssistant, cloud_config_entry) -> None:
     ), patch(
         "homeassistant.components.risco.config_flow.RiscoCloud.site_name",
         new_callable=PropertyMock(return_value=TEST_SITE_NAME),
-    ), patch("homeassistant.components.risco.config_flow.RiscoCloud.close"), patch(
+    ), patch(
+        "homeassistant.components.risco.config_flow.RiscoCloud.close",
+    ), patch(
         "homeassistant.components.risco.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -195,7 +197,9 @@ async def test_form_reauth_with_new_username(
     ), patch(
         "homeassistant.components.risco.config_flow.RiscoCloud.site_name",
         new_callable=PropertyMock(return_value=TEST_SITE_NAME),
-    ), patch("homeassistant.components.risco.config_flow.RiscoCloud.close"), patch(
+    ), patch(
+        "homeassistant.components.risco.config_flow.RiscoCloud.close",
+    ), patch(
         "homeassistant.components.risco.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -302,7 +306,9 @@ async def test_form_local_already_exists(hass: HomeAssistant) -> None:
     ), patch(
         "homeassistant.components.risco.config_flow.RiscoLocal.id",
         new_callable=PropertyMock(return_value=TEST_SITE_NAME),
-    ), patch("homeassistant.components.risco.config_flow.RiscoLocal.disconnect"):
+    ), patch(
+        "homeassistant.components.risco.config_flow.RiscoLocal.disconnect",
+    ):
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"], TEST_LOCAL_DATA
         )

--- a/tests/components/risco/test_config_flow.py
+++ b/tests/components/risco/test_config_flow.py
@@ -161,9 +161,7 @@ async def test_form_reauth(hass: HomeAssistant, cloud_config_entry) -> None:
     ), patch(
         "homeassistant.components.risco.config_flow.RiscoCloud.site_name",
         new_callable=PropertyMock(return_value=TEST_SITE_NAME),
-    ), patch(
-        "homeassistant.components.risco.config_flow.RiscoCloud.close"
-    ), patch(
+    ), patch("homeassistant.components.risco.config_flow.RiscoCloud.close"), patch(
         "homeassistant.components.risco.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -197,9 +195,7 @@ async def test_form_reauth_with_new_username(
     ), patch(
         "homeassistant.components.risco.config_flow.RiscoCloud.site_name",
         new_callable=PropertyMock(return_value=TEST_SITE_NAME),
-    ), patch(
-        "homeassistant.components.risco.config_flow.RiscoCloud.close"
-    ), patch(
+    ), patch("homeassistant.components.risco.config_flow.RiscoCloud.close"), patch(
         "homeassistant.components.risco.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -306,9 +302,7 @@ async def test_form_local_already_exists(hass: HomeAssistant) -> None:
     ), patch(
         "homeassistant.components.risco.config_flow.RiscoLocal.id",
         new_callable=PropertyMock(return_value=TEST_SITE_NAME),
-    ), patch(
-        "homeassistant.components.risco.config_flow.RiscoLocal.disconnect"
-    ):
+    ), patch("homeassistant.components.risco.config_flow.RiscoLocal.disconnect"):
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"], TEST_LOCAL_DATA
         )

--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -54,13 +54,9 @@ def bypass_api_fixture() -> None:
         "homeassistant.components.roborock.RoborockMqttClient._wait_response"
     ), patch(
         "homeassistant.components.roborock.coordinator.RoborockLocalClient._wait_response"
-    ), patch(
-        "roborock.api.AttributeCache.async_value"
-    ), patch(
+    ), patch("roborock.api.AttributeCache.async_value"), patch(
         "roborock.api.AttributeCache.value"
-    ), patch(
-        "homeassistant.components.roborock.image.MAP_SLEEP", 0
-    ):
+    ), patch("homeassistant.components.roborock.image.MAP_SLEEP", 0):
         yield
 
 

--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -54,9 +54,14 @@ def bypass_api_fixture() -> None:
         "homeassistant.components.roborock.RoborockMqttClient._wait_response"
     ), patch(
         "homeassistant.components.roborock.coordinator.RoborockLocalClient._wait_response"
-    ), patch("roborock.api.AttributeCache.async_value"), patch(
-        "roborock.api.AttributeCache.value"
-    ), patch("homeassistant.components.roborock.image.MAP_SLEEP", 0):
+    ), patch(
+        "roborock.api.AttributeCache.async_value",
+    ), patch(
+        "roborock.api.AttributeCache.value",
+    ), patch(
+        "homeassistant.components.roborock.image.MAP_SLEEP",
+        0,
+    ):
         yield
 
 

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -44,9 +44,7 @@ async def silent_ssdp_scanner(hass):
         "homeassistant.components.ssdp.Scanner._async_start_ssdp_listeners"
     ), patch("homeassistant.components.ssdp.Scanner._async_stop_ssdp_listeners"), patch(
         "homeassistant.components.ssdp.Scanner.async_scan"
-    ), patch(
-        "homeassistant.components.ssdp.Server._async_start_upnp_servers"
-    ), patch(
+    ), patch("homeassistant.components.ssdp.Server._async_start_upnp_servers"), patch(
         "homeassistant.components.ssdp.Server._async_stop_upnp_servers"
     ):
         yield

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -44,8 +44,10 @@ async def silent_ssdp_scanner(hass):
         "homeassistant.components.ssdp.Scanner._async_start_ssdp_listeners"
     ), patch("homeassistant.components.ssdp.Scanner._async_stop_ssdp_listeners"), patch(
         "homeassistant.components.ssdp.Scanner.async_scan"
-    ), patch("homeassistant.components.ssdp.Server._async_start_upnp_servers"), patch(
-        "homeassistant.components.ssdp.Server._async_stop_upnp_servers"
+    ), patch(
+        "homeassistant.components.ssdp.Server._async_start_upnp_servers",
+    ), patch(
+        "homeassistant.components.ssdp.Server._async_stop_upnp_servers",
     ):
         yield
 

--- a/tests/components/sensibo/test_button.py
+++ b/tests/components/sensibo/test_button.py
@@ -99,9 +99,7 @@ async def test_button_failure(
     ), patch(
         "homeassistant.components.sensibo.util.SensiboClient.async_reset_filter",
         return_value={"status": "failure"},
-    ), pytest.raises(
-        HomeAssistantError
-    ):
+    ), pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             BUTTON_DOMAIN,
             SERVICE_PRESS,

--- a/tests/components/sensibo/test_button.py
+++ b/tests/components/sensibo/test_button.py
@@ -99,7 +99,9 @@ async def test_button_failure(
     ), patch(
         "homeassistant.components.sensibo.util.SensiboClient.async_reset_filter",
         return_value={"status": "failure"},
-    ), pytest.raises(HomeAssistantError):
+    ), pytest.raises(
+        HomeAssistantError,
+    ):
         await hass.services.async_call(
             BUTTON_DOMAIN,
             SERVICE_PRESS,

--- a/tests/components/sensibo/test_climate.py
+++ b/tests/components/sensibo/test_climate.py
@@ -741,7 +741,9 @@ async def test_climate_set_timer(
     ), patch(
         "homeassistant.components.sensibo.util.SensiboClient.async_set_timer",
         return_value={"status": "failure"},
-    ), pytest.raises(MultipleInvalid):
+    ), pytest.raises(
+        MultipleInvalid,
+    ):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_ENABLE_TIMER,
@@ -758,7 +760,9 @@ async def test_climate_set_timer(
     ), patch(
         "homeassistant.components.sensibo.util.SensiboClient.async_set_timer",
         return_value={"status": "failure"},
-    ), pytest.raises(HomeAssistantError):
+    ), pytest.raises(
+        HomeAssistantError,
+    ):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_ENABLE_TIMER,
@@ -840,7 +844,9 @@ async def test_climate_pure_boost(
         "homeassistant.components.sensibo.util.SensiboClient.async_get_devices_data",
     ), patch(
         "homeassistant.components.sensibo.util.SensiboClient.async_set_pureboost",
-    ), pytest.raises(MultipleInvalid):
+    ), pytest.raises(
+        MultipleInvalid,
+    ):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_ENABLE_PURE_BOOST,
@@ -940,7 +946,9 @@ async def test_climate_climate_react(
         "homeassistant.components.sensibo.util.SensiboClient.async_get_devices_data",
     ), patch(
         "homeassistant.components.sensibo.util.SensiboClient.async_set_climate_react",
-    ), pytest.raises(MultipleInvalid):
+    ), pytest.raises(
+        MultipleInvalid,
+    ):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_ENABLE_PURE_BOOST,
@@ -1245,7 +1253,9 @@ async def test_climate_full_ac_state(
         "homeassistant.components.sensibo.util.SensiboClient.async_get_devices_data",
     ), patch(
         "homeassistant.components.sensibo.util.SensiboClient.async_set_ac_states",
-    ), pytest.raises(MultipleInvalid):
+    ), pytest.raises(
+        MultipleInvalid,
+    ):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_FULL_STATE,

--- a/tests/components/sensibo/test_climate.py
+++ b/tests/components/sensibo/test_climate.py
@@ -741,9 +741,7 @@ async def test_climate_set_timer(
     ), patch(
         "homeassistant.components.sensibo.util.SensiboClient.async_set_timer",
         return_value={"status": "failure"},
-    ), pytest.raises(
-        MultipleInvalid
-    ):
+    ), pytest.raises(MultipleInvalid):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_ENABLE_TIMER,
@@ -760,9 +758,7 @@ async def test_climate_set_timer(
     ), patch(
         "homeassistant.components.sensibo.util.SensiboClient.async_set_timer",
         return_value={"status": "failure"},
-    ), pytest.raises(
-        HomeAssistantError
-    ):
+    ), pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_ENABLE_TIMER,
@@ -844,9 +840,7 @@ async def test_climate_pure_boost(
         "homeassistant.components.sensibo.util.SensiboClient.async_get_devices_data",
     ), patch(
         "homeassistant.components.sensibo.util.SensiboClient.async_set_pureboost",
-    ), pytest.raises(
-        MultipleInvalid
-    ):
+    ), pytest.raises(MultipleInvalid):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_ENABLE_PURE_BOOST,
@@ -946,9 +940,7 @@ async def test_climate_climate_react(
         "homeassistant.components.sensibo.util.SensiboClient.async_get_devices_data",
     ), patch(
         "homeassistant.components.sensibo.util.SensiboClient.async_set_climate_react",
-    ), pytest.raises(
-        MultipleInvalid
-    ):
+    ), pytest.raises(MultipleInvalid):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_ENABLE_PURE_BOOST,
@@ -1253,9 +1245,7 @@ async def test_climate_full_ac_state(
         "homeassistant.components.sensibo.util.SensiboClient.async_get_devices_data",
     ), patch(
         "homeassistant.components.sensibo.util.SensiboClient.async_set_ac_states",
-    ), pytest.raises(
-        MultipleInvalid
-    ):
+    ), pytest.raises(MultipleInvalid):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_FULL_STATE,

--- a/tests/components/sensibo/test_select.py
+++ b/tests/components/sensibo/test_select.py
@@ -89,9 +89,7 @@ async def test_select_set_option(
     ), patch(
         "homeassistant.components.sensibo.util.SensiboClient.async_set_ac_state_property",
         return_value={"result": {"status": "failed"}},
-    ), pytest.raises(
-        HomeAssistantError
-    ):
+    ), pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
@@ -131,9 +129,7 @@ async def test_select_set_option(
     ), patch(
         "homeassistant.components.sensibo.util.SensiboClient.async_set_ac_state_property",
         return_value={"result": {"status": "Failed", "failureReason": "No connection"}},
-    ), pytest.raises(
-        HomeAssistantError
-    ):
+    ), pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,

--- a/tests/components/sensibo/test_select.py
+++ b/tests/components/sensibo/test_select.py
@@ -89,7 +89,9 @@ async def test_select_set_option(
     ), patch(
         "homeassistant.components.sensibo.util.SensiboClient.async_set_ac_state_property",
         return_value={"result": {"status": "failed"}},
-    ), pytest.raises(HomeAssistantError):
+    ), pytest.raises(
+        HomeAssistantError,
+    ):
         await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
@@ -129,7 +131,9 @@ async def test_select_set_option(
     ), patch(
         "homeassistant.components.sensibo.util.SensiboClient.async_set_ac_state_property",
         return_value={"result": {"status": "Failed", "failureReason": "No connection"}},
-    ), pytest.raises(HomeAssistantError):
+    ), pytest.raises(
+        HomeAssistantError,
+    ):
         await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,

--- a/tests/components/sensibo/test_switch.py
+++ b/tests/components/sensibo/test_switch.py
@@ -195,9 +195,7 @@ async def test_switch_command_failure(
     ), patch(
         "homeassistant.components.sensibo.util.SensiboClient.async_set_timer",
         return_value={"status": "failure"},
-    ), pytest.raises(
-        HomeAssistantError
-    ):
+    ), pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_ON,
@@ -213,9 +211,7 @@ async def test_switch_command_failure(
     ), patch(
         "homeassistant.components.sensibo.util.SensiboClient.async_del_timer",
         return_value={"status": "failure"},
-    ), pytest.raises(
-        HomeAssistantError
-    ):
+    ), pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_OFF,

--- a/tests/components/sensibo/test_switch.py
+++ b/tests/components/sensibo/test_switch.py
@@ -195,7 +195,9 @@ async def test_switch_command_failure(
     ), patch(
         "homeassistant.components.sensibo.util.SensiboClient.async_set_timer",
         return_value={"status": "failure"},
-    ), pytest.raises(HomeAssistantError):
+    ), pytest.raises(
+        HomeAssistantError,
+    ):
         await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_ON,
@@ -211,7 +213,9 @@ async def test_switch_command_failure(
     ), patch(
         "homeassistant.components.sensibo.util.SensiboClient.async_del_timer",
         return_value={"status": "failure"},
-    ), pytest.raises(HomeAssistantError):
+    ), pytest.raises(
+        HomeAssistantError,
+    ):
         await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_OFF,

--- a/tests/components/simplisafe/conftest.py
+++ b/tests/components/simplisafe/conftest.py
@@ -105,7 +105,10 @@ async def setup_simplisafe_fixture(hass, api, config):
         return_value=api,
     ), patch(
         "homeassistant.components.simplisafe.SimpliSafe._async_start_websocket_loop"
-    ), patch("homeassistant.components.simplisafe.PLATFORMS", []):
+    ), patch(
+        "homeassistant.components.simplisafe.PLATFORMS",
+        [],
+    ):
         assert await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()
         yield

--- a/tests/components/simplisafe/conftest.py
+++ b/tests/components/simplisafe/conftest.py
@@ -105,9 +105,7 @@ async def setup_simplisafe_fixture(hass, api, config):
         return_value=api,
     ), patch(
         "homeassistant.components.simplisafe.SimpliSafe._async_start_websocket_loop"
-    ), patch(
-        "homeassistant.components.simplisafe.PLATFORMS", []
-    ):
+    ), patch("homeassistant.components.simplisafe.PLATFORMS", []):
         assert await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()
         yield

--- a/tests/components/simplisafe/test_init.py
+++ b/tests/components/simplisafe/test_init.py
@@ -33,9 +33,7 @@ async def test_base_station_migration(
         return_value=api,
     ), patch(
         "homeassistant.components.simplisafe.SimpliSafe._async_start_websocket_loop"
-    ), patch(
-        "homeassistant.components.simplisafe.PLATFORMS", []
-    ):
+    ), patch("homeassistant.components.simplisafe.PLATFORMS", []):
         assert await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()
 

--- a/tests/components/simplisafe/test_init.py
+++ b/tests/components/simplisafe/test_init.py
@@ -33,7 +33,10 @@ async def test_base_station_migration(
         return_value=api,
     ), patch(
         "homeassistant.components.simplisafe.SimpliSafe._async_start_websocket_loop"
-    ), patch("homeassistant.components.simplisafe.PLATFORMS", []):
+    ), patch(
+        "homeassistant.components.simplisafe.PLATFORMS",
+        [],
+    ):
         assert await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()
 

--- a/tests/components/smappee/test_config_flow.py
+++ b/tests/components/smappee/test_config_flow.py
@@ -146,9 +146,7 @@ async def test_user_local_connection_error(hass: HomeAssistant) -> None:
         "pysmappee.mqtt.SmappeeLocalMqtt.start_attempt", return_value=True
     ), patch("pysmappee.mqtt.SmappeeLocalMqtt.start", return_value=True), patch(
         "pysmappee.mqtt.SmappeeLocalMqtt.stop", return_value=True
-    ), patch(
-        "pysmappee.mqtt.SmappeeLocalMqtt.is_config_ready", return_value=None
-    ):
+    ), patch("pysmappee.mqtt.SmappeeLocalMqtt.is_config_ready", return_value=None):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_USER},
@@ -474,9 +472,7 @@ async def test_full_zeroconf_flow(hass: HomeAssistant) -> None:
     ), patch(
         "pysmappee.api.SmappeeLocalApi.load_instantaneous",
         return_value=[{"key": "phase0ActivePower", "value": 0}],
-    ), patch(
-        "homeassistant.components.smappee.async_setup_entry", return_value=True
-    ):
+    ), patch("homeassistant.components.smappee.async_setup_entry", return_value=True):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
@@ -516,9 +512,7 @@ async def test_full_user_local_flow(hass: HomeAssistant) -> None:
     ), patch(
         "pysmappee.api.SmappeeLocalApi.load_instantaneous",
         return_value=[{"key": "phase0ActivePower", "value": 0}],
-    ), patch(
-        "homeassistant.components.smappee.async_setup_entry", return_value=True
-    ):
+    ), patch("homeassistant.components.smappee.async_setup_entry", return_value=True):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_USER},

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -229,8 +229,10 @@ async def silent_ssdp_scanner(hass):
         "homeassistant.components.ssdp.Scanner._async_start_ssdp_listeners"
     ), patch("homeassistant.components.ssdp.Scanner._async_stop_ssdp_listeners"), patch(
         "homeassistant.components.ssdp.Scanner.async_scan"
-    ), patch("homeassistant.components.ssdp.Server._async_start_upnp_servers"), patch(
-        "homeassistant.components.ssdp.Server._async_stop_upnp_servers"
+    ), patch(
+        "homeassistant.components.ssdp.Server._async_start_upnp_servers",
+    ), patch(
+        "homeassistant.components.ssdp.Server._async_stop_upnp_servers",
     ):
         yield
 

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -229,9 +229,7 @@ async def silent_ssdp_scanner(hass):
         "homeassistant.components.ssdp.Scanner._async_start_ssdp_listeners"
     ), patch("homeassistant.components.ssdp.Scanner._async_stop_ssdp_listeners"), patch(
         "homeassistant.components.ssdp.Scanner.async_scan"
-    ), patch(
-        "homeassistant.components.ssdp.Server._async_start_upnp_servers"
-    ), patch(
+    ), patch("homeassistant.components.ssdp.Server._async_start_upnp_servers"), patch(
         "homeassistant.components.ssdp.Server._async_stop_upnp_servers"
     ):
         yield

--- a/tests/components/subaru/conftest.py
+++ b/tests/components/subaru/conftest.py
@@ -145,9 +145,7 @@ async def setup_subaru_config_entry(
         return_value=vehicle_status,
     ), patch(
         MOCK_API_UPDATE,
-    ), patch(
-        MOCK_API_FETCH, side_effect=fetch_effect
-    ):
+    ), patch(MOCK_API_FETCH, side_effect=fetch_effect):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 

--- a/tests/components/switchbee/test_config_flow.py
+++ b/tests/components/switchbee/test_config_flow.py
@@ -39,9 +39,7 @@ async def test_form(hass: HomeAssistant, test_cucode_in_coordinator_data) -> Non
         return_value=True,
     ), patch(
         "switchbee.api.polling.CentralUnitPolling.fetch_states", return_value=None
-    ), patch(
-        "switchbee.api.polling.CentralUnitPolling._login", return_value=None
-    ):
+    ), patch("switchbee.api.polling.CentralUnitPolling._login", return_value=None):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {

--- a/tests/components/system_bridge/test_config_flow.py
+++ b/tests/components/system_bridge/test_config_flow.py
@@ -151,7 +151,9 @@ async def test_user_flow(hass: HomeAssistant) -> None:
     ), patch(
         "systembridgeconnector.websocket_client.WebSocketClient.get_data",
         return_value=FIXTURE_DATA_RESPONSE,
-    ), patch("systembridgeconnector.websocket_client.WebSocketClient.listen"), patch(
+    ), patch(
+        "systembridgeconnector.websocket_client.WebSocketClient.listen",
+    ), patch(
         "homeassistant.components.system_bridge.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -447,7 +449,9 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
     ), patch(
         "systembridgeconnector.websocket_client.WebSocketClient.get_data",
         return_value=FIXTURE_DATA_RESPONSE,
-    ), patch("systembridgeconnector.websocket_client.WebSocketClient.listen"), patch(
+    ), patch(
+        "systembridgeconnector.websocket_client.WebSocketClient.listen",
+    ), patch(
         "homeassistant.components.system_bridge.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -479,7 +483,9 @@ async def test_zeroconf_flow(hass: HomeAssistant) -> None:
     ), patch(
         "systembridgeconnector.websocket_client.WebSocketClient.get_data",
         return_value=FIXTURE_DATA_RESPONSE,
-    ), patch("systembridgeconnector.websocket_client.WebSocketClient.listen"), patch(
+    ), patch(
+        "systembridgeconnector.websocket_client.WebSocketClient.listen",
+    ), patch(
         "homeassistant.components.system_bridge.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:

--- a/tests/components/system_bridge/test_config_flow.py
+++ b/tests/components/system_bridge/test_config_flow.py
@@ -151,9 +151,7 @@ async def test_user_flow(hass: HomeAssistant) -> None:
     ), patch(
         "systembridgeconnector.websocket_client.WebSocketClient.get_data",
         return_value=FIXTURE_DATA_RESPONSE,
-    ), patch(
-        "systembridgeconnector.websocket_client.WebSocketClient.listen"
-    ), patch(
+    ), patch("systembridgeconnector.websocket_client.WebSocketClient.listen"), patch(
         "homeassistant.components.system_bridge.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -449,9 +447,7 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
     ), patch(
         "systembridgeconnector.websocket_client.WebSocketClient.get_data",
         return_value=FIXTURE_DATA_RESPONSE,
-    ), patch(
-        "systembridgeconnector.websocket_client.WebSocketClient.listen"
-    ), patch(
+    ), patch("systembridgeconnector.websocket_client.WebSocketClient.listen"), patch(
         "homeassistant.components.system_bridge.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -483,9 +479,7 @@ async def test_zeroconf_flow(hass: HomeAssistant) -> None:
     ), patch(
         "systembridgeconnector.websocket_client.WebSocketClient.get_data",
         return_value=FIXTURE_DATA_RESPONSE,
-    ), patch(
-        "systembridgeconnector.websocket_client.WebSocketClient.listen"
-    ), patch(
+    ), patch("systembridgeconnector.websocket_client.WebSocketClient.listen"), patch(
         "homeassistant.components.system_bridge.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:

--- a/tests/components/upnp/conftest.py
+++ b/tests/components/upnp/conftest.py
@@ -142,8 +142,10 @@ async def silent_ssdp_scanner(hass):
         "homeassistant.components.ssdp.Scanner._async_start_ssdp_listeners"
     ), patch("homeassistant.components.ssdp.Scanner._async_stop_ssdp_listeners"), patch(
         "homeassistant.components.ssdp.Scanner.async_scan"
-    ), patch("homeassistant.components.ssdp.Server._async_start_upnp_servers"), patch(
-        "homeassistant.components.ssdp.Server._async_stop_upnp_servers"
+    ), patch(
+        "homeassistant.components.ssdp.Server._async_start_upnp_servers",
+    ), patch(
+        "homeassistant.components.ssdp.Server._async_stop_upnp_servers",
     ):
         yield
 

--- a/tests/components/upnp/conftest.py
+++ b/tests/components/upnp/conftest.py
@@ -142,9 +142,7 @@ async def silent_ssdp_scanner(hass):
         "homeassistant.components.ssdp.Scanner._async_start_ssdp_listeners"
     ), patch("homeassistant.components.ssdp.Scanner._async_stop_ssdp_listeners"), patch(
         "homeassistant.components.ssdp.Scanner.async_scan"
-    ), patch(
-        "homeassistant.components.ssdp.Server._async_start_upnp_servers"
-    ), patch(
+    ), patch("homeassistant.components.ssdp.Server._async_start_upnp_servers"), patch(
         "homeassistant.components.ssdp.Server._async_stop_upnp_servers"
     ):
         yield

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -94,9 +94,7 @@ async def test_observer_discovery(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
         "homeassistant.components.usb.comports", return_value=mock_comports
-    ), patch.object(
-        hass.config_entries.flow, "async_init"
-    ) as mock_config_flow:
+    ), patch.object(hass.config_entries.flow, "async_init") as mock_config_flow:
         assert await async_setup_component(hass, "usb", {"usb": {}})
         await hass.async_block_till_done()
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
@@ -145,9 +143,7 @@ async def test_removal_by_observer_before_started(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
         "homeassistant.components.usb.comports", return_value=mock_comports
-    ), patch(
-        "pyudev.MonitorObserver", new=_create_mock_monitor_observer
-    ), patch.object(
+    ), patch("pyudev.MonitorObserver", new=_create_mock_monitor_observer), patch.object(
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow:
         assert await async_setup_component(hass, "usb", {"usb": {}})
@@ -184,9 +180,7 @@ async def test_discovered_by_websocket_scan(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
         "homeassistant.components.usb.comports", return_value=mock_comports
-    ), patch.object(
-        hass.config_entries.flow, "async_init"
-    ) as mock_config_flow:
+    ), patch.object(hass.config_entries.flow, "async_init") as mock_config_flow:
         assert await async_setup_component(hass, "usb", {"usb": {}})
         await hass.async_block_till_done()
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
@@ -224,9 +218,7 @@ async def test_discovered_by_websocket_scan_limited_by_description_matcher(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
         "homeassistant.components.usb.comports", return_value=mock_comports
-    ), patch.object(
-        hass.config_entries.flow, "async_init"
-    ) as mock_config_flow:
+    ), patch.object(hass.config_entries.flow, "async_init") as mock_config_flow:
         assert await async_setup_component(hass, "usb", {"usb": {}})
         await hass.async_block_till_done()
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
@@ -265,9 +257,7 @@ async def test_most_targeted_matcher_wins(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
         "homeassistant.components.usb.comports", return_value=mock_comports
-    ), patch.object(
-        hass.config_entries.flow, "async_init"
-    ) as mock_config_flow:
+    ), patch.object(hass.config_entries.flow, "async_init") as mock_config_flow:
         assert await async_setup_component(hass, "usb", {"usb": {}})
         await hass.async_block_till_done()
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
@@ -305,9 +295,7 @@ async def test_discovered_by_websocket_scan_rejected_by_description_matcher(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
         "homeassistant.components.usb.comports", return_value=mock_comports
-    ), patch.object(
-        hass.config_entries.flow, "async_init"
-    ) as mock_config_flow:
+    ), patch.object(hass.config_entries.flow, "async_init") as mock_config_flow:
         assert await async_setup_component(hass, "usb", {"usb": {}})
         await hass.async_block_till_done()
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
@@ -349,9 +337,7 @@ async def test_discovered_by_websocket_scan_limited_by_serial_number_matcher(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
         "homeassistant.components.usb.comports", return_value=mock_comports
-    ), patch.object(
-        hass.config_entries.flow, "async_init"
-    ) as mock_config_flow:
+    ), patch.object(hass.config_entries.flow, "async_init") as mock_config_flow:
         assert await async_setup_component(hass, "usb", {"usb": {}})
         await hass.async_block_till_done()
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
@@ -389,9 +375,7 @@ async def test_discovered_by_websocket_scan_rejected_by_serial_number_matcher(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
         "homeassistant.components.usb.comports", return_value=mock_comports
-    ), patch.object(
-        hass.config_entries.flow, "async_init"
-    ) as mock_config_flow:
+    ), patch.object(hass.config_entries.flow, "async_init") as mock_config_flow:
         assert await async_setup_component(hass, "usb", {"usb": {}})
         await hass.async_block_till_done()
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
@@ -433,9 +417,7 @@ async def test_discovered_by_websocket_scan_limited_by_manufacturer_matcher(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
         "homeassistant.components.usb.comports", return_value=mock_comports
-    ), patch.object(
-        hass.config_entries.flow, "async_init"
-    ) as mock_config_flow:
+    ), patch.object(hass.config_entries.flow, "async_init") as mock_config_flow:
         assert await async_setup_component(hass, "usb", {"usb": {}})
         await hass.async_block_till_done()
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
@@ -478,9 +460,7 @@ async def test_discovered_by_websocket_scan_rejected_by_manufacturer_matcher(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
         "homeassistant.components.usb.comports", return_value=mock_comports
-    ), patch.object(
-        hass.config_entries.flow, "async_init"
-    ) as mock_config_flow:
+    ), patch.object(hass.config_entries.flow, "async_init") as mock_config_flow:
         assert await async_setup_component(hass, "usb", {"usb": {}})
         await hass.async_block_till_done()
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
@@ -517,9 +497,7 @@ async def test_discovered_by_websocket_rejected_with_empty_serial_number_only(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
         "homeassistant.components.usb.comports", return_value=mock_comports
-    ), patch.object(
-        hass.config_entries.flow, "async_init"
-    ) as mock_config_flow:
+    ), patch.object(hass.config_entries.flow, "async_init") as mock_config_flow:
         assert await async_setup_component(hass, "usb", {"usb": {}})
         await hass.async_block_till_done()
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
@@ -554,9 +532,7 @@ async def test_discovered_by_websocket_scan_match_vid_only(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
         "homeassistant.components.usb.comports", return_value=mock_comports
-    ), patch.object(
-        hass.config_entries.flow, "async_init"
-    ) as mock_config_flow:
+    ), patch.object(hass.config_entries.flow, "async_init") as mock_config_flow:
         assert await async_setup_component(hass, "usb", {"usb": {}})
         await hass.async_block_till_done()
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
@@ -592,9 +568,7 @@ async def test_discovered_by_websocket_scan_match_vid_wrong_pid(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
         "homeassistant.components.usb.comports", return_value=mock_comports
-    ), patch.object(
-        hass.config_entries.flow, "async_init"
-    ) as mock_config_flow:
+    ), patch.object(hass.config_entries.flow, "async_init") as mock_config_flow:
         assert await async_setup_component(hass, "usb", {"usb": {}})
         await hass.async_block_till_done()
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
@@ -629,9 +603,7 @@ async def test_discovered_by_websocket_no_vid_pid(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
         "homeassistant.components.usb.comports", return_value=mock_comports
-    ), patch.object(
-        hass.config_entries.flow, "async_init"
-    ) as mock_config_flow:
+    ), patch.object(hass.config_entries.flow, "async_init") as mock_config_flow:
         assert await async_setup_component(hass, "usb", {"usb": {}})
         await hass.async_block_till_done()
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
@@ -667,9 +639,7 @@ async def test_non_matching_discovered_by_scanner_after_started(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
         "homeassistant.components.usb.comports", return_value=mock_comports
-    ), patch.object(
-        hass.config_entries.flow, "async_init"
-    ) as mock_config_flow:
+    ), patch.object(hass.config_entries.flow, "async_init") as mock_config_flow:
         assert await async_setup_component(hass, "usb", {"usb": {}})
         await hass.async_block_till_done()
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
@@ -708,9 +678,7 @@ async def test_observer_on_wsl_fallback_without_throwing_exception(
         "pyudev.Monitor.filter_by", side_effect=ValueError
     ), patch("homeassistant.components.usb.async_get_usb", return_value=new_usb), patch(
         "homeassistant.components.usb.comports", return_value=mock_comports
-    ), patch.object(
-        hass.config_entries.flow, "async_init"
-    ) as mock_config_flow:
+    ), patch.object(hass.config_entries.flow, "async_init") as mock_config_flow:
         assert await async_setup_component(hass, "usb", {"usb": {}})
         await hass.async_block_till_done()
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
@@ -760,9 +728,7 @@ async def test_not_discovered_by_observer_before_started_on_docker(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
         "homeassistant.components.usb.comports", return_value=mock_comports
-    ), patch(
-        "pyudev.MonitorObserver", new=_create_mock_monitor_observer
-    ):
+    ), patch("pyudev.MonitorObserver", new=_create_mock_monitor_observer):
         assert await async_setup_component(hass, "usb", {"usb": {}})
         await hass.async_block_till_done()
 
@@ -1047,9 +1013,7 @@ async def test_resolve_serial_by_id(
     ), patch(
         "homeassistant.components.usb.get_serial_by_id",
         return_value="/dev/serial/by-id/bla",
-    ), patch.object(
-        hass.config_entries.flow, "async_init"
-    ) as mock_config_flow:
+    ), patch.object(hass.config_entries.flow, "async_init") as mock_config_flow:
         assert await async_setup_component(hass, "usb", {"usb": {}})
         await hass.async_block_till_done()
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)

--- a/tests/components/vilfo/test_config_flow.py
+++ b/tests/components/vilfo/test_config_flow.py
@@ -24,9 +24,7 @@ async def test_form(hass: HomeAssistant) -> None:
         "vilfo.Client.get_board_information", return_value=None
     ), patch(
         "vilfo.Client.resolve_firmware_version", return_value=firmware_version
-    ), patch(
-        "vilfo.Client.resolve_mac_address", return_value=mock_mac
-    ), patch(
+    ), patch("vilfo.Client.resolve_mac_address", return_value=mock_mac), patch(
         "homeassistant.components.vilfo.async_setup_entry"
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
@@ -117,9 +115,7 @@ async def test_form_already_configured(hass: HomeAssistant) -> None:
         return_value=None,
     ), patch(
         "vilfo.Client.resolve_firmware_version", return_value=firmware_version
-    ), patch(
-        "vilfo.Client.resolve_mac_address", return_value=None
-    ):
+    ), patch("vilfo.Client.resolve_mac_address", return_value=None):
         first_flow_result2 = await hass.config_entries.flow.async_configure(
             first_flow_result1["flow_id"],
             {CONF_HOST: "testadmin.vilfo.com", CONF_ACCESS_TOKEN: "test-token"},
@@ -134,9 +130,7 @@ async def test_form_already_configured(hass: HomeAssistant) -> None:
         return_value=None,
     ), patch(
         "vilfo.Client.resolve_firmware_version", return_value=firmware_version
-    ), patch(
-        "vilfo.Client.resolve_mac_address", return_value=None
-    ):
+    ), patch("vilfo.Client.resolve_mac_address", return_value=None):
         second_flow_result2 = await hass.config_entries.flow.async_configure(
             second_flow_result1["flow_id"],
             {CONF_HOST: "testadmin.vilfo.com", CONF_ACCESS_TOKEN: "test-token"},
@@ -177,9 +171,7 @@ async def test_validate_input_returns_data(hass: HomeAssistant) -> None:
         "vilfo.Client.get_board_information", return_value=None
     ), patch(
         "vilfo.Client.resolve_firmware_version", return_value=firmware_version
-    ), patch(
-        "vilfo.Client.resolve_mac_address", return_value=None
-    ):
+    ), patch("vilfo.Client.resolve_mac_address", return_value=None):
         result = await hass.components.vilfo.config_flow.validate_input(
             hass, data=mock_data
         )
@@ -193,9 +185,7 @@ async def test_validate_input_returns_data(hass: HomeAssistant) -> None:
         "vilfo.Client.get_board_information", return_value=None
     ), patch(
         "vilfo.Client.resolve_firmware_version", return_value=firmware_version
-    ), patch(
-        "vilfo.Client.resolve_mac_address", return_value=mock_mac
-    ):
+    ), patch("vilfo.Client.resolve_mac_address", return_value=mock_mac):
         result2 = await hass.components.vilfo.config_flow.validate_input(
             hass, data=mock_data
         )

--- a/tests/components/vlc_telnet/test_config_flow.py
+++ b/tests/components/vlc_telnet/test_config_flow.py
@@ -123,7 +123,9 @@ async def test_errors(
     ), patch(
         "homeassistant.components.vlc_telnet.config_flow.Client.login",
         side_effect=login_side_effect,
-    ), patch("homeassistant.components.vlc_telnet.config_flow.Client.disconnect"):
+    ), patch(
+        "homeassistant.components.vlc_telnet.config_flow.Client.disconnect",
+    ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {"password": "test-password"},
@@ -216,7 +218,9 @@ async def test_reauth_errors(
     ), patch(
         "homeassistant.components.vlc_telnet.config_flow.Client.login",
         side_effect=login_side_effect,
-    ), patch("homeassistant.components.vlc_telnet.config_flow.Client.disconnect"):
+    ), patch(
+        "homeassistant.components.vlc_telnet.config_flow.Client.disconnect",
+    ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {"password": "test-password"},
@@ -311,7 +315,9 @@ async def test_hassio_errors(
     ), patch(
         "homeassistant.components.vlc_telnet.config_flow.Client.login",
         side_effect=login_side_effect,
-    ), patch("homeassistant.components.vlc_telnet.config_flow.Client.disconnect"):
+    ), patch(
+        "homeassistant.components.vlc_telnet.config_flow.Client.disconnect",
+    ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_HASSIO},

--- a/tests/components/vlc_telnet/test_config_flow.py
+++ b/tests/components/vlc_telnet/test_config_flow.py
@@ -123,9 +123,7 @@ async def test_errors(
     ), patch(
         "homeassistant.components.vlc_telnet.config_flow.Client.login",
         side_effect=login_side_effect,
-    ), patch(
-        "homeassistant.components.vlc_telnet.config_flow.Client.disconnect"
-    ):
+    ), patch("homeassistant.components.vlc_telnet.config_flow.Client.disconnect"):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {"password": "test-password"},
@@ -218,9 +216,7 @@ async def test_reauth_errors(
     ), patch(
         "homeassistant.components.vlc_telnet.config_flow.Client.login",
         side_effect=login_side_effect,
-    ), patch(
-        "homeassistant.components.vlc_telnet.config_flow.Client.disconnect"
-    ):
+    ), patch("homeassistant.components.vlc_telnet.config_flow.Client.disconnect"):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {"password": "test-password"},
@@ -315,9 +311,7 @@ async def test_hassio_errors(
     ), patch(
         "homeassistant.components.vlc_telnet.config_flow.Client.login",
         side_effect=login_side_effect,
-    ), patch(
-        "homeassistant.components.vlc_telnet.config_flow.Client.disconnect"
-    ):
+    ), patch("homeassistant.components.vlc_telnet.config_flow.Client.disconnect"):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_HASSIO},

--- a/tests/components/vodafone_station/test_config_flow.py
+++ b/tests/components/vodafone_station/test_config_flow.py
@@ -23,9 +23,7 @@ async def test_user(hass: HomeAssistant) -> None:
         "homeassistant.components.vodafone_station.config_flow.VodafoneStationSercommApi.logout",
     ), patch(
         "homeassistant.components.vodafone_station.async_setup_entry"
-    ) as mock_setup_entry, patch(
-        "requests.get"
-    ) as mock_request_get:
+    ) as mock_setup_entry, patch("requests.get") as mock_request_get:
         mock_request_get.return_value.status_code = 200
 
         result = await hass.config_entries.flow.async_init(
@@ -89,9 +87,7 @@ async def test_exception_connection(hass: HomeAssistant, side_effect, error) -> 
             "homeassistant.components.vodafone_station.config_flow.VodafoneStationSercommApi.login",
         ), patch(
             "homeassistant.components.vodafone_station.config_flow.VodafoneStationSercommApi.logout",
-        ), patch(
-            "homeassistant.components.vodafone_station.async_setup_entry"
-        ):
+        ), patch("homeassistant.components.vodafone_station.async_setup_entry"):
             result2 = await hass.config_entries.flow.async_configure(
                 result["flow_id"],
                 user_input={
@@ -121,9 +117,7 @@ async def test_reauth_successful(hass: HomeAssistant) -> None:
         "homeassistant.components.vodafone_station.config_flow.VodafoneStationSercommApi.login",
     ), patch(
         "homeassistant.components.vodafone_station.config_flow.VodafoneStationSercommApi.logout",
-    ), patch(
-        "homeassistant.components.vodafone_station.async_setup_entry"
-    ), patch(
+    ), patch("homeassistant.components.vodafone_station.async_setup_entry"), patch(
         "requests.get"
     ) as mock_request_get:
         mock_request_get.return_value.status_code = 200
@@ -169,9 +163,7 @@ async def test_reauth_not_successful(hass: HomeAssistant, side_effect, error) ->
         side_effect=side_effect,
     ), patch(
         "homeassistant.components.vodafone_station.config_flow.VodafoneStationSercommApi.logout",
-    ), patch(
-        "homeassistant.components.vodafone_station.async_setup_entry"
-    ):
+    ), patch("homeassistant.components.vodafone_station.async_setup_entry"):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_REAUTH, "entry_id": mock_config.entry_id},
@@ -203,9 +195,7 @@ async def test_reauth_not_successful(hass: HomeAssistant, side_effect, error) ->
             "homeassistant.components.vodafone_station.config_flow.VodafoneStationSercommApi.login",
         ), patch(
             "homeassistant.components.vodafone_station.config_flow.VodafoneStationSercommApi.logout",
-        ), patch(
-            "homeassistant.components.vodafone_station.async_setup_entry"
-        ):
+        ), patch("homeassistant.components.vodafone_station.async_setup_entry"):
             result2 = await hass.config_entries.flow.async_configure(
                 result["flow_id"],
                 user_input={

--- a/tests/components/vodafone_station/test_config_flow.py
+++ b/tests/components/vodafone_station/test_config_flow.py
@@ -23,7 +23,9 @@ async def test_user(hass: HomeAssistant) -> None:
         "homeassistant.components.vodafone_station.config_flow.VodafoneStationSercommApi.logout",
     ), patch(
         "homeassistant.components.vodafone_station.async_setup_entry"
-    ) as mock_setup_entry, patch("requests.get") as mock_request_get:
+    ) as mock_setup_entry, patch(
+        "requests.get",
+    ) as mock_request_get:
         mock_request_get.return_value.status_code = 200
 
         result = await hass.config_entries.flow.async_init(
@@ -87,7 +89,9 @@ async def test_exception_connection(hass: HomeAssistant, side_effect, error) -> 
             "homeassistant.components.vodafone_station.config_flow.VodafoneStationSercommApi.login",
         ), patch(
             "homeassistant.components.vodafone_station.config_flow.VodafoneStationSercommApi.logout",
-        ), patch("homeassistant.components.vodafone_station.async_setup_entry"):
+        ), patch(
+            "homeassistant.components.vodafone_station.async_setup_entry",
+        ):
             result2 = await hass.config_entries.flow.async_configure(
                 result["flow_id"],
                 user_input={
@@ -117,8 +121,10 @@ async def test_reauth_successful(hass: HomeAssistant) -> None:
         "homeassistant.components.vodafone_station.config_flow.VodafoneStationSercommApi.login",
     ), patch(
         "homeassistant.components.vodafone_station.config_flow.VodafoneStationSercommApi.logout",
-    ), patch("homeassistant.components.vodafone_station.async_setup_entry"), patch(
-        "requests.get"
+    ), patch(
+        "homeassistant.components.vodafone_station.async_setup_entry",
+    ), patch(
+        "requests.get",
     ) as mock_request_get:
         mock_request_get.return_value.status_code = 200
 
@@ -163,7 +169,9 @@ async def test_reauth_not_successful(hass: HomeAssistant, side_effect, error) ->
         side_effect=side_effect,
     ), patch(
         "homeassistant.components.vodafone_station.config_flow.VodafoneStationSercommApi.logout",
-    ), patch("homeassistant.components.vodafone_station.async_setup_entry"):
+    ), patch(
+        "homeassistant.components.vodafone_station.async_setup_entry",
+    ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_REAUTH, "entry_id": mock_config.entry_id},
@@ -195,7 +203,9 @@ async def test_reauth_not_successful(hass: HomeAssistant, side_effect, error) ->
             "homeassistant.components.vodafone_station.config_flow.VodafoneStationSercommApi.login",
         ), patch(
             "homeassistant.components.vodafone_station.config_flow.VodafoneStationSercommApi.logout",
-        ), patch("homeassistant.components.vodafone_station.async_setup_entry"):
+        ), patch(
+            "homeassistant.components.vodafone_station.async_setup_entry",
+        ):
             result2 = await hass.config_entries.flow.async_configure(
                 result["flow_id"],
                 user_input={

--- a/tests/components/waqi/test_config_flow.py
+++ b/tests/components/waqi/test_config_flow.py
@@ -235,9 +235,9 @@ async def test_error_in_second_step(
 
     with patch(
         "aiowaqi.WAQIClient.authenticate",
-    ), patch(
-        "aiowaqi.WAQIClient.get_by_coordinates", side_effect=exception
-    ), patch("aiowaqi.WAQIClient.get_by_station_number", side_effect=exception):
+    ), patch("aiowaqi.WAQIClient.get_by_coordinates", side_effect=exception), patch(
+        "aiowaqi.WAQIClient.get_by_station_number", side_effect=exception
+    ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             payload,

--- a/tests/components/watttime/conftest.py
+++ b/tests/components/watttime/conftest.py
@@ -106,9 +106,7 @@ async def setup_watttime_fixture(hass, client, config_auth, config_coordinates):
     ), patch(
         "homeassistant.components.watttime.config_flow.Client.async_login",
         return_value=client,
-    ), patch(
-        "homeassistant.components.watttime.PLATFORMS", []
-    ):
+    ), patch("homeassistant.components.watttime.PLATFORMS", []):
         assert await async_setup_component(
             hass, DOMAIN, {**config_auth, **config_coordinates}
         )

--- a/tests/components/withings/test_diagnostics.py
+++ b/tests/components/withings/test_diagnostics.py
@@ -66,8 +66,10 @@ async def test_diagnostics_cloudhook_instance(
         return_value="https://hooks.nabu.casa/ABCD",
     ), patch(
         "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
-    ), patch("homeassistant.components.cloud.async_delete_cloudhook"), patch(
-        "homeassistant.components.withings.webhook_generate_url"
+    ), patch(
+        "homeassistant.components.cloud.async_delete_cloudhook",
+    ), patch(
+        "homeassistant.components.withings.webhook_generate_url",
     ):
         await setup_integration(hass, webhook_config_entry)
         await prepare_webhook_setup(hass, freezer)

--- a/tests/components/withings/test_diagnostics.py
+++ b/tests/components/withings/test_diagnostics.py
@@ -66,9 +66,7 @@ async def test_diagnostics_cloudhook_instance(
         return_value="https://hooks.nabu.casa/ABCD",
     ), patch(
         "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
-    ), patch(
-        "homeassistant.components.cloud.async_delete_cloudhook"
-    ), patch(
+    ), patch("homeassistant.components.cloud.async_delete_cloudhook"), patch(
         "homeassistant.components.withings.webhook_generate_url"
     ):
         await setup_integration(hass, webhook_config_entry)

--- a/tests/components/withings/test_init.py
+++ b/tests/components/withings/test_init.py
@@ -351,7 +351,9 @@ async def test_removing_entry_with_cloud_unavailable(
     ), patch(
         "homeassistant.components.cloud.async_delete_cloudhook",
         side_effect=CloudNotAvailable(),
-    ), patch("homeassistant.components.withings.webhook_generate_url"):
+    ), patch(
+        "homeassistant.components.withings.webhook_generate_url",
+    ):
         await setup_integration(hass, cloudhook_config_entry)
         assert hass.components.cloud.async_active_subscription() is True
 
@@ -466,8 +468,10 @@ async def test_cloud_disconnect(
         return_value="https://hooks.nabu.casa/ABCD",
     ), patch(
         "homeassistant.components.withings.async_get_config_entry_implementation",
-    ), patch("homeassistant.components.cloud.async_delete_cloudhook"), patch(
-        "homeassistant.components.withings.webhook_generate_url"
+    ), patch(
+        "homeassistant.components.cloud.async_delete_cloudhook",
+    ), patch(
+        "homeassistant.components.withings.webhook_generate_url",
     ):
         await setup_integration(hass, webhook_config_entry)
         await prepare_webhook_setup(hass, freezer)

--- a/tests/components/withings/test_init.py
+++ b/tests/components/withings/test_init.py
@@ -351,9 +351,7 @@ async def test_removing_entry_with_cloud_unavailable(
     ), patch(
         "homeassistant.components.cloud.async_delete_cloudhook",
         side_effect=CloudNotAvailable(),
-    ), patch(
-        "homeassistant.components.withings.webhook_generate_url"
-    ):
+    ), patch("homeassistant.components.withings.webhook_generate_url"):
         await setup_integration(hass, cloudhook_config_entry)
         assert hass.components.cloud.async_active_subscription() is True
 
@@ -468,9 +466,7 @@ async def test_cloud_disconnect(
         return_value="https://hooks.nabu.casa/ABCD",
     ), patch(
         "homeassistant.components.withings.async_get_config_entry_implementation",
-    ), patch(
-        "homeassistant.components.cloud.async_delete_cloudhook"
-    ), patch(
+    ), patch("homeassistant.components.cloud.async_delete_cloudhook"), patch(
         "homeassistant.components.withings.webhook_generate_url"
     ):
         await setup_integration(hass, webhook_config_entry)

--- a/tests/components/wyoming/test_tts.py
+++ b/tests/components/wyoming/test_tts.py
@@ -179,7 +179,9 @@ async def test_get_tts_audio_audio_oserror(
         mock_client,
     ), patch.object(
         mock_client, "read_event", side_effect=OSError("Boom!")
-    ), pytest.raises(HomeAssistantError):
+    ), pytest.raises(
+        HomeAssistantError,
+    ):
         await tts.async_get_media_source_audio(
             hass,
             tts.generate_media_source_id(

--- a/tests/components/wyoming/test_tts.py
+++ b/tests/components/wyoming/test_tts.py
@@ -179,9 +179,7 @@ async def test_get_tts_audio_audio_oserror(
         mock_client,
     ), patch.object(
         mock_client, "read_event", side_effect=OSError("Boom!")
-    ), pytest.raises(
-        HomeAssistantError
-    ):
+    ), pytest.raises(HomeAssistantError):
         await tts.async_get_media_source_audio(
             hass,
             tts.generate_media_source_id(

--- a/tests/components/yamaha_musiccast/test_config_flow.py
+++ b/tests/components/yamaha_musiccast/test_config_flow.py
@@ -21,9 +21,7 @@ async def silent_ssdp_scanner(hass):
         "homeassistant.components.ssdp.Scanner._async_start_ssdp_listeners"
     ), patch("homeassistant.components.ssdp.Scanner._async_stop_ssdp_listeners"), patch(
         "homeassistant.components.ssdp.Scanner.async_scan"
-    ), patch(
-        "homeassistant.components.ssdp.Server._async_start_upnp_servers"
-    ), patch(
+    ), patch("homeassistant.components.ssdp.Server._async_start_upnp_servers"), patch(
         "homeassistant.components.ssdp.Server._async_stop_upnp_servers"
     ):
         yield

--- a/tests/components/yamaha_musiccast/test_config_flow.py
+++ b/tests/components/yamaha_musiccast/test_config_flow.py
@@ -21,8 +21,10 @@ async def silent_ssdp_scanner(hass):
         "homeassistant.components.ssdp.Scanner._async_start_ssdp_listeners"
     ), patch("homeassistant.components.ssdp.Scanner._async_stop_ssdp_listeners"), patch(
         "homeassistant.components.ssdp.Scanner.async_scan"
-    ), patch("homeassistant.components.ssdp.Server._async_start_upnp_servers"), patch(
-        "homeassistant.components.ssdp.Server._async_stop_upnp_servers"
+    ), patch(
+        "homeassistant.components.ssdp.Server._async_start_upnp_servers",
+    ), patch(
+        "homeassistant.components.ssdp.Server._async_stop_upnp_servers",
     ):
         yield
 

--- a/tests/components/yeelight/test_config_flow.py
+++ b/tests/components/yeelight/test_config_flow.py
@@ -439,9 +439,7 @@ async def test_manual_no_capabilities(hass: HomeAssistant) -> None:
         no_device=True
     ), _patch_discovery_timeout(), _patch_discovery_interval(), patch(
         f"{MODULE_CONFIG_FLOW}.AsyncBulb", return_value=mocked_bulb
-    ), patch(
-        f"{MODULE}.async_setup", return_value=True
-    ), patch(
+    ), patch(f"{MODULE}.async_setup", return_value=True), patch(
         f"{MODULE}.async_setup_entry", return_value=True
     ):
         result = await hass.config_entries.flow.async_configure(

--- a/tests/components/yeelight/test_config_flow.py
+++ b/tests/components/yeelight/test_config_flow.py
@@ -439,8 +439,12 @@ async def test_manual_no_capabilities(hass: HomeAssistant) -> None:
         no_device=True
     ), _patch_discovery_timeout(), _patch_discovery_interval(), patch(
         f"{MODULE_CONFIG_FLOW}.AsyncBulb", return_value=mocked_bulb
-    ), patch(f"{MODULE}.async_setup", return_value=True), patch(
-        f"{MODULE}.async_setup_entry", return_value=True
+    ), patch(
+        f"{MODULE}.async_setup",
+        return_value=True,
+    ), patch(
+        f"{MODULE}.async_setup_entry",
+        return_value=True,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {CONF_HOST: IP_ADDRESS}

--- a/tests/components/zwave_js/test_device_trigger.py
+++ b/tests/components/zwave_js/test_device_trigger.py
@@ -163,10 +163,11 @@ async def test_if_notification_notification_fires(
     ] == "event.notification.notification - device - zwave_js_notification - {}".format(
         CommandClass.NOTIFICATION
     )
-    assert calls[1].data[
-        "some"
-    ] == "event.notification.notification2 - device - zwave_js_notification - {}".format(
-        CommandClass.NOTIFICATION
+    assert (
+        calls[1].data["some"]
+        == "event.notification.notification2 - device - zwave_js_notification - {}".format(
+            CommandClass.NOTIFICATION
+        )
     )
 
 
@@ -293,10 +294,11 @@ async def test_if_entry_control_notification_fires(
     ] == "event.notification.notification - device - zwave_js_notification - {}".format(
         CommandClass.ENTRY_CONTROL
     )
-    assert calls[1].data[
-        "some"
-    ] == "event.notification.notification2 - device - zwave_js_notification - {}".format(
-        CommandClass.ENTRY_CONTROL
+    assert (
+        calls[1].data["some"]
+        == "event.notification.notification2 - device - zwave_js_notification - {}".format(
+            CommandClass.ENTRY_CONTROL
+        )
     )
 
 
@@ -705,15 +707,17 @@ async def test_if_basic_value_notification_fires(
     node.receive_event(event)
     await hass.async_block_till_done()
     assert len(calls) == 2
-    assert calls[0].data[
-        "some"
-    ] == "event.value_notification.basic - device - zwave_js_value_notification - {}".format(
-        CommandClass.BASIC
+    assert (
+        calls[0].data["some"]
+        == "event.value_notification.basic - device - zwave_js_value_notification - {}".format(
+            CommandClass.BASIC
+        )
     )
-    assert calls[1].data[
-        "some"
-    ] == "event.value_notification.basic2 - device - zwave_js_value_notification - {}".format(
-        CommandClass.BASIC
+    assert (
+        calls[1].data["some"]
+        == "event.value_notification.basic2 - device - zwave_js_value_notification - {}".format(
+            CommandClass.BASIC
+        )
     )
 
 
@@ -888,15 +892,17 @@ async def test_if_central_scene_value_notification_fires(
     node.receive_event(event)
     await hass.async_block_till_done()
     assert len(calls) == 2
-    assert calls[0].data[
-        "some"
-    ] == "event.value_notification.central_scene - device - zwave_js_value_notification - {}".format(
-        CommandClass.CENTRAL_SCENE
+    assert (
+        calls[0].data["some"]
+        == "event.value_notification.central_scene - device - zwave_js_value_notification - {}".format(
+            CommandClass.CENTRAL_SCENE
+        )
     )
-    assert calls[1].data[
-        "some"
-    ] == "event.value_notification.central_scene2 - device - zwave_js_value_notification - {}".format(
-        CommandClass.CENTRAL_SCENE
+    assert (
+        calls[1].data["some"]
+        == "event.value_notification.central_scene2 - device - zwave_js_value_notification - {}".format(
+            CommandClass.CENTRAL_SCENE
+        )
     )
 
 
@@ -1064,15 +1070,17 @@ async def test_if_scene_activation_value_notification_fires(
     node.receive_event(event)
     await hass.async_block_till_done()
     assert len(calls) == 2
-    assert calls[0].data[
-        "some"
-    ] == "event.value_notification.scene_activation - device - zwave_js_value_notification - {}".format(
-        CommandClass.SCENE_ACTIVATION
+    assert (
+        calls[0].data["some"]
+        == "event.value_notification.scene_activation - device - zwave_js_value_notification - {}".format(
+            CommandClass.SCENE_ACTIVATION
+        )
     )
-    assert calls[1].data[
-        "some"
-    ] == "event.value_notification.scene_activation2 - device - zwave_js_value_notification - {}".format(
-        CommandClass.SCENE_ACTIVATION
+    assert (
+        calls[1].data["some"]
+        == "event.value_notification.scene_activation2 - device - zwave_js_value_notification - {}".format(
+            CommandClass.SCENE_ACTIVATION
+        )
     )
 
 

--- a/tests/components/zwave_js/test_device_trigger.py
+++ b/tests/components/zwave_js/test_device_trigger.py
@@ -158,16 +158,13 @@ async def test_if_notification_notification_fires(
     node.receive_event(event)
     await hass.async_block_till_done()
     assert len(calls) == 2
-    assert calls[0].data[
-        "some"
-    ] == "event.notification.notification - device - zwave_js_notification - {}".format(
-        CommandClass.NOTIFICATION
+    assert (
+        calls[0].data["some"]
+        == f"event.notification.notification - device - zwave_js_notification - {CommandClass.NOTIFICATION}"
     )
     assert (
         calls[1].data["some"]
-        == "event.notification.notification2 - device - zwave_js_notification - {}".format(
-            CommandClass.NOTIFICATION
-        )
+        == f"event.notification.notification2 - device - zwave_js_notification - {CommandClass.NOTIFICATION}"
     )
 
 
@@ -289,16 +286,13 @@ async def test_if_entry_control_notification_fires(
     node.receive_event(event)
     await hass.async_block_till_done()
     assert len(calls) == 2
-    assert calls[0].data[
-        "some"
-    ] == "event.notification.notification - device - zwave_js_notification - {}".format(
-        CommandClass.ENTRY_CONTROL
+    assert (
+        calls[0].data["some"]
+        == f"event.notification.notification - device - zwave_js_notification - {CommandClass.ENTRY_CONTROL}"
     )
     assert (
         calls[1].data["some"]
-        == "event.notification.notification2 - device - zwave_js_notification - {}".format(
-            CommandClass.ENTRY_CONTROL
-        )
+        == f"event.notification.notification2 - device - zwave_js_notification - {CommandClass.ENTRY_CONTROL}"
     )
 
 
@@ -709,15 +703,11 @@ async def test_if_basic_value_notification_fires(
     assert len(calls) == 2
     assert (
         calls[0].data["some"]
-        == "event.value_notification.basic - device - zwave_js_value_notification - {}".format(
-            CommandClass.BASIC
-        )
+        == f"event.value_notification.basic - device - zwave_js_value_notification - {CommandClass.BASIC}"
     )
     assert (
         calls[1].data["some"]
-        == "event.value_notification.basic2 - device - zwave_js_value_notification - {}".format(
-            CommandClass.BASIC
-        )
+        == f"event.value_notification.basic2 - device - zwave_js_value_notification - {CommandClass.BASIC}"
     )
 
 
@@ -894,15 +884,11 @@ async def test_if_central_scene_value_notification_fires(
     assert len(calls) == 2
     assert (
         calls[0].data["some"]
-        == "event.value_notification.central_scene - device - zwave_js_value_notification - {}".format(
-            CommandClass.CENTRAL_SCENE
-        )
+        == f"event.value_notification.central_scene - device - zwave_js_value_notification - {CommandClass.CENTRAL_SCENE}"
     )
     assert (
         calls[1].data["some"]
-        == "event.value_notification.central_scene2 - device - zwave_js_value_notification - {}".format(
-            CommandClass.CENTRAL_SCENE
-        )
+        == f"event.value_notification.central_scene2 - device - zwave_js_value_notification - {CommandClass.CENTRAL_SCENE}"
     )
 
 
@@ -1072,15 +1058,11 @@ async def test_if_scene_activation_value_notification_fires(
     assert len(calls) == 2
     assert (
         calls[0].data["some"]
-        == "event.value_notification.scene_activation - device - zwave_js_value_notification - {}".format(
-            CommandClass.SCENE_ACTIVATION
-        )
+        == f"event.value_notification.scene_activation - device - zwave_js_value_notification - {CommandClass.SCENE_ACTIVATION}"
     )
     assert (
         calls[1].data["some"]
-        == "event.value_notification.scene_activation2 - device - zwave_js_value_notification - {}".format(
-            CommandClass.SCENE_ACTIVATION
-        )
+        == f"event.value_notification.scene_activation2 - device - zwave_js_value_notification - {CommandClass.SCENE_ACTIVATION}"
     )
 
 

--- a/tests/helpers/test_check_config.py
+++ b/tests/helpers/test_check_config.py
@@ -416,9 +416,7 @@ automation:
       service_to_call: test.automation
 input_datetime:
 """,
-        hass.config.path(
-            "blueprints/automation/test_event_service.yaml"
-        ): """
+        hass.config.path("blueprints/automation/test_event_service.yaml"): """
 blueprint:
   name: "Call service based on event"
   domain: automation

--- a/tests/helpers/test_system_info.py
+++ b/tests/helpers/test_system_info.py
@@ -38,13 +38,9 @@ async def test_get_system_info_supervisor_not_available(
         "homeassistant.helpers.system_info.is_docker_env", return_value=True
     ), patch(
         "homeassistant.helpers.system_info.is_official_image", return_value=True
-    ), patch(
-        "homeassistant.components.hassio.is_hassio", return_value=True
-    ), patch(
+    ), patch("homeassistant.components.hassio.is_hassio", return_value=True), patch(
         "homeassistant.components.hassio.get_info", return_value=None
-    ), patch(
-        "homeassistant.helpers.system_info.cached_get_user", return_value="root"
-    ):
+    ), patch("homeassistant.helpers.system_info.cached_get_user", return_value="root"):
         info = await async_get_system_info(hass)
         assert isinstance(info, dict)
         assert info["version"] == current_version
@@ -60,9 +56,7 @@ async def test_get_system_info_supervisor_not_loaded(hass: HomeAssistant) -> Non
         "homeassistant.helpers.system_info.is_docker_env", return_value=True
     ), patch(
         "homeassistant.helpers.system_info.is_official_image", return_value=True
-    ), patch(
-        "homeassistant.components.hassio.get_info", return_value=None
-    ), patch.dict(
+    ), patch("homeassistant.components.hassio.get_info", return_value=None), patch.dict(
         os.environ, {"SUPERVISOR": "127.0.0.1"}
     ):
         info = await async_get_system_info(hass)
@@ -79,9 +73,7 @@ async def test_container_installationtype(hass: HomeAssistant) -> None:
         "homeassistant.helpers.system_info.is_docker_env", return_value=True
     ), patch(
         "homeassistant.helpers.system_info.is_official_image", return_value=True
-    ), patch(
-        "homeassistant.helpers.system_info.cached_get_user", return_value="root"
-    ):
+    ), patch("homeassistant.helpers.system_info.cached_get_user", return_value="root"):
         info = await async_get_system_info(hass)
         assert info["installation_type"] == "Home Assistant Container"
 
@@ -89,9 +81,7 @@ async def test_container_installationtype(hass: HomeAssistant) -> None:
         "homeassistant.helpers.system_info.is_docker_env", return_value=True
     ), patch(
         "homeassistant.helpers.system_info.is_official_image", return_value=False
-    ), patch(
-        "homeassistant.helpers.system_info.cached_get_user", return_value="user"
-    ):
+    ), patch("homeassistant.helpers.system_info.cached_get_user", return_value="user"):
         info = await async_get_system_info(hass)
         assert info["installation_type"] == "Unsupported Third Party Container"
 

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -31,9 +31,7 @@ async def test_requirement_installed_in_venv(hass: HomeAssistant) -> None:
         "homeassistant.util.package.is_virtual_env", return_value=True
     ), patch("homeassistant.util.package.is_docker_env", return_value=False), patch(
         "homeassistant.util.package.install_package", return_value=True
-    ) as mock_install, patch.dict(
-        os.environ, env_without_wheel_links(), clear=True
-    ):
+    ) as mock_install, patch.dict(os.environ, env_without_wheel_links(), clear=True):
         hass.config.skip_pip = False
         mock_integration(hass, MockModule("comp", requirements=["package==0.0.1"]))
         assert await setup.async_setup_component(hass, "comp", {})
@@ -51,9 +49,7 @@ async def test_requirement_installed_in_deps(hass: HomeAssistant) -> None:
         "homeassistant.util.package.is_virtual_env", return_value=False
     ), patch("homeassistant.util.package.is_docker_env", return_value=False), patch(
         "homeassistant.util.package.install_package", return_value=True
-    ) as mock_install, patch.dict(
-        os.environ, env_without_wheel_links(), clear=True
-    ):
+    ) as mock_install, patch.dict(os.environ, env_without_wheel_links(), clear=True):
         hass.config.skip_pip = False
         mock_integration(hass, MockModule("comp", requirements=["package==0.0.1"]))
         assert await setup.async_setup_component(hass, "comp", {})
@@ -368,9 +364,7 @@ async def test_install_with_wheels_index(hass: HomeAssistant) -> None:
         "homeassistant.util.package.is_docker_env", return_value=True
     ), patch("homeassistant.util.package.install_package") as mock_inst, patch.dict(
         os.environ, {"WHEELS_LINKS": "https://wheels.hass.io/test"}
-    ), patch(
-        "os.path.dirname"
-    ) as mock_dir:
+    ), patch("os.path.dirname") as mock_dir:
         mock_dir.return_value = "ha_package_path"
         assert await setup.async_setup_component(hass, "comp", {})
         assert "comp" in hass.config.components
@@ -391,9 +385,7 @@ async def test_install_on_docker(hass: HomeAssistant) -> None:
         "homeassistant.util.package.is_docker_env", return_value=True
     ), patch("homeassistant.util.package.install_package") as mock_inst, patch(
         "os.path.dirname"
-    ) as mock_dir, patch.dict(
-        os.environ, env_without_wheel_links(), clear=True
-    ):
+    ) as mock_dir, patch.dict(os.environ, env_without_wheel_links(), clear=True):
         mock_dir.return_value = "ha_package_path"
         assert await setup.async_setup_component(hass, "comp", {})
         assert "comp" in hass.config.components

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -364,7 +364,9 @@ async def test_install_with_wheels_index(hass: HomeAssistant) -> None:
         "homeassistant.util.package.is_docker_env", return_value=True
     ), patch("homeassistant.util.package.install_package") as mock_inst, patch.dict(
         os.environ, {"WHEELS_LINKS": "https://wheels.hass.io/test"}
-    ), patch("os.path.dirname") as mock_dir:
+    ), patch(
+        "os.path.dirname",
+    ) as mock_dir:
         mock_dir.return_value = "ha_package_path"
         assert await setup.async_setup_component(hass, "comp", {})
         assert "comp" in hass.config.components

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -74,7 +74,9 @@ def test_run_executor_shutdown_throws(
     ), patch(
         "homeassistant.runner.InterruptibleThreadPoolExecutor.shutdown",
         side_effect=RuntimeError,
-    ) as mock_shutdown, patch("homeassistant.core.HomeAssistant.async_run") as mock_run:
+    ) as mock_shutdown, patch(
+        "homeassistant.core.HomeAssistant.async_run",
+    ) as mock_run:
         runner.run(default_config)
 
     assert mock_shutdown.called

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -74,9 +74,7 @@ def test_run_executor_shutdown_throws(
     ), patch(
         "homeassistant.runner.InterruptibleThreadPoolExecutor.shutdown",
         side_effect=RuntimeError,
-    ) as mock_shutdown, patch(
-        "homeassistant.core.HomeAssistant.async_run"
-    ) as mock_run:
+    ) as mock_shutdown, patch("homeassistant.core.HomeAssistant.async_run") as mock_run:
         runner.run(default_config)
 
     assert mock_shutdown.called


### PR DESCRIPTION
## Breaking change (for developers only)

* ~There is no `"python.formatting.provider": "ruff"` configuration for VSCode users.~

## Proposed change

This proposes to switch the formatting for the project from `black` to `ruff-format` ([released in October](https://astral.sh/blog/the-ruff-formatter)).

The Ruff folks are tracking home-assistant's code style c.f. that of `ruff-format`'s, and [it's roughly 99.9% compatible](https://github.com/astral-sh/ruff/actions/runs/6661598076#summary-18104703550) at this point.

You can find the proposed reformatting diff at 2dd0a74b38ecb454762850b1e0c4aba9da2d0986 in this gist: https://gist.github.com/akx/89e5d6ee7bfeda70a2466c1d591d2922 (updated).
To my eye, the changes seem pretty superficial.

As before with Ruff, the big win is performance. There'll be no need to faff around with a Black cache anymore in CI (and the entire partial/full checks could be unified to "just always check everything").

This `hyperfine`ing is on a pretty beefy 12-core M2 Max Macbook, FWIW. Caches are disabled to level the playground.

```
$ env BLACK_CACHE_DIR=/dev/null hyperfine -N -i 'black --check .' 'ruff format --no-cache --check .'
Benchmark 1: black --check .
  Time (mean ± σ):     36.258 s ±  6.661 s    [User: 242.110 s, System: 4.790 s]
  Range (min … max):   27.607 s … 45.987 s    10 runs

Benchmark 2: ruff format --no-cache --check .
  Time (mean ± σ):     418.4 ms ±   9.4 ms    [User: 3603.6 ms, System: 311.9 ms]
  Range (min … max):   407.5 ms … 436.3 ms    10 runs

  Warning: Ignoring non-zero exit code.

Summary
  ruff format --no-cache --check . ran
   86.66 ± 16.04 times faster than black --check .
$
```

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
  - Aside from a warning:
    > The following rules may cause conflicts when used with the formatter: `ISC001`.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
  - For obvious reasons, nope... 😁  
- [ ] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
