### PR TITLE
Speed up websocket and ingress with aiohttp-zlib-ng

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -23,6 +23,7 @@ from aiohttp.web_urldispatcher import (
     UrlDispatcher,
     UrlMappingMatchInfo,
 )
+from aiohttp_zlib_ng import enable_zlib_ng
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -173,6 +174,8 @@ class ApiConfig:
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the HTTP API and debug interface."""
+    enable_zlib_ng()
+
     conf: ConfData | None = config.get(DOMAIN)
 
     if conf is None:

--- a/homeassistant/components/http/manifest.json
+++ b/homeassistant/components/http/manifest.json
@@ -6,5 +6,5 @@
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["aiohttp_cors==0.7.0", "aiohttp-zlib-ng==0.1.0"]
+  "requirements": ["aiohttp_cors==0.7.0", "aiohttp-zlib-ng==0.1.1"]
 }

--- a/homeassistant/components/http/manifest.json
+++ b/homeassistant/components/http/manifest.json
@@ -6,5 +6,5 @@
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["aiohttp_cors==0.7.0"]
+  "requirements": ["aiohttp_cors==0.7.0", "aiohttp-zlib-ng==0.1.0"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,5 +1,5 @@
 aiodiscover==1.5.1
-aiohttp-zlib-ng==0.1.0
+aiohttp-zlib-ng==0.1.1
 aiohttp==3.8.5;python_version<'3.12'
 aiohttp==3.9.0b0;python_version>='3.12'
 aiohttp_cors==0.7.0

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,4 +1,5 @@
 aiodiscover==1.5.1
+aiohttp-zlib-ng==0.1.0
 aiohttp==3.8.5;python_version<'3.12'
 aiohttp==3.9.0b0;python_version>='3.12'
 aiohttp_cors==0.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ requires-python = ">=3.11.0"
 dependencies    = [
     "aiohttp==3.9.0b0;python_version>='3.12'",
     "aiohttp==3.8.5;python_version<'3.12'",
+    "aiohttp_cors==0.7.0",
+    "aiohttp-zlib-ng==0.1.0",
     "astral==2.2",
     "attrs==23.1.0",
     "atomicwrites-homeassistant==1.4.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies    = [
     "aiohttp==3.9.0b0;python_version>='3.12'",
     "aiohttp==3.8.5;python_version<'3.12'",
     "aiohttp_cors==0.7.0",
-    "aiohttp-zlib-ng==0.1.0",
+    "aiohttp-zlib-ng==0.1.1",
     "astral==2.2",
     "attrs==23.1.0",
     "atomicwrites-homeassistant==1.4.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 aiohttp==3.9.0b0;python_version>='3.12'
 aiohttp==3.8.5;python_version<'3.12'
 aiohttp_cors==0.7.0
-aiohttp-zlib-ng==0.1.0
+aiohttp-zlib-ng==0.1.1
 astral==2.2
 attrs==23.1.0
 atomicwrites-homeassistant==1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@
 # Home Assistant Core
 aiohttp==3.9.0b0;python_version>='3.12'
 aiohttp==3.8.5;python_version<'3.12'
+aiohttp_cors==0.7.0
+aiohttp-zlib-ng==0.1.0
 astral==2.2
 attrs==23.1.0
 atomicwrites-homeassistant==1.4.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -258,7 +258,7 @@ aioharmony==0.2.10
 aiohomekit==3.0.9
 
 # homeassistant.components.http
-aiohttp-zlib-ng==0.1.0
+aiohttp-zlib-ng==0.1.1
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -257,6 +257,9 @@ aioharmony==0.2.10
 # homeassistant.components.homekit_controller
 aiohomekit==3.0.9
 
+# homeassistant.components.http
+aiohttp-zlib-ng==0.1.0
+
 # homeassistant.components.emulated_hue
 # homeassistant.components.http
 aiohttp_cors==0.7.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -236,7 +236,7 @@ aioharmony==0.2.10
 aiohomekit==3.0.9
 
 # homeassistant.components.http
-aiohttp-zlib-ng==0.1.0
+aiohttp-zlib-ng==0.1.1
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -235,6 +235,9 @@ aioharmony==0.2.10
 # homeassistant.components.homekit_controller
 aiohomekit==3.0.9
 
+# homeassistant.components.http
+aiohttp-zlib-ng==0.1.0
+
 # homeassistant.components.emulated_hue
 # homeassistant.components.http
 aiohttp_cors==0.7.0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/bdraco/aiohttp-zlib-ng
https://github.com/pycompression/python-zlib-ng

zlib-ng was choosen because:

- Its at the point where cloudflare is using it in production (they have some more patches on top, and some have been contributed back)
- Its a drop-in replacement for zlib with no code changes needed
- Fedora is talking about making it the default zlib implementation https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/CDNPJ4SOTRQMYVCDI3ZSY4SP4FYESCWD/
- well maintained https://github.com/zlib-ng/zlib-ng/releases
- It has significant performance improvements over stock zlib https://www.phoronix.com/news/Zlib-ng-2.1-Beta

Other alternatives (https://bugs.python.org/issue41566) where not choosen because:

python-isal: https://github.com/pycompression/python-isal: not widely compatible, not a drop-in replacement
libdeflate: no stream implementation, not a drop-in replacement

wheels have built successfully: https://wheels.home-assistant.io/musllinux/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
