### PR TITLE
Bump aioesphomeapi to 18.2.4

### DIFF
--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -16,7 +16,7 @@
   "loggers": ["aioesphomeapi", "noiseprotocol"],
   "requirements": [
     "async-interrupt==1.1.1",
-    "aioesphomeapi==18.2.1",
+    "aioesphomeapi==18.2.2",
     "bluetooth-data-tools==1.14.0",
     "esphome-dashboard-api==1.2.3"
   ],

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -16,7 +16,7 @@
   "loggers": ["aioesphomeapi", "noiseprotocol"],
   "requirements": [
     "async-interrupt==1.1.1",
-    "aioesphomeapi==18.2.2",
+    "aioesphomeapi==18.2.3",
     "bluetooth-data-tools==1.14.0",
     "esphome-dashboard-api==1.2.3"
   ],

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -16,7 +16,7 @@
   "loggers": ["aioesphomeapi", "noiseprotocol"],
   "requirements": [
     "async-interrupt==1.1.1",
-    "aioesphomeapi==18.2.3",
+    "aioesphomeapi==18.2.4",
     "bluetooth-data-tools==1.14.0",
     "esphome-dashboard-api==1.2.3"
   ],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -237,7 +237,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==18.2.1
+aioesphomeapi==18.2.2
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -237,7 +237,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==18.2.2
+aioesphomeapi==18.2.3
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -237,7 +237,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==18.2.3
+aioesphomeapi==18.2.4
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -218,7 +218,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==18.2.1
+aioesphomeapi==18.2.2
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -218,7 +218,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==18.2.3
+aioesphomeapi==18.2.4
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -218,7 +218,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==18.2.2
+aioesphomeapi==18.2.3
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/tests/components/esphome/conftest.py
+++ b/tests/components/esphome/conftest.py
@@ -77,6 +77,17 @@ def mock_config_entry(hass) -> MockConfigEntry:
     return config_entry
 
 
+class BaseMockReconnectLogic(ReconnectLogic):
+    """Mock ReconnectLogic."""
+
+    def stop_callback(self) -> None:
+        """Stop the reconnect logic."""
+        # For the purposes of testing, we don't want to wait
+        # for the reconnect logic to finish trying to connect
+        self._cancel_connect("forced disconnect from test")
+        self._is_stopped = True
+
+
 @pytest.fixture
 def mock_device_info() -> DeviceInfo:
     """Return the default mocked device info."""
@@ -132,7 +143,10 @@ def mock_client(mock_device_info) -> APIClient:
     mock_client.address = "127.0.0.1"
     mock_client.api_version = APIVersion(99, 99)
 
-    with patch("homeassistant.components.esphome.APIClient", mock_client), patch(
+    with patch(
+        "homeassistant.components.esphome.manager.ReconnectLogic",
+        BaseMockReconnectLogic,
+    ), patch("homeassistant.components.esphome.APIClient", mock_client), patch(
         "homeassistant.components.esphome.config_flow.APIClient", mock_client
     ):
         yield mock_client
@@ -234,7 +248,7 @@ async def _mock_generic_device_entry(
 
     try_connect_done = Event()
 
-    class MockReconnectLogic(ReconnectLogic):
+    class MockReconnectLogic(BaseMockReconnectLogic):
         """Mock ReconnectLogic."""
 
         def __init__(self, *args, **kwargs):
@@ -255,7 +269,7 @@ async def _mock_generic_device_entry(
             # For the purposes of testing, we don't want to wait
             # for the reconnect logic to finish trying to connect
             self._cancel_connect("forced disconnect from test")
-            super().stop_callback()
+            self._is_stopped = True
 
     with patch(
         "homeassistant.components.esphome.manager.ReconnectLogic", MockReconnectLogic

--- a/tests/components/esphome/conftest.py
+++ b/tests/components/esphome/conftest.py
@@ -250,6 +250,13 @@ async def _mock_generic_device_entry(
             try_connect_done.set()
             return result
 
+        def stop_callback(self) -> None:
+            """Stop the reconnect logic."""
+            # For the purposes of testing, we don't want to wait
+            # for the reconnect logic to finish trying to connect
+            self._cancel_connect("forced disconnect from test")
+            super().stop_callback()
+
     with patch(
         "homeassistant.components.esphome.manager.ReconnectLogic", MockReconnectLogic
     ):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
changelog: https://github.com/esphome/aioesphomeapi/compare/v18.2.1...v18.2.4


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #103517
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
