### PR TITLE
Use constant instead of plain key name for device info attributes

### DIFF
--- a/homeassistant/components/asuswrt/diagnostics.py
+++ b/homeassistant/components/asuswrt/diagnostics.py
@@ -36,7 +36,7 @@ async def async_get_config_entry_diagnostics(
     device_registry = dr.async_get(hass)
     entity_registry = er.async_get(hass)
     hass_device = device_registry.async_get_device(
-        identifiers=router.device_info["identifiers"]
+        identifiers=router.device_info[ATTR_IDENTIFIERS]
     )
     if not hass_device:
         return data

--- a/homeassistant/components/elgato/entity.py
+++ b/homeassistant/components/elgato/entity.py
@@ -1,7 +1,7 @@
 """Base entity for the Elgato integration."""
 from __future__ import annotations
 
-from homeassistant.const import CONF_MAC
+from homeassistant.const import ATTR_CONNECTIONS, CONF_MAC
 from homeassistant.helpers.device_registry import (
     CONNECTION_NETWORK_MAC,
     DeviceInfo,
@@ -31,6 +31,6 @@ class ElgatoEntity(CoordinatorEntity[ElgatoDataUpdateCoordinator]):
             hw_version=str(coordinator.data.info.hardware_board_type),
         )
         if (mac := coordinator.config_entry.data.get(CONF_MAC)) is not None:
-            self._attr_device_info["connections"] = {
+            self._attr_device_info[ATTR_CONNECTIONS] = {
                 (CONNECTION_NETWORK_MAC, format_mac(mac))
             }

--- a/homeassistant/components/fully_kiosk/entity.py
+++ b/homeassistant/components/fully_kiosk/entity.py
@@ -1,6 +1,7 @@
 """Base entity for the Fully Kiosk Browser integration."""
 from __future__ import annotations
 
+from homeassistant.const import ATTR_CONNECTIONS
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -40,7 +41,7 @@ class FullyKioskEntity(CoordinatorEntity[FullyKioskDataUpdateCoordinator], Entit
         if "Mac" in coordinator.data and valid_global_mac_address(
             coordinator.data["Mac"]
         ):
-            device_info["connections"] = {
+            device_info[ATTR_CONNECTIONS] = {
                 (CONNECTION_NETWORK_MAC, coordinator.data["Mac"])
             }
         self._attr_device_info = device_info

--- a/homeassistant/components/kostal_plenticore/diagnostics.py
+++ b/homeassistant/components/kostal_plenticore/diagnostics.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from homeassistant.components.diagnostics import REDACTED, async_redact_data
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PASSWORD
+from homeassistant.const import ATTR_IDENTIFIERS, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
@@ -36,7 +36,7 @@ async def async_get_config_entry_diagnostics(
     }
 
     device_info = {**plenticore.device_info}
-    device_info["identifiers"] = REDACTED  # contains serial number
+    device_info[ATTR_IDENTIFIERS] = REDACTED  # contains serial number
     data["device"] = device_info
 
     return data

--- a/homeassistant/components/samsungtv/entity.py
+++ b/homeassistant/components/samsungtv/entity.py
@@ -2,7 +2,13 @@
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_MAC, CONF_MODEL, CONF_NAME
+from homeassistant.const import (
+    ATTR_CONNECTIONS,
+    ATTR_IDENTIFIERS,
+    CONF_MAC,
+    CONF_MODEL,
+    CONF_NAME,
+)
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
@@ -28,8 +34,8 @@ class SamsungTVEntity(Entity):
             model=config_entry.data.get(CONF_MODEL),
         )
         if self.unique_id:
-            self._attr_device_info["identifiers"] = {(DOMAIN, self.unique_id)}
+            self._attr_device_info[ATTR_IDENTIFIERS] = {(DOMAIN, self.unique_id)}
         if self._mac:
-            self._attr_device_info["connections"] = {
+            self._attr_device_info[ATTR_CONNECTIONS] = {
                 (dr.CONNECTION_NETWORK_MAC, self._mac)
             }

--- a/homeassistant/components/yamaha_musiccast/__init__.py
+++ b/homeassistant/components/yamaha_musiccast/__init__.py
@@ -10,7 +10,7 @@ from aiomusiccast.musiccast_device import MusicCastData, MusicCastDevice
 
 from homeassistant.components import ssdp
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, Platform
+from homeassistant.const import ATTR_CONNECTIONS, ATTR_VIA_DEVICE, CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import (
@@ -176,12 +176,12 @@ class MusicCastDeviceEntity(MusicCastEntity):
         )
 
         if self._zone_id == DEFAULT_ZONE:
-            device_info["connections"] = {
+            device_info[ATTR_CONNECTIONS] = {
                 (CONNECTION_NETWORK_MAC, format_mac(mac))
                 for mac in self.coordinator.data.mac_addresses.values()
             }
         else:
-            device_info["via_device"] = (DOMAIN, self.coordinator.data.device_id)
+            device_info[ATTR_VIA_DEVICE] = (DOMAIN, self.coordinator.data.device_id)
 
         return device_info
 


### PR DESCRIPTION
## Proposed change
Change all occurrences of a plain name of a `DeviceInfo` key to the correct constant.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
