### PR TITLE
Fix zwave_js cover bug for Window Covering CC values

### DIFF
--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -18,7 +18,6 @@ from zwave_js_server.const.command_class.multilevel_switch import (
 from zwave_js_server.const.command_class.window_covering import (
     NO_POSITION_PROPERTY_KEYS,
     NO_POSITION_SUFFIX,
-    WINDOW_COVERING_OPEN_PROPERTY,
     SlatStates,
 )
 from zwave_js_server.model.driver import Driver
@@ -370,7 +369,7 @@ class ZWaveWindowCovering(CoverPositionMixin, CoverTiltMixin):
                 set_values_func(
                     value,
                     stop_value=self.get_zwave_value(
-                        WINDOW_COVERING_OPEN_PROPERTY,
+                        "levelChangeUp",
                         value_property_key=value.property_key,
                     ),
                 )

--- a/homeassistant/components/zwave_js/scripts/convert_device_diagnostics_to_fixture.py
+++ b/homeassistant/components/zwave_js/scripts/convert_device_diagnostics_to_fixture.py
@@ -60,10 +60,12 @@ def extract_fixture_data(diagnostics_data: Any) -> dict:
     ):
         raise ValueError("Invalid diagnostics file format")
     state: dict = diagnostics_data["data"]["state"]
-    if isinstance(state["values"], list):
-        return state
-    values_dict: dict[str, dict] = state.pop("values")
-    state["values"] = list(values_dict.values())
+    if not isinstance(state["values"], list):
+        values_dict: dict[str, dict] = state.pop("values")
+        state["values"] = list(values_dict.values())
+    if not isinstance(state["endpoints"], list):
+        endpoints_dict: dict[str, dict] = state.pop("endpoints")
+        state["endpoints"] = list(endpoints_dict.values())
 
     return state
 

