### PR TITLE
Fix default lock code for lock services

### DIFF
--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -87,40 +87,33 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def _async_lock(entity: LockEntity, service_call: ServiceCall) -> None:
-    """Lock the lock."""
-    code: str = service_call.data.get(
+@callback
+def _add_default_code(entity: LockEntity, service_call: ServiceCall) -> dict[Any, Any]:
+    code = service_call.data.get(
         ATTR_CODE, entity._lock_option_default_code  # pylint: disable=protected-access
     )
     if entity.code_format_cmp and not entity.code_format_cmp.match(code):
         raise ValueError(
             f"Code '{code}' for locking {entity.entity_id} doesn't match pattern {entity.code_format}"
         )
-    await entity.async_lock(**remove_entity_service_fields(service_call))
+    data = remove_entity_service_fields(service_call)
+    data[ATTR_CODE] = code
+    return data
+
+
+async def _async_lock(entity: LockEntity, service_call: ServiceCall) -> None:
+    """Lock the lock."""
+    await entity.async_lock(**_add_default_code(entity, service_call))
 
 
 async def _async_unlock(entity: LockEntity, service_call: ServiceCall) -> None:
     """Unlock the lock."""
-    code: str = service_call.data.get(
-        ATTR_CODE, entity._lock_option_default_code  # pylint: disable=protected-access
-    )
-    if entity.code_format_cmp and not entity.code_format_cmp.match(code):
-        raise ValueError(
-            f"Code '{code}' for unlocking {entity.entity_id} doesn't match pattern {entity.code_format}"
-        )
-    await entity.async_unlock(**remove_entity_service_fields(service_call))
+    await entity.async_unlock(**_add_default_code(entity, service_call))
 
 
 async def _async_open(entity: LockEntity, service_call: ServiceCall) -> None:
     """Open the door latch."""
-    code: str = service_call.data.get(
-        ATTR_CODE, entity._lock_option_default_code  # pylint: disable=protected-access
-    )
-    if entity.code_format_cmp and not entity.code_format_cmp.match(code):
-        raise ValueError(
-            f"Code '{code}' for opening {entity.entity_id} doesn't match pattern {entity.code_format}"
-        )
-    await entity.async_open(**remove_entity_service_fields(service_call))
+    await entity.async_open(**_add_default_code(entity, service_call))
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -89,18 +89,16 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 @callback
 def _add_default_code(entity: LockEntity, service_call: ServiceCall) -> dict[Any, Any]:
-    code: str = service_call.data.get(ATTR_CODE, "")
+    data = remove_entity_service_fields(service_call)
+    code: str = data.pop(ATTR_CODE, "")
     if not code:
         code = entity._lock_option_default_code  # pylint: disable=protected-access
     if entity.code_format_cmp and not entity.code_format_cmp.match(code):
         raise ValueError(
             f"Code '{code}' for locking {entity.entity_id} doesn't match pattern {entity.code_format}"
         )
-    data = remove_entity_service_fields(service_call)
     if code:
         data[ATTR_CODE] = code
-    elif ATTR_CODE in data:
-        data.pop(ATTR_CODE)
     return data
 
 

--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -97,7 +97,8 @@ def _add_default_code(entity: LockEntity, service_call: ServiceCall) -> dict[Any
             f"Code '{code}' for locking {entity.entity_id} doesn't match pattern {entity.code_format}"
         )
     data = remove_entity_service_fields(service_call)
-    data[ATTR_CODE] = code
+    if code:
+        data[ATTR_CODE] = code
     return data
 
 

--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -89,9 +89,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 @callback
 def _add_default_code(entity: LockEntity, service_call: ServiceCall) -> dict[Any, Any]:
-    code: str = service_call.data.get(
-        ATTR_CODE, entity._lock_option_default_code  # pylint: disable=protected-access
-    )
+    code: str = service_call.data.get(ATTR_CODE, "")
+    if not code:
+        code = entity._lock_option_default_code  # pylint: disable=protected-access
     if entity.code_format_cmp and not entity.code_format_cmp.match(code):
         raise ValueError(
             f"Code '{code}' for locking {entity.entity_id} doesn't match pattern {entity.code_format}"
@@ -99,6 +99,8 @@ def _add_default_code(entity: LockEntity, service_call: ServiceCall) -> dict[Any
     data = remove_entity_service_fields(service_call)
     if code:
         data[ATTR_CODE] = code
+    elif ATTR_CODE in data:
+        data.pop(ATTR_CODE)
     return data
 
 

--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -89,7 +89,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 @callback
 def _add_default_code(entity: LockEntity, service_call: ServiceCall) -> dict[Any, Any]:
-    code = service_call.data.get(
+    code: str = service_call.data.get(
         ATTR_CODE, entity._lock_option_default_code  # pylint: disable=protected-access
     )
     if entity.code_format_cmp and not entity.code_format_cmp.match(code):

--- a/homeassistant/components/verisure/lock.py
+++ b/homeassistant/components/verisure/lock.py
@@ -128,19 +128,13 @@ class VerisureDoorlock(CoordinatorEntity[VerisureDataUpdateCoordinator], LockEnt
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Send unlock command."""
-        code: str = kwargs.get(
-            ATTR_CODE,
-            self._lock_option_default_code,
-        )
+        code = kwargs.get(ATTR_CODE)
         if code:
             await self.async_set_lock_state(code, STATE_UNLOCKED)
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Send lock command."""
-        code: str = kwargs.get(
-            ATTR_CODE,
-            self._lock_option_default_code,
-        )
+        code = kwargs.get(ATTR_CODE)
         if code:
             await self.async_set_lock_state(code, STATE_LOCKED)
 

--- a/homeassistant/components/verisure/lock.py
+++ b/homeassistant/components/verisure/lock.py
@@ -128,13 +128,19 @@ class VerisureDoorlock(CoordinatorEntity[VerisureDataUpdateCoordinator], LockEnt
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Send unlock command."""
-        code = kwargs.get(ATTR_CODE)
+        code: str = kwargs.get(
+            ATTR_CODE,
+            self._lock_option_default_code,
+        )
         if code:
             await self.async_set_lock_state(code, STATE_UNLOCKED)
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Send lock command."""
-        code = kwargs.get(ATTR_CODE)
+        code: str = kwargs.get(
+            ATTR_CODE,
+            self._lock_option_default_code,
+        )
         if code:
             await self.async_set_lock_state(code, STATE_LOCKED)
 

--- a/tests/components/lock/test_init.py
+++ b/tests/components/lock/test_init.py
@@ -258,6 +258,28 @@ async def test_lock_with_illegal_code(hass: HomeAssistant) -> None:
         )
 
 
+async def test_lock_with_no_code(hass: HomeAssistant) -> None:
+    """Test lock entity with default code that does not match the code format."""
+    lock = MockLockEntity(
+        supported_features=LockEntityFeature.OPEN,
+    )
+    lock.hass = hass
+
+    await _async_open(lock, ServiceCall(DOMAIN, SERVICE_OPEN, {}))
+    lock.calls_open.assert_called_with({})
+    await _async_lock(lock, ServiceCall(DOMAIN, SERVICE_LOCK, {}))
+    lock.calls_lock.assert_called_with({})
+    await _async_unlock(lock, ServiceCall(DOMAIN, SERVICE_UNLOCK, {}))
+    lock.calls_unlock.assert_called_with({})
+
+    await _async_open(lock, ServiceCall(DOMAIN, SERVICE_OPEN, {ATTR_CODE: ""}))
+    lock.calls_open.assert_called_with({})
+    await _async_lock(lock, ServiceCall(DOMAIN, SERVICE_LOCK, {ATTR_CODE: ""}))
+    lock.calls_lock.assert_called_with({})
+    await _async_unlock(lock, ServiceCall(DOMAIN, SERVICE_UNLOCK, {ATTR_CODE: ""}))
+    lock.calls_unlock.assert_called_with({})
+
+
 async def test_lock_with_default_code(hass: HomeAssistant) -> None:
     """Test lock entity with default code."""
     lock = MockLockEntity(
@@ -275,6 +297,13 @@ async def test_lock_with_default_code(hass: HomeAssistant) -> None:
     await _async_lock(lock, ServiceCall(DOMAIN, SERVICE_LOCK, {}))
     lock.calls_lock.assert_called_with({ATTR_CODE: "1234"})
     await _async_unlock(lock, ServiceCall(DOMAIN, SERVICE_UNLOCK, {}))
+    lock.calls_unlock.assert_called_with({ATTR_CODE: "1234"})
+
+    await _async_open(lock, ServiceCall(DOMAIN, SERVICE_OPEN, {ATTR_CODE: ""}))
+    lock.calls_open.assert_called_with({ATTR_CODE: "1234"})
+    await _async_lock(lock, ServiceCall(DOMAIN, SERVICE_LOCK, {ATTR_CODE: ""}))
+    lock.calls_lock.assert_called_with({ATTR_CODE: "1234"})
+    await _async_unlock(lock, ServiceCall(DOMAIN, SERVICE_UNLOCK, {ATTR_CODE: ""}))
     lock.calls_unlock.assert_called_with({ATTR_CODE: "1234"})
 
 

--- a/tests/components/lock/test_init.py
+++ b/tests/components/lock/test_init.py
@@ -42,6 +42,8 @@ class MockLockEntity(LockEntity):
     ) -> None:
         """Initialize mock lock entity."""
         self._attr_supported_features = supported_features
+        self.calls_lock = MagicMock()
+        self.calls_unlock = MagicMock()
         self.calls_open = MagicMock()
         if code_format is not None:
             self._attr_code_format = code_format
@@ -49,11 +51,13 @@ class MockLockEntity(LockEntity):
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the lock."""
+        self.calls_lock(kwargs)
         self._attr_is_locking = False
         self._attr_is_locked = True
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the lock."""
+        self.calls_unlock(kwargs)
         self._attr_is_unlocking = False
         self._attr_is_locked = False
 
@@ -232,6 +236,28 @@ async def test_lock_unlock_with_code(hass: HomeAssistant) -> None:
     assert not lock.is_locked
 
 
+async def test_lock_with_illegal_code(hass: HomeAssistant) -> None:
+    """Test lock entity with default code that does not match the code format."""
+    lock = MockLockEntity(
+        code_format=r"^\d{4}$",
+        supported_features=LockEntityFeature.OPEN,
+    )
+    lock.hass = hass
+
+    with pytest.raises(ValueError):
+        await _async_open(
+            lock, ServiceCall(DOMAIN, SERVICE_OPEN, {ATTR_CODE: "123456"})
+        )
+    with pytest.raises(ValueError):
+        await _async_lock(
+            lock, ServiceCall(DOMAIN, SERVICE_LOCK, {ATTR_CODE: "123456"})
+        )
+    with pytest.raises(ValueError):
+        await _async_unlock(
+            lock, ServiceCall(DOMAIN, SERVICE_UNLOCK, {ATTR_CODE: "123456"})
+        )
+
+
 async def test_lock_with_default_code(hass: HomeAssistant) -> None:
     """Test lock entity with default code."""
     lock = MockLockEntity(
@@ -245,5 +271,45 @@ async def test_lock_with_default_code(hass: HomeAssistant) -> None:
     assert lock._lock_option_default_code == "1234"
 
     await _async_open(lock, ServiceCall(DOMAIN, SERVICE_OPEN, {}))
+    lock.calls_open.assert_called_with({ATTR_CODE: "1234"})
     await _async_lock(lock, ServiceCall(DOMAIN, SERVICE_LOCK, {}))
+    lock.calls_lock.assert_called_with({ATTR_CODE: "1234"})
     await _async_unlock(lock, ServiceCall(DOMAIN, SERVICE_UNLOCK, {}))
+    lock.calls_unlock.assert_called_with({ATTR_CODE: "1234"})
+
+
+async def test_lock_with_provided_and_default_code(hass: HomeAssistant) -> None:
+    """Test lock entity with provided code when default code is set."""
+    lock = MockLockEntity(
+        code_format=r"^\d{4}$",
+        supported_features=LockEntityFeature.OPEN,
+        lock_option_default_code="1234",
+    )
+    lock.hass = hass
+
+    await _async_open(lock, ServiceCall(DOMAIN, SERVICE_OPEN, {ATTR_CODE: "4321"}))
+    lock.calls_open.assert_called_with({ATTR_CODE: "4321"})
+    await _async_lock(lock, ServiceCall(DOMAIN, SERVICE_LOCK, {ATTR_CODE: "4321"}))
+    lock.calls_lock.assert_called_with({ATTR_CODE: "4321"})
+    await _async_unlock(lock, ServiceCall(DOMAIN, SERVICE_UNLOCK, {ATTR_CODE: "4321"}))
+    lock.calls_unlock.assert_called_with({ATTR_CODE: "4321"})
+
+
+async def test_lock_with_illegal_default_code(hass: HomeAssistant) -> None:
+    """Test lock entity with default code that does not match the code format."""
+    lock = MockLockEntity(
+        code_format=r"^\d{4}$",
+        supported_features=LockEntityFeature.OPEN,
+        lock_option_default_code="123456",
+    )
+    lock.hass = hass
+
+    assert lock.state_attributes == {"code_format": r"^\d{4}$"}
+    assert lock._lock_option_default_code == "123456"
+
+    with pytest.raises(ValueError):
+        await _async_open(lock, ServiceCall(DOMAIN, SERVICE_OPEN, {}))
+    with pytest.raises(ValueError):
+        await _async_lock(lock, ServiceCall(DOMAIN, SERVICE_LOCK, {}))
+    with pytest.raises(ValueError):
+        await _async_unlock(lock, ServiceCall(DOMAIN, SERVICE_UNLOCK, {}))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixing passing the the default code for lock entities when set, unless another code is set in the service call.

Note: The `matter` integration has a workaround for this that should be removed in a separate PR as soon as this PR is merged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #101404
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
