### PR TITLE
✨ Support TARGET_TEMPERATURE_RANGE for water heater entities

### DIFF
--- a/homeassistant/components/water_heater/__init__.py
+++ b/homeassistant/components/water_heater/__init__.py
@@ -28,6 +28,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
     PLATFORM_SCHEMA_BASE,
+    make_entity_service_schema,
 )
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
@@ -62,6 +63,7 @@ class WaterHeaterEntityFeature(IntFlag):
     OPERATION_MODE = 2
     AWAY_MODE = 4
     ON_OFF = 8
+    TARGET_TEMPERATURE_RANGE = 16
 
 
 # These SUPPORT_* constants are deprecated as of Home Assistant 2022.5.
@@ -79,7 +81,7 @@ ATTR_TARGET_TEMP_HIGH = "target_temp_high"
 ATTR_TARGET_TEMP_LOW = "target_temp_low"
 ATTR_CURRENT_TEMPERATURE = "current_temperature"
 
-CONVERTIBLE_ATTRIBUTE = [ATTR_TEMPERATURE]
+CONVERTIBLE_ATTRIBUTE = [ATTR_TEMPERATURE, ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -91,14 +93,19 @@ SET_AWAY_MODE_SCHEMA = vol.Schema(
         vol.Required(ATTR_AWAY_MODE): cv.boolean,
     }
 )
