### PR TITLE
enable application_credentials component to take custom redirect_uri

### DIFF
--- a/homeassistant/components/envisalink/binary_sensor.py
+++ b/homeassistant/components/envisalink/binary_sensor.py
@@ -85,12 +85,19 @@ class EnvisalinkBinarySensor(EnvisalinkDevice, BinarySensorEntity):
         # unless it is already at the maximum value, in which case we set it
         # to None since we can't determine the actual value.
         seconds_ago = self._info["last_fault"]
+        _LOGGER.info(
+            "zone %s - last_fault: %s", 
+            self._zone_number, self._info["last_fault"])
         if seconds_ago < 65536 * 5:
             now = dt_util.now().replace(microsecond=0)
             delta = datetime.timedelta(seconds=seconds_ago)
             last_trip_time = (now - delta).isoformat()
+            _LOGGER.info(
+                "zone %s - last_trip_time:  %s delta: %s now %s",
+                self._zone_number, last_trip_time, delta, now)
         else:
             last_trip_time = None
+            _LOGGER.info("zone %s - last_trip_time reset", self._zone_number)
 
         attr[ATTR_LAST_TRIP_TIME] = last_trip_time
 


### PR DESCRIPTION
Enables self-hosted setups with no dependencies on "my.home-assistant.io" to use oauth integrations.


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  FR https://community.home-assistant.io/t/application-credentials-support-local-oauth-redirect-endpoints/490533 
  describes the problem where those using Home Assistant but have their 
  own DNS, TLS attached to their home are unable to integrate with Oauth 
  (in my case Google Nest).  config_entry_oauth2_flow.py currently hardcodes the redirect_uri 
  and this supports allowing application_credentials to override the Oauth2Implementation's
  redirect_uri method with one that gets its value from configuration.yaml 
  ("application_credentials.redirect_uri").  This matters to folks who do not want to
  take a dependency my.home-assistant.io and as this is a "free" Internet maintained 
  implementation and creates a "cloud" dependency for HA.

  This implementation enables 'my' to be enabled to get the default_config: values while just
  overriding this one blocker.  The current workarounds force folks to throw out default_config.

  If there is an easier way, to create a config driven change to support this, let me know.

  More background:
  https://github.com/home-assistant/core/issues/79431
  https://github.com/home-assistant/core/issues/73625
  https://github.com/home-assistant/core/issues/73113
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #490533
- This PR is related to issue: 79431
- Link to documentation pull request:  [#29710](https://github.com/home-assistant/home-assistant.io/pull/29710)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
