### PR TITLE
Fix race starting reauth that allowed for multiple flows to be created

### DIFF
--- a/homeassistant/components/androidtv_remote/__init__.py
+++ b/homeassistant/components/androidtv_remote/__init__.py
@@ -57,7 +57,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     def reauth_needed() -> None:
         """Start a reauth flow if Android TV is hard reset while reconnecting."""
-        entry.async_start_reauth(hass)
+        hass.async_create_background_task(
+            entry.async_init_reauth(hass), f"reauth flow {DOMAIN} {entry.entry_id}"
+        )
 
     # Start a task (canceled in disconnect) to keep reconnecting if device becomes
     # network unreachable. If device gets a new IP address the zeroconf flow will

--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -226,7 +226,7 @@ class AppleTVManager:
             if conf := await self._scan():
                 await self._connect(conf, raise_missing_credentials)
         except exceptions.AuthenticationError:
-            self.config_entry.async_start_reauth(self.hass)
+            await self.config_entry.async_init_reauth(self.hass)
             await self.disconnect()
             _LOGGER.exception(
                 "Authentication failed for %s, try reconfiguring device",

--- a/homeassistant/components/bthome/__init__.py
+++ b/homeassistant/components/bthome/__init__.py
@@ -93,7 +93,12 @@ def process_service_info(
 
     # If payload is encrypted and the bindkey is not verified then we need to reauth
     if data.encryption_scheme != EncryptionScheme.NONE and not data.bindkey_verified:
-        entry.async_start_reauth(hass, data={"device": data})
+        # There is a small risk of race here if its called multiple times
+        # before the task it run since tasks are not eager.
+        hass.async_create_background_task(
+            entry.async_init_reauth(hass, data={"device": data}),
+            f"reauth flow {DOMAIN} {entry.entry_id}",
+        )
 
     return update
 

--- a/homeassistant/components/devolo_home_network/button.py
+++ b/homeassistant/components/devolo_home_network/button.py
@@ -123,7 +123,7 @@ class DevoloButtonEntity(DevoloEntity, ButtonEntity):
         try:
             await self.entity_description.press_func(self.device)
         except DevicePasswordProtected as ex:
-            self.entry.async_start_reauth(self.hass)
+            await self.entry.async_init_reauth(self.hass)
             raise HomeAssistantError(
                 f"Device {self.entry.title} require re-authenticatication to set or change the password"
             ) from ex

--- a/homeassistant/components/devolo_home_network/switch.py
+++ b/homeassistant/components/devolo_home_network/switch.py
@@ -115,7 +115,7 @@ class DevoloSwitchEntity(DevoloCoordinatorEntity[_DataT], SwitchEntity):
         try:
             await self.entity_description.turn_on_func(self.device)
         except DevicePasswordProtected as ex:
-            self.entry.async_start_reauth(self.hass)
+            await self.entry.async_init_reauth(self.hass)
             raise HomeAssistantError(
                 f"Device {self.entry.title} require re-authenticatication to set or change the password"
             ) from ex
@@ -128,7 +128,7 @@ class DevoloSwitchEntity(DevoloCoordinatorEntity[_DataT], SwitchEntity):
         try:
             await self.entity_description.turn_off_func(self.device)
         except DevicePasswordProtected as ex:
-            self.entry.async_start_reauth(self.hass)
+            await self.entry.async_init_reauth(self.hass)
             raise HomeAssistantError(
                 f"Device {self.entry.title} require re-authenticatication to set or change the password"
             ) from ex

--- a/homeassistant/components/devolo_home_network/update.py
+++ b/homeassistant/components/devolo_home_network/update.py
@@ -121,7 +121,7 @@ class DevoloUpdateEntity(DevoloCoordinatorEntity, UpdateEntity):
         try:
             await self.entity_description.update_func(self.device)
         except DevicePasswordProtected as ex:
-            self.entry.async_start_reauth(self.hass)
+            await self.entry.async_init_reauth(self.hass)
             raise HomeAssistantError(
                 f"Device {self.entry.title} require re-authentication to set or change the password"
             ) from ex

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -516,7 +516,7 @@ class ESPHomeManager:
                 InvalidAuthAPIError,
             ),
         ):
-            self.entry.async_start_reauth(self.hass)
+            await self.entry.async_init_reauth(self.hass)
 
     async def async_start(self) -> None:
         """Start the esphome connection manager."""

