### PR TITLE
Move base entity of system_bridge to own module

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1291,6 +1291,7 @@ omit =
     homeassistant/components/system_bridge/__init__.py
     homeassistant/components/system_bridge/binary_sensor.py
     homeassistant/components/system_bridge/coordinator.py
+    homeassistant/components/system_bridge/entity.py
     homeassistant/components/system_bridge/media_player.py
     homeassistant/components/system_bridge/notify.py
     homeassistant/components/system_bridge/sensor.py

--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -36,8 +36,6 @@ from homeassistant.helpers import (
     discovery,
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, MODULES
 from .coordinator import SystemBridgeDataUpdateCoordinator
@@ -330,43 +328,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload the config entry when it changed."""
     await hass.config_entries.async_reload(entry.entry_id)
-
-
-class SystemBridgeEntity(CoordinatorEntity[SystemBridgeDataUpdateCoordinator]):
-    """Defines a base System Bridge entity."""
-
-    _attr_has_entity_name = True
-
-    def __init__(
-        self,
-        coordinator: SystemBridgeDataUpdateCoordinator,
-        api_port: int,
-        key: str,
-    ) -> None:
-        """Initialize the System Bridge entity."""
-        super().__init__(coordinator)
-
-        self._hostname = coordinator.data.system.hostname
-        self._key = f"{self._hostname}_{key}"
-        self._configuration_url = (
-            f"http://{self._hostname}:{api_port}/app/settings.html"
-        )
-        self._mac_address = coordinator.data.system.mac_address
-        self._uuid = coordinator.data.system.uuid
-        self._version = coordinator.data.system.version
-
-    @property
-    def unique_id(self) -> str:
-        """Return the unique ID for this entity."""
-        return self._key
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information about this System Bridge instance."""
-        return DeviceInfo(
-            configuration_url=self._configuration_url,
-            connections={(dr.CONNECTION_NETWORK_MAC, self._mac_address)},
-            identifiers={(DOMAIN, self._uuid)},
-            name=self._hostname,
-            sw_version=self._version,
-        )

--- a/homeassistant/components/system_bridge/binary_sensor.py
+++ b/homeassistant/components/system_bridge/binary_sensor.py
@@ -14,9 +14,9 @@ from homeassistant.const import CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import SystemBridgeEntity
 from .const import DOMAIN
 from .coordinator import SystemBridgeDataUpdateCoordinator
+from .entity import SystemBridgeEntity
 
 
 @dataclass

--- a/homeassistant/components/system_bridge/entity.py
+++ b/homeassistant/components/system_bridge/entity.py
@@ -1,0 +1,47 @@
+"""Base entity for the system bridge integration."""
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import SystemBridgeDataUpdateCoordinator
+
+
+class SystemBridgeEntity(CoordinatorEntity[SystemBridgeDataUpdateCoordinator]):
+    """Defines a base System Bridge entity."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: SystemBridgeDataUpdateCoordinator,
+        api_port: int,
+        key: str,
+    ) -> None:
+        """Initialize the System Bridge entity."""
+        super().__init__(coordinator)
+
+        self._hostname = coordinator.data.system.hostname
+        self._key = f"{self._hostname}_{key}"
+        self._configuration_url = (
+            f"http://{self._hostname}:{api_port}/app/settings.html"
+        )
+        self._mac_address = coordinator.data.system.mac_address
+        self._uuid = coordinator.data.system.uuid
+        self._version = coordinator.data.system.version
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique ID for this entity."""
+        return self._key
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information about this System Bridge instance."""
+        return DeviceInfo(
+            configuration_url=self._configuration_url,
+            connections={(dr.CONNECTION_NETWORK_MAC, self._mac_address)},
+            identifiers={(DOMAIN, self._uuid)},
+            name=self._hostname,
+            sw_version=self._version,
+        )

--- a/homeassistant/components/system_bridge/media_player.py
+++ b/homeassistant/components/system_bridge/media_player.py
@@ -22,9 +22,9 @@ from homeassistant.const import CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import SystemBridgeEntity
 from .const import DOMAIN
 from .coordinator import SystemBridgeCoordinatorData, SystemBridgeDataUpdateCoordinator
+from .entity import SystemBridgeEntity
 
 STATUS_CHANGING: Final[str] = "CHANGING"
 STATUS_STOPPED: Final[str] = "STOPPED"

--- a/homeassistant/components/system_bridge/sensor.py
+++ b/homeassistant/components/system_bridge/sensor.py
@@ -28,9 +28,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import UNDEFINED, StateType
 from homeassistant.util.dt import utcnow
 
-from . import SystemBridgeEntity
 from .const import DOMAIN
 from .coordinator import SystemBridgeCoordinatorData, SystemBridgeDataUpdateCoordinator
+from .entity import SystemBridgeEntity
 
 ATTR_AVAILABLE: Final = "available"
 ATTR_FILESYSTEM: Final = "filesystem"

--- a/homeassistant/components/system_bridge/update.py
+++ b/homeassistant/components/system_bridge/update.py
@@ -7,9 +7,9 @@ from homeassistant.const import CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import SystemBridgeEntity
 from .const import DOMAIN
 from .coordinator import SystemBridgeDataUpdateCoordinator
+from .entity import SystemBridgeEntity
 
 
 async def async_setup_entry(


### PR DESCRIPTION
## Proposed change
While reviewing https://github.com/home-assistant/core/pull/102966, I saw that the base entity of system_bridge is in `__init__.py`, which makes it extra long.

Therefore, this PR moves the base entity to its own module to improve readability and follow the general pattern.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