--- a/tests/components/zwave_js/fixtures/cover_iblinds_v3_state.json
+++ b/tests/components/zwave_js/fixtures/cover_iblinds_v3_state.json
@@ -1,5 +1,5 @@
 {
-  "nodeId": 12,
+  "nodeId": 131,
   "index": 0,
   "installerIcon": 6656,
   "userIcon": 6656,
@@ -7,12 +7,13 @@
   "ready": true,
   "isListening": false,
   "isRouting": true,
-  "isSecure": true,
+  "isSecure": false,
   "manufacturerId": 647,
   "productId": 114,
   "productType": 4,
   "firmwareVersion": "3.12.1",
   "zwavePlusVersion": 2,
+  "name": "Blind West Bed 1",
   "deviceConfig": {
     "filename": "/data/db/devices/0x0287/iblindsv3.json",
     "isEmbedded": true,
@@ -38,321 +39,61 @@
     "associations": {},
     "paramInformation": {
       "_map": {}
+    },
+    "compat": {
+      "removeCCs": {}
     }
   },
   "label": "iblinds V3",
   "interviewAttempts": 1,
-  "endpoints": [
-    {
-      "nodeId": 12,
-      "index": 0,
-      "installerIcon": 6656,
-      "userIcon": 6656,
-      "deviceClass": {
-        "basic": {
-          "key": 4,
-          "label": "Routing Slave"
-        },
-        "generic": {
-          "key": 17,
-          "label": "Multilevel Switch"
-        },
-        "specific": {
-          "key": 7,
-          "label": "Motor Control Class C"
-        },
-        "mandatorySupportedCCs": [32, 38, 37, 114, 134],
-        "mandatoryControlledCCs": []
-      },
-      "commandClasses": [
-        {
-          "id": 38,
-          "name": "Multilevel Switch",
-          "version": 4,
-          "isSecure": true
-        },
-        {
-          "id": 37,
-          "name": "Binary Switch",
-          "version": 2,
-          "isSecure": true
-        },
-        {
-          "id": 114,
-          "name": "Manufacturer Specific",
-          "version": 2,
-          "isSecure": true
-        },
-        {
-          "id": 134,
-          "name": "Version",
-          "version": 3,
-          "isSecure": true
-        },
-        {
-          "id": 94,
-          "name": "Z-Wave Plus Info",
-          "version": 2,
-          "isSecure": false
-        },
-        {
-          "id": 133,
-          "name": "Association",
-          "version": 2,
-          "isSecure": true
-        },
-        {
-          "id": 89,
-          "name": "Association Group Information",
-          "version": 3,
-          "isSecure": true
-        },
-        {
-          "id": 85,
-          "name": "Transport Service",
-          "version": 2,
-          "isSecure": false
-        },
-        {
-          "id": 90,
-          "name": "Device Reset Locally",
-          "version": 1,
-          "isSecure": true
-        },
-        {
-          "id": 115,
-          "name": "Powerlevel",
-          "version": 1,
-          "isSecure": true
-        },
-        {
-          "id": 159,
-          "name": "Security 2",
-          "version": 1,
-          "isSecure": true
-        },
-        {
-          "id": 108,
-          "name": "Supervision",
-          "version": 1,
-          "isSecure": false
-        },
-        {
-          "id": 122,
-          "name": "Firmware Update Meta Data",
-          "version": 5,
-          "isSecure": true
-        },
-        {
-          "id": 128,
-          "name": "Battery",
-          "version": 1,
-          "isSecure": true
-        },
-        {
-          "id": 112,
-          "name": "Configuration",
-          "version": 4,
-          "isSecure": true
-        },
-        {
-          "id": 135,
-          "name": "Indicator",
-          "version": 3,
-          "isSecure": true
-        },
-        {
-          "id": 142,
-          "name": "Multi Channel Association",
-          "version": 3,
-          "isSecure": true
-        },
-        {
-          "id": 106,
-          "name": "Window Covering",
-          "version": 1,
-          "isSecure": true
-        },
-        {
-          "id": 152,
-          "name": "Security",
-          "version": 1,
-          "isSecure": true
-        }
-      ]
+  "isFrequentListening": "1000ms",
+  "maxDataRate": 100000,
+  "supportedDataRates": [40000, 100000],
+  "protocolVersion": 3,
+  "supportsBeaming": true,
+  "supportsSecurity": false,
+  "nodeType": 1,
+  "zwavePlusNodeType": 0,
+  "zwavePlusRoleType": 7,
+  "deviceClass": {
+    "basic": {
+      "key": 4,
+      "label": "Routing Slave"
+    },
+    "generic": {
+      "key": 17,
+      "label": "Multilevel Switch"
+    },
+    "specific": {
+      "key": 7,
+      "label": "Motor Control Class C"
+    },
+    "mandatorySupportedCCs": [32, 38, 37, 114, 134],
+    "mandatoryControlledCCs": []
+  },
+  "interviewStage": "Complete",
+  "deviceDatabaseUrl": "https://devices.zwave-js.io/?jumpTo=0x0287:0x0004:0x0072:3.12.1",
+  "statistics": {
+    "commandsTX": 95,
+    "commandsRX": 110,
+    "commandsDroppedRX": 0,
+    "commandsDroppedTX": 0,
+    "timeoutResponse": 0,
+    "rtt": 1295.6,
+    "lastSeen": "2023-11-02T18:41:40.552Z",
+    "rssi": -69,
+    "lwr": {
+      "protocolDataRate": 2,
+      "repeaters": [],
+      "rssi": -71,
+      "repeaterRSSI": []
     }
-  ],
+  },
+  "highestSecurityClass": -1,
+  "isControllerNode": false,
+  "keepAwake": false,
+  "lastSeen": "2023-11-02T18:41:40.552Z",
   "values": [
-    {
-      "endpoint": 0,
-      "commandClass": 37,
-      "commandClassName": "Binary Switch",
-      "property": "currentValue",
-      "propertyName": "currentValue",
-      "ccVersion": 2,
-      "metadata": {
-        "type": "boolean",
-        "readable": true,
-        "writeable": false,
-        "label": "Current value",
-        "stateful": true,
-        "secret": false
-      },
-      "value": false
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 37,
-      "commandClassName": "Binary Switch",
-      "property": "targetValue",
-      "propertyName": "targetValue",
-      "ccVersion": 2,
-      "metadata": {
-        "type": "boolean",
-        "readable": true,
-        "writeable": true,
-        "label": "Target value",
-        "valueChangeOptions": ["transitionDuration"],
-        "stateful": true,
-        "secret": false
-      },
-      "value": false
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 37,
-      "commandClassName": "Binary Switch",
-      "property": "duration",
-      "propertyName": "duration",
-      "ccVersion": 2,
-      "metadata": {
-        "type": "duration",
-        "readable": true,
-        "writeable": false,
-        "label": "Remaining duration",
-        "stateful": true,
-        "secret": false
-      },
-      "value": {
-        "value": 0,
-        "unit": "seconds"
-      }
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 38,
-      "commandClassName": "Multilevel Switch",
-      "property": "targetValue",
-      "propertyName": "targetValue",
-      "ccVersion": 4,
-      "metadata": {
-        "type": "number",
-        "readable": true,
-        "writeable": true,
-        "label": "Target value",
-        "valueChangeOptions": ["transitionDuration"],
-        "min": 0,
-        "max": 99,
-        "stateful": true,
-        "secret": false
-      },
-      "value": 0
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 38,
-      "commandClassName": "Multilevel Switch",
-      "property": "duration",
-      "propertyName": "duration",
-      "ccVersion": 4,
-      "metadata": {
-        "type": "duration",
-        "readable": true,
-        "writeable": false,
-        "label": "Remaining duration",
-        "stateful": true,
-        "secret": false
-      },
-      "value": {
-        "value": 0,
-        "unit": "seconds"
-      }
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 38,
-      "commandClassName": "Multilevel Switch",
-      "property": "currentValue",
-      "propertyName": "currentValue",
-      "ccVersion": 4,
-      "metadata": {
-        "type": "number",
-        "readable": true,
-        "writeable": false,
-        "label": "Current value",
-        "min": 0,
-        "max": 99,
-        "stateful": true,
-        "secret": false
-      },
-      "value": 0
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 38,
-      "commandClassName": "Multilevel Switch",
-      "property": "Up",
-      "propertyName": "Up",
-      "ccVersion": 4,
-      "metadata": {
-        "type": "boolean",
-        "readable": false,
-        "writeable": true,
-        "label": "Perform a level change (Up)",
-        "ccSpecific": {
-          "switchType": 2
-        },
-        "valueChangeOptions": ["transitionDuration"],
-        "stateful": true,
-        "secret": false
-      }
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 38,
-      "commandClassName": "Multilevel Switch",
-      "property": "Down",
-      "propertyName": "Down",
-      "ccVersion": 4,
-      "metadata": {
-        "type": "boolean",
-        "readable": false,
-        "writeable": true,
-        "label": "Perform a level change (Down)",
-        "ccSpecific": {
-          "switchType": 2
-        },
-        "valueChangeOptions": ["transitionDuration"],
-        "stateful": true,
-        "secret": false
-      }
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 38,
-      "commandClassName": "Multilevel Switch",
-      "property": "restorePrevious",
-      "propertyName": "restorePrevious",
-      "ccVersion": 4,
-      "metadata": {
-        "type": "boolean",
-        "readable": false,
-        "writeable": true,
-        "label": "Restore previous value",
-        "stateful": true,
-        "secret": false
-      }
-    },
     {
       "endpoint": 0,
       "commandClass": 106,
@@ -361,7 +102,7 @@
       "propertyKey": 23,
       "propertyName": "currentValue",
       "propertyKeyName": "Horizontal Slats Angle",
-      "ccVersion": 0,
+      "ccVersion": 1,
       "metadata": {
         "type": "number",
         "readable": true,
@@ -373,9 +114,9 @@
         "min": 0,
         "max": 99,
         "states": {
-          "0": "Closed (up)",
+          "0": "Closed (up inside)",
           "50": "Open",
-          "99": "Closed (down)"
+          "99": "Closed (down inside)"
         },
         "stateful": true,
         "secret": false
@@ -390,7 +131,7 @@
       "propertyKey": 23,
       "propertyName": "targetValue",
       "propertyKeyName": "Horizontal Slats Angle",
-      "ccVersion": 0,
+      "ccVersion": 1,
       "metadata": {
         "type": "number",
         "readable": true,
@@ -403,14 +144,14 @@
         "min": 0,
         "max": 99,
         "states": {
-          "0": "Closed (up)",
+          "0": "Closed (up inside)",
           "50": "Open",
-          "99": "Closed (down)"
+          "99": "Closed (down inside)"
         },
         "stateful": true,
         "secret": false
       },
-      "value": 99
+      "value": 0
     },
     {
       "endpoint": 0,
@@ -420,7 +161,7 @@
       "propertyKey": 23,
       "propertyName": "duration",
       "propertyKeyName": "Horizontal Slats Angle",
-      "ccVersion": 0,
+      "ccVersion": 1,
       "metadata": {
         "type": "duration",
         "readable": true,
@@ -441,44 +182,24 @@
       "endpoint": 0,
       "commandClass": 106,
       "commandClassName": "Window Covering",
-      "property": "open",
+      "property": "levelChangeUp",
       "propertyKey": 23,
-      "propertyName": "open",
+      "propertyName": "levelChangeUp",
       "propertyKeyName": "Horizontal Slats Angle",
-      "ccVersion": 0,
+      "ccVersion": 1,
       "metadata": {
         "type": "boolean",
         "readable": false,
         "writeable": true,
-        "label": "Open - Horizontal Slats Angle",
+        "label": "Change tilt (down inside) - Horizontal Slats Angle",
         "ccSpecific": {
           "parameter": 23
         },
         "valueChangeOptions": ["transitionDuration"],
-        "stateful": true,
-        "secret": false
-      },
-      "nodeId": 12,
-      "value": true
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 106,
-      "commandClassName": "Window Covering",
-      "property": "close0",
-      "propertyKey": 23,
-      "propertyName": "close0",
-      "propertyKeyName": "Horizontal Slats Angle",
-      "ccVersion": 0,
-      "metadata": {
-        "type": "boolean",
-        "readable": false,
-        "writeable": true,
-        "label": "Close Up - Horizontal Slats Angle",
-        "ccSpecific": {
-          "parameter": 23
+        "states": {
+          "true": "Start",
+          "false": "Stop"
         },
-        "valueChangeOptions": ["transitionDuration"],
         "stateful": true,
         "secret": false
       }
@@ -487,25 +208,27 @@
       "endpoint": 0,
       "commandClass": 106,
       "commandClassName": "Window Covering",
-      "property": "close99",
+      "property": "levelChangeDown",
       "propertyKey": 23,
-      "propertyName": "close99",
+      "propertyName": "levelChangeDown",
       "propertyKeyName": "Horizontal Slats Angle",
-      "ccVersion": 0,
+      "ccVersion": 1,
       "metadata": {
         "type": "boolean",
         "readable": false,
         "writeable": true,
-        "label": "Close Down - Horizontal Slats Angle",
+        "label": "Change tilt (up inside) - Horizontal Slats Angle",
         "ccSpecific": {
           "parameter": 23
         },
         "valueChangeOptions": ["transitionDuration"],
+        "states": {
+          "true": "Start",
+          "false": "Stop"
+        },
         "stateful": true,
         "secret": false
-      },
-      "nodeId": 12,
-      "value": true
+      }
     },
     {
       "endpoint": 0,
@@ -604,7 +327,7 @@
         "allowManualEntry": true,
         "isFromConfig": true
       },
-      "value": 50
+      "value": 45
     },
     {
       "endpoint": 0,
@@ -655,6 +378,32 @@
         "isFromConfig": true
       },
       "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 11,
+      "propertyName": "MC",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "MC",
+        "label": "MC",
+        "default": 1,
+        "min": 0,
+        "max": 1,
+        "valueSize": 1,
+        "format": 0,
+        "noBulkSupport": true,
+        "isAdvanced": false,
+        "requiresReInclusion": false,
+        "allowManualEntry": true,
+        "isFromConfig": false
+      },
+      "value": 1
     },
     {
       "endpoint": 0,
@@ -721,7 +470,9 @@
         "format": 0,
         "allowManualEntry": true,
         "isFromConfig": true
-      }
+      },
+      "nodeId": 131,
+      "value": 99
     },
     {
       "endpoint": 0,
@@ -1169,7 +920,9 @@
         "max": 255,
         "stateful": true,
         "secret": false
-      }
+      },
+      "nodeId": 131,
+      "value": 47
     },
     {
       "endpoint": 0,
@@ -1183,54 +936,209 @@
         "readable": false,
         "writeable": true,
         "label": "Identify",
+        "states": {
+          "true": "Identify"
+        },
         "stateful": true,
         "secret": false
       }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 135,
