### PR TITLE
Abort config flow if Google Tasks API is not enabled

### DIFF
--- a/homeassistant/components/google_tasks/config_flow.py
+++ b/homeassistant/components/google_tasks/config_flow.py
@@ -2,6 +2,13 @@
 import logging
 from typing import Any
 
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from googleapiclient.http import HttpRequest
+
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_TOKEN
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from .const import DOMAIN, OAUTH2_SCOPES
@@ -28,3 +35,24 @@ class OAuth2FlowHandler(
             "access_type": "offline",
             "prompt": "consent",
         }
+
+    async def async_oauth_create_entry(self, data: dict[str, Any]) -> FlowResult:
+        """Create an entry for the flow."""
+        try:
+            resource = build(
+                "tasks",
+                "v1",
+                credentials=Credentials(token=data[CONF_TOKEN][CONF_ACCESS_TOKEN]),
+            )
+            cmd: HttpRequest = resource.tasklists().list()
+            await self.hass.async_add_executor_job(cmd.execute)
+        except HttpError as ex:
+            error = ex.reason
+            return self.async_abort(
+                reason="access_not_configured",
+                description_placeholders={"message": error},
+            )
+        except Exception as ex:  # pylint: disable=broad-except
+            self.logger.error("Unknown error occurred: %s", ex.args)
+            return self.async_abort(reason="unknown")
+        return self.async_create_entry(title=self.flow_impl.name, data=data)

--- a/homeassistant/components/google_tasks/config_flow.py
+++ b/homeassistant/components/google_tasks/config_flow.py
@@ -53,6 +53,6 @@ class OAuth2FlowHandler(
                 description_placeholders={"message": error},
             )
         except Exception as ex:  # pylint: disable=broad-except
-            self.logger.error("Unknown error occurred: %s", ex.args)
+            self.logger.exception("Unknown error occurred: %s", ex)
             return self.async_abort(reason="unknown")
         return self.async_create_entry(title=self.flow_impl.name, data=data)

--- a/homeassistant/components/google_tasks/strings.json
+++ b/homeassistant/components/google_tasks/strings.json
@@ -15,7 +15,9 @@
       "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
       "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
       "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