-SET_TEMPERATURE_SCHEMA = vol.Schema(
-    vol.All(
+SET_TEMPERATURE_SCHEMA = vol.All(
+    cv.has_at_least_one_key(
+        ATTR_TEMPERATURE, ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW
+    ),
+    make_entity_service_schema(
         {
-            vol.Required(ATTR_TEMPERATURE, "temperature"): vol.Coerce(float),
+            vol.Exclusive(ATTR_TEMPERATURE, "temperature"): vol.Coerce(float),
+            vol.Inclusive(ATTR_TARGET_TEMP_HIGH, "temperature"): vol.Coerce(float),
+            vol.Inclusive(ATTR_TARGET_TEMP_LOW, "temperature"): vol.Coerce(float),
             vol.Optional(ATTR_ENTITY_ID): cv.comp_entity_ids,
             vol.Optional(ATTR_OPERATION_MODE): cv.string,
         }
-    )
+    ),
 )
 SET_OPERATION_MODE_SCHEMA = vol.Schema(
     {
@@ -127,7 +134,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         SERVICE_SET_AWAY_MODE, SET_AWAY_MODE_SCHEMA, async_service_away_mode
     )
     component.async_register_entity_service(
-        SERVICE_SET_TEMPERATURE, SET_TEMPERATURE_SCHEMA, async_service_temperature_set
+        SERVICE_SET_TEMPERATURE,
+        SET_TEMPERATURE_SCHEMA,
+        async_service_temperature_set,
+        [
+            WaterHeaterEntityFeature.TARGET_TEMPERATURE,
+            WaterHeaterEntityFeature.TARGET_TEMPERATURE_RANGE,
+        ],
     )
     component.async_register_entity_service(
         SERVICE_SET_OPERATION_MODE,
@@ -177,7 +190,7 @@ class WaterHeaterEntity(Entity):
     _attr_operation_list: list[str] | None = None
     _attr_precision: float
     _attr_state: None = None
-    _attr_supported_features: WaterHeaterEntityFeature = WaterHeaterEntityFeature(0)
+    _attr_supported_features: WaterHeaterEntityFeature = WaterHeaterEntityFeature(1)
     _attr_target_temperature_high: float | None = None
     _attr_target_temperature_low: float | None = None
     _attr_target_temperature: float | None = None
@@ -219,6 +232,7 @@ class WaterHeaterEntity(Entity):
     @property
     def state_attributes(self) -> dict[str, Any]:
         """Return the optional state attributes."""
+        supported_features = self.supported_features
         data: dict[str, Any] = {
             ATTR_CURRENT_TEMPERATURE: show_temp(
                 self.hass,
@@ -226,25 +240,27 @@ class WaterHeaterEntity(Entity):
                 self.temperature_unit,
                 self.precision,
             ),
-            ATTR_TEMPERATURE: show_temp(
+        }
+        if supported_features & WaterHeaterEntityFeature.TARGET_TEMPERATURE:
+            data[ATTR_TEMPERATURE] = show_temp(
                 self.hass,
                 self.target_temperature,
                 self.temperature_unit,
                 self.precision,
-            ),
-            ATTR_TARGET_TEMP_HIGH: show_temp(
+            )
+        if supported_features & WaterHeaterEntityFeature.TARGET_TEMPERATURE_RANGE:
+            data[ATTR_TARGET_TEMP_HIGH] = show_temp(
                 self.hass,
                 self.target_temperature_high,
                 self.temperature_unit,
                 self.precision,
-            ),
-            ATTR_TARGET_TEMP_LOW: show_temp(
+            )
+            data[ATTR_TARGET_TEMP_LOW] = show_temp(
                 self.hass,
                 self.target_temperature_low,
                 self.temperature_unit,
                 self.precision,
-            ),
-        }
+            )
 
         if self.supported_features & WaterHeaterEntityFeature.OPERATION_MODE:
             data[ATTR_OPERATION_MODE] = self.current_operation
@@ -282,12 +298,18 @@ class WaterHeaterEntity(Entity):
 
     @property
     def target_temperature_high(self) -> float | None:
-        """Return the highbound target temperature we try to reach."""
+        """Return the highbound target temperature we try to reach.
+
+        Requires WaterHeaterEntityFeature.TARGET_TEMPERATURE_RANGE.
+        """
         return self._attr_target_temperature_high
 
     @property
     def target_temperature_low(self) -> float | None:
-        """Return the lowbound target temperature we try to reach."""
+        """Return the lowbound target temperature we try to reach.
+
+        Requires WaterHeaterEntityFeature.TARGET_TEMPERATURE_RANGE.
+        """
         return self._attr_target_temperature_low
 
     @property

--- a/tests/components/water_heater/test_init.py
+++ b/tests/components/water_heater/test_init.py
@@ -53,13 +53,34 @@ async def test_set_temp_schema(
     assert len(calls) == 1
     assert calls[-1].data == data
 
+async def test_set_temp_schema_high(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test the set temperature schema with ok required data."""
+    domain = "water_heater"
+    service = "test_set_temperature"
+    schema = SET_TEMPERATURE_SCHEMA
+    calls = async_mock_service(hass, domain, service, schema)
+
+    data = {
+        "target_temp_high": 30.0,
+        "target_temp_low": 20.0,
+        "operation_mode": "gas",
+        "entity_id": ["water_heater.test_id"],
+    }
+    await hass.services.async_call(domain, service, data)
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert calls[-1].data == data
+
 
 class MockWaterHeaterEntity(WaterHeaterEntity):
     """Mock water heater device to use in tests."""
 
     _attr_operation_list: list[str] = ["off", "heat_pump", "gas"]
     _attr_operation = "heat_pump"
-    _attr_supported_features = WaterHeaterEntityFeature.ON_OFF
+    _attr_supported_features = WaterHeaterEntityFeature.ON_OFF | WaterHeaterEntityFeature.TARGET_TEMPERATURE_RANGE
 
 
 async def test_sync_turn_on(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

Expected changes:
- integration exposing water heater entities should be aware that `set_temperature` might not contain `temperature` field anymore but can contain `target_temp_high` and `target_temp_low` instead.

State of water_heater entities will not contain `target_temp_high` and `target_temp_low` unless those features are explicitly supported.

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This patch allows to set temperature_target_{high, low} with `water_heater.set_temperature` service.

Those values were already present before this patch but could not be set with a service.
This patch changes the default WaterHeaterEntityFeature to include TARGET_TEMPERATURE to be fully backward compatible.

This is heavily inspired by the same behavior on ClimateEntity.

This patch opens the way for the UI to expose/update high/low temperature targets.

See https://github.com/home-assistant/architecture/discussions/995


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1962

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