--- a/homeassistant/components/fitbit/sensor.py
+++ b/homeassistant/components/fitbit/sensor.py
@@ -726,7 +726,7 @@ class FitbitSensor(SensorEntity):
             )
         except FitbitAuthException:
             self._attr_available = False
-            self.config_entry.async_start_reauth(self.hass)
+            await self.config_entry.async_init_reauth(self.hass)
         except FitbitApiException:
             self._attr_available = False
         else:

--- a/homeassistant/components/google_assistant_sdk/helpers.py
+++ b/homeassistant/components/google_assistant_sdk/helpers.py
@@ -68,7 +68,7 @@ async def async_send_text_commands(
         await session.async_ensure_token_valid()
     except aiohttp.ClientResponseError as err:
         if 400 <= err.status < 500:
-            entry.async_start_reauth(hass)
+            await entry.async_init_reauth(hass)
         raise err
 
     credentials = Credentials(session.token[CONF_ACCESS_TOKEN])

--- a/homeassistant/components/google_mail/api.py
+++ b/homeassistant/components/google_mail/api.py
@@ -48,7 +48,7 @@ class AsyncConfigEntryAuth:
                 or hasattr(ex, "status")
                 and ex.status == 400
             ):
-                self.oauth_session.config_entry.async_start_reauth(
+                await self.oauth_session.config_entry.async_init_reauth(
                     self.oauth_session.hass
                 )
             raise HomeAssistantError(ex) from ex

--- a/homeassistant/components/google_sheets/__init__.py
+++ b/homeassistant/components/google_sheets/__init__.py
@@ -96,7 +96,9 @@ async def async_setup_service(hass: HomeAssistant) -> None:
         try:
             sheet = service.open_by_key(entry.unique_id)
         except RefreshError as ex:
-            entry.async_start_reauth(hass)
+            hass.async_create_background_task(
+                entry.async_init_reauth(hass), f"reauth flow {DOMAIN} {entry.entry_id}"
+            )
             raise ex
         except APIError as ex:
             raise HomeAssistantError("Failed to write data") from ex

--- a/homeassistant/components/homewizard/__init__.py
+++ b/homeassistant/components/homewizard/__init__.py
@@ -17,7 +17,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await coordinator.api.close()
 
         if coordinator.api_disabled:
-            entry.async_start_reauth(hass)
+            await entry.async_init_reauth(hass)
 
         raise
 

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -230,7 +230,7 @@ class IcloudAccount:
 
     def _require_reauth(self):
         """Require the user to log in again."""
-        self.hass.add_job(self._config_entry.async_start_reauth, self.hass)
+        self.hass.add_job(self._config_entry.async_init_reauth, self.hass)
 
     def _determine_interval(self) -> int:
         """Calculate new interval between two API fetch (in minutes)."""

--- a/homeassistant/components/imap/coordinator.py
+++ b/homeassistant/components/imap/coordinator.py
@@ -379,7 +379,7 @@ class ImapPollingDataUpdateCoordinator(ImapDataUpdateCoordinator):
                 _LOGGER.warning(
                     "Username or password incorrect, starting reauthentication"
                 )
-                self.config_entry.async_start_reauth(self.hass)
+                await self.config_entry.async_init_reauth(self.hass)
             self.async_set_update_error(ex)
             raise ConfigEntryAuthFailed() from ex
 
@@ -420,7 +420,7 @@ class ImapPushDataUpdateCoordinator(ImapDataUpdateCoordinator):
                     _LOGGER.warning(
                         "Username or password incorrect, starting reauthentication"
                     )
-                    self.config_entry.async_start_reauth(self.hass)
+                    await self.config_entry.async_init_reauth(self.hass)
                 self.async_set_update_error(ex)
                 await asyncio.sleep(BACKOFF_TIME)
             except InvalidFolder as ex:

--- a/homeassistant/components/shelly/climate.py
+++ b/homeassistant/components/shelly/climate.py
@@ -276,7 +276,7 @@ class BlockSleepingClimate(
                 f" {repr(err)}"
             ) from err
         except InvalidAuthError:
-            self.coordinator.entry.async_start_reauth(self.hass)
+            await self.coordinator.entry.async_init_reauth(self.hass)
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
@@ -378,6 +378,9 @@ class BlockSleepingClimate(
                     ]["schedule_profile_names"],
                 ]
             except InvalidAuthError:
