### PR TITLE
Add torrent status metadata to qBittorrent integration

### DIFF
--- a/homeassistant/components/qbittorrent/__init__.py
+++ b/homeassistant/components/qbittorrent/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import DOMAIN
+from .const import CONF_CREATE_TORRENT_SENSORS, DOMAIN
 from .coordinator import QBittorrentDataCoordinator
 from .helpers import setup_client
 
@@ -27,6 +27,9 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up qBittorrent from a config entry."""
     hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][CONF_CREATE_TORRENT_SENSORS] = entry.data.get(
+        CONF_CREATE_TORRENT_SENSORS, False
+    )
     try:
         client = await hass.async_add_executor_job(
             setup_client,

--- a/homeassistant/components/qbittorrent/config_flow.py
+++ b/homeassistant/components/qbittorrent/config_flow.py
@@ -8,11 +8,16 @@ from qbittorrent.client import LoginRequired
 from requests.exceptions import RequestException
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    OptionsFlowWithConfigEntry,
+)
 from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME, CONF_VERIFY_SSL
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 
-from .const import DEFAULT_NAME, DEFAULT_URL, DOMAIN
+from .const import CONF_CREATE_TORRENT_SENSORS, DEFAULT_NAME, DEFAULT_URL, DOMAIN
 from .helpers import setup_client
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,9 +31,15 @@ USER_DATA_SCHEMA = vol.Schema(
     }
 )
 
+OPTIONS_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_CREATE_TORRENT_SENSORS, default=False): bool,
+    }
+)
+
 
 class QbittorrentConfigFlow(ConfigFlow, domain=DOMAIN):
-    """Config flow for the qBittorrent integration."""
+    """Config flow for the qBittorrent integration (for initial configuration)."""
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -55,3 +66,31 @@ class QbittorrentConfigFlow(ConfigFlow, domain=DOMAIN):
 
         schema = self.add_suggested_values_to_schema(USER_DATA_SCHEMA, user_input)
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> QbittorrentOptionsFlowHandler:
+        """Get the options flow for this handler."""
+        return QbittorrentOptionsFlowHandler(config_entry)
+
+
+class QbittorrentOptionsFlowHandler(OptionsFlowWithConfigEntry):
+    """Options flow for the qBittorrent integration (for modifying options once set up)."""
+
+    async def async_step_init(self, user_input=None):
+        """Manage the qBittorrent options."""
+        return await self.async_step_qbittorrent_options(user_input)
+
+    async def async_step_qbittorrent_options(self, user_input=None):
+        """Manage the qBittorrent options once an entry has already been initially configured."""
+        if not user_input:
+            schema = self.add_suggested_values_to_schema(
+                OPTIONS_DATA_SCHEMA, self.config_entry.options
+            )
+            return self.async_show_form(
+                step_id="qbittorrent_options", data_schema=schema
+            )
+
+        return self.async_create_entry(title=DEFAULT_NAME, data=user_input)

--- a/homeassistant/components/qbittorrent/config_flow.py
+++ b/homeassistant/components/qbittorrent/config_flow.py
@@ -8,16 +8,11 @@ from qbittorrent.client import LoginRequired
 from requests.exceptions import RequestException
 import voluptuous as vol
 
-from homeassistant.config_entries import (
-    ConfigEntry,
-    ConfigFlow,
-    OptionsFlowWithConfigEntry,
-)
+from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME, CONF_VERIFY_SSL
-from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 
-from .const import CONF_CREATE_TORRENT_SENSORS, DEFAULT_NAME, DEFAULT_URL, DOMAIN
+from .const import DEFAULT_NAME, DEFAULT_URL, DOMAIN
 from .helpers import setup_client
 
 _LOGGER = logging.getLogger(__name__)
@@ -28,12 +23,6 @@ USER_DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_USERNAME): str,
         vol.Required(CONF_PASSWORD): str,
         vol.Optional(CONF_VERIFY_SSL, default=True): bool,
-    }
-)
-
-OPTIONS_DATA_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_CREATE_TORRENT_SENSORS, default=False): bool,
     }
 )
 
@@ -66,31 +55,3 @@ class QbittorrentConfigFlow(ConfigFlow, domain=DOMAIN):
 
         schema = self.add_suggested_values_to_schema(USER_DATA_SCHEMA, user_input)
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
-
-    @staticmethod
-    @callback
-    def async_get_options_flow(
-        config_entry: ConfigEntry,
-    ) -> QbittorrentOptionsFlowHandler:
-        """Get the options flow for this handler."""
-        return QbittorrentOptionsFlowHandler(config_entry)
-
-
-class QbittorrentOptionsFlowHandler(OptionsFlowWithConfigEntry):
-    """Options flow for the qBittorrent integration (for modifying options once set up)."""
-
-    async def async_step_init(self, user_input=None):
-        """Manage the qBittorrent options."""
-        return await self.async_step_qbittorrent_options(user_input)
-
-    async def async_step_qbittorrent_options(self, user_input=None):
-        """Manage the qBittorrent options once an entry has already been initially configured."""
-        if not user_input:
-            schema = self.add_suggested_values_to_schema(
-                OPTIONS_DATA_SCHEMA, self.config_entry.options
-            )
-            return self.async_show_form(
-                step_id="qbittorrent_options", data_schema=schema
-            )
-
-        return self.async_create_entry(title=DEFAULT_NAME, data=user_input)

--- a/homeassistant/components/qbittorrent/const.py
+++ b/homeassistant/components/qbittorrent/const.py
@@ -5,3 +5,26 @@ DOMAIN: Final = "qbittorrent"
 
 DEFAULT_NAME = "qBittorrent"
 DEFAULT_URL = "http://127.0.0.1:8080"
+
+CONF_CREATE_TORRENT_SENSORS: Final = "create_torrent_sensors"
+
+"""
+Normalized states which match with qBittorrent's UI frontend categories:
+https://github.com/qbittorrent/qBittorrent/blob/7bd8f262dbcd153685ead13e972afba95b7eff6d/src/webui/www/private/scripts/dynamicTable.js#L967
+"""
+QBITTORRENT_TORRENT_STATES = {
+    "downloading": {"forcedDL", "metaDL", "forcedMetaDL", "downloading"},
+    "uploading": {"forcedUP", "uploading"},
+    "stalled": {"stalledUP", "stalledDL"},
+    "stopped": {"pausedDL"},
+    "completed": {"pausedUP"},
+    "queued": {"queued"},
+    "checking": {
+        "checkingDL",
+        "checkingUP",
+        "queuedForChecking",
+        "checkingResumeData",
+        "moving",
+    },
+    "error": {"error", "unknown", "missingFiles"},
+}

--- a/homeassistant/components/qbittorrent/sensor.py
+++ b/homeassistant/components/qbittorrent/sensor.py
@@ -83,23 +83,15 @@ def count_torrents(data: dict[str, Any], filter_state=None) -> int:
     return count
 
 
-def _map_torrent_state(raw_state: str) -> str:
-    """Given a raw torrent state, return the normalized state which matches with it."""
-    for key, options in QBITTORRENT_TORRENT_STATES.items():
-        if raw_state in options:
-            return key
-    return "unknown"
-
-
-def list_torrents(data: dict[str, Any], filter_state=None) -> Mapping[str, str]:
+def list_torrents(data: dict[str, Any], filter_state=None) -> Mapping[str, Any]:
     """Return a map from torrent name to the torrent's status, for torrents matching the given state filter."""
     torrents = data["torrents"]
