### PR TITLE
Fixing my fan: it reports valid values for speed are [1..26], but rep…

### DIFF
--- a/homeassistant/components/tuya/fan.py
+++ b/homeassistant/components/tuya/fan.py
@@ -250,6 +250,8 @@ class TuyaFanEntity(TuyaEntity, FanEntity):
         if self._speeds is not None:
             if (value := self.device.status.get(self._speeds.dpcode)) is None:
                 return None
+            if value not in self._speeds.range:
+                return ordered_list_item_to_percentage(self._speeds.range, self._speeds.range[0])
             return ordered_list_item_to_percentage(self._speeds.range, value)
 
         return None


### PR DESCRIPTION
…orts speed 0 when the fan is off (maybe interesting for you: it does that only in "standard instruction mode set", not in "dpcode instruction mode set")

This leads to

```
2023-10-15 20:42:13.849 ERROR (MainThread) [homeassistant.components.fan] Error adding entities for domain fan with platform tuya
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 507, in async_add_entities
    await asyncio.gather(*tasks)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 752, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1057, in add_to_platform_finish
    self.async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 779, in async_write_ha_state
    self._async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 879, in _async_write_ha_state
    state, attr = self._async_generate_attributes()
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 822, in _async_generate_attributes
    attr.update(self.state_attributes or {})
                ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/fan/__init__.py", line 357, in state_attributes
    data[ATTR_PERCENTAGE] = self.percentage
                            ^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/tuya/fan.py", line 253, in percentage
    return ordered_list_item_to_percentage(self._speeds.range, value)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/util/percentage.py", line 25, in ordered_list_item_to_percentage
    raise ValueError(f'The item "{item}" is not in "{ordered_list}"')
ValueError: The item "0" is not in "['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26']"
```

Excerpt of the status report of the fan in "standard instruction set mode":

```
       "product_id": "2r65vzsm3j3dv5bc",
      "product_name": "芯动力喷雾风扇",
     "status": [
        {
          "code": "switch",
          "value": true
        },
        {
          "code": "mode",
          "value": "normal"
        },
        {
          "code": "fan_speed",
          "value": "0"
        },
        {
          "code": "switch_horizontal",
          "value": "false"
        },
        {
          "code": "countdown",
          "value": "0"
        },
        {
          "code": "countdown_left",
          "value": 0
        },
        {
          "code": "anion",
          "value": false
        }
      ],
```

Excerpt of the definition of the device in "standard instruction set mode":

```
    "functions": [
      {
        "code": "switch",
        "type": "Boolean",
        "values": "{}"
      },
      {
        "code": "mode",
        "type": "Enum",
        "values": "{\"range\":[\"nature\",\"sleep\",\"fresh\",\"smart\",\"strong\",\"closed\"]}"
      },
      {
        "code": "fan_speed",
        "type": "Enum",
        "values": "{\"range\":[\"1\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7\",\"8\",\"9\",\"10\",\"11\",\"12\",\"13\",\"14\",\"15\",\"16\",\"17\",\"18\",\"19\",\"20\",\"21\",\"22\",\"23\",\"24\",\"25\",\"26\"]}"
      },
      {
        "code": "switch_horizontal",
        "type": "Boolean",
        "values": "{}"
      },
      {
        "code": "countdown",
        "type": "Enum",
        "values": "{\"range\":[\"0\",\"1\",\"2\",\"3\",\"4\",\"5\",\"6\"]}"
      },
      {
        "code": "anion",
        "type": "Boolean",
        "values": "{}"
      }
    ],
```

I know that this is not a bug is this implementation, but in the device - nevertheless: this commit makes my device work, without it doesn't ;-)

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #102349
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