-                self.coordinator.entry.async_start_reauth(self.hass)
+                self.hass.async_create_background_task(
+                    self.coordinator.entry.async_init_reauth(self.hass),
+                    f"reauth flow {DOMAIN} {self.coordinator.entry.entry_id}",
+                )
             else:
                 self.async_write_ha_state()

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -294,7 +294,7 @@ class ShellyBlockCoordinator(ShellyCoordinatorBase[BlockDevice]):
         except DeviceConnectionError as err:
             raise UpdateFailed(f"Error fetching data: {repr(err)}") from err
         except InvalidAuthError:
-            self.entry.async_start_reauth(self.hass)
+            await self.entry.async_init_reauth(self.hass)
 
     @callback
     def _async_handle_update(
@@ -378,7 +378,7 @@ class ShellyRestCoordinator(ShellyCoordinatorBase[BlockDevice]):
         except DeviceConnectionError as err:
             raise UpdateFailed(f"Error fetching data: {repr(err)}") from err
         except InvalidAuthError:
-            self.entry.async_start_reauth(self.hass)
+            await self.entry.async_init_reauth(self.hass)
         else:
             update_device_fw_info(self.hass, self.device, self.entry)
 
@@ -532,7 +532,7 @@ class ShellyRpcCoordinator(ShellyCoordinatorBase[RpcDevice]):
         except DeviceConnectionError as err:
             raise UpdateFailed(f"Device disconnected: {repr(err)}") from err
         except InvalidAuthError:
-            self.entry.async_start_reauth(self.hass)
+            await self.entry.async_init_reauth(self.hass)
 
     async def _async_disconnected(self) -> None:
         """Handle device disconnected."""
@@ -633,7 +633,7 @@ class ShellyRpcCoordinator(ShellyCoordinatorBase[RpcDevice]):
             try:
                 await async_stop_scanner(self.device)
             except InvalidAuthError:
-                self.entry.async_start_reauth(self.hass)
+                await self.entry.async_init_reauth(self.hass)
         await self.device.shutdown()
         await self._async_disconnected()
 
@@ -663,7 +663,7 @@ class ShellyRpcPollingCoordinator(ShellyCoordinatorBase[RpcDevice]):
         except (DeviceConnectionError, RpcCallError) as err:
             raise UpdateFailed(f"Device disconnected: {repr(err)}") from err
         except InvalidAuthError:
-            self.entry.async_start_reauth(self.hass)
+            await self.entry.async_init_reauth(self.hass)
 
 
 def get_block_coordinator_by_device_id(

--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -353,7 +353,7 @@ class ShellyBlockEntity(CoordinatorEntity[ShellyBlockCoordinator]):
                 f" {repr(err)}"
             ) from err
         except InvalidAuthError:
-            self.coordinator.entry.async_start_reauth(self.hass)
+            await self.coordinator.entry.async_init_reauth(self.hass)
 
 
 class ShellyRpcEntity(CoordinatorEntity[ShellyRpcCoordinator]):
@@ -406,7 +406,7 @@ class ShellyRpcEntity(CoordinatorEntity[ShellyRpcCoordinator]):
                 f" {params}, error: {repr(err)}"
             ) from err
         except InvalidAuthError:
-            self.coordinator.entry.async_start_reauth(self.hass)
+            await self.coordinator.entry.async_init_reauth(self.hass)
 
 
 class ShellyBlockAttributeEntity(ShellyBlockEntity, Entity):

--- a/homeassistant/components/shelly/number.py
+++ b/homeassistant/components/shelly/number.py
@@ -144,4 +144,4 @@ class BlockSleepingNumber(ShellySleepingBlockAttributeEntity, RestoreNumber):
                 f" {repr(err)}"
             ) from err
         except InvalidAuthError:
-            self.coordinator.entry.async_start_reauth(self.hass)
+            await self.coordinator.entry.async_init_reauth(self.hass)

--- a/homeassistant/components/shelly/update.py
+++ b/homeassistant/components/shelly/update.py
@@ -207,7 +207,7 @@ class RestUpdateEntity(ShellyRestAttributeEntity, UpdateEntity):
         except DeviceConnectionError as err:
             raise HomeAssistantError(f"Error starting OTA update: {repr(err)}") from err
         except InvalidAuthError:
-            self.coordinator.entry.async_start_reauth(self.hass)
+            await self.coordinator.entry.async_init_reauth(self.hass)
         else:
             LOGGER.debug("Result of OTA update call: %s", result)
 
@@ -293,7 +293,7 @@ class RpcUpdateEntity(ShellyRpcAttributeEntity, UpdateEntity):
         except RpcCallError as err:
             raise HomeAssistantError(f"OTA update request error: {repr(err)}") from err
         except InvalidAuthError:
