### PR TITLE
Add button platform to Roborock

### DIFF
--- a/homeassistant/components/roborock/button.py
+++ b/homeassistant/components/roborock/button.py
@@ -1,0 +1,116 @@
+"""Support for Roborock button."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from roborock.roborock_typing import RoborockCommand
+
+from homeassistant.components.button import (
+    ButtonDeviceClass,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import slugify
+
+from .const import DOMAIN
+from .coordinator import RoborockDataUpdateCoordinator
+from .device import RoborockEntity
+
+
+@dataclass
+class RoborockButtonDescriptionMixin:
+    """Define an entity description mixin for button entities."""
+
+    command: RoborockCommand
+    param: list | dict | None
+
+
+@dataclass
+class RoborockButtonDescription(
+    ButtonEntityDescription, RoborockButtonDescriptionMixin
+):
+    """Describes a Roborock button entity."""
+
+
+CONSUMABLE_BUTTON_DESCRIPTIONS = [
+    RoborockButtonDescription(
+        key="reset_sensor_consumable",
+        device_class=ButtonDeviceClass.UPDATE,
+        translation_key="reset_sensor_consumable",
+        command=RoborockCommand.RESET_CONSUMABLE,
+        param=["sensor_dirty_time"],
+        entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
+    ),
+    RoborockButtonDescription(
+        key="reset_air_filter_consumable",
+        device_class=ButtonDeviceClass.UPDATE,
+        translation_key="reset_air_filter_consumable",
+        command=RoborockCommand.RESET_CONSUMABLE,
+        param=["filter_work_time"],
+        entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
+    ),
+    RoborockButtonDescription(
+        key="reset_side_brush_consumable",
+        device_class=ButtonDeviceClass.UPDATE,
+        translation_key="reset_side_brush_consumable",
+        command=RoborockCommand.RESET_CONSUMABLE,
+        param=["side_brush_work_time"],
+        entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
+    ),
+    RoborockButtonDescription(
+        key="reset_main_brush_consumable",
+        device_class=ButtonDeviceClass.UPDATE,
+        translation_key="reset_main_brush_consumable",
+        command=RoborockCommand.RESET_CONSUMABLE,
+        param=["main_brush_work_time"],
+        entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Roborock button platform."""
+    coordinators: dict[str, RoborockDataUpdateCoordinator] = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]
+    async_add_entities(
+        RoborockButtonEntity(
+            f"{description.key}_{slugify(device_id)}",
+            coordinator,
+            description,
+        )
+        for device_id, coordinator in coordinators.items()
+        for description in CONSUMABLE_BUTTON_DESCRIPTIONS
+    )
+
+
+class RoborockButtonEntity(RoborockEntity, ButtonEntity):
+    """A class to define Roborock button entities."""
+
+    entity_description: RoborockButtonDescription
+
+    def __init__(
+        self,
+        unique_id: str,
+        coordinator: RoborockDataUpdateCoordinator,
+        entity_description: RoborockButtonDescription,
+    ) -> None:
+        """Create a button entity."""
+        super().__init__(unique_id, coordinator.device_info, coordinator.api)
+        self.entity_description = entity_description
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        await self.send(self.entity_description.command, self.entity_description.param)

--- a/homeassistant/components/roborock/button.py
+++ b/homeassistant/components/roborock/button.py
@@ -5,11 +5,7 @@ from dataclasses import dataclass
 
 from roborock.roborock_typing import RoborockCommand
 
