### PR TITLE
Allow overriding blueprints on import

### DIFF
--- a/homeassistant/components/automation/helpers.py
+++ b/homeassistant/components/automation/helpers.py
@@ -1,5 +1,6 @@
 """Helpers for automation integration."""
 from homeassistant.components import blueprint
+from homeassistant.const import SERVICE_RELOAD
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.singleton import singleton
 
@@ -15,8 +16,17 @@ def _blueprint_in_use(hass: HomeAssistant, blueprint_path: str) -> bool:
     return len(automations_with_blueprint(hass, blueprint_path)) > 0
 
 
+async def _reload_blueprint_automations(
+    hass: HomeAssistant, blueprint_path: str
+) -> None:
+    """Reload all automations that rely on a specific blueprint."""
+    await hass.services.async_call(DOMAIN, SERVICE_RELOAD)
+
+
 @singleton(DATA_BLUEPRINTS)
 @callback
 def async_get_blueprints(hass: HomeAssistant) -> blueprint.DomainBlueprints:
     """Get automation blueprints."""
-    return blueprint.DomainBlueprints(hass, DOMAIN, LOGGER, _blueprint_in_use)
+    return blueprint.DomainBlueprints(
+        hass, DOMAIN, LOGGER, _blueprint_in_use, _reload_blueprint_automations
+    )

--- a/homeassistant/components/blueprint/models.py
+++ b/homeassistant/components/blueprint/models.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 import logging
 import pathlib
 import shutil
@@ -189,12 +189,14 @@ class DomainBlueprints:
         domain: str,
         logger: logging.Logger,
         blueprint_in_use: Callable[[HomeAssistant, str], bool],
+        reload_blueprint_consumers: Callable[[HomeAssistant, str], Awaitable[None]],
     ) -> None:
         """Initialize a domain blueprints instance."""
         self.hass = hass
         self.domain = domain
         self.logger = logger
         self._blueprint_in_use = blueprint_in_use
+        self._reload_blueprint_consumers = reload_blueprint_consumers
         self._blueprints: dict[str, Blueprint | None] = {}
         self._load_lock = asyncio.Lock()
 
@@ -283,7 +285,7 @@ class DomainBlueprints:
                 blueprint = await self.hass.async_add_executor_job(
                     self._load_blueprint, blueprint_path
                 )
-            except Exception:
+            except FailedToLoad:
                 self._blueprints[blueprint_path] = None
                 raise
 
@@ -315,30 +317,40 @@ class DomainBlueprints:
         await self.hass.async_add_executor_job(path.unlink)
         self._blueprints[blueprint_path] = None
 
-    def _create_file(self, blueprint: Blueprint, blueprint_path: str) -> None:
-        """Create blueprint file."""
+    def _create_file(
+        self, blueprint: Blueprint, blueprint_path: str, allow_override: bool
+    ) -> bool:
+        """Create blueprint file.
+
+        Returns true if the action updated an existing blueprint.
+        """
 
         path = pathlib.Path(
             self.hass.config.path(BLUEPRINT_FOLDER, self.domain, blueprint_path)
         )
-        if path.exists():
+        exists = path.exists()
+
+        if not allow_override and exists:
             raise FileAlreadyExists(self.domain, blueprint_path)
 
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(blueprint.yaml(), encoding="utf-8")
+        return exists
 
     async def async_add_blueprint(
-        self, blueprint: Blueprint, blueprint_path: str
-    ) -> None:
+        self, blueprint: Blueprint, blueprint_path: str, allow_override=False
+    ) -> bool:
         """Add a blueprint."""
-        if not blueprint_path.endswith(".yaml"):
-            blueprint_path = f"{blueprint_path}.yaml"
-
-        await self.hass.async_add_executor_job(
-            self._create_file, blueprint, blueprint_path
+        is_update = await self.hass.async_add_executor_job(
+            self._create_file, blueprint, blueprint_path, allow_override
         )
 
         self._blueprints[blueprint_path] = blueprint
+
+        if is_update:
+            await self._reload_blueprint_consumers(self.hass, blueprint_path)
+
+        return is_update
 
     async def async_populate(self) -> None:
         """Create folder if it doesn't exist and populate with examples."""

--- a/homeassistant/components/blueprint/models.py
+++ b/homeassistant/components/blueprint/models.py
@@ -322,7 +322,7 @@ class DomainBlueprints:
     ) -> bool:
         """Create blueprint file.
 
-        Returns true if the action updated an existing blueprint.
+        Returns true if the action overrides an existing blueprint.
         """
 
         path = pathlib.Path(
@@ -341,16 +341,16 @@ class DomainBlueprints:
         self, blueprint: Blueprint, blueprint_path: str, allow_override=False
     ) -> bool:
         """Add a blueprint."""
