### PR TITLE
Cleanups in HomeWizard Energy sensors

### DIFF
--- a/homeassistant/components/homewizard/sensor.py
+++ b/homeassistant/components/homewizard/sensor.py
@@ -89,7 +89,9 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         translation_key="active_tariff",
         icon="mdi:calendar-clock",
         has_fn=lambda data: data.active_tariff is not None,
-        value_fn=lambda data: data.active_tariff,
+        value_fn=lambda data: (
+            None if data.active_tariff is None else str(data.active_tariff)
+        ),
         device_class=SensorDeviceClass.ENUM,
         options=["1", "2", "3", "4"],
     ),

--- a/homeassistant/components/homewizard/sensor.py
+++ b/homeassistant/components/homewizard/sensor.py
@@ -216,7 +216,9 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
-        has_fn=lambda data: data.active_power_l1_w is not None,
+        has_fn=lambda data: (
+            data.active_power_l1_w is not None and data.active_power_l2_w is not None
+        ),
         value_fn=lambda data: data.active_power_l1_w,
     ),
     HomeWizardSensorEntityDescription(

--- a/homeassistant/components/homewizard/sensor.py
+++ b/homeassistant/components/homewizard/sensor.py
@@ -213,6 +213,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
         has_fn=lambda data: data.active_power_w is not None,
         value_fn=lambda data: data.active_power_w,
     ),
@@ -222,6 +223,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
         has_fn=lambda data: (
             data.active_power_l1_w is not None and data.active_power_l2_w is not None
         ),
@@ -233,6 +235,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
         has_fn=lambda data: data.active_power_l2_w is not None,
         value_fn=lambda data: data.active_power_l2_w,
     ),
@@ -242,6 +245,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
         has_fn=lambda data: data.active_power_l3_w is not None,
         value_fn=lambda data: data.active_power_l3_w,
     ),

--- a/homeassistant/components/homewizard/sensor.py
+++ b/homeassistant/components/homewizard/sensor.py
@@ -121,7 +121,10 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        has_fn=lambda data: data.total_power_import_t1_kwh is not None,
+        has_fn=lambda data: (
+            data.total_power_import_t1_kwh is not None
+            and data.total_power_import_t2_kwh is not None
+        ),
         value_fn=lambda data: data.total_power_import_t1_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
@@ -167,7 +170,10 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        has_fn=lambda data: data.total_power_export_t1_kwh is not None,
+        has_fn=lambda data: (
+            data.total_power_export_t1_kwh is not None
+            and data.total_power_export_t2_kwh is not None
+        ),
         enabled_fn=lambda data: data.total_power_export_t1_kwh != 0,
         value_fn=lambda data: data.total_power_export_t1_kwh or None,
     ),

--- a/homeassistant/components/homewizard/sensor.py
+++ b/homeassistant/components/homewizard/sensor.py
@@ -89,9 +89,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         translation_key="active_tariff",
         icon="mdi:calendar-clock",
         has_fn=lambda data: data.active_tariff is not None,
-        value_fn=lambda data: (
-            None if data.active_tariff is None else str(data.active_tariff)
-        ),
+        value_fn=lambda data: data.active_tariff,
         device_class=SensorDeviceClass.ENUM,
         options=["1", "2", "3", "4"],
     ),