-from homeassistant.components.button import (
-    ButtonDeviceClass,
-    ButtonEntity,
-    ButtonEntityDescription,
-)
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
@@ -39,7 +35,7 @@ class RoborockButtonDescription(
 CONSUMABLE_BUTTON_DESCRIPTIONS = [
     RoborockButtonDescription(
         key="reset_sensor_consumable",
-        device_class=ButtonDeviceClass.UPDATE,
+        icon="mdi:eye-outline",
         translation_key="reset_sensor_consumable",
         command=RoborockCommand.RESET_CONSUMABLE,
         param=["sensor_dirty_time"],
@@ -48,7 +44,7 @@ CONSUMABLE_BUTTON_DESCRIPTIONS = [
     ),
     RoborockButtonDescription(
         key="reset_air_filter_consumable",
-        device_class=ButtonDeviceClass.UPDATE,
+        icon="mdi:air-filter",
         translation_key="reset_air_filter_consumable",
         command=RoborockCommand.RESET_CONSUMABLE,
         param=["filter_work_time"],
@@ -57,7 +53,7 @@ CONSUMABLE_BUTTON_DESCRIPTIONS = [
     ),
     RoborockButtonDescription(
         key="reset_side_brush_consumable",
-        device_class=ButtonDeviceClass.UPDATE,
+        icon="mdi:brush",
         translation_key="reset_side_brush_consumable",
         command=RoborockCommand.RESET_CONSUMABLE,
         param=["side_brush_work_time"],
@@ -66,7 +62,7 @@ CONSUMABLE_BUTTON_DESCRIPTIONS = [
     ),
     RoborockButtonDescription(
         key="reset_main_brush_consumable",
-        device_class=ButtonDeviceClass.UPDATE,
+        icon="mdi:brush",
         translation_key="reset_main_brush_consumable",
         command=RoborockCommand.RESET_CONSUMABLE,
         param=["main_brush_work_time"],

--- a/homeassistant/components/roborock/const.py
+++ b/homeassistant/components/roborock/const.py
@@ -7,12 +7,12 @@ CONF_BASE_URL = "base_url"
 CONF_USER_DATA = "user_data"
 
 PLATFORMS = [
-    Platform.VACUUM,
+    Platform.BUTTON,
+    Platform.BINARY_SENSOR,
+    Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.TIME,
-    Platform.NUMBER,
-    Platform.BINARY_SENSOR,
-    Platform.BUTTON,
+    Platform.VACUUM,
 ]

--- a/homeassistant/components/roborock/const.py
+++ b/homeassistant/components/roborock/const.py
@@ -14,4 +14,5 @@ PLATFORMS = [
     Platform.TIME,
     Platform.NUMBER,
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
 ]

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -41,6 +41,20 @@
         "name": "Water shortage"
       }
     },
+    "button": {
+      "reset_sensor_consumable": {
+        "name": "Reset sensor consumable"
+      },
+      "reset_air_filter_consumable": {
+        "name": "Reset air filter consumable"
+      },
+      "reset_side_brush_consumable": {
+        "name": "Reset side brush consumable"
+      },
+      "reset_main_brush_consumable": {
+        "name": "Reset main brush consumable"
+      }
+    },
     "number": {
       "volume": {
         "name": "Volume"

--- a/tests/components/roborock/test_button.py
+++ b/tests/components/roborock/test_button.py
@@ -1,0 +1,40 @@
+"""Test Roborock Button platform."""
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.button import SERVICE_PRESS
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.parametrize(
+    ("entity_id"),
+    [
+        ("button.roborock_s7_maxv_reset_sensor_consumable"),
+        ("button.roborock_s7_maxv_reset_air_filter_consumable"),
+        ("button.roborock_s7_maxv_reset_side_brush_consumable"),
+        "button.roborock_s7_maxv_reset_main_brush_consumable",
+    ],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_update_success(
+    hass: HomeAssistant,
+    bypass_api_fixture,
+    setup_entry: MockConfigEntry,
+    entity_id: str,
+) -> None:
+    """Test allowed changing values for number entities."""
+    # Ensure that the entity exist, as these test can pass even if there is no entity.
+    assert hass.states.get(entity_id) is not None
+    with patch(
+        "homeassistant.components.roborock.coordinator.RoborockLocalClient.send_message"
+    ) as mock_send_message:
+        await hass.services.async_call(
+            "button",
+            SERVICE_PRESS,
+            blocking=True,
+            target={"entity_id": entity_id},
+        )
+    assert mock_send_message.assert_called_once

--- a/tests/components/roborock/test_button.py
+++ b/tests/components/roborock/test_button.py
@@ -18,6 +18,7 @@ from tests.common import MockConfigEntry
         "button.roborock_s7_maxv_reset_main_brush_consumable",
     ],
 )
+@pytest.mark.freeze_time("2023-10-30 08:50:00")
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_update_success(
     hass: HomeAssistant,
@@ -27,7 +28,7 @@ async def test_update_success(
 ) -> None:
     """Test pressing the button entities."""
     # Ensure that the entity exist, as these test can pass even if there is no entity.
-    assert hass.states.get(entity_id) is not None
+    assert hass.states.get(entity_id).state == "unknown"
     with patch(
         "homeassistant.components.roborock.coordinator.RoborockLocalClient.send_message"
     ) as mock_send_message:
@@ -38,3 +39,4 @@ async def test_update_success(
             target={"entity_id": entity_id},
         )
     assert mock_send_message.assert_called_once
+    assert hass.states.get(entity_id).state == "2023-10-30T08:50:00+00:00"

--- a/tests/components/roborock/test_button.py
+++ b/tests/components/roborock/test_button.py
@@ -25,7 +25,7 @@ async def test_update_success(
     setup_entry: MockConfigEntry,
     entity_id: str,
 ) -> None:
-    """Test allowed changing values for number entities."""
+    """Test pressing the button entities."""
     # Ensure that the entity exist, as these test can pass even if there is no entity.
     assert hass.states.get(entity_id) is not None
     with patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This gives users a way to reset their consumable data after they do maintenance on their vacuum. I've disabled it by default - as the user should know what they are doing before they hit this button as it cannot be undone.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29591

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
