### PR TITLE
Add conversation agent for Wyoming

### DIFF
--- a/homeassistant/components/wyoming/config_flow.py
+++ b/homeassistant/components/wyoming/config_flow.py
@@ -59,12 +59,26 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # wake-word-detection
         wake_installed = [wake for wake in service.info.wake if wake.installed]
 
+        # intent recognition
+        intent_installed = [
+            intent for intent in service.info.intent if intent.installed
+        ]
+
+        # intent handling
+        handle_installed = [
+            handle for handle in service.info.handle if handle.installed
+        ]
+
         if asr_installed:
             name = asr_installed[0].name
         elif tts_installed:
             name = tts_installed[0].name
         elif wake_installed:
             name = wake_installed[0].name
+        elif intent_installed:
+            name = intent_installed[0].name
+        elif handle_installed:
+            name = handle_installed[0].name
         else:
             return self.async_abort(reason="no_services")
 
@@ -97,6 +111,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     not any(asr for asr in service.info.asr if asr.installed)
                     and not any(tts for tts in service.info.tts if tts.installed)
                     and not any(wake for wake in service.info.wake if wake.installed)
+                    and not any(
+                        intent for intent in service.info.intent if intent.installed
+                    )
+                    and not any(
+                        handle for handle in service.info.handle if handle.installed
+                    )
                 ):
                     return self.async_abort(reason="no_services")
 

