### PR TITLE
Bump vallox_websocket_api to 4.0.2

### DIFF
--- a/homeassistant/components/vallox/__init__.py
+++ b/homeassistant/components/vallox/__init__.py
@@ -135,7 +135,7 @@ class ValloxState:
     @property
     def sw_version(self) -> str:
         """Return the SW version."""
-        return cast(str, _api_get_sw_version(self.metric_cache))
+        return _api_get_sw_version(self.metric_cache)
 
     @property
     def uuid(self) -> UUID | None:

--- a/homeassistant/components/vallox/manifest.json
+++ b/homeassistant/components/vallox/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/vallox",
   "iot_class": "local_polling",
   "loggers": ["vallox_websocket_api"],
-  "requirements": ["vallox-websocket-api==3.3.0"]
+  "requirements": ["vallox-websocket-api==4.0.0"]
 }

--- a/homeassistant/components/vallox/manifest.json
+++ b/homeassistant/components/vallox/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/vallox",
   "iot_class": "local_polling",
   "loggers": ["vallox_websocket_api"],
-  "requirements": ["vallox-websocket-api==4.0.0"]
+  "requirements": ["vallox-websocket-api==4.0.2"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2658,7 +2658,7 @@ url-normalize==1.4.3
 uvcclient==0.11.0
 
 # homeassistant.components.vallox
-vallox-websocket-api==3.3.0
+vallox-websocket-api==4.0.0
 
 # homeassistant.components.rdw
 vehicle==2.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2658,7 +2658,7 @@ url-normalize==1.4.3
 uvcclient==0.11.0
 
 # homeassistant.components.vallox
-vallox-websocket-api==4.0.0
+vallox-websocket-api==4.0.2
 
 # homeassistant.components.rdw
 vehicle==2.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1976,7 +1976,7 @@ url-normalize==1.4.3
 uvcclient==0.11.0
 
 # homeassistant.components.vallox
-vallox-websocket-api==4.0.0
+vallox-websocket-api==4.0.2
 
 # homeassistant.components.rdw
 vehicle==2.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1976,7 +1976,7 @@ url-normalize==1.4.3
 uvcclient==0.11.0
 
 # homeassistant.components.vallox
-vallox-websocket-api==3.3.0
+vallox-websocket-api==4.0.0
 
 # homeassistant.components.rdw
 vehicle==2.0.0

--- a/tests/components/vallox/test_switch.py
+++ b/tests/components/vallox/test_switch.py
@@ -1,4 +1,6 @@
 """Tests for Vallox switch platform."""
+from unittest.mock import patch
+
 import pytest
 
 from homeassistant.components.switch.const import DOMAIN as SWITCH_DOMAIN
@@ -30,7 +32,9 @@ async def test_switch_entities(
     metrics = {metric_key: value}
 
     # Act
-    with patch_metrics(metrics=metrics):
+    with patch_metrics(metrics=metrics), patch(
+        "homeassistant.components.vallox.Vallox.set_settable_address"
+    ):
         await hass.config_entries.async_setup(mock_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -56,7 +60,9 @@ async def test_bypass_lock_switch_entitity_set(
 ) -> None:
     """Test bypass lock switch set."""
     # Act
-    with patch_metrics(metrics={}), patch_metrics_set() as metrics_set:
+    with patch_metrics(metrics={}), patch_metrics_set() as metrics_set, patch(
+        "homeassistant.components.vallox.Vallox.set_settable_address"
+    ):
         await hass.config_entries.async_setup(mock_entry.entry_id)
         await hass.async_block_till_done()
         await hass.services.async_call(


### PR DESCRIPTION
## Proposed change

Changelog: https://github.com/yozik04/vallox_websocket_api/compare/3.3.0...4.0.2

Attempts to fix #99294.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #99294
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
