### PR TITLE
Hide mac address from HomeWizard Energy config entry/discovery titles

### DIFF
--- a/homeassistant/components/homewizard/config_flow.py
+++ b/homeassistant/components/homewizard/config_flow.py
@@ -121,14 +121,18 @@ class HomeWizardConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors = {"base": ex.error_code}
             else:
                 return self.async_create_entry(
-                    title=f"{self.discovery.product_name} ({self.discovery.serial})",
+                    title=self.discovery.product_name,
                     data={CONF_IP_ADDRESS: self.discovery.ip},
                 )
 
         self._set_confirm_only()
-        self.context["title_placeholders"] = {
-            "name": f"{self.discovery.product_name} ({self.discovery.serial})"
-        }
+
+        # We won't be adding mac/serial to the title for devices
+        # that users generally don't have multiple of.
+        name = self.discovery.product_name
+        if self.discovery.product_type not in ["HWE-P1", "HWE-WTR"]:
+            name = f"{name} ({self.discovery.serial})"
+        self.context["title_placeholders"] = {"name": name}
 
         return self.async_show_form(
             step_id="discovery_confirm",

--- a/homeassistant/components/homewizard/config_flow.py
+++ b/homeassistant/components/homewizard/config_flow.py
@@ -62,7 +62,7 @@ class HomeWizardConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
                 self._abort_if_unique_id_configured(updates=user_input)
                 return self.async_create_entry(
-                    title=f"{device_info.product_name} ({device_info.serial})",
+                    title=f"{device_info.product_name}",
                     data=user_input,
                 )
 

--- a/tests/components/homewizard/test_config_flow.py
+++ b/tests/components/homewizard/test_config_flow.py
@@ -43,7 +43,7 @@ async def test_manual_flow_works(
         )
 
     assert result["type"] == "create_entry"
-    assert result["title"] == "P1 meter (aabbccddeeff)"
+    assert result["title"] == "P1 meter"
     assert result["data"][CONF_IP_ADDRESS] == "2.2.2.2"
 
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1

--- a/tests/components/homewizard/test_config_flow.py
+++ b/tests/components/homewizard/test_config_flow.py
@@ -68,8 +68,8 @@ async def test_discovery_flow_works(
         properties={
             "api_enabled": "1",
             "path": "/api/v1",
-            "product_name": "P1 meter",
-            "product_type": "HWE-P1",
+            "product_name": "Energy Socket",
+            "product_type": "HWE-SKT",
             "serial": "aabbccddeeff",
         },
     )
@@ -109,11 +109,11 @@ async def test_discovery_flow_works(
         )
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == "P1 meter (aabbccddeeff)"
+    assert result["title"] == "Energy Socket"
     assert result["data"][CONF_IP_ADDRESS] == "192.168.43.183"
 
     assert result["result"]
-    assert result["result"].unique_id == "HWE-P1_aabbccddeeff"
+    assert result["result"].unique_id == "HWE-SKT_aabbccddeeff"
 
 
 async def test_discovery_flow_during_onboarding(
@@ -149,7 +149,7 @@ async def test_discovery_flow_during_onboarding(
         )
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == "P1 meter (aabbccddeeff)"
+    assert result["title"] == "P1 meter"
     assert result["data"][CONF_IP_ADDRESS] == "192.168.43.183"
 
     assert result["result"]
@@ -214,7 +214,7 @@ async def test_discovery_flow_during_onboarding_disabled_api(
         )
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == "P1 meter (aabbccddeeff)"
+    assert result["title"] == "P1 meter"
     assert result["data"][CONF_IP_ADDRESS] == "192.168.43.183"
 
     assert result["result"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Removes the serial/MAC address of the devices from the discovery titles of HomeWizard devices that the user won't have multiple of (like the water meter or P1 meter). The others I've left intact, as in those cases, people might have multiple (although I highly doubt the helpfulness, to be honest).

See last two device in this screenshot:

![CleanShot 2023-10-27 at 22 16 15@2x](https://github.com/home-assistant/core/assets/195327/597cf737-f78e-4074-a292-9d90688c80c4)

Also, remove the serial/MAC address from the device names. As of Home Assistant 2023.11, these are shown on the device pages already anyway. So, removing them provides a cleaner user experience.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
