### PR TITLE
Add remote entity to AndroidTV

### DIFF
--- a/homeassistant/components/androidtv/__init__.py
+++ b/homeassistant/components/androidtv/__init__.py
@@ -61,7 +61,7 @@ ADB_PYTHON_EXCEPTIONS: tuple = (
 )
 ADB_TCP_EXCEPTIONS: tuple = (ConnectionResetError, RuntimeError)
 
-PLATFORMS = [Platform.MEDIA_PLAYER]
+PLATFORMS = [Platform.MEDIA_PLAYER, Platform.REMOTE]
 RELOAD_OPTIONS = [CONF_STATE_DETECTION_RULES]
 
 _INVALID_MACS = {"ff:ff:ff:ff:ff:ff"}

--- a/homeassistant/components/androidtv/entity.py
+++ b/homeassistant/components/androidtv/entity.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
 )
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity import Entity
 
@@ -87,6 +88,9 @@ def adb_decorator[_ADBDeviceT: AndroidTVEntity, **_P, _R](
                 await self.aftv.adb_close()
                 self._attr_available = False
                 return None
+            except ServiceValidationError:
+                # Service validation error is thrown because raised by remote services
+                raise
             except Exception as err:  # noqa: BLE001
                 # An unforeseen exception occurred. Close the ADB connection so that
                 # it doesn't happen over and over again.

--- a/homeassistant/components/androidtv/remote.py
+++ b/homeassistant/components/androidtv/remote.py
@@ -11,9 +11,10 @@ from androidtv.constants import KEYS
 from homeassistant.components.remote import ATTR_NUM_REPEATS, RemoteEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_TURN_OFF_COMMAND, CONF_TURN_ON_COMMAND
+from .const import CONF_TURN_OFF_COMMAND, CONF_TURN_ON_COMMAND, DOMAIN
 from .entity import AndroidTVEntity, adb_decorator
 
 _LOGGER = logging.getLogger(__name__)
@@ -66,5 +67,9 @@ class AndroidTVRemote(AndroidTVEntity, RemoteEntity):
             for cmd in command_list:
                 try:
                     await self.aftv.adb_shell(cmd)
-                except UnicodeDecodeError:
-                    _LOGGER.error("Failed to send command %s", cmd)
+                except UnicodeDecodeError as ex:
+                    raise ServiceValidationError(
+                        translation_domain=DOMAIN,
+                        translation_key="failed_send",
+                        translation_placeholders={"cmd": cmd},
+                    ) from ex

--- a/homeassistant/components/androidtv/remote.py
+++ b/homeassistant/components/androidtv/remote.py
@@ -1,0 +1,70 @@
+"""Support for the AndroidTV remote."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+import logging
+from typing import Any
+
+from androidtv.constants import KEYS
+
+from homeassistant.components.remote import ATTR_NUM_REPEATS, RemoteEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import CONF_TURN_OFF_COMMAND, CONF_TURN_ON_COMMAND
+from .entity import AndroidTVEntity, adb_decorator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the AndroidTV remote from a config entry."""
+    async_add_entities([AndroidTVRemote(entry)])
+
+
+class AndroidTVRemote(AndroidTVEntity, RemoteEntity):
+    """Device that sends commands to a AndroidTV."""
+
+    _attr_name = None
+    _attr_should_poll = False
+
+    @adb_decorator()
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the device."""
+        options = self._entry_runtime_data.dev_opt
+        if turn_on_cmd := options.get(CONF_TURN_ON_COMMAND):
+            await self.aftv.adb_shell(turn_on_cmd)
+        else:
+            await self.aftv.turn_on()
+
+    @adb_decorator()
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the device."""
+        options = self._entry_runtime_data.dev_opt
+        if turn_off_cmd := options.get(CONF_TURN_OFF_COMMAND):
+            await self.aftv.adb_shell(turn_off_cmd)
+        else:
+            await self.aftv.turn_off()
+
+    @adb_decorator()
+    async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
+        """Send a command to a device."""
+
+        num_repeats = kwargs[ATTR_NUM_REPEATS]
+        command_list = []
+        for cmd in command:
+            if key := KEYS.get(cmd):
+                command_list.append(f"input keyevent {key}")
+            else:
+                command_list.append(cmd)
+
+        for _ in range(num_repeats):
+            for cmd in command_list:
+                try:
+                    await self.aftv.adb_shell(cmd)
+                except UnicodeDecodeError:
+                    _LOGGER.error("Failed to send command %s", cmd)

--- a/homeassistant/components/androidtv/strings.json
+++ b/homeassistant/components/androidtv/strings.json
@@ -103,5 +103,10 @@
       "name": "Learn sendevent",
       "description": "Translates a key press on a remote into ADB 'sendevent' commands. You must press one button on the remote within 8 seconds of calling this service."
     }
