### PR TITLE
Update Idasen Desk to fulfill Silver requirements

### DIFF
--- a/homeassistant/components/idasen_desk/__init__.py
+++ b/homeassistant/components/idasen_desk/__init__.py
@@ -44,6 +44,7 @@ class IdasenDeskCoordinator(DataUpdateCoordinator[int | None]):
         super().__init__(hass, logger, name=name)
         self._address = address
         self._expected_connected = False
+        self._connection_lost = False
 
         self.desk = Desk(self.async_set_updated_data)
 
@@ -63,6 +64,7 @@ class IdasenDeskCoordinator(DataUpdateCoordinator[int | None]):
         """Disconnect from desk."""
         _LOGGER.debug("Disconnecting from %s", self._address)
         self._expected_connected = False
+        self._connection_lost = False
         await self.desk.disconnect()
 
     @callback
@@ -71,7 +73,11 @@ class IdasenDeskCoordinator(DataUpdateCoordinator[int | None]):
         if self._expected_connected:
             if not self.desk.is_connected:
                 _LOGGER.debug("Desk disconnected. Reconnecting")
+                self._connection_lost = True
                 self.hass.async_create_task(self.async_connect())
+            elif self._connection_lost:
+                _LOGGER.info("Reconnected to desk")
+                self._connection_lost = False
         elif self.desk.is_connected:
             _LOGGER.warning("Desk is connected but should not be. Disconnecting")
             self.hass.async_create_task(self.desk.disconnect())

--- a/homeassistant/components/idasen_desk/cover.py
+++ b/homeassistant/components/idasen_desk/cover.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from bleak.exc import BleakError
+
 from homeassistant.components.cover import (
     ATTR_POSITION,
     CoverDeviceClass,
@@ -12,6 +14,7 @@ from homeassistant.components.cover import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_NAME
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -71,19 +74,33 @@ class IdasenDeskCover(CoordinatorEntity[IdasenDeskCoordinator], CoverEntity):
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
-        await self._desk.move_down()
+        try:
+            await self._desk.move_down()
+        except BleakError as err:
+            raise HomeAssistantError("Failed to move down: Bluetooth error") from err
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        await self._desk.move_up()
+        try:
+            await self._desk.move_up()
+        except BleakError as err:
+            raise HomeAssistantError("Failed to move up: Bluetooth error") from err
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
-        await self._desk.stop()
+        try:
+            await self._desk.stop()
+        except BleakError as err:
+            raise HomeAssistantError("Failed to stop moving: Bluetooth error") from err
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover shutter to a specific position."""
-        await self._desk.move_to(int(kwargs[ATTR_POSITION]))
+        try:
+            await self._desk.move_to(int(kwargs[ATTR_POSITION]))
+        except BleakError as err:
+            raise HomeAssistantError(
+                "Failed to move to specified position: Bluetooth error"
+            ) from err
 
     @callback
     def _handle_coordinator_update(self, *args: Any) -> None:

--- a/homeassistant/components/idasen_desk/manifest.json
+++ b/homeassistant/components/idasen_desk/manifest.json
@@ -11,5 +11,6 @@
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/idasen_desk",
   "iot_class": "local_push",
+  "quality_scale": "silver",
   "requirements": ["idasen-ha==2.3"]
 }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Minor changes to make the integration fulfill the requirements for the Silver quality scale.

Silver🥈 checklist:

- [x] Satisfying all No score level requirements.
- [x] Connection/configuration is handled via a component.
- [ ] ~~Set an appropriate SCAN_INTERVAL (if a polling integration)~~ - NOT APPLICABLE
- [x] Raise PlatformNotReady if unable to connect during platform setup (if appropriate)
- [ ] ~~Handles expiration of auth credentials. Refresh if possible or print correct error and fail setup. If based on a config entry, should trigger a new config entry flow to re-authorize.~~ - NOT APPLICABLE
- [ ] ~~Handles internet unavailable. Log a warning once when unavailable, log once when reconnected.~~ - NOT APPLICABLE
- [x] Handles device/service unavailable. Log a warning once when unavailable, log once when reconnected.
- [x] Operations like service calls and entity methods (e.g. Set HVAC Mode) have proper exception handling. Raise ValueError on invalid user input and raise HomeAssistantError for other failures such as a problem communicating with a device.
- [x] Set available property to False if appropriate
- [x] Entities have unique ID (if available)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