-    attrs = {}
+    attrs: Mapping[str, Any] = {"torrent_names": []}
 
     for torrent in torrents.values():
         if not filter_state or torrent["state"] in filter_state:
             torrent_name = torrent["name"]
-            attrs[torrent_name] = _map_torrent_state(torrent["state"])
+            attrs["torrent_names"].append(torrent_name)
 
     return attrs
 

--- a/homeassistant/components/qbittorrent/strings.json
+++ b/homeassistant/components/qbittorrent/strings.json
@@ -17,5 +17,15 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
+  },
+  "options": {
+    "step": {
+      "qbittorrent_options": {
+        "description": "Options for qBittorrent",
+        "data": {
+          "create_torrent_sensors": "Create sensors for torrent statuses"
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/qbittorrent/strings.json
+++ b/homeassistant/components/qbittorrent/strings.json
@@ -17,15 +17,5 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
-  },
-  "options": {
-    "step": {
-      "qbittorrent_options": {
-        "description": "Options for qBittorrent",
-        "data": {
-          "create_torrent_sensors": "Create sensors for torrent statuses"
-        }
-      }
-    }
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds additional data from the qBittorrent API as optional HomeAssistant state sensors which shows the count of torrents across different categories, along with their names.

Adds an options section to the qBittorrent component with a default false option `CONF_CREATE_TORRENT_SENSORS`. When enabled, the following measurement sensors are created:

- `sensor.qbittorrent_torrents`: The total number of torrents in qBittorrent.
- `sensor.qbittorrent_torrents_downloading`: The number of downloading torrents.
- `sensor.qbittorrent_torrents_uploading`: The number of uploading (seeding) torrents.
- `sensor.qbittorrent_torrents_stalled`: The number of torrents which have stalled to download.
- `sensor.qbittorrent_torrents_stopped`: The number of torrents which were stopped from downloading or uploading by the user.
- `sensor.qbittorrent_torrents_completed`: The number of torrents which have been downloaded and met their required upload threshold.
- `sensor.qbittorrent_torrents_queued`: The number of torrents which are in the download queue.
- `sensor.qbittorrent_torrents_checking`: The number of torrents which are being checked.
- `sensor.qbittorrent_torrents_error`: The number of torrents which experienced errors during download.

Each contains the numeric count as a raw value of how many torrents match that criteria, and has an attribute named `torrent_names` with a list of the matching torrent names. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

The new post-initialization options window:

<img width="391" alt="image" src="https://github.com/home-assistant/core/assets/192620/d2d581c0-b28b-453a-a42a-5f6f5e43f179">

A list of the new entities in the UI:

<img width="912" alt="image" src="https://github.com/home-assistant/core/assets/192620/bf548869-2ac7-416e-8a21-c3678e700cb5">


- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/compare/next...jwoglom:home-assistant.io:patch-1

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] - https://github.com/home-assistant/home-assistant.io/pull/29595

<s>
If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.
</s>

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
