### PR TITLE
Fix entity category for sensor fails mqtt sensor platform setup

### DIFF
--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -69,12 +69,13 @@ _PLATFORM_SCHEMA_BASE = MQTT_RO_SCHEMA.extend(
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)
 
 DISCOVERY_SCHEMA = vol.All(
-    validate_sensor_entity_category(binary_sensor.DOMAIN),
+    validate_sensor_entity_category(binary_sensor.DOMAIN, discovery=True),
     _PLATFORM_SCHEMA_BASE.extend({}, extra=vol.REMOVE_EXTRA),
 )
 
 PLATFORM_SCHEMA_MODERN = vol.All(
-    validate_sensor_entity_category(binary_sensor.DOMAIN), _PLATFORM_SCHEMA_BASE
+    validate_sensor_entity_category(binary_sensor.DOMAIN, discovery=False),
+    _PLATFORM_SCHEMA_BASE,
 )
 
 

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -69,11 +69,13 @@ _PLATFORM_SCHEMA_BASE = MQTT_RO_SCHEMA.extend(
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)
 
 DISCOVERY_SCHEMA = vol.All(
-    validate_sensor_entity_category,
+    validate_sensor_entity_category(binary_sensor.DOMAIN),
     _PLATFORM_SCHEMA_BASE.extend({}, extra=vol.REMOVE_EXTRA),
 )
 
-PLATFORM_SCHEMA_MODERN = vol.All(validate_sensor_entity_category, _PLATFORM_SCHEMA_BASE)
+PLATFORM_SCHEMA_MODERN = vol.All(
+    validate_sensor_entity_category(binary_sensor.DOMAIN), _PLATFORM_SCHEMA_BASE
+)
 
 
 async def async_setup_entry(

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -42,7 +42,6 @@ from .mixins import (
     MqttAvailability,
     MqttEntity,
     async_setup_entity_entry_helper,
-    validate_sensor_entity_category,
     write_state_on_attr_change,
 )
 from .models import MqttValueTemplate, ReceiveMessage
@@ -69,12 +68,10 @@ _PLATFORM_SCHEMA_BASE = MQTT_RO_SCHEMA.extend(
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)
 
 DISCOVERY_SCHEMA = vol.All(
-    validate_sensor_entity_category(binary_sensor.DOMAIN, discovery=True),
     _PLATFORM_SCHEMA_BASE.extend({}, extra=vol.REMOVE_EXTRA),
 )
 
 PLATFORM_SCHEMA_MODERN = vol.All(
-    validate_sensor_entity_category(binary_sensor.DOMAIN, discovery=False),
     _PLATFORM_SCHEMA_BASE,
 )
 

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -88,7 +88,7 @@ PLATFORM_SCHEMA_MODERN = vol.All(
     # Deprecated in HA Core 2021.11.0 https://github.com/home-assistant/core/pull/54840
     # Removed in HA Core 2023.6.0
     cv.removed(CONF_LAST_RESET_TOPIC),
-    validate_sensor_entity_category,
+    validate_sensor_entity_category(sensor.DOMAIN),
     _PLATFORM_SCHEMA_BASE,
 )
 
@@ -96,7 +96,7 @@ DISCOVERY_SCHEMA = vol.All(
     # Deprecated in HA Core 2021.11.0 https://github.com/home-assistant/core/pull/54840
     # Removed in HA Core 2023.6.0
     cv.removed(CONF_LAST_RESET_TOPIC),
-    validate_sensor_entity_category,
+    validate_sensor_entity_category(sensor.DOMAIN),
     _PLATFORM_SCHEMA_BASE.extend({}, extra=vol.REMOVE_EXTRA),
 )
 

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -88,7 +88,7 @@ PLATFORM_SCHEMA_MODERN = vol.All(
     # Deprecated in HA Core 2021.11.0 https://github.com/home-assistant/core/pull/54840
     # Removed in HA Core 2023.6.0
     cv.removed(CONF_LAST_RESET_TOPIC),
-    validate_sensor_entity_category(sensor.DOMAIN),
+    validate_sensor_entity_category(sensor.DOMAIN, discovery=False),
     _PLATFORM_SCHEMA_BASE,
 )
 
@@ -96,7 +96,7 @@ DISCOVERY_SCHEMA = vol.All(
     # Deprecated in HA Core 2021.11.0 https://github.com/home-assistant/core/pull/54840
     # Removed in HA Core 2023.6.0
     cv.removed(CONF_LAST_RESET_TOPIC),
-    validate_sensor_entity_category(sensor.DOMAIN),
+    validate_sensor_entity_category(sensor.DOMAIN, discovery=True),
     _PLATFORM_SCHEMA_BASE.extend({}, extra=vol.REMOVE_EXTRA),
 )
 

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -20,6 +20,10 @@
       "title": "MQTT entities with auxiliary heat support found",
       "description": "Entity `{entity_id}` has auxiliary heat support enabled, which has been deprecated for MQTT climate devices. Please adjust your configuration and remove deprecated config options from your configuration and restart Home Assistant to fix this issue."
     },