-        is_update = await self.hass.async_add_executor_job(
+        overrides_existing = await self.hass.async_add_executor_job(
             self._create_file, blueprint, blueprint_path, allow_override
         )
 
         self._blueprints[blueprint_path] = blueprint
 
-        if is_update:
+        if overrides_existing:
             await self._reload_blueprint_consumers(self.hass, blueprint_path)
 
-        return is_update
+        return overrides_existing
 
     async def async_populate(self) -> None:
         """Create folder if it doesn't exist and populate with examples."""

--- a/homeassistant/components/blueprint/websocket_api.py
+++ b/homeassistant/components/blueprint/websocket_api.py
@@ -14,7 +14,7 @@ from homeassistant.util import yaml
 
 from . import importer, models
 from .const import DOMAIN
-from .errors import FileAlreadyExists
+from .errors import FailedToLoad, FileAlreadyExists
 
 
 @callback
@@ -81,6 +81,23 @@ async def ws_import_blueprint(
         )
         return
 
+    # Check it exists and if so, which automations are using it
+    domain = imported_blueprint.blueprint.metadata["domain"]
+    domain_blueprints: models.DomainBlueprints | None = hass.data.get(DOMAIN, {}).get(
+        domain
+    )
+    if domain_blueprints is None:
+        connection.send_error(
+            msg["id"], websocket_api.ERR_INVALID_FORMAT, "Unsupported domain"
+        )
+        return
+
+    suggested_path = f"{imported_blueprint.suggested_filename}.yaml"
+    try:
+        exists = bool(await domain_blueprints.async_get_blueprint(suggested_path))
+    except FailedToLoad:
+        exists = False
+
     connection.send_result(
         msg["id"],
         {
@@ -90,6 +107,7 @@ async def ws_import_blueprint(
                 "metadata": imported_blueprint.blueprint.metadata,
             },
             "validation_errors": imported_blueprint.blueprint.validate(),
+            "exists": exists,
         },
     )
 
@@ -101,6 +119,7 @@ async def ws_import_blueprint(
         vol.Required("path"): cv.path,
         vol.Required("yaml"): cv.string,
         vol.Optional("source_url"): cv.url,
+        vol.Optional("allow_override"): bool,
     }
 )
 @websocket_api.async_response
