### PR TITLE
Fix 5B Gas meter in dsmr

### DIFF
--- a/homeassistant/components/dsmr/const.py
+++ b/homeassistant/components/dsmr/const.py
@@ -34,6 +34,3 @@ DSMR_VERSIONS = {"2.2", "4", "5", "5B", "5L", "5S", "Q3D"}
 
 DSMR_PROTOCOL = "dsmr_protocol"
 RFXTRX_DSMR_PROTOCOL = "rfxtrx_dsmr_protocol"
-
-# Temp obis until sensors replaced by mbus variants
-BELGIUM_5MIN_GAS_METER_READING = r"\d-\d:24\.2\.3.+?\r\n"

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -44,7 +44,6 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.util import Throttle
 
 from .const import (
-    BELGIUM_5MIN_GAS_METER_READING,
     CONF_DSMR_VERSION,
     CONF_PRECISION,
     CONF_PROTOCOL,
@@ -383,16 +382,6 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
     DSMRSensorEntityDescription(
-        key="belgium_5min_gas_meter_reading",
-        translation_key="gas_meter_reading",
-        obis_reference=BELGIUM_5MIN_GAS_METER_READING,
-        dsmr_versions={"5B"},
-        is_gas=True,
-        force_update=True,
-        device_class=SensorDeviceClass.GAS,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-    ),
-    DSMRSensorEntityDescription(
         key="gas_meter_reading",
         translation_key="gas_meter_reading",
         obis_reference=obis_references.GAS_METER_READING,
@@ -403,6 +392,35 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
 )
+
+
+def add_gas_sensor_5B(
+    telegram: dict[str, DSMRObject]
+) -> tuple[DSMRSensorEntityDescription]:
+    """Return correct entity for 5B Gas meter."""
+    ref = None
+    if obis_references.BELGIUM_MBUS4_METER_READING2 in telegram:
+        ref = obis_references.BELGIUM_MBUS4_METER_READING2
+    if obis_references.BELGIUM_MBUS3_METER_READING2 in telegram:
+        ref = obis_references.BELGIUM_MBUS3_METER_READING2
+    if obis_references.BELGIUM_MBUS2_METER_READING2 in telegram:
+        ref = obis_references.BELGIUM_MBUS2_METER_READING2
+    if obis_references.BELGIUM_MBUS1_METER_READING2 in telegram:
+        ref = obis_references.BELGIUM_MBUS1_METER_READING2
+    if ref is None:
+        ref = obis_references.BELGIUM_MBUS1_METER_READING2
+    return (
+        DSMRSensorEntityDescription(
+            key="belgium_5min_gas_meter_reading",
+            translation_key="gas_meter_reading",
+            obis_reference=ref,
+            dsmr_versions={"5B"},
+            is_gas=True,
+            force_update=True,
+            device_class=SensorDeviceClass.GAS,
+            state_class=SensorStateClass.TOTAL_INCREASING,
+        ),
+    )
 
 
 async def async_setup_entry(
@@ -438,6 +456,10 @@ async def async_setup_entry(
                 return (entity_description.device_class, UNIT_CONVERSION[uom])
             return (entity_description.device_class, uom)
 
+        all_sensors = SENSORS
+        if dsmr_version == "5B":
+            all_sensors = SENSORS + add_gas_sensor_5B(telegram)
+
         entities.extend(
             [
                 DSMREntity(
@@ -448,7 +470,7 @@ async def async_setup_entry(
                         telegram, description
                     ),  # type: ignore[arg-type]
                 )
-                for description in SENSORS
+                for description in all_sensors
                 if (
                     description.dsmr_versions is None
                     or dsmr_version in description.dsmr_versions

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -396,30 +396,28 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
 
 def add_gas_sensor_5B(
     telegram: dict[str, DSMRObject]
-) -> tuple[DSMRSensorEntityDescription]:
+) -> DSMRSensorEntityDescription:
     """Return correct entity for 5B Gas meter."""
     ref = None
-    if obis_references.BELGIUM_MBUS4_METER_READING2 in telegram:
-        ref = obis_references.BELGIUM_MBUS4_METER_READING2
-    if obis_references.BELGIUM_MBUS3_METER_READING2 in telegram:
-        ref = obis_references.BELGIUM_MBUS3_METER_READING2
-    if obis_references.BELGIUM_MBUS2_METER_READING2 in telegram:
-        ref = obis_references.BELGIUM_MBUS2_METER_READING2
     if obis_references.BELGIUM_MBUS1_METER_READING2 in telegram:
         ref = obis_references.BELGIUM_MBUS1_METER_READING2
-    if ref is None:
+    elif obis_references.BELGIUM_MBUS2_METER_READING2 in telegram:
+        ref = obis_references.BELGIUM_MBUS2_METER_READING2
+    elif obis_references.BELGIUM_MBU3_METER_READING2 in telegram:
+        ref = obis_references.BELGIUM_MBUS3_METER_READING2
+    elif obis_references.BELGIUM_MBUS4_METER_READING2 in telegram:
+        ref = obis_references.BELGIUM_MBUS4_METER_READING2
+    elif ref is None:
         ref = obis_references.BELGIUM_MBUS1_METER_READING2
-    return (
-        DSMRSensorEntityDescription(
-            key="belgium_5min_gas_meter_reading",
-            translation_key="gas_meter_reading",
-            obis_reference=ref,
-            dsmr_versions={"5B"},
-            is_gas=True,
-            force_update=True,
-            device_class=SensorDeviceClass.GAS,
-            state_class=SensorStateClass.TOTAL_INCREASING,
-        ),
+    return DSMRSensorEntityDescription(
+        key="belgium_5min_gas_meter_reading",
+        translation_key="gas_meter_reading",
+        obis_reference=ref,
+        dsmr_versions={"5B"},
+        is_gas=True,
+        force_update=True,
+        device_class=SensorDeviceClass.GAS,
+        state_class=SensorStateClass.TOTAL_INCREASING,
     )
 
 
@@ -458,7 +456,7 @@ async def async_setup_entry(
 
         all_sensors = SENSORS
         if dsmr_version == "5B":
-            all_sensors = SENSORS + add_gas_sensor_5B(telegram)
+            all_sensors += (add_gas_sensor_5B(telegram),)
 
         entities.extend(
             [

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -394,16 +394,14 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
 )
 
 
-def add_gas_sensor_5B(
-    telegram: dict[str, DSMRObject]
-) -> DSMRSensorEntityDescription:
+def add_gas_sensor_5B(telegram: dict[str, DSMRObject]) -> DSMRSensorEntityDescription:
     """Return correct entity for 5B Gas meter."""
     ref = None
     if obis_references.BELGIUM_MBUS1_METER_READING2 in telegram:
         ref = obis_references.BELGIUM_MBUS1_METER_READING2
     elif obis_references.BELGIUM_MBUS2_METER_READING2 in telegram:
         ref = obis_references.BELGIUM_MBUS2_METER_READING2
-    elif obis_references.BELGIUM_MBU3_METER_READING2 in telegram:
+    elif obis_references.BELGIUM_MBUS3_METER_READING2 in telegram:
         ref = obis_references.BELGIUM_MBUS3_METER_READING2
     elif obis_references.BELGIUM_MBUS4_METER_READING2 in telegram:
         ref = obis_references.BELGIUM_MBUS4_METER_READING2

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -11,7 +11,6 @@ from itertools import chain, repeat
 from unittest.mock import DEFAULT, MagicMock
 
 from homeassistant import config_entries
-from homeassistant.components.dsmr.const import BELGIUM_5MIN_GAS_METER_READING
 from homeassistant.components.sensor import (
     ATTR_OPTIONS,
     ATTR_STATE_CLASS,
@@ -483,6 +482,10 @@ async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
     from dsmr_parser.obis_references import (
         BELGIUM_CURRENT_AVERAGE_DEMAND,
         BELGIUM_MAXIMUM_DEMAND_MONTH,
+        BELGIUM_MBUS1_METER_READING2,
+        BELGIUM_MBUS2_METER_READING2,
+        BELGIUM_MBUS3_METER_READING2,
+        BELGIUM_MBUS4_METER_READING2,
         ELECTRICITY_ACTIVE_TARIFF,
     )
     from dsmr_parser.objects import CosemObject, MBusObject
@@ -500,11 +503,32 @@ async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
     }
 
     telegram = {
-        BELGIUM_5MIN_GAS_METER_READING: MBusObject(
-            BELGIUM_5MIN_GAS_METER_READING,
+        BELGIUM_MBUS1_METER_READING2: MBusObject(
+            BELGIUM_MBUS1_METER_READING2,
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(745.695), "unit": "m3"},
+            ],
+        ),
+        BELGIUM_MBUS2_METER_READING2: MBusObject(
+            BELGIUM_MBUS2_METER_READING2,
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642214)},
+                {"value": Decimal(745.696), "unit": "m3"},
+            ],
+        ),
+        BELGIUM_MBUS3_METER_READING2: MBusObject(
+            BELGIUM_MBUS3_METER_READING2,
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642215)},
+                {"value": Decimal(745.697), "unit": "m3"},
+            ],
+        ),
+        BELGIUM_MBUS4_METER_READING2: MBusObject(
+            BELGIUM_MBUS4_METER_READING2,
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642216)},
+                {"value": Decimal(745.698), "unit": "m3"},
             ],
         ),
         BELGIUM_CURRENT_AVERAGE_DEMAND: CosemObject(
@@ -562,6 +586,146 @@ async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
     assert max_demand.state == "4.11"
     assert max_demand.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPower.KILO_WATT
     assert max_demand.attributes.get(ATTR_STATE_CLASS) is None
+
+    # check if gas consumption is parsed correctly
+    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption")
+    assert gas_consumption.state == "745.695"
+    assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.GAS
+    assert (
+        gas_consumption.attributes.get(ATTR_STATE_CLASS)
+        == SensorStateClass.TOTAL_INCREASING
+    )
+    assert (
+        gas_consumption.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        == UnitOfVolume.CUBIC_METERS
+    )
+
+
+async def test_belgian_meter_alt(hass: HomeAssistant, dsmr_connection_fixture) -> None:
+    """Test if Belgian meter is correctly parsed."""
+    (connection_factory, transport, protocol) = dsmr_connection_fixture
+
+    from dsmr_parser.obis_references import (
+        BELGIUM_MBUS1_METER_READING1,
+        BELGIUM_MBUS3_METER_READING2,
+    )
+    from dsmr_parser.objects import MBusObject
+
+    entry_data = {
+        "port": "/dev/ttyUSB0",
+        "dsmr_version": "5B",
+        "precision": 4,
+        "reconnect_interval": 30,
+        "serial_id": "1234",
+        "serial_id_gas": "5678",
+    }
+    entry_options = {
+        "time_between_update": 0,
+    }
+
+    telegram = {
+        BELGIUM_MBUS1_METER_READING1: MBusObject(
+            BELGIUM_MBUS1_METER_READING1,
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642213)},
+                {"value": Decimal(745.695), "unit": "m3"},
+            ],
+        ),
+        BELGIUM_MBUS3_METER_READING2: MBusObject(
+            BELGIUM_MBUS3_METER_READING2,
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642214)},
+                {"value": Decimal(745.696), "unit": "m3"},
+            ],
+        ),
+    }
+
+    mock_entry = MockConfigEntry(
+        domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
+    )
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    telegram_callback = connection_factory.call_args_list[0][0][2]
+
+    # simulate a telegram pushed from the smartmeter and parsed by dsmr_parser
+    telegram_callback(telegram)
+
+    # after receiving telegram entities need to have the chance to be created
+    await hass.async_block_till_done()
+
+    # check if gas consumption is parsed correctly
+    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption")
+    assert gas_consumption.state == "745.696"
+    assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.GAS
+    assert (
+        gas_consumption.attributes.get(ATTR_STATE_CLASS)
+        == SensorStateClass.TOTAL_INCREASING
+    )
+    assert (
+        gas_consumption.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        == UnitOfVolume.CUBIC_METERS
+    )
+
+
+async def test_belgian_meter_alt2(hass: HomeAssistant, dsmr_connection_fixture) -> None:
+    """Test if Belgian meter is correctly parsed."""
+    (connection_factory, transport, protocol) = dsmr_connection_fixture
+
+    from dsmr_parser.obis_references import (
+        BELGIUM_MBUS1_METER_READING2,
+        BELGIUM_MBUS2_METER_READING1,
+    )
+    from dsmr_parser.objects import MBusObject
+
+    entry_data = {
+        "port": "/dev/ttyUSB0",
+        "dsmr_version": "5B",
+        "precision": 4,
+        "reconnect_interval": 30,
+        "serial_id": "1234",
+        "serial_id_gas": "5678",
+    }
+    entry_options = {
+        "time_between_update": 0,
+    }
+
+    telegram = {
+        BELGIUM_MBUS1_METER_READING2: MBusObject(
+            BELGIUM_MBUS1_METER_READING2,
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642213)},
+                {"value": Decimal(745.695), "unit": "m3"},
+            ],
+        ),
+        BELGIUM_MBUS2_METER_READING1: MBusObject(
+            BELGIUM_MBUS2_METER_READING1,
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642214)},
+                {"value": Decimal(745.696), "unit": "m3"},
+            ],
+        ),
+    }
+
+    mock_entry = MockConfigEntry(
+        domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
+    )
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    telegram_callback = connection_factory.call_args_list[0][0][2]
+
+    # simulate a telegram pushed from the smartmeter and parsed by dsmr_parser
+    telegram_callback(telegram)
+
+    # after receiving telegram entities need to have the chance to be created
+    await hass.async_block_till_done()
 
     # check if gas consumption is parsed correctly
     gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption")

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -18,6 +18,8 @@ from dsmr_parser.obis_references import (
     BELGIUM_MBUS2_METER_READING2,
     BELGIUM_MBUS3_METER_READING1,
     BELGIUM_MBUS3_METER_READING2,
+    BELGIUM_MBUS4_METER_READING1,
+    BELGIUM_MBUS4_METER_READING2,
 )
 import pytest
 