+  },
+  "exceptions": {
+    "failed_send": {
+      "message": "Failed to send command {cmd}"
+    }
   }
 }

--- a/tests/components/androidtv/test_remote.py
+++ b/tests/components/androidtv/test_remote.py
@@ -1,8 +1,9 @@
 """The tests for the androidtv remote platform."""
 
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import call, patch
 
+from androidtv.constants import KEYS
 import pytest
 
 from homeassistant.components.androidtv.const import (
@@ -21,6 +22,7 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 
 from . import patchers
 from .common import (
@@ -45,9 +47,12 @@ async def _test_service(
     ha_service_name,
     androidtv_method,
     additional_service_data=None,
-    return_value=None,
+    expected_call_args=None,
 ) -> None:
     """Test generic Android media player entity service."""
+    if expected_call_args is None:
+        expected_call_args = [None]
+
     service_data = {ATTR_ENTITY_ID: entity_id}
     if additional_service_data:
         service_data.update(additional_service_data)
@@ -57,16 +62,17 @@ async def _test_service(
         if "android" in entity_id
         else "firetv.firetv_async.FireTVAsync"
     )
-    with patch(
-        f"androidtv.{androidtv_patch}.{androidtv_method}", return_value=return_value
-    ) as service_call:
+    with patch(f"androidtv.{androidtv_patch}.{androidtv_method}") as api_call:
         await hass.services.async_call(
             REMOTE_DOMAIN,
             ha_service_name,
             service_data=service_data,
             blocking=True,
         )
-        assert service_call.called
+        assert api_call.called
+        assert api_call.call_count == len(expected_call_args)
+        expected_calls = [call(s) if s else call() for s in expected_call_args]
+        assert api_call.call_args_list == expected_calls
 
 
 @pytest.mark.parametrize("config", [CONFIG_ANDROID_DEFAULT, CONFIG_FIRETV_DEFAULT])
@@ -92,6 +98,12 @@ async def test_services_remote(hass: HomeAssistant, config) -> None:
                 SERVICE_SEND_COMMAND,
                 "adb_shell",
                 {ATTR_COMMAND: ["BACK", "test"], ATTR_NUM_REPEATS: 2},
+                [
+                    f"input keyevent {KEYS["BACK"]}",
+                    "test",
+                    f"input keyevent {KEYS["BACK"]}",
+                    "test",
+                ],
             )
 
 
@@ -117,8 +129,12 @@ async def test_services_remote_custom(hass: HomeAssistant, config) -> None:
             patchers.patch_shell(SHELL_RESPONSE_STANDBY)[patch_key],
             patchers.PATCH_SCREENCAP,
         ):
-            await _test_service(hass, entity_id, SERVICE_TURN_OFF, "adb_shell")
-            await _test_service(hass, entity_id, SERVICE_TURN_ON, "adb_shell")
+            await _test_service(
+                hass, entity_id, SERVICE_TURN_OFF, "adb_shell", None, ["test off"]
+            )
+            await _test_service(
+                hass, entity_id, SERVICE_TURN_ON, "adb_shell", None, ["test on"]
+            )
 
 
 async def test_remote_unicode_decode_error(hass: HomeAssistant) -> None:
@@ -135,13 +151,14 @@ async def test_remote_unicode_decode_error(hass: HomeAssistant) -> None:
         with patch(
             "androidtv.basetv.basetv_async.BaseTVAsync.adb_shell",
             side_effect=UnicodeDecodeError("utf-8", response, 0, len(response), "TEST"),
-        ):
-            await hass.services.async_call(
-                REMOTE_DOMAIN,
-                SERVICE_SEND_COMMAND,
-                service_data={ATTR_ENTITY_ID: entity_id, ATTR_COMMAND: "BACK"},
-                blocking=True,
-            )
-
-            state = hass.states.get(entity_id)
-            assert state is not None
+        ) as api_call:
+            try:
+                await hass.services.async_call(
+                    REMOTE_DOMAIN,
+                    SERVICE_SEND_COMMAND,
+                    service_data={ATTR_ENTITY_ID: entity_id, ATTR_COMMAND: "BACK"},
+                    blocking=True,
+                )
+                pytest.fail("Exception not raised")
+            except ServiceValidationError:
+                assert api_call.call_count == 1

