### PR TITLE
Add OVOS/Neon Voice Assistants integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -929,6 +929,8 @@ build.json @home-assistant/supervisor
 /tests/components/overkiz/ @imicknl @vlebourl @tetienne @nyroDev
 /homeassistant/components/ovo_energy/ @timmo001
 /tests/components/ovo_energy/ @timmo001
+/homeassistant/components/ovos/ @atd
+/tests/components/ovos/ @atd
 /homeassistant/components/p1_monitor/ @klaasnicolaas
 /tests/components/p1_monitor/ @klaasnicolaas
 /homeassistant/components/panel_custom/ @home-assistant/frontend

--- a/homeassistant/components/ovos/__init__.py
+++ b/homeassistant/components/ovos/__init__.py
@@ -1,0 +1,44 @@
+"""The ovos integration."""
+from __future__ import annotations
+
+import logging
+
+from ovos_bus_client import MessageBusClient
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import discovery
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS: list[Platform] = [Platform.NOTIFY]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up ovos from a config entry."""
+
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN].setdefault("entries", {})
+
+    client = MessageBusClient(host=entry.data["host"], port=entry.data["port"])
+    client.run_in_thread()
+
+    hass.data[DOMAIN]["entries"][entry.entry_id] = {"client": client}
+
+    discovery.load_platform(hass, Platform.NOTIFY, DOMAIN, {}, {})
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        entry_id = entry.entry_id
+
+        hass.data[DOMAIN]["entries"][entry_id]["client"].close()
+        hass.data[DOMAIN]["entries"].pop(entry_id)
+
+    return unload_ok

--- a/homeassistant/components/ovos/config_flow.py
+++ b/homeassistant/components/ovos/config_flow.py
@@ -1,0 +1,80 @@
+"""Config flow for ovos integration."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.exceptions import HomeAssistantError
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required("host"): str,
+        vol.Optional("port", default=8181): int,
+    }
+)
+
+
+async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
+    """Validate the user input allows us to connect.
+
+    Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
+    """
+    # If your PyPI package is not built with async, pass your methods
+    # to the executor:
+    # await hass.async_add_executor_job(
+    #     your_validate_func, data["username"], data["password"]
+    # )
+
+    # If you cannot connect:
+    # throw CannotConnect
+    # If the authentication is wrong:
+    # InvalidAuth
+
+    # Return info that you want to store in the config entry.
+    return {"title": data["host"]}
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for ovos."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                return self.async_create_entry(title=info["title"], data=user_input)
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+
+class CannotConnect(HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/ovos/const.py
+++ b/homeassistant/components/ovos/const.py
@@ -1,0 +1,3 @@
+"""Constants for the ovos integration."""
+
+DOMAIN = "ovos"

--- a/homeassistant/components/ovos/manifest.json
+++ b/homeassistant/components/ovos/manifest.json
@@ -1,0 +1,14 @@
+{
+  "domain": "ovos",
+  "name": "ovos",
+  "codeowners": ["@atd"],
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://www.home-assistant.io/integrations/ovos",
+  "homekit": {},
+  "integration_type": "device",
+  "iot_class": "local_push",
+  "requirements": ["ovos-bus-client==0.0.5"],
+  "ssdp": [],
+  "zeroconf": []
+}

--- a/homeassistant/components/ovos/notify.py
+++ b/homeassistant/components/ovos/notify.py
@@ -1,0 +1,46 @@
+"""OpenVoiceOS (OVOS) and Neon AI notification platform."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ovos_bus_client import Message
+
+from homeassistant.components.notify import BaseNotificationService
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def get_service(
+    hass: HomeAssistant,
+    config: ConfigType,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> OvosNotificationService:
+    """Get the OVOS notification service."""
+    return OvosNotificationService(hass.data[DOMAIN])
+
+
+class OvosNotificationService(BaseNotificationService):
+    """The OVOS Notification Service."""
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        """Initialize the service."""
+        self.config = config
+
+    def send_message(
+        self, message: str = "", lang: str = "en-us", **kwargs: Any
+    ) -> None:
+        """Send a message to OVOS/Neon to speak on instance."""
+        for _entry_id, entry_config in self.config["entries"].items():
+            client = entry_config["client"]
+
+            try:
+                client.emit(Message("speak", {"utterance": message, "lang": lang}))
+            except ConnectionRefusedError:
+                _LOGGER.error("Could not reach this instance of OVOS")
+            except ValueError:
+                _LOGGER.error("Error from OVOS messagebus")

--- a/homeassistant/components/ovos/strings.json
+++ b/homeassistant/components/ovos/strings.json
@@ -1,0 +1,19 @@
+{
+  "config": {
+    "step": {
+      "confirm": {
+        "description": "[%key:common::config_flow::description::confirm_setup%]"
+      },
+      "user": {
+        "data": {
+          "host": "Host",
+          "port": "Port"
+        }
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]"
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -343,6 +343,7 @@ FLOWS = {
         "otbr",
         "overkiz",
         "ovo_energy",
+        "ovos",
         "owntracks",
         "p1_monitor",
         "panasonic_viera",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -4147,6 +4147,12 @@
       "config_flow": true,
       "iot_class": "cloud_polling"
     },
+    "ovos": {
+      "name": "ovos",
+      "integration_type": "device",
+      "config_flow": true,
+      "iot_class": "local_push"
+    },
     "owntracks": {
       "name": "OwnTracks",
       "integration_type": "hub",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1406,6 +1406,9 @@ orvibo==1.1.1
 # homeassistant.components.ovo_energy
 ovoenergy==1.2.0
 
+# homeassistant.components.ovos
+ovos-bus-client==0.0.5
+
 # homeassistant.components.p1_monitor
 p1monitor==2.1.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1078,6 +1078,9 @@ oralb-ble==0.17.6
 # homeassistant.components.ovo_energy
 ovoenergy==1.2.0
 
+# homeassistant.components.ovos
+ovos-bus-client==0.0.5
+
 # homeassistant.components.p1_monitor
 p1monitor==2.1.1
 

--- a/tests/components/ovos/__init__.py
+++ b/tests/components/ovos/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the ovos integration."""

--- a/tests/components/ovos/test_config_flow.py
+++ b/tests/components/ovos/test_config_flow.py
@@ -1,0 +1,42 @@
+"""Test the OVOS config flow."""
+from unittest.mock import patch
+
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.components.ovos.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
+
+FIXTURE_USER_INPUT = {CONF_HOST: "localhost", CONF_PORT: 8181}
+
+
+async def test_show_form(hass: HomeAssistant) -> None:
+    """Test that the setup form is served."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+
+async def test_full_flow_implementation(hass: HomeAssistant) -> None:
+    """Test registering an integration and finishing flow works."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with patch(
+        "homeassistant.components.ovos.async_setup_entry",
+        return_value=True,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            FIXTURE_USER_INPUT,
+        )
+
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["data"][CONF_HOST] == FIXTURE_USER_INPUT[CONF_HOST]
+    assert result2["data"][CONF_PORT] == FIXTURE_USER_INPUT[CONF_PORT]

