### PR TITLE
Fix litterrobot test failure due to time zone dependence

### DIFF
--- a/tests/components/litterrobot/test_time.py
+++ b/tests/components/litterrobot/test_time.py
@@ -1,10 +1,11 @@
 """Test the Litter-Robot time entity."""
 from __future__ import annotations
 
-from datetime import time
+from datetime import datetime, time
 from unittest.mock import MagicMock
 
 from pylitterbot import LitterRobot3
+import pytest
 
 from homeassistant.components.time import DOMAIN as PLATFORM_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID
@@ -15,6 +16,7 @@ from .conftest import setup_integration
 SLEEP_START_TIME_ENTITY_ID = "time.test_sleep_mode_start_time"
 
 
+@pytest.mark.freeze_time(datetime(2023, 11, 1, 12))
 async def test_sleep_mode_start_time(
     hass: HomeAssistant, mock_account: MagicMock
 ) -> None:

--- a/tests/components/litterrobot/test_time.py
+++ b/tests/components/litterrobot/test_time.py
@@ -16,7 +16,7 @@ from .conftest import setup_integration
 SLEEP_START_TIME_ENTITY_ID = "time.test_sleep_mode_start_time"
 
 
-@pytest.mark.freeze_time(datetime(2023, 11, 1, 12))
+@pytest.mark.freeze_time(datetime(2023, 7, 1, 12))
 async def test_sleep_mode_start_time(
     hass: HomeAssistant, mock_account: MagicMock
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This test started failing today without any related code changes, presumably due to the end of DST in `America/New_York` where the test fixture device is located. This caused failures on several other PRs, e.g.:
- https://github.com/home-assistant/core/actions/runs/6761808543/job/18377266500?pr=103438
- https://github.com/home-assistant/core/actions/runs/6761664780/job/18376893767?pr=103410
- https://github.com/home-assistant/core/actions/runs/6759978613/job/18373211247?pr=103385


This PR fixes the test failure by using freezegun to ensure a constant date.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