--- a/tests/components/androidtv/test_remote.py
+++ b/tests/components/androidtv/test_remote.py
@@ -1,0 +1,147 @@
+"""The tests for the androidtv remote platform."""
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.androidtv.const import (
+    CONF_TURN_OFF_COMMAND,
+    CONF_TURN_ON_COMMAND,
+)
+from homeassistant.components.remote import (
+    ATTR_NUM_REPEATS,
+    DOMAIN as REMOTE_DOMAIN,
+    SERVICE_SEND_COMMAND,
+)
+from homeassistant.const import (
+    ATTR_COMMAND,
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.core import HomeAssistant
+
+from . import patchers
+from .common import (
+    CONFIG_ANDROID_DEFAULT,
+    CONFIG_FIRETV_DEFAULT,
+    SHELL_RESPONSE_OFF,
+    SHELL_RESPONSE_STANDBY,
+    setup_mock_entry,
+)
+
+from tests.common import MockConfigEntry
+
+
+def _setup(config: dict[str, Any]) -> tuple[str, str, MockConfigEntry]:
+    """Prepare mock entry for the media player tests."""
+    return setup_mock_entry(config, REMOTE_DOMAIN)
+
+
+async def _test_service(
+    hass: HomeAssistant,
+    entity_id,
+    ha_service_name,
+    androidtv_method,
+    additional_service_data=None,
+    return_value=None,
+) -> None:
+    """Test generic Android media player entity service."""
+    service_data = {ATTR_ENTITY_ID: entity_id}
+    if additional_service_data:
+        service_data.update(additional_service_data)
+
+    androidtv_patch = (
+        "androidtv.androidtv_async.AndroidTVAsync"
+        if "android" in entity_id
+        else "firetv.firetv_async.FireTVAsync"
+    )
+    with patch(
+        f"androidtv.{androidtv_patch}.{androidtv_method}", return_value=return_value
+    ) as service_call:
+        await hass.services.async_call(
+            REMOTE_DOMAIN,
+            ha_service_name,
+            service_data=service_data,
+            blocking=True,
+        )
+        assert service_call.called
+
+
+@pytest.mark.parametrize("config", [CONFIG_ANDROID_DEFAULT, CONFIG_FIRETV_DEFAULT])
+async def test_services_remote(hass: HomeAssistant, config) -> None:
+    """Test services for remote entity."""
+    patch_key, entity_id, config_entry = _setup(config)
+    config_entry.add_to_hass(hass)
+
+    with patchers.patch_connect(True)[patch_key]:
+        with patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
+            assert await hass.config_entries.async_setup(config_entry.entry_id)
+            await hass.async_block_till_done()
+
+        with (
+            patchers.patch_shell(SHELL_RESPONSE_STANDBY)[patch_key],
+            patchers.PATCH_SCREENCAP,
+        ):
+            await _test_service(hass, entity_id, SERVICE_TURN_OFF, "turn_off")
+            await _test_service(hass, entity_id, SERVICE_TURN_ON, "turn_on")
+            await _test_service(
+                hass,
+                entity_id,
+                SERVICE_SEND_COMMAND,
+                "adb_shell",
+                {ATTR_COMMAND: ["BACK", "test"], ATTR_NUM_REPEATS: 2},
+            )
+
+
+@pytest.mark.parametrize("config", [CONFIG_ANDROID_DEFAULT, CONFIG_FIRETV_DEFAULT])
+async def test_services_remote_custom(hass: HomeAssistant, config) -> None:
+    """Test services with custom options for remote entity."""
+    patch_key, entity_id, config_entry = _setup(config)
+    config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        config_entry,
+        options={
+            CONF_TURN_OFF_COMMAND: "test off",
+            CONF_TURN_ON_COMMAND: "test on",
+        },
+    )
+
+    with patchers.patch_connect(True)[patch_key]:
+        with patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
+            assert await hass.config_entries.async_setup(config_entry.entry_id)
+            await hass.async_block_till_done()
+
+        with (
+            patchers.patch_shell(SHELL_RESPONSE_STANDBY)[patch_key],
+            patchers.PATCH_SCREENCAP,
+        ):
+            await _test_service(hass, entity_id, SERVICE_TURN_OFF, "adb_shell")
+            await _test_service(hass, entity_id, SERVICE_TURN_ON, "adb_shell")
+
+
+async def test_remote_unicode_decode_error(hass: HomeAssistant) -> None:
+    """Test sending a command via the send_command remote service that raises a UnicodeDecodeError exception."""
+    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROID_DEFAULT)
+    config_entry.add_to_hass(hass)
+    response = b"test response"
+
+    with patchers.patch_connect(True)[patch_key]:
+        with patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
+            assert await hass.config_entries.async_setup(config_entry.entry_id)
+            await hass.async_block_till_done()
+
+        with patch(
+            "androidtv.basetv.basetv_async.BaseTVAsync.adb_shell",
+            side_effect=UnicodeDecodeError("utf-8", response, 0, len(response), "TEST"),
+        ):
+            await hass.services.async_call(
+                REMOTE_DOMAIN,
+                SERVICE_SEND_COMMAND,
+                service_data={ATTR_ENTITY_ID: entity_id, ATTR_COMMAND: "BACK"},
+                blocking=True,
+            )
+
+            state = hass.states.get(entity_id)
+            assert state is not None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add remote entity to AndroidTV. Remote entity is used by many custom cards to send command to the device.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29777

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
