### PR TITLE
Pin jaraco.functools to fix builds and CI

### DIFF
--- a/homeassistant/components/abode/manifest.json
+++ b/homeassistant/components/abode/manifest.json
@@ -9,5 +9,5 @@
   },
   "iot_class": "cloud_push",
   "loggers": ["jaraco.abode", "lomond"],
-  "requirements": ["jaraco.abode==3.3.0"]
+  "requirements": ["jaraco.abode==3.3.0", "jaraco.functools==3.9.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1097,6 +1097,9 @@ janus==1.0.0
 # homeassistant.components.abode
 jaraco.abode==3.3.0
 
+# homeassistant.components.abode
+jaraco.functools==3.9.0
+
 # homeassistant.components.jellyfin
 jellyfin-apiclient-python==1.9.2
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -865,6 +865,9 @@ janus==1.0.0
 # homeassistant.components.abode
 jaraco.abode==3.3.0
 
+# homeassistant.components.abode
+jaraco.functools==3.9.0
+
 # homeassistant.components.jellyfin
 jellyfin-apiclient-python==1.9.2
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
builds/ci are broken due to release 4.0.0 of https://pypi.org/project/jaraco.functools/4.0.0/

abode uses an old version of jaraco.abode which relies on an old version of jaraco.functools


```
venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
    exec(co, module.__dict__)
tests/components/abode/conftest.py:5: in <module>
    from jaraco.abode.helpers import urls as URL
venv/lib/python3.12/site-packages/jaraco/abode/__init__.py:5: in <module>
    from .client import Client
venv/lib/python3.12/site-packages/jaraco/abode/client.py:18: in <module>
    from .event_controller import EventController
venv/lib/python3.12/site-packages/jaraco/abode/event_controller.py:13: in <module>
    from .helpers import timeline as TIMELINE
venv/lib/python3.12/site-packages/jaraco/abode/helpers/timeline.py:6: in <module>
    from jaraco.functools import call_aside
E   ImportError: cannot import name 'call_aside' from 'jaraco.functools' (/home/runner/work/core/core/venv/lib/python3.12/site-packages/jaraco/functools/__init__.py)
```
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