+      "commandClassName": "Indicator",
+      "property": "timeout",
+      "propertyName": "timeout",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "Timeout",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "commandClassName": "Multilevel Switch",
+      "commandClass": 38,
+      "property": "targetValue",
+      "endpoint": 0,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 99,
+        "stateful": true,
+        "secret": false
+      },
+      "propertyName": "targetValue",
+      "nodeId": 131,
+      "value": 45
+    },
+    {
+      "commandClassName": "Multilevel Switch",
+      "commandClass": 38,
+      "property": "duration",
+      "endpoint": 0,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": false,
+        "label": "Remaining duration",
+        "stateful": true,
+        "secret": false
+      },
+      "propertyName": "duration",
+      "nodeId": 131,
+      "value": {
+        "value": 0,
+        "unit": "seconds"
+      }
+    },
+    {
+      "commandClassName": "Multilevel Switch",
+      "commandClass": 38,
+      "property": "currentValue",
+      "endpoint": 0,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "min": 0,
+        "max": 99,
+        "stateful": true,
+        "secret": false
+      },
+      "propertyName": "currentValue",
+      "nodeId": 131,
+      "value": 45
     }
   ],
-  "isFrequentListening": "1000ms",
-  "maxDataRate": 100000,
-  "supportedDataRates": [40000, 100000],
-  "protocolVersion": 3,
-  "supportsBeaming": true,
-  "supportsSecurity": false,
-  "nodeType": 1,
-  "zwavePlusNodeType": 0,
-  "zwavePlusRoleType": 7,
-  "deviceClass": {
-    "basic": {
-      "key": 4,
-      "label": "Routing Slave"
-    },
-    "generic": {
-      "key": 17,
-      "label": "Multilevel Switch"
-    },
-    "specific": {
-      "key": 7,
-      "label": "Motor Control Class C"
-    },
-    "mandatorySupportedCCs": [32, 38, 37, 114, 134],
-    "mandatoryControlledCCs": []
-  },
-  "interviewStage": "Complete",
-  "deviceDatabaseUrl": "https://devices.zwave-js.io/?jumpTo=0x0287:0x0004:0x0072:3.12.1",
-  "statistics": {
-    "commandsTX": 109,
-    "commandsRX": 101,
-    "commandsDroppedRX": 2,
-    "commandsDroppedTX": 0,
-    "timeoutResponse": 8,
-    "rtt": 1217.2,
-    "rssi": -43,
-    "lwr": {
-      "protocolDataRate": 2,
-      "repeaters": [],
-      "rssi": -45,
-      "repeaterRSSI": []
+  "endpoints": [
+    {
+      "nodeId": 131,
+      "index": 0,
+      "installerIcon": 6656,
+      "userIcon": 6656,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 17,
+          "label": "Multilevel Switch"
+        },
+        "specific": {
+          "key": 7,
+          "label": "Motor Control Class C"
+        },
+        "mandatorySupportedCCs": [32, 38, 37, 114, 134],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 114,
+          "name": "Manufacturer Specific",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 134,
+          "name": "Version",
+          "version": 3,
+          "isSecure": false
+        },
+        {
+          "id": 94,
+          "name": "Z-Wave Plus Info",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 133,
+          "name": "Association",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 89,
+          "name": "Association Group Information",
+          "version": 3,
+          "isSecure": false
+        },
+        {
+          "id": 85,
+          "name": "Transport Service",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 90,
+          "name": "Device Reset Locally",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 115,
+          "name": "Powerlevel",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 159,
+          "name": "Security 2",
+          "version": 1,
+          "isSecure": true
+        },
+        {
+          "id": 108,
+          "name": "Supervision",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 122,
+          "name": "Firmware Update Meta Data",
+          "version": 5,
+          "isSecure": false
+        },
+        {
+          "id": 128,
+          "name": "Battery",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 112,
+          "name": "Configuration",
+          "version": 4,
+          "isSecure": false
+        },
+        {
+          "id": 135,
+          "name": "Indicator",
+          "version": 3,
+          "isSecure": false
+        },
+        {
+          "id": 142,
+          "name": "Multi Channel Association",
+          "version": 3,
+          "isSecure": false
+        },
+        {
+          "id": 106,
+          "name": "Window Covering",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
     }
-  },
-  "highestSecurityClass": 1,
-  "isControllerNode": false,
-  "keepAwake": false
+  ]
 }

