### PR TITLE
Nextbus: Listify directions

### DIFF
--- a/homeassistant/components/nextbus/config_flow.py
+++ b/homeassistant/components/nextbus/config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.selector import (
 )
 
 from .const import CONF_AGENCY, CONF_ROUTE, CONF_STOP, DOMAIN
+from .util import listify
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -51,7 +52,7 @@ def _get_stop_tags(
     title_counts = Counter(tags.values())
 
     stop_directions: dict[str, str] = {}
-    for direction in route_config["route"]["direction"]:
+    for direction in listify(route_config["route"]["direction"]):
         for stop in direction["stop"]:
             stop_directions[stop["tag"]] = direction["name"]
 

--- a/tests/components/nextbus/conftest.py
+++ b/tests/components/nextbus/conftest.py
@@ -1,11 +1,37 @@
 """Test helpers for NextBus tests."""
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
 
+@pytest.fixture(
+    params=[
+        {"name": "Outbound", "stop": [{"tag": "5650"}]},
+        [
+            {
+                "name": "Outbound",
+                "stop": [{"tag": "5650"}],
+            },
+            {
+                "name": "Inbound",
+                "stop": [{"tag": "5651"}],
+            },
+        ],
+    ]
+)
+def route_config_direction(request: pytest.FixtureRequest) -> Any:
+    """Generate alternative directions values.
+
+    When only on edirection is returned, it is not returned as a list, but instead an object.
+    """
+    return request.param
+
+
 @pytest.fixture
-def mock_nextbus_lists(mock_nextbus: MagicMock) -> MagicMock:
+def mock_nextbus_lists(
+    mock_nextbus: MagicMock, route_config_direction: Any
+) -> MagicMock:
     """Mock all list functions in nextbus to test validate logic."""
     instance = mock_nextbus.return_value
     instance.get_agency_list.return_value = {
@@ -22,16 +48,7 @@ def mock_nextbus_lists(mock_nextbus: MagicMock) -> MagicMock:
                 # Error case test. Duplicate title with no unique direction
                 {"tag": "5652", "title": "Market St & 7th St"},
             ],
-            "direction": [
-                {
-                    "name": "Outbound",
-                    "stop": [{"tag": "5650"}],
-                },
-                {
-                    "name": "Inbound",
-                    "stop": [{"tag": "5651"}],
-                },
-            ],
+            "direction": route_config_direction,
         }
     }
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When a single value is returned, the list wrapper is not present in the json payload. This patch ensures that the result is always a list.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #103335
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