--- a/tests/components/ovos/test_notify.py
+++ b/tests/components/ovos/test_notify.py
@@ -1,0 +1,33 @@
+"""Test the OVOS config flow."""
+from unittest.mock import MagicMock
+
+from ovos_bus_client import MessageBusClient
+
+from homeassistant.components.ovos import DOMAIN
+from homeassistant.components.ovos.notify import get_service
+from homeassistant.core import HomeAssistant
+
+
+class MessageBusClientMock(MessageBusClient):
+    """Mock MessageBusClient."""
+
+    def __init__(self):
+        """Skip configuration."""
+        pass
+
+
+async def test_send_message(hass: HomeAssistant) -> None:
+    """Test sending a message in the notification service."""
+    message_bus_client = MessageBusClientMock()
+    message_bus_client.emit = MagicMock()
+
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN].setdefault("entries", {})
+    hass.data[DOMAIN]["entries"]["id"] = {"client": message_bus_client}
+
+    service = get_service(hass, {})
+    service.send_message("testing notifications")
+
+    message = message_bus_client.emit.call_args.args[0]
+    assert (message.msg_type) == "speak"
+    assert (message.data) == {"utterance": "testing notifications", "lang": "en-us"}


### PR DESCRIPTION
This change adapts the code from the Mycroft integration to allow for Notify support for both OpenVoice OS (OVOS) and Neon.AI Voice Assistants. They are community-led forks of the Mycroft Private Voice Assistant and, as Mycroft has gone bankrupt, their successors. Neon uses OVOS as its upstream core provider.

Eventually more support for these voice assistants would be added, but for now, this enables the previous support that the Mycroft integration had.

This continues the work of @mikejgray at  https://github.com/home-assistant/core/pull/93837

Documentation PR https://github.com/home-assistant/home-assistant.io/pull/29730

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This change adapts the code from the Mycroft integration to allow for Notify support for both OpenVoice OS (OVOS) and Neon.AI Voice Assistants. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