--- a/tests/components/zwave_js/fixtures/zooz_zse44_state.json
+++ b/tests/components/zwave_js/fixtures/zooz_zse44_state.json
@@ -88,140 +88,6 @@
   "isControllerNode": false,
   "keepAwake": false,
   "lastSeen": "2023-08-09T13:26:05.031Z",
-  "endpoints": {
-    "0": {
-      "nodeId": 23,
-      "index": 0,
-      "installerIcon": 3327,
-      "userIcon": 3327,
-      "deviceClass": {
-        "basic": {
-          "key": 4,
-          "label": "Routing Slave"
-        },
-        "generic": {
-          "key": 7,
-          "label": "Notification Sensor"
-        },
-        "specific": {
-          "key": 1,
-          "label": "Notification Sensor"
-        },
-        "mandatorySupportedCCs": [],
-        "mandatoryControlledCCs": []
-      },
-      "commandClasses": [
-        {
-          "id": 94,
-          "name": "Z-Wave Plus Info",
-          "version": 2,
-          "isSecure": false
-        },
-        {
-          "id": 133,
-          "name": "Association",
-          "version": 3,
-          "isSecure": true
-        },
-        {
-          "id": 142,
-          "name": "Multi Channel Association",
-          "version": 4,
-          "isSecure": true
-        },
-        {
-          "id": 89,
-          "name": "Association Group Information",
-          "version": 3,
-          "isSecure": true
-        },
-        {
-          "id": 49,
-          "name": "Multilevel Sensor",
-          "version": 11,
-          "isSecure": true
-        },
-        {
-          "id": 85,
-          "name": "Transport Service",
-          "version": 2,
-          "isSecure": false
-        },
-        {
-          "id": 134,
-          "name": "Version",
-          "version": 3,
-          "isSecure": true
-        },
-        {
-          "id": 114,
-          "name": "Manufacturer Specific",
-          "version": 2,
-          "isSecure": true
-        },
-        {
-          "id": 90,
-          "name": "Device Reset Locally",
-          "version": 1,
-          "isSecure": true
-        },
-        {
-          "id": 115,
-          "name": "Powerlevel",
-          "version": 1,
-          "isSecure": true
-        },
-        {
-          "id": 128,
-          "name": "Battery",
-          "version": 3,
-          "isSecure": true
-        },
-        {
-          "id": 159,
-          "name": "Security 2",
-          "version": 1,
-          "isSecure": true
-        },
-        {
-          "id": 113,
-          "name": "Notification",
-          "version": 8,
-          "isSecure": true
-        },
-        {
-          "id": 135,
-          "name": "Indicator",
-          "version": 4,
-          "isSecure": true
-        },
-        {
-          "id": 112,
-          "name": "Configuration",
-          "version": 4,
-          "isSecure": true
-        },
-        {
-          "id": 132,
-          "name": "Wake Up",
-          "version": 1,
-          "isSecure": true
-        },
-        {
-          "id": 108,
-          "name": "Supervision",
-          "version": 2,
-          "isSecure": false
-        },
-        {
-          "id": 122,
-          "name": "Firmware Update Meta Data",
-          "version": 7,
-          "isSecure": true
-        }
-      ]
-    }
-  },
   "values": [
     {
       "endpoint": 0,
@@ -1325,6 +1191,140 @@
         "secret": false
       },
       "value": 0
+    }
+  ],
+  "endpoints": [
+    {
+      "nodeId": 23,
+      "index": 0,
+      "installerIcon": 3327,
+      "userIcon": 3327,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 7,
+          "label": "Notification Sensor"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Notification Sensor"
+        },
+        "mandatorySupportedCCs": [],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 94,
+          "name": "Z-Wave Plus Info",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 133,
+          "name": "Association",
+          "version": 3,
+          "isSecure": true
+        },
+        {
+          "id": 142,
+          "name": "Multi Channel Association",
+          "version": 4,
+          "isSecure": true
+        },
+        {
+          "id": 89,
+          "name": "Association Group Information",
+          "version": 3,
+          "isSecure": true
+        },
+        {
+          "id": 49,
+          "name": "Multilevel Sensor",
+          "version": 11,
+          "isSecure": true
+        },
+        {
+          "id": 85,
+          "name": "Transport Service",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 134,
+          "name": "Version",
+          "version": 3,
+          "isSecure": true
+        },
+        {
+          "id": 114,
+          "name": "Manufacturer Specific",
+          "version": 2,
+          "isSecure": true
+        },
+        {
+          "id": 90,
+          "name": "Device Reset Locally",
+          "version": 1,
+          "isSecure": true
+        },
+        {
+          "id": 115,
+          "name": "Powerlevel",
+          "version": 1,
+          "isSecure": true
+        },
+        {
+          "id": 128,
+          "name": "Battery",
+          "version": 3,
+          "isSecure": true
+        },
+        {
+          "id": 159,
+          "name": "Security 2",
+          "version": 1,
+          "isSecure": true
+        },
+        {
+          "id": 113,
+          "name": "Notification",
+          "version": 8,
+          "isSecure": true
+        },
+        {
+          "id": 135,
+          "name": "Indicator",
+          "version": 4,
+          "isSecure": true
+        },
+        {
+          "id": 112,
+          "name": "Configuration",
+          "version": 4,
+          "isSecure": true
+        },
+        {
+          "id": 132,
+          "name": "Wake Up",
+          "version": 1,
+          "isSecure": true
+        },
+        {
+          "id": 108,
+          "name": "Supervision",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 122,
+          "name": "Firmware Update Meta Data",
+          "version": 7,
+          "isSecure": true
+        }
+      ]
     }
   ]
 }