@@ -626,6 +628,18 @@ async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
             BELGIUM_MBUS2_METER_READING1,
             BELGIUM_MBUS3_METER_READING2,
             "745.695",
+        ),
+        (
+            BELGIUM_MBUS4_METER_READING2,
+            BELGIUM_MBUS2_METER_READING1,
+            BELGIUM_MBUS3_METER_READING1,
+            "745.695",
+        ),
+        (
+            BELGIUM_MBUS4_METER_READING1,
+            BELGIUM_MBUS2_METER_READING1,
+            BELGIUM_MBUS3_METER_READING2,
+            "745.697",
         ),
     ],
 )

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -8,7 +8,18 @@ import asyncio
 import datetime
 from decimal import Decimal
 from itertools import chain, repeat
+from typing import Literal
 from unittest.mock import DEFAULT, MagicMock
+
+from dsmr_parser.obis_references import (
+    BELGIUM_MBUS1_METER_READING1,
+    BELGIUM_MBUS1_METER_READING2,
+    BELGIUM_MBUS2_METER_READING1,
+    BELGIUM_MBUS2_METER_READING2,
+    BELGIUM_MBUS3_METER_READING1,
+    BELGIUM_MBUS3_METER_READING2,
+)
+import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.sensor import (
@@ -601,84 +612,34 @@ async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
     )
 
 