--- a/tests/components/homewizard/test_sensor.py
+++ b/tests/components/homewizard/test_sensor.py
@@ -254,6 +254,32 @@ async def test_sensor_entity_wifi_strength(
     assert entry.disabled
 
 
+async def test_no_sensor_entity_total_power_import_tariff_1_kwh(
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
+    """Test entity does not load total power import t1 on single phase."""
+
+    api = get_mock_device()
+    api.data = AsyncMock(
+        return_value=Data.from_dict({"total_power_import_t1_kwh": 1234.123})
+    )
+
+    with patch(
+        "homeassistant.components.homewizard.coordinator.HomeWizardEnergy",
+        return_value=api,
+    ):
+        entry = mock_config_entry
+        entry.data = mock_config_entry_data
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert not hass.states.get(
+        "sensor.product_name_aabbccddeeff_total_power_import_tariff_1"
+    )
+
+
 async def test_sensor_entity_total_power_import_tariff_1_kwh(
     hass: HomeAssistant, mock_config_entry_data, mock_config_entry
 ) -> None:
@@ -261,7 +287,12 @@ async def test_sensor_entity_total_power_import_tariff_1_kwh(
 
     api = get_mock_device()
     api.data = AsyncMock(
-        return_value=Data.from_dict({"total_power_import_t1_kwh": 1234.123})
+        return_value=Data.from_dict(
+            {
+                "total_power_import_t1_kwh": 1234.123,
+                "total_power_import_t2_kwh": 1234.123,
+            }
+        )
     )
 
     with patch(
@@ -342,6 +373,32 @@ async def test_sensor_entity_total_power_import_tariff_2_kwh(
     assert ATTR_ICON not in state.attributes
 
 
+async def test_no_sensor_entity_total_power_export_tariff_1_kwh(
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
+    """Test entity not load total power export t1 on single phase."""
+
+    api = get_mock_device()
+    api.data = AsyncMock(
+        return_value=Data.from_dict({"total_power_export_t1_kwh": 1234.123})
+    )
+
+    with patch(
+        "homeassistant.components.homewizard.coordinator.HomeWizardEnergy",
+        return_value=api,
+    ):
+        entry = mock_config_entry
+        entry.data = mock_config_entry_data
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert not hass.states.get(
+        "sensor.product_name_aabbccddeeff_total_power_export_tariff_1"
+    )
+
+
 async def test_sensor_entity_total_power_export_tariff_1_kwh(
     hass: HomeAssistant, mock_config_entry_data, mock_config_entry
 ) -> None:
@@ -349,7 +406,12 @@ async def test_sensor_entity_total_power_export_tariff_1_kwh(
 
     api = get_mock_device()
     api.data = AsyncMock(
-        return_value=Data.from_dict({"total_power_export_t1_kwh": 1234.123})
+        return_value=Data.from_dict(
+            {
+                "total_power_export_t1_kwh": 1234.123,
+                "total_power_export_t2_kwh": 1234.123,
+            }
+        )
     )
 
     with patch(
@@ -1704,7 +1766,7 @@ async def test_sensors_unreachable(
 
     api = get_mock_device()
     api.data = AsyncMock(
-        return_value=Data.from_dict({"total_power_import_t1_kwh": 1234.123})
+        return_value=Data.from_dict({"total_power_import_kwh": 1234.123})
     )
 
     with patch(
@@ -1720,9 +1782,7 @@ async def test_sensors_unreachable(
         utcnow = dt_util.utcnow()  # Time after the integration is setup
 
         assert (
-            hass.states.get(
-                "sensor.product_name_aabbccddeeff_total_power_import_tariff_1"
-            ).state
+            hass.states.get("sensor.product_name_aabbccddeeff_total_power_import").state
             == "1234.123"
         )
 
@@ -1730,9 +1790,7 @@ async def test_sensors_unreachable(
         async_fire_time_changed(hass, utcnow + timedelta(seconds=5))
         await hass.async_block_till_done()
         assert (
-            hass.states.get(
-                "sensor.product_name_aabbccddeeff_total_power_import_tariff_1"
-            ).state
+            hass.states.get("sensor.product_name_aabbccddeeff_total_power_import").state
             == "unavailable"
         )
 
@@ -1740,9 +1798,7 @@ async def test_sensors_unreachable(
         async_fire_time_changed(hass, utcnow + timedelta(seconds=10))
         await hass.async_block_till_done()
         assert (
-            hass.states.get(
-                "sensor.product_name_aabbccddeeff_total_power_import_tariff_1"
-            ).state
+            hass.states.get("sensor.product_name_aabbccddeeff_total_power_import").state
             == "1234.123"
         )
 
@@ -1754,7 +1810,7 @@ async def test_api_disabled(
 
     api = get_mock_device()
     api.data = AsyncMock(
-        return_value=Data.from_dict({"total_power_import_t1_kwh": 1234.123})
+        return_value=Data.from_dict({"total_power_import_kwh": 1234.123})
     )
 
     with patch(
@@ -1770,9 +1826,7 @@ async def test_api_disabled(
         utcnow = dt_util.utcnow()  # Time after the integration is setup
 
         assert (
-            hass.states.get(
-                "sensor.product_name_aabbccddeeff_total_power_import_tariff_1"
-            ).state
+            hass.states.get("sensor.product_name_aabbccddeeff_total_power_import").state
             == "1234.123"
         )
 
@@ -1780,8 +1834,6 @@ async def test_api_disabled(
         async_fire_time_changed(hass, utcnow + timedelta(seconds=5))
         await hass.async_block_till_done()
         assert (
-            hass.states.get(
-                "sensor.product_name_aabbccddeeff_total_power_import_tariff_1"
-            ).state
+            hass.states.get("sensor.product_name_aabbccddeeff_total_power_import").state
             == "unavailable"
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When a HomeWizard Energy device only measures a single phase (e.g., a plug or single-phase kWh meter), it will create a duplicate power sensor.

Normally the integration creates a sensor for each phase + a total. However, when there is just a single phase, the total & the phase sensors, will have the same value (and thus, duplicate data is shown and recorded).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
