### PR TITLE
Handle smarttub sensor values being None

### DIFF
--- a/homeassistant/components/smarttub/manifest.json
+++ b/homeassistant/components/smarttub/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["smarttub"],
   "quality_scale": "platinum",
-  "requirements": ["python-smarttub==0.0.33"]
+  "requirements": ["python-smarttub==0.0.35"]
 }

--- a/homeassistant/components/smarttub/sensor.py
+++ b/homeassistant/components/smarttub/sensor.py
@@ -6,6 +6,7 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -93,8 +94,9 @@ class SmartTubSensor(SmartTubSensorBase, SensorEntity):
         """Return the current state of the sensor."""
         if isinstance(self._state, Enum):
             return self._state.name.lower()
-        elif self._state is None:
-            return "unknown"
+
+        if self._state is None:
+            return STATE_UNKNOWN
 
         return self._state.lower()
 

--- a/homeassistant/components/smarttub/sensor.py
+++ b/homeassistant/components/smarttub/sensor.py
@@ -6,7 +6,6 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -90,10 +89,10 @@ class SmartTubSensor(SmartTubSensorBase, SensorEntity):
     """Generic class for SmartTub status sensors."""
 
     @property
-    def native_value(self) -> str:
+    def native_value(self) -> str | None:
         """Return the current state of the sensor."""
         if self._state is None:
-            return STATE_UNKNOWN
+            return None
 
         if isinstance(self._state, Enum):
             return self._state.name.lower()

--- a/homeassistant/components/smarttub/sensor.py
+++ b/homeassistant/components/smarttub/sensor.py
@@ -93,6 +93,9 @@ class SmartTubSensor(SmartTubSensorBase, SensorEntity):
         """Return the current state of the sensor."""
         if isinstance(self._state, Enum):
             return self._state.name.lower()
+        elif self._state is None:
+            return "unknown"
+
         return self._state.lower()
 
 

--- a/homeassistant/components/smarttub/sensor.py
+++ b/homeassistant/components/smarttub/sensor.py
@@ -92,11 +92,11 @@ class SmartTubSensor(SmartTubSensorBase, SensorEntity):
     @property
     def native_value(self) -> str:
         """Return the current state of the sensor."""
-        if isinstance(self._state, Enum):
-            return self._state.name.lower()
-
         if self._state is None:
             return STATE_UNKNOWN
+
+        if isinstance(self._state, Enum):
+            return self._state.name.lower()
 
         return self._state.lower()
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2187,7 +2187,7 @@ python-ripple-api==0.0.3
 python-roborock==0.35.0
 
 # homeassistant.components.smarttub
-python-smarttub==0.0.33
+python-smarttub==0.0.35
 
 # homeassistant.components.songpal
 python-songpal==0.15.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1631,7 +1631,7 @@ python-qbittorrent==0.4.3
 python-roborock==0.35.0
 
 # homeassistant.components.smarttub
-python-smarttub==0.0.33
+python-smarttub==0.0.35
 
 # homeassistant.components.songpal
 python-songpal==0.15.2

--- a/tests/components/smarttub/test_sensor.py
+++ b/tests/components/smarttub/test_sensor.py
@@ -2,7 +2,6 @@
 import pytest
 import smarttub
 
-from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
 
@@ -46,7 +45,7 @@ async def test_null_blowoutcycle(
     entity_id = f"sensor.{spa.brand}_{spa.model}_blowout_cycle"
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.state == STATE_UNKNOWN
+    assert state.state is None
 
 
 async def test_primary_filtration(

--- a/tests/components/smarttub/test_sensor.py
+++ b/tests/components/smarttub/test_sensor.py
@@ -2,6 +2,7 @@
 import pytest
 import smarttub
 
+from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
 
@@ -45,7 +46,7 @@ async def test_null_blowoutcycle(
     entity_id = f"sensor.{spa.brand}_{spa.model}_blowout_cycle"
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.state is None
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_primary_filtration(

--- a/tests/components/smarttub/test_sensor.py
+++ b/tests/components/smarttub/test_sensor.py
@@ -27,6 +27,27 @@ async def test_sensor(
     assert state.state == expected_state
 
 
+# https://github.com/home-assistant/core/issues/102339
+async def test_null_blowoutcycle(
+    spa,
+    spa_state,
+    config_entry,
+    hass: HomeAssistant,
+) -> None:
+    """Test blowoutCycle having null value."""
+
+    spa_state.blowout_cycle = None
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_id = f"sensor.{spa.brand}_{spa.model}_blowout_cycle"
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "unknown"
+
+
 async def test_primary_filtration(
     spa, spa_state, setup_entry, hass: HomeAssistant
 ) -> None:

--- a/tests/components/smarttub/test_sensor.py
+++ b/tests/components/smarttub/test_sensor.py
@@ -2,6 +2,7 @@
 import pytest
 import smarttub
 
+from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
 
@@ -45,7 +46,7 @@ async def test_null_blowoutcycle(
     entity_id = f"sensor.{spa.brand}_{spa.model}_blowout_cycle"
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.state == "unknown"
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_primary_filtration(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In some cases, the smarttub API can return `null` for a sensor which normally has a value represented by the enum. Handle this gracefully by setting the state to None.

https://github.com/mdz/python-smarttub/compare/v0.0.33...v0.0.35

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

Fixing this bug requires a small change to the dependency

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #102339 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