@@ -130,8 +149,13 @@ async def ws_save_blueprint(
         connection.send_error(msg["id"], websocket_api.ERR_INVALID_FORMAT, str(err))
         return
 
+    if not path.endswith(".yaml"):
+        path = f"{path}.yaml"
+
     try:
-        await domain_blueprints[domain].async_add_blueprint(blueprint, path)
+        updated_existing = await domain_blueprints[domain].async_add_blueprint(
+            blueprint, path, allow_override=msg.get("allow_override", False)
+        )
     except FileAlreadyExists:
         connection.send_error(msg["id"], "already_exists", "File already exists")
         return
@@ -141,6 +165,9 @@ async def ws_save_blueprint(
 
     connection.send_result(
         msg["id"],
+        {
+            "updated_existing": updated_existing,
+        },
     )
 
 

--- a/homeassistant/components/blueprint/websocket_api.py
+++ b/homeassistant/components/blueprint/websocket_api.py
@@ -153,7 +153,7 @@ async def ws_save_blueprint(
         path = f"{path}.yaml"
 
     try:
-        updated_existing = await domain_blueprints[domain].async_add_blueprint(
+        overrides_existing = await domain_blueprints[domain].async_add_blueprint(
             blueprint, path, allow_override=msg.get("allow_override", False)
         )
     except FileAlreadyExists:
@@ -166,7 +166,7 @@ async def ws_save_blueprint(
     connection.send_result(
         msg["id"],
         {
-            "updated_existing": updated_existing,
+            "overrides_existing": overrides_existing,
         },
     )
 

--- a/homeassistant/components/script/helpers.py
+++ b/homeassistant/components/script/helpers.py
@@ -1,5 +1,6 @@
 """Helpers for automation integration."""
 from homeassistant.components.blueprint import DomainBlueprints
+from homeassistant.const import SERVICE_RELOAD
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.singleton import singleton
 
@@ -15,8 +16,15 @@ def _blueprint_in_use(hass: HomeAssistant, blueprint_path: str) -> bool:
     return len(scripts_with_blueprint(hass, blueprint_path)) > 0
 
 
+async def _reload_blueprint_scripts(hass: HomeAssistant, blueprint_path: str) -> None:
+    """Reload all script that rely on a specific blueprint."""
+    await hass.services.async_call(DOMAIN, SERVICE_RELOAD)
+
+
 @singleton(DATA_BLUEPRINTS)
 @callback
 def async_get_blueprints(hass: HomeAssistant) -> DomainBlueprints:
     """Get script blueprints."""
-    return DomainBlueprints(hass, DOMAIN, LOGGER, _blueprint_in_use)
+    return DomainBlueprints(
+        hass, DOMAIN, LOGGER, _blueprint_in_use, _reload_blueprint_scripts
+    )

--- a/tests/components/blueprint/test_models.py
+++ b/tests/components/blueprint/test_models.py
@@ -1,6 +1,6 @@
 """Test blueprint models."""
 import logging
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -49,7 +49,7 @@ def blueprint_2():
 def domain_bps(hass):
     """Domain blueprints fixture."""
     return models.DomainBlueprints(
-        hass, "automation", logging.getLogger(__name__), None
+        hass, "automation", logging.getLogger(__name__), None, AsyncMock()
     )
 
 
@@ -257,12 +257,8 @@ async def test_domain_blueprints_inputs_from_config(domain_bps, blueprint_1) -> 
 async def test_domain_blueprints_add_blueprint(domain_bps, blueprint_1) -> None:
     """Test DomainBlueprints.async_add_blueprint."""
     with patch.object(domain_bps, "_create_file") as create_file_mock:
-        # Should add extension when not present.
-        await domain_bps.async_add_blueprint(blueprint_1, "something")
+        await domain_bps.async_add_blueprint(blueprint_1, "something.yaml")
         assert create_file_mock.call_args[0][1] == "something.yaml"
-
-        await domain_bps.async_add_blueprint(blueprint_1, "something2.yaml")
-        assert create_file_mock.call_args[0][1] == "something2.yaml"
 
     # Should be in cache.
     with patch.object(domain_bps, "_load_blueprint") as mock_load:

--- a/tests/components/blueprint/test_websocket_api.py
+++ b/tests/components/blueprint/test_websocket_api.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
+import yaml
 
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -129,6 +130,52 @@ async def test_import_blueprint(
             },
         },
         "validation_errors": None,
+        "exists": False,
+    }
+
+
+async def test_import_blueprint_update(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_ws_client: WebSocketGenerator,
+    setup_bp,
+) -> None:
+    """Test importing blueprints."""
+    raw_data = Path(
+        hass.config.path("blueprints/automation/in_folder/in_folder_blueprint.yaml")
+    ).read_text()
+
+    aioclient_mock.get(
+        "https://raw.githubusercontent.com/in_folder/home-assistant-config/main/blueprints/automation/in_folder_blueprint.yaml",
+        text=raw_data,
+    )
+
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {
+            "id": 5,
+            "type": "blueprint/import",
+            "url": "https://github.com/in_folder/home-assistant-config/blob/main/blueprints/automation/in_folder_blueprint.yaml",
+        }
+    )
+
+    msg = await client.receive_json()
+
+    assert msg["id"] == 5
+    assert msg["success"]
+    assert msg["result"] == {
+        "suggested_filename": "in_folder/in_folder_blueprint",
+        "raw_data": raw_data,
+        "blueprint": {
+            "metadata": {
+                "domain": "automation",
+                "input": {"action": None, "trigger": None},
+                "name": "In Folder Blueprint",
+                "source_url": "https://github.com/in_folder/home-assistant-config/blob/main/blueprints/automation/in_folder_blueprint.yaml",
+            }
+        },
+        "validation_errors": None,
+        "exists": True,
     }
 
 
@@ -210,6 +257,42 @@ async def test_save_existing_file(
     assert msg["id"] == 7
     assert not msg["success"]
     assert msg["error"] == {"code": "already_exists", "message": "File already exists"}
+
+
+async def test_save_existing_file_override(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test saving blueprints."""
+
+    client = await hass_ws_client(hass)
+    with patch("pathlib.Path.write_text") as write_mock:
+        await client.send_json(
+            {
+                "id": 7,
+                "type": "blueprint/save",
+                "path": "test_event_service",
+                "yaml": 'blueprint: {name: "name", domain: "automation"}',
+                "domain": "automation",
+                "source_url": "https://github.com/balloob/home-assistant-config/blob/main/blueprints/automation/test_event_service.yaml",
+                "allow_override": True,
+            }
+        )
+
+        msg = await client.receive_json()
+
+    assert msg["id"] == 7
+    assert msg["success"]
+    assert msg["result"] == {"updated_existing": True}
+    assert yaml.safe_load(write_mock.mock_calls[0][1][0]) == {
+        "blueprint": {
+            "name": "name",
+            "domain": "automation",
+            "source_url": "https://github.com/balloob/home-assistant-config/blob/main/blueprints/automation/test_event_service.yaml",
+            "input": {},
+        }
+    }
 
 
 async def test_save_file_error(

--- a/tests/components/blueprint/test_websocket_api.py
+++ b/tests/components/blueprint/test_websocket_api.py
@@ -284,7 +284,7 @@ async def test_save_existing_file_override(
 
     assert msg["id"] == 7
     assert msg["success"]
-    assert msg["result"] == {"updated_existing": True}
+    assert msg["result"] == {"overrides_existing": True}
     assert yaml.safe_load(write_mock.mock_calls[0][1][0]) == {
         "blueprint": {
             "name": "name",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow overriding blueprints on import:

The websocket command `blueprint/import` returns a new field `exists: bool` in the response.

The websocket command `blueprint/save` takes a new parameter `allow_override`. When set to True, will allow the blueprint to override an existing one. The result is now a dictionary `{"updated_existing": bool}`.

When a blueprint is updated, it will automatically reload the automations/scripts to make use of this.

Note for a future PR: `DomainBlueprints` is a candidate to be turned into an abstract base class instead of passing in methods.

Marked as draft until the frontend is done as building out the frontend might require some more changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