+    "invalid_entity_category": {
+      "title": "An MQTT {domain} with an invalid entity category was found",
+      "description": "Home Assistant detected a manually configured `{domain}` that has an `entity_category` set to `config`. Config with invalid setting:\n\n```yaml\n{config}\n```\n\nWhen set, make sure `entity_category` for a `{domain}` is set to `diagnostic` or `None`. Update your configuration and restart Home Assistant to fix this issue."
+    },
     "invalid_platform_config": {
       "title": "Invalid config found for mqtt {domain} item",
       "description": "Home Assistant detected an invalid config for a manually configured item.\n\nPlatform domain: **{domain}**\nConfiguration file: **{config_file}**\nNear line: **{line}**\nConfiguration found:\n```yaml\n{config}\n```\nError: **{error}**.\n\nMake sure the configuration is valid and [reload](/developer-tools/yaml) the manually configured MQTT items or restart Home Assistant to fix this issue."

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -22,7 +22,7 @@
     },
     "invalid_entity_category": {
       "title": "An MQTT {domain} with an invalid entity category was found",
-      "description": "Home Assistant detected a manually configured `{domain}` that has an `entity_category` set to `config`. Config with invalid setting:\n\n```yaml\n{config}\n```\n\nWhen set, make sure `entity_category` for a `{domain}` is set to `diagnostic` or `None`. Update your configuration and restart Home Assistant to fix this issue."
+      "description": "Home Assistant detected a manually configured MQTT `{domain}` entity that has an `entity_category` set to `config`. \nConfiguration file: **{config_file}**\nNear line: **{line}**\n\nConfig with invalid setting:\n\n```yaml\n{config}\n```\n\nWhen set, make sure `entity_category` for a `{domain}` is set to `diagnostic` or `None`. Update your YAML configuration and restart Home Assistant to fix this issue."
     },
     "invalid_platform_config": {
       "title": "Invalid config found for mqtt {domain} item",

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -2172,18 +2172,6 @@ async def test_setup_manual_mqtt_with_invalid_config(
             },
             "sensor.test",
         ),
