### PR TITLE
Differentiate between warnings and errors in check_config helper

### DIFF
--- a/homeassistant/components/config/core.py
+++ b/homeassistant/components/config/core.py
@@ -7,9 +7,8 @@ import voluptuous as vol
 from homeassistant.components import websocket_api
 from homeassistant.components.http import HomeAssistantView, require_admin
 from homeassistant.components.sensor import async_update_suggested_units
-from homeassistant.config import async_check_ha_config_file
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import check_config, config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util import location, unit_system
 
@@ -31,11 +30,18 @@ class CheckConfigView(HomeAssistantView):
     @require_admin
     async def post(self, request):
         """Validate configuration and return results."""
-        errors = await async_check_ha_config_file(request.app["hass"])
 
-        state = "invalid" if errors else "valid"
+        res = await check_config.async_check_ha_config_file(request.app["hass"])
 
-        return self.json({"result": state, "errors": errors})
+        state = "invalid" if res.errors else "valid"
+
+        return self.json(
+            {
+                "result": state,
+                "errors": res.error_str or None,
+                "warnings": res.warning_str or None,
+            }
+        )
 
 
 @websocket_api.require_admin

--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -119,6 +119,10 @@ async def async_check_ha_config_file(  # noqa: C901
         try:
             integration = await async_get_integration_with_requirements(hass, domain)
         except loader.IntegrationNotFound as ex:
+            # We get this error if an integration is not found. In recovery mode and
+            # safe mode, this currently happens for all custom integrations. Don't
+            # show errors for a missing integration in recovery mode or safe mode to
+            # not confuse the user.
             if not hass.config.recovery_mode and not hass.config.safe_mode:
                 result.add_warning(f"Integration error: {domain} - {ex}")
         except RequirementsNotFound as ex:
@@ -253,6 +257,10 @@ async def async_check_ha_config_file(  # noqa: C901
                 )
                 platform = p_integration.get_platform(domain)
             except loader.IntegrationNotFound as ex:
+                # We get this error if an integration is not found. In recovery mode and
+                # safe mode, this currently happens for all custom integrations. Don't
+                # show errors for a missing integration in recovery mode or safe mode to
+                # not confuse the user.
                 if not hass.config.recovery_mode and not hass.config.safe_mode:
                     result.add_warning(f"Platform error {domain}.{p_name} - {ex}")
                 continue

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -40,6 +40,7 @@ PATCHES: dict[str, Any] = {}
 
 C_HEAD = "bold"
 ERROR_STR = "General Errors"
+WARNING_STR = "General Warnings"
 
 
 def color(the_color, *args, reset=None):
@@ -116,6 +117,18 @@ def run(script_args: list) -> int:
             dump_dict(config, reset="red")
             print(color("reset"))
 
+    if res["warn"]:
+        print(color("bold_white", "Incorrect config"))
+        for domain, config in res["warn"].items():
+            domain_info.append(domain)
+            print(
+                " ",
+                color("bold_yellow", domain + ":"),
+                color("yellow", "", reset="yellow"),
+            )
+            dump_dict(config, reset="yellow")
+            print(color("reset"))
+
     if domain_info:
         if "all" in domain_info:
             print(color("bold_white", "Successful config (all)"))
@@ -160,7 +173,8 @@ def check(config_dir, secrets=False):
     res: dict[str, Any] = {
         "yaml_files": OrderedDict(),  # yaml_files loaded
         "secrets": OrderedDict(),  # secret cache and secrets loaded
-        "except": OrderedDict(),  # exceptions raised (with config)
+        "except": OrderedDict(),  # critical exceptions raised (with config)
+        "warn": OrderedDict(),  # non critical exceptions raised (with config)
         #'components' is a HomeAssistantConfig  # noqa: E265
         "secret_cache": {},
     }
@@ -214,6 +228,12 @@ def check(config_dir, secrets=False):
             res["except"].setdefault(domain, []).append(err.message)
             if err.config:
                 res["except"].setdefault(domain, []).append(err.config)
+
+        for err in res["components"].warnings:
+            domain = err.domain or WARNING_STR
+            res["warn"].setdefault(domain, []).append(err.message)
+            if err.config:
+                res["warn"].setdefault(domain, []).append(err.config)
 
     except Exception as err:  # pylint: disable=broad-except
         print(color("red", "Fatal error while loading config:"), str(err))

--- a/tests/components/config/test_core.py
+++ b/tests/components/config/test_core.py
@@ -1,6 +1,6 @@
 """Test core config."""
 from http import HTTPStatus
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -37,9 +37,14 @@ async def test_validate_config_ok(
 
     client = await hass_client()
 
+    no_error = Mock()
+    no_error.errors = None
+    no_error.error_str = ""
+    no_error.warning_str = ""
+
     with patch(
-        "homeassistant.components.config.core.async_check_ha_config_file",
-        return_value=None,
+        "homeassistant.components.config.core.check_config.async_check_ha_config_file",
+        return_value=no_error,
     ):
         resp = await client.post("/api/config/core/check_config")
 
@@ -47,10 +52,16 @@ async def test_validate_config_ok(
     result = await resp.json()
     assert result["result"] == "valid"
     assert result["errors"] is None
+    assert result["warnings"] is None
+
+    error_warning = Mock()
+    error_warning.errors = ["beer"]
+    error_warning.error_str = "beer"
+    error_warning.warning_str = "milk"
 
     with patch(
-        "homeassistant.components.config.core.async_check_ha_config_file",
-        return_value="beer",
+        "homeassistant.components.config.core.check_config.async_check_ha_config_file",
+        return_value=error_warning,
     ):
         resp = await client.post("/api/config/core/check_config")
 
@@ -58,6 +69,24 @@ async def test_validate_config_ok(
     result = await resp.json()
     assert result["result"] == "invalid"
     assert result["errors"] == "beer"
+    assert result["warnings"] == "milk"
+
+    warning = Mock()
+    warning.errors = None
+    warning.error_str = ""
+    warning.warning_str = "milk"
+
+    with patch(
+        "homeassistant.components.config.core.check_config.async_check_ha_config_file",
+        return_value=warning,
+    ):
+        resp = await client.post("/api/config/core/check_config")
+
+    assert resp.status == HTTPStatus.OK
+    result = await resp.json()
+    assert result["result"] == "valid"
+    assert result["errors"] is None
+    assert result["warnings"] == "milk"
 
 
 async def test_validate_config_requires_admin(

--- a/tests/helpers/test_check_config.py
+++ b/tests/helpers/test_check_config.py
@@ -1,6 +1,6 @@
 """Test check_config helper."""
 import logging
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -54,13 +54,13 @@ def _assert_warnings_errors(
     error_str = ""
     warning_str = ""
 
-    for idx, error in enumerate(res.errors):
-        assert error == errors[idx]
+    for idx, error in enumerate(errors):
+        assert error == res.errors[idx]
         error_str += error.message
     assert res.error_str == error_str
 
-    for idx, warning in enumerate(res.warnings):
-        assert warning == warnings[idx]
+    for idx, warning in enumerate(warnings):
+        assert warning == res.warnings[idx]
         warning_str += warning.message
     assert res.warning_str == warning_str
 
@@ -298,13 +298,12 @@ async def test_missing_included_file(hass: HomeAssistant) -> None:
         res = await async_check_ha_config_file(hass)
         log_ha_config(res)
 
-        error = CheckConfigError(
-            ANY,
-            None,
-            None,
-        )
-        _assert_warnings_errors(res, [error], [])
+        assert len(res.errors) == 1
+        assert len(res.warnings) == 0
+
         assert res.errors[0].message.startswith("Error loading")
+        assert res.errors[0].domain is None
+        assert res.errors[0].config is None
 
 
 async def test_automation_config_platform(hass: HomeAssistant) -> None:
@@ -366,8 +365,6 @@ bla:
             {"value": 1},
         )
         _assert_warnings_errors(res, [error], [])
-        assert len(res.errors) == 1
-        assert len(res.warnings) == 0
 
 
 async def test_removed_yaml_support(hass: HomeAssistant) -> None:

--- a/tests/helpers/test_check_config.py
+++ b/tests/helpers/test_check_config.py
@@ -274,7 +274,7 @@ async def test_component_config_platform_import_error(hass: HomeAssistant) -> No
 async def test_component_platform_import_error(hass: HomeAssistant) -> None:
     """Test errors if component or platform not found."""
     # Make sure they don't exist
-    files = {YAML_CONFIG_FILE: BASE_CONFIG + "light:\n  platform: beer"}
+    files = {YAML_CONFIG_FILE: BASE_CONFIG + "light:\n  platform: demo"}
     with patch(
         "homeassistant.loader.Integration.get_platform",
         side_effect=[None, ImportError("blablabla")],
@@ -284,7 +284,7 @@ async def test_component_platform_import_error(hass: HomeAssistant) -> None:
 
         assert res.keys() == {"homeassistant", "light"}
         error = CheckConfigError(
-            "Platform error light.beer - Integration 'beer' not found.",
+            "Platform error light.demo - blablabla",
             None,
             None,
         )

--- a/tests/helpers/test_check_config.py
+++ b/tests/helpers/test_check_config.py
@@ -45,24 +45,24 @@ def log_ha_config(conf):
 
 def _assert_warnings_errors(
     res: HomeAssistantConfig,
-    errors: list[CheckConfigError],
-    warnings: list[CheckConfigError],
+    expected_warnings: list[CheckConfigError],
+    expected_errors: list[CheckConfigError],
 ) -> None:
-    assert len(res.errors) == len(errors)
-    assert len(res.warnings) == len(warnings)
+    assert len(res.warnings) == len(expected_warnings)
+    assert len(res.errors) == len(expected_errors)
 
-    error_str = ""
-    warning_str = ""
+    expected_warning_str = ""
+    expected_error_str = ""
 
-    for idx, error in enumerate(errors):
-        assert error == res.errors[idx]
-        error_str += error.message
-    assert res.error_str == error_str
+    for idx, expected_warning in enumerate(expected_warnings):
+        assert res.warnings[idx] == expected_warning
+        expected_warning_str += expected_warning.message
+    assert res.warning_str == expected_warning_str
 
-    for idx, warning in enumerate(warnings):
-        assert warning == res.warnings[idx]
-        warning_str += warning.message
-    assert res.warning_str == warning_str
+    for idx, expected_error in enumerate(expected_errors):
+        assert res.errors[idx] == expected_error
+        expected_error_str += expected_error.message
+    assert res.error_str == expected_error_str
 
 
 async def test_bad_core_config(hass: HomeAssistant) -> None:
@@ -77,7 +77,7 @@ async def test_bad_core_config(hass: HomeAssistant) -> None:
             "homeassistant",
             {"unit_system": "bad"},
         )
-        _assert_warnings_errors(res, [error], [])
+        _assert_warnings_errors(res, [], [error])
 
 
 async def test_config_platform_valid(hass: HomeAssistant) -> None:
@@ -104,7 +104,7 @@ async def test_component_platform_not_found(hass: HomeAssistant) -> None:
         warning = CheckConfigError(
             "Integration error: beer - Integration 'beer' not found.", None, None
         )
-        _assert_warnings_errors(res, [], [warning])
+        _assert_warnings_errors(res, [warning], [])
 
 
 async def test_component_requirement_not_found(hass: HomeAssistant) -> None:
@@ -127,7 +127,7 @@ async def test_component_requirement_not_found(hass: HomeAssistant) -> None:
             None,
             None,
         )
-        _assert_warnings_errors(res, [], [warning])
+        _assert_warnings_errors(res, [warning], [])
 
 
 async def test_component_not_found_recovery_mode(hass: HomeAssistant) -> None:
@@ -173,7 +173,7 @@ async def test_component_import_error(hass: HomeAssistant) -> None:
             None,
             None,
         )
-        _assert_warnings_errors(res, [], [warning])
+        _assert_warnings_errors(res, [warning], [])
 
 
 @pytest.mark.parametrize(
@@ -218,7 +218,7 @@ async def test_component_platform_not_found_2(hass: HomeAssistant) -> None:
         warning = CheckConfigError(
             "Platform error light.beer - Integration 'beer' not found.", None, None
         )
-        _assert_warnings_errors(res, [], [warning])
+        _assert_warnings_errors(res, [warning], [])
 
 
 async def test_platform_not_found_recovery_mode(hass: HomeAssistant) -> None:
@@ -268,7 +268,7 @@ async def test_component_config_platform_import_error(hass: HomeAssistant) -> No
             None,
             None,
         )
-        _assert_warnings_errors(res, [error], [])
+        _assert_warnings_errors(res, [], [error])
 
 
 async def test_component_platform_import_error(hass: HomeAssistant) -> None:
@@ -283,12 +283,12 @@ async def test_component_platform_import_error(hass: HomeAssistant) -> None:
         log_ha_config(res)
 
         assert res.keys() == {"homeassistant", "light"}
-        error = CheckConfigError(
+        warning = CheckConfigError(
             "Platform error light.demo - blablabla",
             None,
             None,
         )
-        _assert_warnings_errors(res, [], [error])
+        _assert_warnings_errors(res, [warning], [])
 
 
 async def test_package_invalid(hass: HomeAssistant) -> None:
@@ -308,7 +308,7 @@ async def test_package_invalid(hass: HomeAssistant) -> None:
             "homeassistant.packages.p1.group",
             {"group": ["a"]},
         )
-        _assert_warnings_errors(res, [], [warning])
+        _assert_warnings_errors(res, [warning], [])
 
 
 async def test_missing_included_file(hass: HomeAssistant) -> None:
@@ -384,7 +384,7 @@ bla:
             "bla",
             {"value": 1},
         )
-        _assert_warnings_errors(res, [error], [])
+        _assert_warnings_errors(res, [], [error])
 
 
 async def test_removed_yaml_support(hass: HomeAssistant) -> None:

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -49,6 +49,7 @@ def test_bad_core_config(mock_is_file, event_loop, mock_hass_config_yaml: None) 
     res = check_config.check(get_test_config_dir())
     assert res["except"].keys() == {"homeassistant"}
     assert res["except"]["homeassistant"][1] == {"unit_system": "bad"}
+    assert res["warn"] == {}
 
 
 @pytest.mark.parametrize("hass_config_yaml", [BASE_CONFIG + "light:\n  platform: demo"])
@@ -62,6 +63,7 @@ def test_config_platform_valid(
     assert res["except"] == {}
     assert res["secret_cache"] == {}
     assert res["secrets"] == {}
+    assert res["warn"] == {}
     assert len(res["yaml_files"]) == 1
 
 
@@ -87,9 +89,10 @@ def test_component_platform_not_found(
     # Make sure they don't exist
     res = check_config.check(get_test_config_dir())
     assert res["components"].keys() == platforms
-    assert res["except"] == {check_config.ERROR_STR: [error]}
+    assert res["except"] == {}
     assert res["secret_cache"] == {}
     assert res["secrets"] == {}
+    assert res["warn"] == {check_config.WARNING_STR: [error]}
     assert len(res["yaml_files"]) == 1
 
 
@@ -123,6 +126,7 @@ def test_secrets(mock_is_file, event_loop, mock_hass_config_yaml: None) -> None:
         get_test_config_dir("secrets.yaml"): {"http_pw": "http://google.com"}
     }
     assert res["secrets"] == {"http_pw": "http://google.com"}
+    assert res["warn"] == {}
     assert normalize_yaml_files(res) == [
         ".../configuration.yaml",
         ".../secrets.yaml",
@@ -136,13 +140,12 @@ def test_package_invalid(mock_is_file, event_loop, mock_hass_config_yaml: None) 
     """Test an invalid package."""
     res = check_config.check(get_test_config_dir())
 
-    assert res["except"].keys() == {"homeassistant.packages.p1.group"}
-    assert res["except"]["homeassistant.packages.p1.group"][1] == {"group": ["a"]}
-    assert len(res["except"]) == 1
+    assert res["except"] == {}
     assert res["components"].keys() == {"homeassistant"}
-    assert len(res["components"]) == 1
     assert res["secret_cache"] == {}
     assert res["secrets"] == {}
+    assert res["warn"].keys() == {"homeassistant.packages.p1.group"}
+    assert res["warn"]["homeassistant.packages.p1.group"][1] == {"group": ["a"]}
     assert len(res["yaml_files"]) == 1
 
 
@@ -158,4 +161,5 @@ def test_bootstrap_error(event_loop, mock_hass_config_yaml: None) -> None:
     assert res["components"] == {}  # No components, load failed
     assert res["secret_cache"] == {}
     assert res["secrets"] == {}
+    assert res["warn"] == {}
     assert res["yaml_files"] == {}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Differentiate between warnings and errors in check_config helper

Restarting or shutting down core is not blocked by warnings reported by the check_config helper.

These issues are classified as errors, preventing core from restarting or shutting down:
- configuration file is missing
- configuration file can't be loaded, for example because of a yaml syntax error
- `homeassistant` configuration is not valid
- An integration has a `config` platform, but the `config` platform can't be imported
- An integration has a `config` platform, but calling it fails

#### Rationale
We block restarting or shutting down core via services if the configuration is invalid. The checks currently block shutting down also for critical errors.

With this PR, we will for example allow restarting or shutting down if the configuration references a non-existing integration which we handle during startup, but we still block restarting or shutting down if the configuration can not be parsed.

The goal is that that we want to be able to restart even if individual integrations have invalid config since the application should be robust for errors in individual integrations and we should be able to address invalid config per integration without blocking the whole application from restarting.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
