### PR TITLE
Handle invalid credentials in ViCare integration

### DIFF
--- a/homeassistant/components/vicare/config_flow.py
+++ b/homeassistant/components/vicare/config_flow.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from PyViCare.PyViCareUtils import PyViCareInvalidCredentialsError
+from PyViCare.PyViCareUtils import (
+    PyViCareInvalidConfigurationError,
+    PyViCareInvalidCredentialsError,
+)
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -53,6 +56,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 await self.hass.async_add_executor_job(
                     vicare_login, self.hass, user_input
                 )
+            except PyViCareInvalidConfigurationError:
+                errors["base"] = "invalid_auth"
             except PyViCareInvalidCredentialsError:
                 errors["base"] = "invalid_auth"
             else:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This handles an exception raised during the login process. 

```
File "/config/custom_components/vicare/config_flow.py", line 62, in async_step_user
File "/config/custom_components/vicare/__init__.py", line 44, in vicare_login
vicare_api.initWithCredentials(
File "/usr/local/lib/python3.11/site-packages/PyViCare/PyViCare.py", line 26, in initWithCredentials
self.initWithExternalOAuth(ViCareOAuthManager(
File "/usr/local/lib/python3.11/site-packages/PyViCare/PyViCareOAuthManager.py", line 30, in __init__
File "/usr/local/lib/python3.11/site-packages/PyViCare/PyViCareOAuthManager.py", line 38, in __restore_oauth_session_from_token
File "/usr/local/lib/python3.11/site-packages/PyViCare/PyViCareOAuthManager.py", line 68, in __create_new_session
raise PyViCareInvalidConfigurationError(response.json())
PyViCare.PyViCareUtils.PyViCareInvalidConfigurationError: (PyViCareInvalidConfigurationError(...), 'Invalid credentials. Error: invalid_request. Description: Client not registered.. Please check your configuration: clientid and redirect uri.')
```

When using invalid credentials or an invalid client id, the login requests fails ans the library raises a [`PyViCareInvalidConfigurationError`](https://github.com/somm15/PyViCare/blob/8ba411483a865e074d1146fd1b8b7a8c4f4be122/PyViCare/PyViCareOAuthManager.py#L67-L68) which was not handled.

<img width="401" alt="Bildschirmfoto 2023-10-30 um 11 46 42" src="https://github.com/home-assistant/core/assets/9592452/460ca616-aa53-4ca2-ae47-7e4b280f86cd">

For now it's just handled as the `PyViCareInvalidCredentialsError`, but probably a more specific error description that considers the response would be better. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
