### PR TITLE
Add button platform to Opengarage

### DIFF
--- a/homeassistant/components/opengarage/__init__.py
+++ b/homeassistant/components/opengarage/__init__.py
@@ -18,7 +18,7 @@ from .const import CONF_DEVICE_KEY, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.COVER, Platform.SENSOR, Platform.BUTTON]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.COVER, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/opengarage/__init__.py
+++ b/homeassistant/components/opengarage/__init__.py
@@ -18,13 +18,11 @@ from .const import CONF_DEVICE_KEY, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.COVER, Platform.SENSOR]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.COVER, Platform.SENSOR, Platform.BUTTON]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up OpenGarage from a config entry."""
-    hass.data.setdefault(DOMAIN, {})
-
     open_garage_connection = opengarage.OpenGarage(
         f"{entry.data[CONF_HOST]}:{entry.data[CONF_PORT]}",
         entry.data[CONF_DEVICE_KEY],
@@ -36,7 +34,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         open_garage_connection=open_garage_connection,
     )
     await open_garage_data_coordinator.async_config_entry_first_refresh()
-    hass.data[DOMAIN][entry.entry_id] = open_garage_data_coordinator
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = open_garage_data_coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/opengarage/button.py
+++ b/homeassistant/components/opengarage/button.py
@@ -1,0 +1,89 @@
+"""OpenGarage button."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, cast
+
+import opengarage
+
+from homeassistant.components.button import (
+    ButtonDeviceClass,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import OpenGarageDataUpdateCoordinator
+from .const import DOMAIN
+from .entity import OpenGarageEntity
+
+
+@dataclass
+class OpenGarageButtonEntityDescriptionMixin:
+    """Mixin to describe a OpenGarage button entity."""
+
+    press_action: Callable[[opengarage.OpenGarage], Any]
+
+
+@dataclass
+class OpenGarageButtonEntityDescription(
+    ButtonEntityDescription, OpenGarageButtonEntityDescriptionMixin
+):
+    """OpenGarage Browser button description."""
+
+
+BUTTONS: tuple[OpenGarageButtonEntityDescription, ...] = (
+    OpenGarageButtonEntityDescription(
+        key="reboot_device",
+        translation_key="reboot_device",
+        device_class=ButtonDeviceClass.RESTART,
+        entity_category=EntityCategory.CONFIG,
+        press_action=lambda opengarage: opengarage.reboot(),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the OpenGarage button entities."""
+    coordinator: OpenGarageDataUpdateCoordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]
+
+    async_add_entities(
+        OpenGarageButtonEntity(
+            coordinator, cast(str, config_entry.unique_id), description
+        )
+        for description in BUTTONS
+    )
+
+
+class OpenGarageButtonEntity(OpenGarageEntity, ButtonEntity):
+    """Representation of a OpenGarage button."""
+
+    entity_description: OpenGarageButtonEntityDescription
+
+    def __init__(
+        self,
+        coordinator: OpenGarageDataUpdateCoordinator,
+        device_id: str,
+        description: OpenGarageButtonEntityDescription,
+    ) -> None:
+        """Initialize the button."""
+        super().__init__(coordinator, device_id)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.data['name']}-{description.key}"
+
+    async def async_press(self) -> None:
+        """Set the value of the entity."""
+        await self.entity_description.press_action(
+            self.coordinator.open_garage_connection
+        )
+        await self.coordinator.async_refresh()

--- a/homeassistant/components/opengarage/button.py
+++ b/homeassistant/components/opengarage/button.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, cast
 
-import opengarage
+from opengarage import OpenGarage
 
 from homeassistant.components.button import (
     ButtonDeviceClass,
@@ -26,7 +26,7 @@ from .entity import OpenGarageEntity
 class OpenGarageButtonEntityDescriptionMixin:
     """Mixin to describe a OpenGarage button entity."""
 
-    press_action: Callable[[opengarage.OpenGarage], Any]
+    press_action: Callable[[OpenGarage], Any]
 
 
 @dataclass
@@ -38,8 +38,7 @@ class OpenGarageButtonEntityDescription(
 
 BUTTONS: tuple[OpenGarageButtonEntityDescription, ...] = (
     OpenGarageButtonEntityDescription(
-        key="reboot_device",
-        translation_key="reboot_device",
+        key="restart",
         device_class=ButtonDeviceClass.RESTART,
         entity_category=EntityCategory.CONFIG,
         press_action=lambda opengarage: opengarage.reboot(),
@@ -66,7 +65,7 @@ async def async_setup_entry(
 
 
 class OpenGarageButtonEntity(OpenGarageEntity, ButtonEntity):
-    """Representation of a OpenGarage button."""
+    """Representation of an OpenGarage button."""
 
     entity_description: OpenGarageButtonEntityDescription
 
@@ -77,9 +76,7 @@ class OpenGarageButtonEntity(OpenGarageEntity, ButtonEntity):
         description: OpenGarageButtonEntityDescription,
     ) -> None:
         """Initialize the button."""
-        super().__init__(coordinator, device_id)
-        self.entity_description = description
-        self._attr_unique_id = f"{coordinator.data['name']}-{description.key}"
+        super().__init__(coordinator, device_id, description)
 
     async def async_press(self) -> None:
         """Set the value of the entity."""

--- a/homeassistant/components/opengarage/button.py
+++ b/homeassistant/components/opengarage/button.py
@@ -22,14 +22,14 @@ from .const import DOMAIN
 from .entity import OpenGarageEntity
 
 
-@dataclass
+@dataclass(frozen=True)
 class OpenGarageButtonEntityDescriptionMixin:
     """Mixin to describe a OpenGarage button entity."""
 
     press_action: Callable[[OpenGarage], Any]
 
 
-@dataclass
+@dataclass(frozen=True)
 class OpenGarageButtonEntityDescription(
     ButtonEntityDescription, OpenGarageButtonEntityDescriptionMixin
 ):
@@ -79,7 +79,7 @@ class OpenGarageButtonEntity(OpenGarageEntity, ButtonEntity):
         super().__init__(coordinator, device_id, description)
 
     async def async_press(self) -> None:
-        """Set the value of the entity."""
+        """Press the button."""
         await self.entity_description.press_action(
             self.coordinator.open_garage_connection
         )

--- a/homeassistant/components/opengarage/button.py
+++ b/homeassistant/components/opengarage/button.py
@@ -22,18 +22,11 @@ from .const import DOMAIN
 from .entity import OpenGarageEntity
 
 
-@dataclass(frozen=True)
-class OpenGarageButtonEntityDescriptionMixin:
-    """Mixin to describe a OpenGarage button entity."""
+@dataclass(frozen=True, kw_only=True)
+class OpenGarageButtonEntityDescription(ButtonEntityDescription):
+    """OpenGarage Browser button description."""
 
     press_action: Callable[[OpenGarage], Any]
-
-
-@dataclass(frozen=True)
-class OpenGarageButtonEntityDescription(
-    ButtonEntityDescription, OpenGarageButtonEntityDescriptionMixin
-):
-    """OpenGarage Browser button description."""
 
 
 BUTTONS: tuple[OpenGarageButtonEntityDescription, ...] = (

--- a/homeassistant/components/opengarage/strings.json
+++ b/homeassistant/components/opengarage/strings.json
@@ -27,6 +27,11 @@
       "vehicle": {
         "name": "Vehicle"
       }
+    },
+    "button": {
+      "reboot_device": {
+        "name": "Reboot device"
+      }
     }
   }
 }

--- a/homeassistant/components/opengarage/strings.json
+++ b/homeassistant/components/opengarage/strings.json
@@ -27,11 +27,6 @@
       "vehicle": {
         "name": "Vehicle"
       }
-    },
-    "button": {
-      "reboot_device": {
-        "name": "Reboot device"
-      }
     }
   }
 }

--- a/tests/components/opengarage/conftest.py
+++ b/tests/components/opengarage/conftest.py
@@ -1,0 +1,59 @@
+"""Fixtures for the OpenGarage integration tests."""
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.components.opengarage.const import CONF_DEVICE_KEY, DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_VERIFY_SSL
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        title="Test device",
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "http://1.1.1.1",
+            CONF_PORT: "80",
+            CONF_DEVICE_KEY: "abc123",
+            CONF_VERIFY_SSL: False,
+        },
+        unique_id="12345",
+    )
+
+
+@pytest.fixture
+def mock_opengarage() -> Generator[MagicMock, None, None]:
+    """Return a mocked OpenGarage client."""
+    with patch(
+        "homeassistant.components.opengarage.opengarage.OpenGarage",
+        autospec=True,
+    ) as client_mock:
+        client = client_mock.return_value
+        client.device_url = "http://1.1.1.1:80"
+        client.update_state.return_value = {
+            "name": "abcdef",
+            "mac": "aa:bb:cc:dd:ee:ff",
+            "fwv": "1.2.0",
+        }
+        yield client
+
+
+@pytest.fixture
+async def init_integration(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_opengarage: MagicMock
+) -> MockConfigEntry:
+    """Set up the OpenGarage integration for testing."""
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    return mock_config_entry

--- a/tests/components/opengarage/test_button.py
+++ b/tests/components/opengarage/test_button.py
@@ -13,18 +13,17 @@ async def test_buttons(
     hass: HomeAssistant,
     mock_opengarage: MagicMock,
     init_integration: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test standard OpenGarage buttons."""
-    entity_registry = er.async_get(hass)
-    device_registry = dr.async_get(hass)
-
-    entry = entity_registry.async_get("button.abcdef_reboot_device")
+    entry = entity_registry.async_get("button.abcdef_restart")
     assert entry
-    assert entry.unique_id == "abcdef-reboot_device"
+    assert entry.unique_id == "12345_restart"
     await hass.services.async_call(
         button.DOMAIN,
         button.SERVICE_PRESS,
-        {ATTR_ENTITY_ID: "button.abcdef_reboot_device"},
+        {ATTR_ENTITY_ID: "button.abcdef_restart"},
         blocking=True,
     )
     assert len(mock_opengarage.reboot.mock_calls) == 1

--- a/tests/components/opengarage/test_button.py
+++ b/tests/components/opengarage/test_button.py
@@ -1,0 +1,34 @@
+"""Test the OpenGarage Browser buttons."""
+from unittest.mock import MagicMock
+
+import homeassistant.components.button as button
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from tests.common import MockConfigEntry
+
+
+async def test_buttons(
+    hass: HomeAssistant,
+    mock_opengarage: MagicMock,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test standard OpenGarage buttons."""
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+
+    entry = entity_registry.async_get("button.abcdef_reboot_device")
+    assert entry
+    assert entry.unique_id == "abcdef-reboot_device"
+    await hass.services.async_call(
+        button.DOMAIN,
+        button.SERVICE_PRESS,
+        {ATTR_ENTITY_ID: "button.abcdef_reboot_device"},
+        blocking=True,
+    )
+    assert len(mock_opengarage.reboot.mock_calls) == 1
+
+    assert entry.device_id
+    device_entry = device_registry.async_get(entry.device_id)
+    assert device_entry


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Add support to the OpenGarage integration for rebooting a device, via a new button entity.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository] — https://github.com/home-assistant/home-assistant.io/pull/30632

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [X] Untested files have been added to `.coveragerc`.


To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