--- a/tests/components/zwave_js/scripts/test_convert_device_diagnostics_to_fixture.py
+++ b/tests/components/zwave_js/scripts/test_convert_device_diagnostics_to_fixture.py
@@ -58,7 +58,6 @@ def test_load_file() -> None:
 
 def test_main(capfd: pytest.CaptureFixture[str]) -> None:
     """Test main function."""
-    Path(__file__).parents[1] / "fixtures" / "zooz_zse44_state.json"
     fixture_str = load_fixture("zwave_js/zooz_zse44_state.json")
     fixture_dict = json.loads(fixture_str)
 

--- a/tests/components/zwave_js/scripts/test_convert_device_diagnostics_to_fixture.py
+++ b/tests/components/zwave_js/scripts/test_convert_device_diagnostics_to_fixture.py
@@ -36,6 +36,10 @@ def test_fixture_functions() -> None:
     old_diagnostics_format_data["data"]["state"]["values"] = list(
         old_diagnostics_format_data["data"]["state"]["values"].values()
     )
+    old_diagnostics_format_data["data"]["state"]["endpoints"] = list(
+        old_diagnostics_format_data["data"]["state"]["endpoints"].values()
+    )
+
     assert (
         extract_fixture_data(old_diagnostics_format_data)
         == old_diagnostics_format_data["data"]["state"]

--- a/tests/components/zwave_js/test_cover.py
+++ b/tests/components/zwave_js/test_cover.py
@@ -829,7 +829,7 @@ async def test_iblinds_v3_cover(
     hass: HomeAssistant, client, iblinds_v3, integration
 ) -> None:
     """Test iBlinds v3 cover which uses Window Covering CC."""
-    entity_id = "cover.window_blind_controller_horizontal_slats_angle"
+    entity_id = "cover.blind_west_bed_1_horizontal_slats_angle"
     state = hass.states.get(entity_id)
     assert state
     # This device has no state because there is no position value
@@ -854,7 +854,7 @@ async def test_iblinds_v3_cover(
     assert len(client.async_send_command.call_args_list) == 1
     args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
-    assert args["nodeId"] == 12
+    assert args["nodeId"] == 131
     assert args["valueId"] == {
         "endpoint": 0,
         "commandClass": 106,
@@ -875,7 +875,7 @@ async def test_iblinds_v3_cover(
     assert len(client.async_send_command.call_args_list) == 1
     args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
-    assert args["nodeId"] == 12
+    assert args["nodeId"] == 131
     assert args["valueId"] == {
         "endpoint": 0,
         "commandClass": 106,
@@ -896,7 +896,7 @@ async def test_iblinds_v3_cover(
     assert len(client.async_send_command.call_args_list) == 1
     args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
-    assert args["nodeId"] == 12
+    assert args["nodeId"] == 131
     assert args["valueId"] == {
         "endpoint": 0,
         "commandClass": 106,
@@ -917,11 +917,11 @@ async def test_iblinds_v3_cover(
     assert len(client.async_send_command.call_args_list) == 1
     args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
-    assert args["nodeId"] == 12
+    assert args["nodeId"] == 131
     assert args["valueId"] == {
         "endpoint": 0,
         "commandClass": 106,
-        "property": "open",
+        "property": "levelChangeUp",
         "propertyKey": 23,
     }
     assert args["value"] is False


### PR DESCRIPTION
## Proposed change
There are two bugs here:
1. My script to generate fixtures didn't work. It is now fixed
2. I missed this change https://github.com/zwave-js/node-zwave-js/pull/5807 so stop cover was not working as expected, but the fixture I used to develop against was one that was pulled before this change was made. I have added the necessary constants to the upstream lib but this allows us to fix it in a patch release for the core until we can get the lib released and the dependency bumped. Seems like not a big enough problem to do when the fix is so simple

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/103268
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