--- a/homeassistant/components/wyoming/conversation.py
+++ b/homeassistant/components/wyoming/conversation.py
@@ -1,0 +1,155 @@
+"""Support for Wyoming intent services."""
+import logging
+from typing import Literal
+
+from wyoming.asr import Transcript
+from wyoming.client import AsyncTcpClient
+from wyoming.handle import Handled, NotHandled
+from wyoming.info import HandleProgram, IntentProgram
+from wyoming.intent import Intent, NotRecognized, Recognize
+
+from homeassistant.components.conversation import agent
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
+
+from .const import DOMAIN
+from .data import WyomingService
+from .error import WyomingError
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class WyomingConversationError(WyomingError):
+    """Base class for Wyoming conversation errors."""
+
+
+class WyomingConversationAgent(agent.AbstractConversationAgent):
+    """Wyoming conversation agent."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        service: WyomingService,
+    ) -> None:
+        """Set up provider."""
+        self.hass = hass
+        self.service = service
+        self._intent_service: IntentProgram | None = None
+        self._handle_service: HandleProgram | None = None
+
+        for intent_program in service.info.intent:
+            if intent_program.installed:
+                self._intent_service = intent_program
+                break
+
+        for handle_program in service.info.handle:
+            if handle_program.installed:
+                self._handle_service = handle_program
+                break
+
+        self._supported_languages: list[str] = []
+        if self._intent_service is not None:
+            for intent_model in self._intent_service.models:
+                self._supported_languages.extend(intent_model.languages)
+
+            self._attr_name = self._intent_service.name
+        elif self._handle_service is not None:
+            for handle_model in self._handle_service.models:
+                self._supported_languages.extend(handle_model.languages)
+
+            self._attr_name = self._handle_service.name
+        else:
+            raise WyomingConversationError("No intent or handle services")
+
+        self._attr_unique_id = f"{config_entry.entry_id}-conversation"
+
+    @property
+    def supported_languages(self) -> list[str] | Literal["*"]:
+        """Return a list of supported languages."""
+        return self._supported_languages
+
+    async def async_process(
+        self, user_input: agent.ConversationInput
+    ) -> agent.ConversationResult:
+        """Process a sentence."""
+        if self._intent_service is not None:
+            return await self._async_process_intent(user_input)
+
+        if self._handle_service is not None:
+            return await self._async_process_handle(user_input)
+
+        raise WyomingConversationError("No intent or handle service")
+
+    async def _async_process_intent(
+        self, user_input: agent.ConversationInput
+    ) -> agent.ConversationResult:
+        try:
+            async with AsyncTcpClient(self.service.host, self.service.port) as client:
+                # Recognize -> Intent | NotRecognized
+                await client.write_event(Recognize(user_input.text).event())
+                result_event = await client.read_event()
+
+                if result_event is not None:
+                    if Intent.is_type(result_event.type):
+                        result_intent = Intent.from_event(result_event)
+                        _LOGGER.debug("Recognized intent: %s", result_intent)
+                        intent_slots = {
+                            e.name: {"value": e.value} for e in result_intent.entities
+                        }
+                        intent_response = await intent.async_handle(
+                            self.hass,
+                            DOMAIN,
+                            intent_type=result_intent.name,
+                            slots=intent_slots,
+                            text_input=user_input.text,
+                            context=user_input.context,
+                            language=user_input.language,
+                        )
+
+                        return agent.ConversationResult(
+                            response=intent_response,
+                            conversation_id=user_input.conversation_id,
+                        )
+
+                    if NotRecognized.is_type(result_event.type):
+                        _LOGGER.warning("No intent was recognized")
+
+        except (OSError, WyomingError):
+            _LOGGER.exception("Unexpected error during intent recognition")
+
+        return _empty_result(user_input.language)
+
+    async def _async_process_handle(
+        self, user_input: agent.ConversationInput
+    ) -> agent.ConversationResult:
+        try:
+            async with AsyncTcpClient(self.service.host, self.service.port) as client:
+                # Transcript -> Handled | NotHandled
+                await client.write_event(Transcript(user_input.text).event())
+                result_event = await client.read_event()
+
+                if Handled.is_type(result_event.type):
+                    # Handled contains response text only
+                    result_handled = Handled.from_event(result_event)
+                    _LOGGER.debug("User input was handled: %s", result_handled)
+                    response = intent.IntentResponse(user_input.language)
+                    response.async_set_speech(result_handled.text)
+                    return agent.ConversationResult(
+                        response=response,
+                        conversation_id=user_input.conversation_id,
+                    )
+
+                if NotHandled.is_type(result_event.type):
+                    _LOGGER.warning("User input was not handled")
+
+        except (OSError, WyomingError):
+            _LOGGER.exception("Unexpected error during user input handling")
+
+        return _empty_result(user_input.language)
+
+
+def _empty_result(language: str) -> agent.ConversationResult:
+    """Return an empty conversation result."""
+    return agent.ConversationResult(response=intent.IntentResponse(language))

--- a/homeassistant/components/wyoming/manifest.json
+++ b/homeassistant/components/wyoming/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/wyoming",
   "iot_class": "local_push",
-  "requirements": ["wyoming==1.2.0"]
+  "requirements": ["wyoming==1.3.0"]
 }

--- a/homeassistant/components/wyoming/tts.py
+++ b/homeassistant/components/wyoming/tts.py
@@ -25,7 +25,7 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Wyoming speech-to-text."""
+    """Set up Wyoming text-to-speech."""
     service: WyomingService = hass.data[DOMAIN][config_entry.entry_id]
     async_add_entities(
         [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2734,7 +2734,7 @@ wled==0.17.0
 wolf-smartset==0.1.11
 
 # homeassistant.components.wyoming
-wyoming==1.2.0
+wyoming==1.3.0
 
 # homeassistant.components.xbox
 xbox-webapi==2.0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2037,7 +2037,7 @@ wled==0.17.0
 wolf-smartset==0.1.11
 
 # homeassistant.components.wyoming
-wyoming==1.2.0
+wyoming==1.3.0
 
 # homeassistant.components.xbox
 xbox-webapi==2.0.11

--- a/tests/components/wyoming/__init__.py
+++ b/tests/components/wyoming/__init__.py
@@ -5,7 +5,11 @@ from wyoming.info import (
     AsrModel,
     AsrProgram,
     Attribution,
+    HandleModel,
+    HandleProgram,
     Info,
+    IntentModel,
+    IntentProgram,
     TtsProgram,
     TtsVoice,
     TtsVoiceSpeaker,
@@ -67,6 +71,44 @@ WAKE_WORD_INFO = Info(
                     installed=True,
                     attribution=TEST_ATTR,
                     languages=["en-US"],
+                )
+            ],
+        )
+    ]
+)
+INTENT_INFO = Info(
+    intent=[
+        IntentProgram(
+            name="Test Intent Recognition",
+            description="Test Intent Recognition",
+            installed=True,
+            attribution=TEST_ATTR,
+            models=[
+                IntentModel(
+                    name="Test Model",
+                    description="Test Model",
+                    installed=True,
+                    attribution=TEST_ATTR,
+                    languages=["en-us"],
+                )
+            ],
+        )
+    ]
+)
+HANDLE_INFO = Info(
+    handle=[
+        HandleProgram(
+            name="Test Intent Handling",
+            description="Test Intent Handling",
+            installed=True,
+            attribution=TEST_ATTR,
+            models=[
+                HandleModel(
+                    name="Test Model",
+                    description="Test Model",
+                    installed=True,
+                    attribution=TEST_ATTR,
+                    languages=["en-us"],
                 )
             ],
         )

--- a/tests/components/wyoming/conftest.py
+++ b/tests/components/wyoming/conftest.py
@@ -8,7 +8,7 @@ from homeassistant.components import stt
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from . import STT_INFO, TTS_INFO, WAKE_WORD_INFO
+from . import HANDLE_INFO, INTENT_INFO, STT_INFO, TTS_INFO, WAKE_WORD_INFO
 
 from tests.common import MockConfigEntry
 
@@ -68,6 +68,36 @@ def wake_word_config_entry(hass: HomeAssistant) -> ConfigEntry:
 
 
 @pytest.fixture
+def intent_config_entry(hass: HomeAssistant) -> ConfigEntry:
+    """Create a config entry."""
+    entry = MockConfigEntry(
+        domain="wyoming",
+        data={
+            "host": "1.2.3.4",
+            "port": 1234,
+        },
+        title="Test Intent Recognition",
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+@pytest.fixture
+def handle_config_entry(hass: HomeAssistant) -> ConfigEntry:
+    """Create a config entry."""
+    entry = MockConfigEntry(
+        domain="wyoming",
+        data={
+            "host": "1.2.3.4",
+            "port": 1234,
+        },
+        title="Test Intent Handling",
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+@pytest.fixture
 async def init_wyoming_stt(hass: HomeAssistant, stt_config_entry: ConfigEntry):
     """Initialize Wyoming STT."""
     with patch(
@@ -97,6 +127,26 @@ async def init_wyoming_wake_word(
         return_value=WAKE_WORD_INFO,
     ):
         await hass.config_entries.async_setup(wake_word_config_entry.entry_id)
+
+
+@pytest.fixture
+async def init_wyoming_intent(hass: HomeAssistant, intent_config_entry: ConfigEntry):
+    """Initialize Wyoming intent recognition."""
+    with patch(
+        "homeassistant.components.wyoming.data.load_wyoming_info",
+        return_value=INTENT_INFO,
+    ):
+        await hass.config_entries.async_setup(intent_config_entry.entry_id)
+
+
+@pytest.fixture
+async def init_wyoming_handle(hass: HomeAssistant, handle_config_entry: ConfigEntry):
+    """Initialize Wyoming intent handling."""
+    with patch(
+        "homeassistant.components.wyoming.data.load_wyoming_info",
+        return_value=HANDLE_INFO,
+    ):
+        await hass.config_entries.async_setup(handle_config_entry.entry_id)
 
 
 @pytest.fixture

--- a/tests/components/wyoming/snapshots/test_conversation.ambr
+++ b/tests/components/wyoming/snapshots/test_conversation.ambr
@@ -1,0 +1,78 @@
+# serializer version: 1
+# name: test_intent_handled
+  list([
+    dict({
+      'data': dict({
+        'text': 'Turn on test light',
+      }),
+      'payload': None,
+      'type': 'transcript',
+    }),
+  ])
+# ---
+# name: test_intent_handling_client_dropped
+  list([
+    dict({
+      'data': dict({
+        'text': 'This will never be handled',
+      }),
+      'payload': None,
+      'type': 'transcript',
+    }),
+  ])
+# ---
+# name: test_intent_not_handled
+  list([
+    dict({
+      'data': dict({
+        'text': "You won't understand this",
+      }),
+      'payload': None,
+      'type': 'transcript',
+    }),
+  ])
+# ---
+# name: test_intent_not_recognized
+  list([
+    dict({
+      'data': dict({
+        'text': "You won't understand this",
+      }),
+      'payload': None,
+      'type': 'recognize',
+    }),
+  ])
+# ---
+# name: test_intent_recognition_client_dropped
+  list([
+    dict({
+      'data': dict({
+        'text': 'This will never be recognized',
+      }),
+      'payload': None,
+      'type': 'recognize',
+    }),
+  ])
+# ---
+# name: test_intent_recognition_failed
+  list([
+    dict({
+      'data': dict({
+        'text': 'Do something unexpected',
+      }),
+      'payload': None,
+      'type': 'recognize',
+    }),
+  ])
+# ---
+# name: test_intent_recognized
+  list([
+    dict({
+      'data': dict({
+        'text': 'Turn on test light',
+      }),
+      'payload': None,
+      'type': 'recognize',
+    }),
+  ])
+# ---

--- a/tests/components/wyoming/test_conversation.py
+++ b/tests/components/wyoming/test_conversation.py
@@ -1,0 +1,247 @@
+"""Test tts."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+from wyoming.handle import Handled, NotHandled
+from wyoming.intent import Entity, Intent, NotRecognized
+
+from homeassistant.components import conversation
+from homeassistant.const import ATTR_FRIENDLY_NAME
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.helpers import entity_registry as er, intent
+from homeassistant.setup import async_setup_component
+
+from . import MockAsyncTcpClient
+
+from tests.common import async_mock_service
+
+
+@pytest.fixture
+async def init_components(hass: HomeAssistant):
+    """Initialize relevant components with empty configs."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, "conversation", {})
+    assert await async_setup_component(hass, "intent", {})
+
+
+async def test_intent_recognized(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    init_components,
+    init_wyoming_intent,
+    intent_config_entry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test intent recogntion."""
+    test_light = entity_registry.async_get_or_create("light", "demo", "1234")
+    hass.states.async_set(
+        test_light.entity_id, "off", attributes={ATTR_FRIENDLY_NAME: "test light"}
+    )
+    calls = async_mock_service(hass, "light", "turn_on")
+
+    intent_events = [
+        Intent(
+            name="HassTurnOn",
+            entities=[Entity(name="name", value="test light")],
+            text="Turned on light",
+        ).event()
+    ]
+
+    with patch(
+        "homeassistant.components.wyoming.conversation.AsyncTcpClient",
+        MockAsyncTcpClient(intent_events),
+    ) as mock_client:
+        result = await conversation.async_converse(
+            hass,
+            "Turn on test light",
+            conversation_id=None,
+            context=Context(),
+            agent_id=intent_config_entry.entry_id,
+        )
+        assert len(calls) == 1
+        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response.speech == {
+            "plain": {"speech": "Turned on light", "extra_data": None}
+        }
+
+    assert mock_client.written == snapshot
+
+
+async def test_intent_not_recognized(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    init_components,
+    init_wyoming_intent,
+    intent_config_entry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test intent recogntion."""
+    intent_events = [NotRecognized("I don't understand").event()]
+
+    with patch(
+        "homeassistant.components.wyoming.conversation.AsyncTcpClient",
+        MockAsyncTcpClient(intent_events),
+    ) as mock_client:
+        result = await conversation.async_converse(
+            hass,
+            "You won't understand this",
+            conversation_id=None,
+            context=Context(),
+            agent_id=intent_config_entry.entry_id,
+        )
+        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert (
+            result.response.error_code == intent.IntentResponseErrorCode.NO_INTENT_MATCH
+        )
+
+    assert mock_client.written == snapshot
+
+
+async def test_intent_recognition_failed(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    init_components,
+    init_wyoming_intent,
+    intent_config_entry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test intent recogntion."""
+    intent_events = [Intent(name="NotAnIntent").event()]
+
+    with patch(
+        "homeassistant.components.wyoming.conversation.AsyncTcpClient",
+        MockAsyncTcpClient(intent_events),
+    ) as mock_client, pytest.raises(intent.UnknownIntent):
+        await conversation.async_converse(
+            hass,
+            "Do something unexpected",
+            conversation_id=None,
+            context=Context(),
+            agent_id=intent_config_entry.entry_id,
+        )
+
+    assert mock_client.written == snapshot
+
+
+async def test_intent_recognition_client_dropped(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    init_components,
+    init_wyoming_intent,
+    intent_config_entry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test intent recogntion."""
+    intent_events = [None]
+
+    with patch(
+        "homeassistant.components.wyoming.conversation.AsyncTcpClient",
+        MockAsyncTcpClient(intent_events),
+    ) as mock_client:
+        result = await conversation.async_converse(
+            hass,
+            "This will never be recognized",
+            conversation_id=None,
+            context=Context(),
+            agent_id=intent_config_entry.entry_id,
+        )
+
+        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.error_code == intent.IntentResponseErrorCode.UNKNOWN
+
+    assert mock_client.written == snapshot
+
+
+async def test_intent_handled(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    init_components,
+    init_wyoming_handle,
+    handle_config_entry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test intent recogntion."""
+    handle_events = [Handled("Turned on light").event()]
+
+    with patch(
+        "homeassistant.components.wyoming.conversation.AsyncTcpClient",
+        MockAsyncTcpClient(handle_events),
+    ) as mock_client:
+        result = await conversation.async_converse(
+            hass,
+            "Turn on test light",
+            conversation_id=None,
+            context=Context(),
+            agent_id=handle_config_entry.entry_id,
+        )
+        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response.speech == {
+            "plain": {"speech": "Turned on light", "extra_data": None}
+        }
+
+    assert mock_client.written == snapshot
+
+
+async def test_intent_not_handled(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    init_components,
+    init_wyoming_handle,
+    handle_config_entry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test intent recogntion."""
+    handle_events = [NotHandled("I don't understand").event()]
+
+    with patch(
+        "homeassistant.components.wyoming.conversation.AsyncTcpClient",
+        MockAsyncTcpClient(handle_events),
+    ) as mock_client:
+        result = await conversation.async_converse(
+            hass,
+            "You won't understand this",
+            conversation_id=None,
+            context=Context(),
+            agent_id=handle_config_entry.entry_id,
+        )
+        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert (
+            result.response.error_code
+            == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
+        )
+        assert result.response.speech == {
+            "plain": {"speech": "I don't understand", "extra_data": None}
+        }
+
+    assert mock_client.written == snapshot
+
+
+async def test_intent_handling_client_dropped(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    init_components,
+    init_wyoming_handle,
+    handle_config_entry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test intent recogntion."""
+    handle_events = [None]
+
+    with patch(
+        "homeassistant.components.wyoming.conversation.AsyncTcpClient",
+        MockAsyncTcpClient(handle_events),
+    ) as mock_client:
+        result = await conversation.async_converse(
+            hass,
+            "This will never be handled",
+            conversation_id=None,
+            context=Context(),
+            agent_id=handle_config_entry.entry_id,
+        )
+        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.error_code == intent.IntentResponseErrorCode.UNKNOWN
+
+    assert mock_client.written == snapshot


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a conversation agent that can communicate with services using the [Wyoming protocol](https://github.com/rhasspy/wyoming).
This agent supports two kinds of Wyoming services:
1. Intent recognizers - text input, intent + slots output with optional text response
2. Intent handlers - text input, text output

Intent recognition services must produce intents that are either [built in to Home Assistant](https://developers.home-assistant.io/docs/intent_builtin) or have been added by an integration such as [`intent_script`](https://www.home-assistant.io/integrations/intent_script/). Example: "turn on the bed light" -> `HassTurnOn(name=bed light)`

Intent handling services only produce text responses, which is better suited for chat bot conversations or when Home Assistant is not being asked to directly perform an action. Example: "how are you today?" -> "I'm fine, thank you."

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