-        (
-            {
-                mqtt.DOMAIN: {
-                    "binary_sensor": {
-                        "name": "test",
-                        "state_topic": "test-topic",
-                        "entity_category": "config",
-                    }
-                }
-            },
-            "binary_sensor.test",
-        ),
     ],
 )
 @patch(
@@ -2214,14 +2202,6 @@ async def test_setup_manual_mqtt_with_invalid_entity_category(
                 "entity_category": "config",
             },
             "sensor.test",
-        ),
-        (
-            {
-                "name": "test",
-                "state_topic": "test-topic",
-                "entity_category": "config",
-            },
-            "binary_sensor.test",
         ),
     ],
 )

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -30,7 +30,12 @@ from homeassistant.const import (
 import homeassistant.core as ha
 from homeassistant.core import CoreState, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import device_registry as dr, entity_registry as er, template
+from homeassistant.helpers import (
+    device_registry as dr,
+    entity_registry as er,
+    issue_registry as ir,
+    template,
+)
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import async_get_platforms
 from homeassistant.helpers.typing import ConfigType
@@ -42,6 +47,7 @@ from .test_common import help_all_subscribe_calls
 from tests.common import (
     MockConfigEntry,
     MockEntity,
+    async_capture_events,
     async_fire_mqtt_message,
     async_fire_time_changed,
     mock_restore_cache,
@@ -2190,10 +2196,57 @@ async def test_setup_manual_mqtt_with_invalid_entity_category(
     entity_id: str,
 ) -> None:
     """Test set up a manual sensor item with an invalid entity category."""
+    events = async_capture_events(hass, ir.EVENT_REPAIRS_ISSUE_REGISTRY_UPDATED)
     assert await mqtt_mock_entry()
     assert "Entity category `config` is invalid for sensors, ignoring" in caplog.text
     state = hass.states.get(entity_id)
     assert state is not None
+    assert len(events) == 1
+
+
+@pytest.mark.parametrize(
+    ("config", "entity_id"),
+    [
+        (
+            {
+                "name": "test",
+                "state_topic": "test-topic",
+                "entity_category": "config",
+            },
+            "sensor.test",
+        ),
+        (
+            {
+                "name": "test",
+                "state_topic": "test-topic",
+                "entity_category": "config",
+            },
+            "binary_sensor.test",
+        ),
+    ],
+)
+@patch(
+    "homeassistant.components.mqtt.PLATFORMS", [Platform.BINARY_SENSOR, Platform.SENSOR]
+)
+async def test_setup_discovery_mqtt_with_invalid_entity_category(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+    config: dict[str, Any],
+    entity_id: str,
+) -> None:
+    """Test set up a discovered sensor item with an invalid entity category."""
+    events = async_capture_events(hass, ir.EVENT_REPAIRS_ISSUE_REGISTRY_UPDATED)
+    assert await mqtt_mock_entry()
+
+    domain = entity_id.split(".")[0]
+    json_config = json.dumps(config)
+    async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", json_config)
+    await hass.async_block_till_done()
+    assert "Entity category `config` is invalid for sensors, ignoring" in caplog.text
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert len(events) == 0
 
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [])

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -2152,26 +2152,32 @@ async def test_setup_manual_mqtt_with_invalid_config(
 
 
 @pytest.mark.parametrize(
-    "hass_config",
+    ("hass_config", "entity_id"),
     [
-        {
-            mqtt.DOMAIN: {
-                "sensor": {
-                    "name": "test",
-                    "state_topic": "test-topic",
-                    "entity_category": "config",
+        (
+            {
+                mqtt.DOMAIN: {
+                    "sensor": {
+                        "name": "test",
+                        "state_topic": "test-topic",
+                        "entity_category": "config",
+                    }
                 }
-            }
-        },
-        {
-            mqtt.DOMAIN: {
-                "binary_sensor": {
-                    "name": "test",
-                    "state_topic": "test-topic",
-                    "entity_category": "config",
+            },
+            "sensor.test",
+        ),
+        (
+            {
+                mqtt.DOMAIN: {
+                    "binary_sensor": {
+                        "name": "test",
+                        "state_topic": "test-topic",
+                        "entity_category": "config",
+                    }
                 }
-            }
-        },
+            },
+            "binary_sensor.test",
+        ),
     ],
 )
 @patch(
@@ -2181,10 +2187,13 @@ async def test_setup_manual_mqtt_with_invalid_entity_category(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
     caplog: pytest.LogCaptureFixture,
+    entity_id: str,
 ) -> None:
     """Test set up a manual sensor item with an invalid entity category."""
     assert await mqtt_mock_entry()
-    assert "Entity category `config` is invalid" in caplog.text
+    assert "Entity category `config` is invalid for sensors, ignoring" in caplog.text
+    state = hass.states.get(entity_id)
+    assert state is not None
 
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR introduces a grace period of 3 months to allow MQTT sensors to have an invalid entity category.
It partly reverts changes make by #103210 for binary_sensor as this is also not wanted for the patch release.
#103210 disallowed sensors and binary sensors to have an `entity_category` set to `config`, this PR changes that behavior to an issue registration instead of failing setup.

Validation for entity category was added to the sensor core component  https://github.com/home-assistant/core/pull/101471 but it's correct use was already communicated at october 2021.

Related: https://github.com/home-assistant/core/pull/103511

Screenshot:

![afbeelding](https://github.com/home-assistant/core/assets/7188918/f6316ca3-1d47-490d-9d98-d91b2c2e07de)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
