### PR TITLE
[RFH] [DO NOT MERGE] aiohttp + wifi mesh networks results in request hangs

### DIFF
--- a/homeassistant/components/airzone_cloud/__init__.py
+++ b/homeassistant/components/airzone_cloud/__init__.py
@@ -26,7 +26,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.data[CONF_PASSWORD],
     )
 
-    airzone = AirzoneCloudApi(aiohttp_client.async_get_clientsession(hass), options)
+    session = aiohttp_client.async_get_clientsession(hass)
+    session.connector._limit = 4
+    airzone = AirzoneCloudApi(session, options)
     await airzone.login()
     inst_list = await airzone.list_installations()
     for inst in inst_list:

--- a/homeassistant/components/airzone_cloud/config_flow.py
+++ b/homeassistant/components/airzone_cloud/config_flow.py
@@ -89,8 +89,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if CONF_ID in user_input:
                 return await self.async_step_inst_pick(user_input)
 
+            session = aiohttp_client.async_get_clientsession(self.hass)
+            session.connector._limit = 4
             self.airzone = AirzoneCloudApi(
-                aiohttp_client.async_get_clientsession(self.hass),
+                session,
                 ConnectionOptions(
                     user_input[CONF_USERNAME],
                     user_input[CONF_PASSWORD],


### PR DESCRIPTION
Some users with Home Assistant behind Wifi Mesh networks are experiencing timeouts with the Airzone Cloud integration.
This integration uses aiohttp to communicate with the Cloud API and triggers most of the requests in parallel.

The issue is that some users, both of them with the Home Assistant server behind a Wifi mesh network are experiencing connection hangs which results in timeouts.
One of these users solved it by connecting the Home Assistant server to its router, but unfortunately this isn't possible for all of them.
However, it seems that limiting the number of parallel connections to 4 solves the issue.
It would be great if someone could shed some light here on how to fix this for these users.
Maybe there's something in aiohttp that I did wrong in my integration lib or something that can be tweaked...
I'm hoping that maybe someone has come across this issue in the past with a different integration...

(BTW, I'm opening this as a PR to have context about the integration and the debugging, but if this is not acceptable please tell me and I will create an issue or a post in the community)

## Proposed change
None.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