-async def test_belgian_meter_alt(hass: HomeAssistant, dsmr_connection_fixture) -> None:
-    """Test if Belgian meter is correctly parsed."""
-    (connection_factory, transport, protocol) = dsmr_connection_fixture
-
-    from dsmr_parser.obis_references import (
-        BELGIUM_MBUS1_METER_READING1,
-        BELGIUM_MBUS3_METER_READING2,
-    )
-    from dsmr_parser.objects import MBusObject
-
-    entry_data = {
-        "port": "/dev/ttyUSB0",
-        "dsmr_version": "5B",
-        "precision": 4,
-        "reconnect_interval": 30,
-        "serial_id": "1234",
-        "serial_id_gas": "5678",
-    }
-    entry_options = {
-        "time_between_update": 0,
-    }
-
-    telegram = {
-        BELGIUM_MBUS1_METER_READING1: MBusObject(
+@pytest.mark.parametrize(
+    ("key1", "key2", "key3", "gas_value"),
+    [
+        (
             BELGIUM_MBUS1_METER_READING1,
-            [
-                {"value": datetime.datetime.fromtimestamp(1551642213)},
-                {"value": Decimal(745.695), "unit": "m3"},
-            ],
+            BELGIUM_MBUS2_METER_READING2,
+            BELGIUM_MBUS3_METER_READING1,
+            "745.696",
         ),
-        BELGIUM_MBUS3_METER_READING2: MBusObject(
+        (
+            BELGIUM_MBUS1_METER_READING2,
+            BELGIUM_MBUS2_METER_READING1,
             BELGIUM_MBUS3_METER_READING2,
-            [
-                {"value": datetime.datetime.fromtimestamp(1551642214)},
-                {"value": Decimal(745.696), "unit": "m3"},
-            ],
+            "745.695",
         ),
-    }
-
-    mock_entry = MockConfigEntry(
-        domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
-    )
-
-    mock_entry.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(mock_entry.entry_id)
-    await hass.async_block_till_done()
-
-    telegram_callback = connection_factory.call_args_list[0][0][2]
-
-    # simulate a telegram pushed from the smartmeter and parsed by dsmr_parser
-    telegram_callback(telegram)
-
-    # after receiving telegram entities need to have the chance to be created
-    await hass.async_block_till_done()
-
-    # check if gas consumption is parsed correctly
-    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption")
-    assert gas_consumption.state == "745.696"
-    assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.GAS
-    assert (
-        gas_consumption.attributes.get(ATTR_STATE_CLASS)
-        == SensorStateClass.TOTAL_INCREASING
-    )
-    assert (
-        gas_consumption.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-        == UnitOfVolume.CUBIC_METERS
-    )
-
-
-async def test_belgian_meter_alt2(hass: HomeAssistant, dsmr_connection_fixture) -> None:
+    ],
+)
+async def test_belgian_meter_alt(
+    hass: HomeAssistant,
+    dsmr_connection_fixture,
+    key1: Literal,
+    key2: Literal,
+    key3: Literal,
+    gas_value: str,
+) -> None:
     """Test if Belgian meter is correctly parsed."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
-    from dsmr_parser.obis_references import (
-        BELGIUM_MBUS1_METER_READING2,
-        BELGIUM_MBUS2_METER_READING1,
-    )
     from dsmr_parser.objects import MBusObject
 
     entry_data = {
@@ -694,18 +655,25 @@ async def test_belgian_meter_alt2(hass: HomeAssistant, dsmr_connection_fixture) 
     }
 
     telegram = {
-        BELGIUM_MBUS1_METER_READING2: MBusObject(
-            BELGIUM_MBUS1_METER_READING2,
+        key1: MBusObject(
+            key1,
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(745.695), "unit": "m3"},
             ],
         ),
-        BELGIUM_MBUS2_METER_READING1: MBusObject(
-            BELGIUM_MBUS2_METER_READING1,
+        key2: MBusObject(
+            key2,
             [
                 {"value": datetime.datetime.fromtimestamp(1551642214)},
                 {"value": Decimal(745.696), "unit": "m3"},
+            ],
+        ),
+        key3: MBusObject(
+            key3,
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642215)},
+                {"value": Decimal(745.697), "unit": "m3"},
             ],
         ),
     }
@@ -729,7 +697,7 @@ async def test_belgian_meter_alt2(hass: HomeAssistant, dsmr_connection_fixture) 
 
     # check if gas consumption is parsed correctly
     gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption")
-    assert gas_consumption.state == "745.695"
+    assert gas_consumption.state == gas_value
     assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.GAS
     assert (
         gas_consumption.attributes.get(ATTR_STATE_CLASS)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In commit 1b73219 the gas meter broke for 5B.
As the change can't be reverted easily without removing the peak usage sensors, we implement a workaround.

The first MBUS_METER_READING2 value will contain the gas meter data just like the previous BELGIUM_5MIN_GAS_METER_READING did. But this without the need to touch dsmr_parser (version).

Fixes: #103306, fixes #103293

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