-      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]"
+      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]",
+      "access_not_configured": "Please read the below message we got from Google:\n\n{message}",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "create_entry": {
       "default": "[%key:common::config_flow::create_entry::authenticated%]"

--- a/homeassistant/components/google_tasks/strings.json
+++ b/homeassistant/components/google_tasks/strings.json
@@ -16,7 +16,7 @@
       "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
       "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
       "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]",
-      "access_not_configured": "Please read the below message we got from Google:\n\n{message}",
+      "access_not_configured": "Unable to access the Google API:\n\n{message}",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "create_entry": {

--- a/tests/components/google_tasks/fixtures/api_not_enabled_response.json
+++ b/tests/components/google_tasks/fixtures/api_not_enabled_response.json
@@ -1,0 +1,15 @@
+{
+  "error": {
+    "code": 403,
+    "message": "Google Tasks API has not been used in project 977052058199 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/tasks.googleapis.com/overview?project=0 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
+    "errors": [
+      {
+        "message": "Google Tasks API has not been used in project 977052058199 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/tasks.googleapis.com/overview?project=0 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
+        "domain": "usageLimits",
+        "reason": "accessNotConfigured",
+        "extendedHelp": "https://console.developers.google.com"
+      }
+    ],
+    "status": "PERMISSION_DENIED"
+  }
+}

--- a/tests/components/google_tasks/fixtures/api_not_enabled_response.json
+++ b/tests/components/google_tasks/fixtures/api_not_enabled_response.json
@@ -1,10 +1,10 @@
 {
   "error": {
     "code": 403,
-    "message": "Google Tasks API has not been used in project 977052058199 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/tasks.googleapis.com/overview?project=0 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
+    "message": "Google Tasks API has not been used in project 0 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/tasks.googleapis.com/overview?project=0 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
     "errors": [
       {
-        "message": "Google Tasks API has not been used in project 977052058199 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/tasks.googleapis.com/overview?project=0 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
+        "message": "Google Tasks API has not been used in project 0 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/tasks.googleapis.com/overview?project=0 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
         "domain": "usageLimits",
         "reason": "accessNotConfigured",
         "extendedHelp": "https://console.developers.google.com"

--- a/tests/components/google_tasks/test_config_flow.py
+++ b/tests/components/google_tasks/test_config_flow.py
@@ -129,3 +129,55 @@ async def test_api_not_enabled(
         result["description_placeholders"]["message"]
         == "Google Tasks API has not been used in project 0 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/tasks.googleapis.com/overview?project=0 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry."
     )
+
+
+async def test_general_exception(
+    hass: HomeAssistant,
+    hass_client_no_auth,
+    aioclient_mock,
+    current_request_with_host,
+    setup_credentials,
+) -> None:
+    """Check flow aborts if exception happens."""
+    result = await hass.config_entries.flow.async_init(
+        "google_tasks", context={"source": config_entries.SOURCE_USER}
+    )
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": "https://example.com/auth/external/callback",
+        },
+    )
+
+    assert result["url"] == (
+        f"{OAUTH2_AUTHORIZE}?response_type=code&client_id={CLIENT_ID}"
+        "&redirect_uri=https://example.com/auth/external/callback"
+        f"&state={state}"
+        "&scope=https://www.googleapis.com/auth/tasks"
+        "&access_type=offline&prompt=consent"
+    )
+
+    client = await hass_client_no_auth()
+    resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
+    assert resp.status == 200
+    assert resp.headers["content-type"] == "text/html; charset=utf-8"
+
+    aioclient_mock.post(
+        OAUTH2_TOKEN,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": "mock-access-token",
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    with patch(
+        "homeassistant.components.google_tasks.config_flow.build",
+        side_effect=Exception,
+    ):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "unknown"

--- a/tests/components/google_tasks/test_config_flow.py
+++ b/tests/components/google_tasks/test_config_flow.py
@@ -127,5 +127,5 @@ async def test_api_not_enabled(
     assert result["reason"] == "access_not_configured"
     assert (
         result["description_placeholders"]["message"]
-        == "Google Tasks API has not been used in project 977052058199 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/tasks.googleapis.com/overview?project=0 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry."
+        == "Google Tasks API has not been used in project 0 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/tasks.googleapis.com/overview?project=0 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry."
     )

--- a/tests/components/google_tasks/test_config_flow.py
+++ b/tests/components/google_tasks/test_config_flow.py
@@ -79,7 +79,7 @@ async def test_api_not_enabled(
     current_request_with_host,
     setup_credentials,
 ) -> None:
-    """Check full flow."""
+    """Check flow aborts if api is not enabled."""
     result = await hass.config_entries.flow.async_init(
         "google_tasks", context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/google_tasks/test_config_flow.py
+++ b/tests/components/google_tasks/test_config_flow.py
@@ -2,6 +2,9 @@
 
 from unittest.mock import patch
 
+from googleapiclient.errors import HttpError
+from httplib2 import Response
+
 from homeassistant import config_entries
 from homeassistant.components.google_tasks.const import (
     DOMAIN,
@@ -9,7 +12,10 @@ from homeassistant.components.google_tasks.const import (
     OAUTH2_TOKEN,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import config_entry_oauth2_flow
+
+from tests.common import load_fixture
 
 CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
@@ -59,8 +65,67 @@ async def test_full_flow(
 
     with patch(
         "homeassistant.components.google_tasks.async_setup_entry", return_value=True
-    ) as mock_setup:
-        await hass.config_entries.flow.async_configure(result["flow_id"])
-
+    ) as mock_setup, patch("homeassistant.components.google_tasks.config_flow.build"):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert len(mock_setup.mock_calls) == 1
+
+
+async def test_api_not_enabled(
+    hass: HomeAssistant,
+    hass_client_no_auth,
+    aioclient_mock,
+    current_request_with_host,
+    setup_credentials,
+) -> None:
+    """Check full flow."""
+    result = await hass.config_entries.flow.async_init(
+        "google_tasks", context={"source": config_entries.SOURCE_USER}
+    )
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": "https://example.com/auth/external/callback",
+        },
+    )
+
+    assert result["url"] == (
+        f"{OAUTH2_AUTHORIZE}?response_type=code&client_id={CLIENT_ID}"
+        "&redirect_uri=https://example.com/auth/external/callback"
+        f"&state={state}"
+        "&scope=https://www.googleapis.com/auth/tasks"
+        "&access_type=offline&prompt=consent"
+    )
+
+    client = await hass_client_no_auth()
+    resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
+    assert resp.status == 200
+    assert resp.headers["content-type"] == "text/html; charset=utf-8"
+
+    aioclient_mock.post(
+        OAUTH2_TOKEN,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": "mock-access-token",
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    with patch(
+        "homeassistant.components.google_tasks.config_flow.build",
+        side_effect=HttpError(
+            Response({"status": "403"}),
+            bytes(load_fixture("google_tasks/api_not_enabled_response.json"), "utf-8"),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "access_not_configured"
+    assert (
+        result["description_placeholders"]["message"]
+        == "Google Tasks API has not been used in project 977052058199 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/tasks.googleapis.com/overview?project=0 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry."
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When creating the Youtube integration I got this as feedback. Yesterday I setup the integration without enabling the API on my production machine and it just worked. This PR aborts the flow when the API is not enabled.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