-            self.coordinator.entry.async_start_reauth(self.hass)
+            await self.coordinator.entry.async_init_reauth(self.hass)
         else:
             self._ota_in_progress = True
             LOGGER.debug("OTA update call successful")

--- a/homeassistant/components/totalconnect/alarm_control_panel.py
+++ b/homeassistant/components/totalconnect/alarm_control_panel.py
@@ -166,7 +166,7 @@ class TotalConnectAlarm(
         try:
             await self.hass.async_add_executor_job(self._disarm)
         except UsercodeInvalid as error:
-            self.coordinator.config_entry.async_start_reauth(self.hass)
+            await self.coordinator.config_entry.async_init_reauth(self.hass)
             raise HomeAssistantError(
                 "TotalConnect usercode is invalid. Did not disarm"
             ) from error
@@ -185,7 +185,7 @@ class TotalConnectAlarm(
         try:
             await self.hass.async_add_executor_job(self._arm_home)
         except UsercodeInvalid as error:
-            self.coordinator.config_entry.async_start_reauth(self.hass)
+            await self.coordinator.config_entry.async_init_reauth(self.hass)
             raise HomeAssistantError(
                 "TotalConnect usercode is invalid. Did not arm home"
             ) from error
@@ -204,7 +204,7 @@ class TotalConnectAlarm(
         try:
             await self.hass.async_add_executor_job(self._arm_away)
         except UsercodeInvalid as error:
-            self.coordinator.config_entry.async_start_reauth(self.hass)
+            await self.coordinator.config_entry.async_init_reauth(self.hass)
             raise HomeAssistantError(
                 "TotalConnect usercode is invalid. Did not arm away"
             ) from error
@@ -223,7 +223,7 @@ class TotalConnectAlarm(
         try:
             await self.hass.async_add_executor_job(self._arm_night)
         except UsercodeInvalid as error:
-            self.coordinator.config_entry.async_start_reauth(self.hass)
+            await self.coordinator.config_entry.async_init_reauth(self.hass)
             raise HomeAssistantError(
                 "TotalConnect usercode is invalid. Did not arm night"
             ) from error
@@ -242,7 +242,7 @@ class TotalConnectAlarm(
         try:
             await self.hass.async_add_executor_job(self._arm_home_instant)
         except UsercodeInvalid as error:
-            self.coordinator.config_entry.async_start_reauth(self.hass)
+            await self.coordinator.config_entry.async_init_reauth(self.hass)
             raise HomeAssistantError(
                 "TotalConnect usercode is invalid. Did not arm home instant"
             ) from error
@@ -261,7 +261,7 @@ class TotalConnectAlarm(
         try:
             await self.hass.async_add_executor_job(self._arm_away_instant)
         except UsercodeInvalid as error:
-            self.coordinator.config_entry.async_start_reauth(self.hass)
+            await self.coordinator.config_entry.async_init_reauth(self.hass)
             raise HomeAssistantError(
                 "TotalConnect usercode is invalid. Did not arm away instant"
             ) from error

--- a/homeassistant/components/tractive/__init__.py
+++ b/homeassistant/components/tractive/__init__.py
@@ -233,7 +233,7 @@ class TractiveClient:
                         self._last_pos_time = event["position"]["time"]
                         self._send_position_update(event)
             except aiotractive.exceptions.UnauthorizedError:
-                self._config_entry.async_start_reauth(self._hass)
+                await self._config_entry.async_init_reauth(self._hass)
                 await self.unsubscribe()
                 _LOGGER.error(
                     "Authentication failed for %s, try reconfiguring device",

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -139,7 +139,7 @@ class ProtectData:
             else:
                 await self.async_stop()
                 _LOGGER.exception("Reauthentication required")
-                self._entry.async_start_reauth(self._hass)
+                await self._entry.async_init_reauth(self._hass)
             self.last_update_success = False
         except ClientError:
             if self.last_update_success:

--- a/homeassistant/components/uptimerobot/switch.py
+++ b/homeassistant/components/uptimerobot/switch.py
@@ -53,7 +53,7 @@ class UptimeRobotSwitch(UptimeRobotEntity, SwitchEntity):
             response = await self.api.async_edit_monitor(**kwargs)
         except UptimeRobotAuthenticationException:
             LOGGER.debug("API authentication error, calling reauth")
-            self.coordinator.config_entry.async_start_reauth(self.hass)
+            await self.coordinator.config_entry.async_init_reauth(self.hass)
             return
         except UptimeRobotException as exception:
             LOGGER.error("API exception: %s", exception)

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -318,7 +318,7 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
             try:
                 await self._client.connect()
             except WebOsTvPairError:
-                self._entry.async_start_reauth(self.hass)
+                await self._entry.async_init_reauth(self.hass)
             else:
                 update_client_key(self.hass, self._entry, self._client)
 

--- a/homeassistant/components/xiaomi_ble/__init__.py
+++ b/homeassistant/components/xiaomi_ble/__init__.py
@@ -98,7 +98,12 @@ def process_service_info(
         and data.encryption_scheme != EncryptionScheme.NONE
         and not data.bindkey_verified
     ):
-        entry.async_start_reauth(hass, data={"device": data})
+        # There is a small risk of race here if its called multiple times
+        # before the task it run since tasks are not eager.
+        hass.async_create_background_task(
+            entry.async_init_reauth(hass, data={"device": data}),
+            f"reauth flow {DOMAIN} {entry.entry_id}",
+        )
 
     return update
 

--- a/homeassistant/components/yalexs_ble/__init__.py
+++ b/homeassistant/components/yalexs_ble/__init__.py
@@ -111,7 +111,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     ) -> None:
         """Handle state changed."""
         if new_state.auth and not new_state.auth.successful:
-            entry.async_start_reauth(hass)
+            hass.async_create_background_task(
+                entry.async_init_reauth(hass), f"reauth flow {DOMAIN} {entry.entry_id}"
+            )
 
     entry.async_on_unload(push_lock.register_callback(_async_state_changed))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/yolink/entity.py
+++ b/homeassistant/components/yolink/entity.py
@@ -68,7 +68,7 @@ class YoLinkEntity(CoordinatorEntity[YoLinkCoordinator]):
             # call_device will check result, fail by raise YoLinkClientError
             await self.coordinator.device.call_device(request)
         except YoLinkAuthFailError as yl_auth_err:
-            self.config_entry.async_start_reauth(self.hass)
+            await self.config_entry.async_init_reauth(self.hass)
             raise HomeAssistantError(yl_auth_err) from yl_auth_err
         except YoLinkClientError as yl_client_err:
             raise HomeAssistantError(yl_client_err) from yl_client_err

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -732,7 +732,6 @@ class ConfigEntry:
         """
         report(
             "ConfigEntry.async_start_reauth is deprecated and will be removed in Home Assistant 2024.3, await ConfigEntry.async_init_reauth instead",
-            error_if_core=False,
         )
         if any(self.async_get_active_flows(hass, {SOURCE_REAUTH})):
             # Reauth flow already in progress for this entry

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -732,6 +732,7 @@ class ConfigEntry:
         """
         report(
             "ConfigEntry.async_start_reauth is deprecated and will be removed in Home Assistant 2024.3, await ConfigEntry.async_init_reauth instead",
+            error_if_core=False,
         )
         if any(self.async_get_active_flows(hass, {SOURCE_REAUTH})):
             # Reauth flow already in progress for this entry

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -361,7 +361,7 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
                 raise
 
             if self.config_entry:
-                self.config_entry.async_start_reauth(self.hass)
+                await self.config_entry.async_init_reauth(self.hass)
         except NotImplementedError as err:
             self.last_exception = err
             raise err

--- a/tests/components/androidtv_remote/test_config_flow.py
+++ b/tests/components/androidtv_remote/test_config_flow.py
@@ -769,7 +769,7 @@ async def test_reauth_flow_success(
     )
     mock_config_entry.add_to_hass(hass)
 
-    mock_config_entry.async_start_reauth(hass)
+    await mock_config_entry.async_init_reauth(hass)
     await hass.async_block_till_done()
 
     flows = hass.config_entries.flow.async_progress()
@@ -838,7 +838,7 @@ async def test_reauth_flow_cannot_connect(
     )
     mock_config_entry.add_to_hass(hass)
 
-    mock_config_entry.async_start_reauth(hass)
+    await mock_config_entry.async_init_reauth(hass)
     await hass.async_block_till_done()
 
     flows = hass.config_entries.flow.async_progress()

--- a/tests/components/google_assistant_sdk/test_config_flow.py
+++ b/tests/components/google_assistant_sdk/test_config_flow.py
@@ -97,7 +97,7 @@ async def test_reauth(
     )
     config_entry.add_to_hass(hass)
 
-    config_entry.async_start_reauth(hass)
+    await config_entry.async_init_reauth(hass)
     await hass.async_block_till_done()
 
     flows = hass.config_entries.flow.async_progress()

--- a/tests/components/google_mail/test_config_flow.py
+++ b/tests/components/google_mail/test_config_flow.py
@@ -102,7 +102,7 @@ async def test_reauth(
     """
     config_entry.add_to_hass(hass)
 
-    config_entry.async_start_reauth(hass)
+    await config_entry.async_init_reauth(hass)
     await hass.async_block_till_done()
 
     flows = hass.config_entries.flow.async_progress()

--- a/tests/components/google_sheets/test_config_flow.py
+++ b/tests/components/google_sheets/test_config_flow.py
@@ -187,7 +187,7 @@ async def test_reauth(
     )
     config_entry.add_to_hass(hass)
 
-    config_entry.async_start_reauth(hass)
+    await config_entry.async_init_reauth(hass)
     await hass.async_block_till_done()
 
     flows = hass.config_entries.flow.async_progress()
@@ -268,7 +268,7 @@ async def test_reauth_abort(
     )
     config_entry.add_to_hass(hass)
 
-    config_entry.async_start_reauth(hass)
+    await config_entry.async_init_reauth(hass)
     await hass.async_block_till_done()
 
     flows = hass.config_entries.flow.async_progress()

--- a/tests/components/homewizard/test_init.py
+++ b/tests/components/homewizard/test_init.py
@@ -79,7 +79,7 @@ async def test_load_removes_reauth_flow(
     mock_config_entry.add_to_hass(hass)
 
     # Add reauth flow from 'previously' failed init
-    mock_config_entry.async_start_reauth(hass)
+    await mock_config_entry.async_init_reauth(hass)
     await hass.async_block_till_done()
 
     flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)

--- a/tests/components/nest/test_config_flow.py
+++ b/tests/components/nest/test_config_flow.py
@@ -96,7 +96,7 @@ class OAuthFixture:
 
     async def async_reauth(self, config_entry: ConfigEntry) -> dict:
         """Initiate a reuath flow."""
-        config_entry.async_start_reauth(self.hass)
+        await config_entry.async_init_reauth(self.hass)
         await self.hass.async_block_till_done()
 
         # Advance through the reauth flow

--- a/tests/components/opower/test_config_flow.py
+++ b/tests/components/opower/test_config_flow.py
@@ -278,7 +278,7 @@ async def test_form_valid_reauth(
 ) -> None:
     """Test that we can handle a valid reauth."""
     mock_config_entry.state = ConfigEntryState.LOADED
-    mock_config_entry.async_start_reauth(hass)
+    await mock_config_entry.async_init_reauth(hass)
     await hass.async_block_till_done()
 
     flows = hass.config_entries.flow.async_progress()
@@ -327,7 +327,7 @@ async def test_form_valid_reauth_with_mfa(
         },
     )
     mock_config_entry.state = ConfigEntryState.LOADED
-    mock_config_entry.async_start_reauth(hass)
+    await mock_config_entry.async_init_reauth(hass)
     await hass.async_block_till_done()
 
     flows = hass.config_entries.flow.async_progress()

--- a/tests/components/uptimerobot/test_switch.py
+++ b/tests/components/uptimerobot/test_switch.py
@@ -107,7 +107,7 @@ async def test_authentication_error(
         "pyuptimerobot.UptimeRobot.async_edit_monitor",
         side_effect=UptimeRobotAuthenticationException,
     ), patch(
-        "homeassistant.config_entries.ConfigEntry.async_start_reauth"
+        "homeassistant.config_entries.ConfigEntry.async_init_reauth"
     ) as config_entry_reauth:
         await hass.services.async_call(
             SWITCH_DOMAIN,

--- a/tests/components/youtube/test_config_flow.py
+++ b/tests/components/youtube/test_config_flow.py
@@ -242,7 +242,7 @@ async def test_reauth(
     """
     config_entry.add_to_hass(hass)
 
-    config_entry.async_start_reauth(hass)
+    await config_entry.async_init_reauth(hass)
     await hass.async_block_till_done()
 
     flows = hass.config_entries.flow.async_progress()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix race starting reauth that allowed for multiple flows to be created

Another option would be to add a queue and locking, but it seemed more complex and better to simply await the flow creation instead in the places were it could race

<img width="1359" alt="Screenshot 2023-10-31 at 10 03 35 AM" src="https://github.com/home-assistant/core/assets/663432/251b5cac-3eaa-4da6-ac24-e6a0d5608036">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
