### PR TITLE
Show proper name on Airzone Cloud errors

### DIFF
--- a/homeassistant/components/airzone_cloud/climate.py
+++ b/homeassistant/components/airzone_cloud/climate.py
@@ -20,6 +20,7 @@ from aioairzone_cloud.const import (
     AZD_MASTER,
     AZD_MODE,
     AZD_MODES,
+    AZD_NAME,
     AZD_NUM_DEVICES,
     AZD_NUM_GROUPS,
     AZD_POWER,
@@ -386,4 +387,6 @@ class AirzoneZoneClimate(AirzoneZoneEntity, AirzoneDeviceClimate):
         await self._async_update_params(params)
 
         if slave_raise:
-            raise HomeAssistantError(f"Mode can't be changed on slave zone {self.name}")
+            raise HomeAssistantError(
+                f"Mode can't be changed on slave zone {self.get_airzone_value(AZD_NAME)}"
+            )

--- a/homeassistant/components/airzone_cloud/climate.py
+++ b/homeassistant/components/airzone_cloud/climate.py
@@ -20,7 +20,6 @@ from aioairzone_cloud.const import (
     AZD_MASTER,
     AZD_MODE,
     AZD_MODES,
-    AZD_NAME,
     AZD_NUM_DEVICES,
     AZD_NUM_GROUPS,
     AZD_POWER,
@@ -388,5 +387,5 @@ class AirzoneZoneClimate(AirzoneZoneEntity, AirzoneDeviceClimate):
 
         if slave_raise:
             raise HomeAssistantError(
-                f"Mode can't be changed on slave zone {self.get_airzone_value(AZD_NAME)}"
+                f"Mode can't be changed on slave zone {self.entity_id}"
             )

--- a/homeassistant/components/airzone_cloud/entity.py
+++ b/homeassistant/components/airzone_cloud/entity.py
@@ -80,14 +80,16 @@ class AirzoneAidooEntity(AirzoneEntity):
 
     async def _async_update_params(self, params: dict[str, Any]) -> None:
         """Send Aidoo parameters to Cloud API."""
-        _LOGGER.debug("aidoo=%s: update_params=%s", self.name, params)
+        _LOGGER.debug(
+            "aidoo=%s: update_params=%s", self.get_airzone_value(AZD_NAME), params
+        )
         try:
             await self.coordinator.airzone.api_set_aidoo_id_params(
                 self.aidoo_id, params
             )
         except AirzoneCloudError as error:
             raise HomeAssistantError(
-                f"Failed to set {self.name} params: {error}"
+                f"Failed to set {self.get_airzone_value(AZD_NAME)} params: {error}"
             ) from error
 
         self.coordinator.async_set_updated_data(self.coordinator.airzone.data())
@@ -122,14 +124,16 @@ class AirzoneGroupEntity(AirzoneEntity):
 
     async def _async_update_params(self, params: dict[str, Any]) -> None:
         """Send Group parameters to Cloud API."""
-        _LOGGER.debug("group=%s: update_params=%s", self.name, params)
+        _LOGGER.debug(
+            "group=%s: update_params=%s", self.get_airzone_value(AZD_NAME), params
+        )
         try:
             await self.coordinator.airzone.api_set_group_id_params(
                 self.group_id, params
             )
         except AirzoneCloudError as error:
             raise HomeAssistantError(
-                f"Failed to set {self.name} params: {error}"
+                f"Failed to set {self.get_airzone_value(AZD_NAME)} params: {error}"
             ) from error
 
         self.coordinator.async_set_updated_data(self.coordinator.airzone.data())
@@ -164,14 +168,18 @@ class AirzoneInstallationEntity(AirzoneEntity):
 
     async def _async_update_params(self, params: dict[str, Any]) -> None:
         """Send Installation parameters to Cloud API."""
-        _LOGGER.debug("installation=%s: update_params=%s", self.name, params)
+        _LOGGER.debug(
+            "installation=%s: update_params=%s",
+            self.get_airzone_value(AZD_NAME),
+            params,
+        )
         try:
             await self.coordinator.airzone.api_set_installation_id_params(
                 self.inst_id, params
             )
         except AirzoneCloudError as error:
             raise HomeAssistantError(
-                f"Failed to set {self.name} params: {error}"
+                f"Failed to set {self.get_airzone_value(AZD_NAME)} params: {error}"
             ) from error
 
         self.coordinator.async_set_updated_data(self.coordinator.airzone.data())
@@ -267,12 +275,14 @@ class AirzoneZoneEntity(AirzoneEntity):
 
     async def _async_update_params(self, params: dict[str, Any]) -> None:
         """Send Zone parameters to Cloud API."""
-        _LOGGER.debug("zone=%s: update_params=%s", self.name, params)
+        _LOGGER.debug(
+            "zone=%s: update_params=%s", self.get_airzone_value(AZD_NAME), params
+        )
         try:
             await self.coordinator.airzone.api_set_zone_id_params(self.zone_id, params)
         except AirzoneCloudError as error:
             raise HomeAssistantError(
-                f"Failed to set {self.name} params: {error}"
+                f"Failed to set {self.get_airzone_value(AZD_NAME)} params: {error}"
             ) from error
 
         self.coordinator.async_set_updated_data(self.coordinator.airzone.data())

--- a/homeassistant/components/airzone_cloud/entity.py
+++ b/homeassistant/components/airzone_cloud/entity.py
@@ -80,16 +80,14 @@ class AirzoneAidooEntity(AirzoneEntity):
 
     async def _async_update_params(self, params: dict[str, Any]) -> None:
         """Send Aidoo parameters to Cloud API."""
-        _LOGGER.debug(
-            "aidoo=%s: update_params=%s", self.get_airzone_value(AZD_NAME), params
-        )
+        _LOGGER.debug("aidoo=%s: update_params=%s", self.entity_id, params)
         try:
             await self.coordinator.airzone.api_set_aidoo_id_params(
                 self.aidoo_id, params
             )
         except AirzoneCloudError as error:
             raise HomeAssistantError(
-                f"Failed to set {self.get_airzone_value(AZD_NAME)} params: {error}"
+                f"Failed to set {self.entity_id} params: {error}"
             ) from error
 
         self.coordinator.async_set_updated_data(self.coordinator.airzone.data())
@@ -124,16 +122,14 @@ class AirzoneGroupEntity(AirzoneEntity):
 
     async def _async_update_params(self, params: dict[str, Any]) -> None:
         """Send Group parameters to Cloud API."""
-        _LOGGER.debug(
-            "group=%s: update_params=%s", self.get_airzone_value(AZD_NAME), params
-        )
+        _LOGGER.debug("group=%s: update_params=%s", self.entity_id, params)
         try:
             await self.coordinator.airzone.api_set_group_id_params(
                 self.group_id, params
             )
         except AirzoneCloudError as error:
             raise HomeAssistantError(
-                f"Failed to set {self.get_airzone_value(AZD_NAME)} params: {error}"
+                f"Failed to set {self.entity_id} params: {error}"
             ) from error
 
         self.coordinator.async_set_updated_data(self.coordinator.airzone.data())
@@ -170,7 +166,7 @@ class AirzoneInstallationEntity(AirzoneEntity):
         """Send Installation parameters to Cloud API."""
         _LOGGER.debug(
             "installation=%s: update_params=%s",
-            self.get_airzone_value(AZD_NAME),
+            self.entity_id,
             params,
         )
         try:
@@ -179,7 +175,7 @@ class AirzoneInstallationEntity(AirzoneEntity):
             )
         except AirzoneCloudError as error:
             raise HomeAssistantError(
-                f"Failed to set {self.get_airzone_value(AZD_NAME)} params: {error}"
+                f"Failed to set {self.entity_id} params: {error}"
             ) from error
 
         self.coordinator.async_set_updated_data(self.coordinator.airzone.data())
@@ -275,14 +271,12 @@ class AirzoneZoneEntity(AirzoneEntity):
 
     async def _async_update_params(self, params: dict[str, Any]) -> None:
         """Send Zone parameters to Cloud API."""
-        _LOGGER.debug(
-            "zone=%s: update_params=%s", self.get_airzone_value(AZD_NAME), params
-        )
+        _LOGGER.debug("zone=%s: update_params=%s", self.entity_id, params)
         try:
             await self.coordinator.airzone.api_set_zone_id_params(self.zone_id, params)
         except AirzoneCloudError as error:
             raise HomeAssistantError(
-                f"Failed to set {self.get_airzone_value(AZD_NAME)} params: {error}"
+                f"Failed to set {self.entity_id} params: {error}"
             ) from error
 
         self.coordinator.async_set_updated_data(self.coordinator.airzone.data())


### PR DESCRIPTION
## Proposed change
Show proper entity name on Airzone Cloud errors.
After entity name code changes, if there's a HomeAssistantError raised, None will be shown for its name.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
