### PR TITLE
Add support to Google Calendar for Web auth credentials

### DIFF
--- a/homeassistant/components/google/api.py
+++ b/homeassistant/components/google/api.py
@@ -49,8 +49,8 @@ class InvalidCredential(OAuthError):
     """Error with an invalid credential that does not support device auth."""
 
 
-class DeviceAuth(AuthImplementation):
-    """OAuth implementation for Device Auth with callback to Web Auth."""
+class GoogleHybridAuth(AuthImplementation):
+    """OAuth implementation that supports both Web Auth (base class) and Device Auth."""
 
     async def async_resolve_external_data(self, external_data: Any) -> dict:
         """Resolve a Google API Credentials object to Home Assistant token."""

--- a/homeassistant/components/google/api.py
+++ b/homeassistant/components/google/api.py
@@ -45,11 +45,18 @@ class OAuthError(Exception):
     """OAuth related error."""
 
 
+class InvalidCredential(OAuthError):
+    """Error with an invalid credential that does not support device auth."""
+
+
 class DeviceAuth(AuthImplementation):
-    """OAuth implementation for Device Auth."""
+    """OAuth implementation for Device Auth with callback to Web Auth."""
 
     async def async_resolve_external_data(self, external_data: Any) -> dict:
         """Resolve a Google API Credentials object to Home Assistant token."""
+        if DEVICE_AUTH_CREDS not in external_data:
+            # Assume the Web Auth flow was used, so use the default behavior
+            return await super().async_resolve_external_data(external_data)
         creds: Credentials = external_data[DEVICE_AUTH_CREDS]
         delta = creds.token_expiry.replace(tzinfo=datetime.UTC) - dt_util.utcnow()
         _LOGGER.debug(
@@ -192,6 +199,10 @@ async def async_create_device_flow(
             oauth_flow.step1_get_device_and_user_codes
         )
     except OAuth2DeviceCodeError as err:
+        _LOGGER.debug("OAuth2DeviceCodeError error: %s", err)
+        # Web auth credentials reply with invalid_client when hitting this endpoint
+        if "Error: invalid_client" in str(err):
+            raise InvalidCredential(str(err)) from err
         raise OAuthError(str(err)) from err
     return DeviceFlow(hass, oauth_flow, device_flow_info)
 

--- a/homeassistant/components/google/application_credentials.py
+++ b/homeassistant/components/google/application_credentials.py
@@ -9,7 +9,7 @@ from homeassistant.components.application_credentials import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from .api import DeviceAuth
+from .api import GoogleHybridAuth
 
 AUTHORIZATION_SERVER = AuthorizationServer(
     oauth2client.GOOGLE_AUTH_URI, oauth2client.GOOGLE_TOKEN_URI
@@ -20,7 +20,7 @@ async def async_get_auth_implementation(
     hass: HomeAssistant, auth_domain: str, credential: ClientCredential
 ) -> config_entry_oauth2_flow.AbstractOAuth2Implementation:
     """Return auth implementation."""
-    return DeviceAuth(hass, auth_domain, credential, AUTHORIZATION_SERVER)
+    return GoogleHybridAuth(hass, auth_domain, credential, AUTHORIZATION_SERVER)
 
 
 async def async_get_description_placeholders(hass: HomeAssistant) -> dict[str, str]:

--- a/homeassistant/components/google/config_flow.py
+++ b/homeassistant/components/google/config_flow.py
@@ -59,7 +59,7 @@ class OAuth2FlowHandler(
     redirect urls.
 
     The Application Credentials integration does not currently record which type
-    of credentail the user entered (and if we ask the user, they may not know or may
+    of credential the user entered (and if we ask the user, they may not know or may
     make a mistake) so we try to determine the credential type automatically. This
     implementation first attempts Device Auth by talking to the token API in the first
     step of the device flow, then if that fails it will redirect using Web Auth.

--- a/homeassistant/components/google/config_flow.py
+++ b/homeassistant/components/google/config_flow.py
@@ -62,8 +62,6 @@ class OAuth2FlowHandler(
     @property
     def extra_authorize_data(self) -> dict[str, Any]:
         """Extra data that needs to be appended to the authorize url."""
-        if not self._web_auth:
-            raise ValueError("Unexpected state; should only be called during web auth")
         return {
             "scope": DEFAULT_FEATURE_ACCESS.scope,
             # Add params to ensure we get back a refresh token

--- a/homeassistant/components/google/const.py
+++ b/homeassistant/components/google/const.py
@@ -1,12 +1,12 @@
 """Constants for google integration."""
 from __future__ import annotations
 
-from enum import Enum
+from enum import Enum, StrEnum
 
 DOMAIN = "google"
-DEVICE_AUTH_IMPL = "device_auth"
 
 CONF_CALENDAR_ACCESS = "calendar_access"
+CONF_CREDENTIAL_TYPE = "credential_type"
 DATA_CALENDARS = "calendars"
 DATA_SERVICE = "service"
 DATA_CONFIG = "config"
@@ -30,6 +30,13 @@ class FeatureAccess(Enum):
 
 
 DEFAULT_FEATURE_ACCESS = FeatureAccess.read_write
+
+
+class CredentialType(StrEnum):
+    """Type of application credentials used."""
+
+    DEVICE_AUTH = "device_auth"
+    WEB_AUTH = "web_auth"
 
 
 EVENT_DESCRIPTION = "description"

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -350,7 +350,10 @@ def component_setup(
     async def _setup_func() -> bool:
         assert await async_setup_component(hass, "application_credentials", {})
         await async_import_client_credential(
-            hass, DOMAIN, ClientCredential("client-id", "client-secret"), "device_auth"
+            hass,
+            DOMAIN,
+            ClientCredential("client-id", "client-secret"),
+            DOMAIN,
         )
         config_entry.add_to_hass(hass)
         return await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -353,7 +353,6 @@ def component_setup(
             hass,
             DOMAIN,
             ClientCredential("client-id", "client-secret"),
-            DOMAIN,
         )
         config_entry.add_to_hass(hass)
         return await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -218,7 +218,7 @@ def config_entry(
         domain=DOMAIN,
         unique_id=config_entry_unique_id,
         data={
-            "auth_implementation": "device_auth",
+            "auth_implementation": DOMAIN,
             "token": {
                 "access_token": "ACCESS_TOKEN",
                 "refresh_token": "REFRESH_TOKEN",

--- a/tests/components/google/test_config_flow.py
+++ b/tests/components/google/test_config_flow.py
@@ -241,7 +241,9 @@ async def test_expired_after_exchange(
 ) -> None:
     """Test credential exchange expires."""
     await async_import_client_credential(
-        hass, DOMAIN, ClientCredential(CLIENT_ID, CLIENT_SECRET), "imported-cred"
+        hass,
+        DOMAIN,
+        ClientCredential(CLIENT_ID, CLIENT_SECRET),
     )
 
     result = await hass.config_entries.flow.async_init(
@@ -276,7 +278,6 @@ async def test_exchange_error(
         hass,
         DOMAIN,
         ClientCredential(CLIENT_ID, CLIENT_SECRET),
-        DOMAIN,
     )
 
     result = await hass.config_entries.flow.async_init(
@@ -344,7 +345,7 @@ async def test_duplicate_config_entries(
 ) -> None:
     """Test that the same account cannot be setup twice."""
     await async_import_client_credential(
-        hass, DOMAIN, ClientCredential(CLIENT_ID, CLIENT_SECRET), "imported-cred"
+        hass, DOMAIN, ClientCredential(CLIENT_ID, CLIENT_SECRET)
     )
 
     # Load a config entry
@@ -386,7 +387,7 @@ async def test_multiple_config_entries(
 ) -> None:
     """Test that multiple config entries can be set at once."""
     await async_import_client_credential(
-        hass, DOMAIN, ClientCredential(CLIENT_ID, CLIENT_SECRET), "imported-cred"
+        hass, DOMAIN, ClientCredential(CLIENT_ID, CLIENT_SECRET)
     )
 
     # Load a config entry
@@ -483,7 +484,6 @@ async def test_reauth_flow(
         hass,
         DOMAIN,
         ClientCredential(CLIENT_ID, CLIENT_SECRET),
-        DOMAIN,
     )
 
     entries = hass.config_entries.async_entries(DOMAIN)
@@ -559,7 +559,9 @@ async def test_calendar_lookup_failure(
 ) -> None:
     """Test successful config flow and title fetch fails gracefully."""
     await async_import_client_credential(
-        hass, DOMAIN, ClientCredential(CLIENT_ID, CLIENT_SECRET), "device_auth"
+        hass,
+        DOMAIN,
+        ClientCredential(CLIENT_ID, CLIENT_SECRET),
     )
 
     result = await hass.config_entries.flow.async_init(
@@ -654,7 +656,9 @@ async def test_web_auth_compatibility(
 ) -> None:
     """Test that we can callback to web auth tokens."""
     await async_import_client_credential(
-        hass, DOMAIN, ClientCredential(CLIENT_ID, CLIENT_SECRET), "imported-cred"
+        hass,
+        DOMAIN,
+        ClientCredential(CLIENT_ID, CLIENT_SECRET),
     )
 
     with patch(
@@ -743,10 +747,7 @@ async def test_web_reauth_flow(
     )
     config_entry.add_to_hass(hass)
     await async_import_client_credential(
-        hass,
-        DOMAIN,
-        ClientCredential(CLIENT_ID, CLIENT_SECRET),
-        DOMAIN,
+        hass, DOMAIN, ClientCredential(CLIENT_ID, CLIENT_SECRET)
     )
 
     entries = hass.config_entries.async_entries(DOMAIN)

--- a/tests/components/google/test_config_flow.py
+++ b/tests/components/google/test_config_flow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 import datetime
 from http import HTTPStatus
+from typing import Any
 from unittest.mock import Mock, patch
 
 from aiohttp.client_exceptions import ClientError
@@ -21,9 +22,14 @@ from homeassistant.components.application_credentials import (
     ClientCredential,
     async_import_client_credential,
 )
-from homeassistant.components.google.const import DOMAIN
+from homeassistant.components.google.const import (
+    CONF_CREDENTIAL_TYPE,
+    DOMAIN,
+    CredentialType,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
@@ -31,9 +37,13 @@ from homeassistant.util.dt import utcnow
 from .conftest import CLIENT_ID, CLIENT_SECRET, EMAIL_ADDRESS, YieldFixture
 
 from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.test_util.aiohttp import AioHttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 CODE_CHECK_INTERVAL = 1
 CODE_CHECK_ALARM_TIMEDELTA = datetime.timedelta(seconds=CODE_CHECK_INTERVAL * 2)
+OAUTH2_AUTHORIZE = "https://accounts.google.com/o/oauth2/v2/auth"
+OAUTH2_TOKEN = "https://oauth2.googleapis.com/token"
 
 
 @pytest.fixture(autouse=True)
@@ -175,6 +185,7 @@ async def test_full_flow_application_creds(
             "scope": "https://www.googleapis.com/auth/calendar",
             "token_type": "Bearer",
         },
+        "credential_type": "device_auth",
     }
     assert result.get("options") == {"calendar_access": "read_write"}
 
@@ -262,7 +273,10 @@ async def test_exchange_error(
 ) -> None:
     """Test an error while exchanging the code for credentials."""
     await async_import_client_credential(
-        hass, DOMAIN, ClientCredential(CLIENT_ID, CLIENT_SECRET), "device_auth"
+        hass,
+        DOMAIN,
+        ClientCredential(CLIENT_ID, CLIENT_SECRET),
+        DOMAIN,
     )
 
     result = await hass.config_entries.flow.async_init(
@@ -307,13 +321,14 @@ async def test_exchange_error(
     data["token"].pop("expires_at")
     data["token"].pop("expires_in")
     assert data == {
-        "auth_implementation": "device_auth",
+        "auth_implementation": DOMAIN,
         "token": {
             "access_token": "ACCESS_TOKEN",
             "refresh_token": "REFRESH_TOKEN",
             "scope": "https://www.googleapis.com/auth/calendar",
             "token_type": "Bearer",
         },
+        "credential_type": "device_auth",
     }
 
     assert len(mock_setup.mock_calls) == 1
@@ -455,17 +470,20 @@ async def test_reauth_flow(
     mock_code_flow: Mock,
     mock_exchange: Mock,
 ) -> None:
-    """Test can't configure when config entry already exists."""
+    """Test reauth of an existing config entry."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={
-            "auth_implementation": "device_auth",
+            "auth_implementation": DOMAIN,
             "token": {"access_token": "OLD_ACCESS_TOKEN"},
         },
     )
     config_entry.add_to_hass(hass)
     await async_import_client_credential(
-        hass, DOMAIN, ClientCredential(CLIENT_ID, CLIENT_SECRET), "device_auth"
+        hass,
+        DOMAIN,
+        ClientCredential(CLIENT_ID, CLIENT_SECRET),
+        DOMAIN,
     )
 
     entries = hass.config_entries.async_entries(DOMAIN)
@@ -512,13 +530,14 @@ async def test_reauth_flow(
     data["token"].pop("expires_at")
     data["token"].pop("expires_in")
     assert data == {
-        "auth_implementation": "device_auth",
+        "auth_implementation": DOMAIN,
         "token": {
             "access_token": "ACCESS_TOKEN",
             "refresh_token": "REFRESH_TOKEN",
             "scope": "https://www.googleapis.com/auth/calendar",
             "token_type": "Bearer",
         },
+        "credential_type": "device_auth",
     }
 
     assert len(mock_setup.mock_calls) == 1
@@ -624,3 +643,190 @@ async def test_options_flow_no_changes(
     )
     assert result["type"] == "create_entry"
     assert config_entry.options == {"calendar_access": "read_write"}
+
+
+async def test_web_auth_compatibility(
+    hass: HomeAssistant,
+    current_request_with_host: None,
+    mock_code_flow: Mock,
+    aioclient_mock: AioHttpClientMocker,
+    hass_client_no_auth: ClientSessionGenerator,
+) -> None:
+    """Test that we can callback to web auth tokens."""
+    await async_import_client_credential(
+        hass, DOMAIN, ClientCredential(CLIENT_ID, CLIENT_SECRET), "imported-cred"
+    )
+
+    with patch(
+        "homeassistant.components.google.api.OAuth2WebServerFlow.step1_get_device_and_user_codes",
+        side_effect=OAuth2DeviceCodeError(
+            "Invalid response 401. Error: invalid_client"
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": "https://example.com/auth/external/callback",
+        },
+    )
+    assert result["type"] == "external"
+    assert result["url"] == (
+        f"{OAUTH2_AUTHORIZE}?response_type=code&client_id={CLIENT_ID}"
+        "&redirect_uri=https://example.com/auth/external/callback"
+        f"&state={state}"
+        "&scope=https://www.googleapis.com/auth/calendar"
+        "&access_type=offline&prompt=consent"
+    )
+
+    client = await hass_client_no_auth()
+    resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
+    assert resp.status == 200
+    assert resp.headers["content-type"] == "text/html; charset=utf-8"
+
+    aioclient_mock.post(
+        OAUTH2_TOKEN,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": "mock-access-token",
+            "type": "Bearer",
+            "expires_in": 60,
+            "scope": "https://www.googleapis.com/auth/calendar",
+        },
+    )
+
+    with patch(
+        "homeassistant.components.google.async_setup_entry", return_value=True
+    ) as mock_setup:
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    token = result.get("data", {}).get("token", {})
+    del token["expires_at"]
+    assert token == {
+        "access_token": "mock-access-token",
+        "expires_in": 60,
+        "refresh_token": "mock-refresh-token",
+        "type": "Bearer",
+        "scope": "https://www.googleapis.com/auth/calendar",
+    }
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert len(mock_setup.mock_calls) == 1
+
+
+@pytest.mark.parametrize(
+    "entry_data",
+    [
+        {},
+        {CONF_CREDENTIAL_TYPE: CredentialType.WEB_AUTH},
+    ],
+)
+async def test_web_reauth_flow(
+    hass: HomeAssistant,
+    mock_code_flow: Mock,
+    mock_exchange: Mock,
+    aioclient_mock: AioHttpClientMocker,
+    hass_client_no_auth: ClientSessionGenerator,
+    entry_data: dict[str, Any],
+) -> None:
+    """Test reauth of an existing config entry with a web credential."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            **entry_data,
+            "auth_implementation": DOMAIN,
+            "token": {"access_token": "OLD_ACCESS_TOKEN"},
+        },
+    )
+    config_entry.add_to_hass(hass)
+    await async_import_client_credential(
+        hass,
+        DOMAIN,
+        ClientCredential(CLIENT_ID, CLIENT_SECRET),
+        DOMAIN,
+    )
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": config_entry.entry_id,
+        },
+        data=config_entry.data,
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "reauth_confirm"
+
+    with patch(
+        "homeassistant.components.google.api.OAuth2WebServerFlow.step1_get_device_and_user_codes",
+        side_effect=OAuth2DeviceCodeError(
+            "Invalid response 401. Error: invalid_client"
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id=result["flow_id"],
+            user_input={},
+        )
+
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": "https://example.com/auth/external/callback",
+        },
+    )
+    assert result.get("type") == "external"
+    assert result["url"] == (
+        f"{OAUTH2_AUTHORIZE}?response_type=code&client_id={CLIENT_ID}"
+        "&redirect_uri=https://example.com/auth/external/callback"
+        f"&state={state}"
+        "&scope=https://www.googleapis.com/auth/calendar"
+        "&access_type=offline&prompt=consent"
+    )
+
+    client = await hass_client_no_auth()
+    resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
+    assert resp.status == 200
+    assert resp.headers["content-type"] == "text/html; charset=utf-8"
+
+    aioclient_mock.post(
+        OAUTH2_TOKEN,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": "mock-access-token",
+            "token_type": "Bearer",
+            "expires_in": 60,
+            "scope": "https://www.googleapis.com/auth/calendar",
+        },
+    )
+
+    with patch(
+        "homeassistant.components.google.async_setup_entry", return_value=True
+    ) as mock_setup:
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    data = dict(entries[0].data)
+    data["token"].pop("expires_at")
+    data["token"].pop("expires_in")
+    assert data == {
+        "auth_implementation": DOMAIN,
+        "token": {
+            "access_token": "mock-access-token",
+            "refresh_token": "mock-refresh-token",
+            "scope": "https://www.googleapis.com/auth/calendar",
+            "token_type": "Bearer",
+        },
+        "credential_type": "web_auth",
+    }
+
+    assert len(mock_setup.mock_calls) == 1

--- a/tests/components/google/test_config_flow.py
+++ b/tests/components/google/test_config_flow.py
@@ -37,7 +37,7 @@ from homeassistant.util.dt import utcnow
 from .conftest import CLIENT_ID, CLIENT_SECRET, EMAIL_ADDRESS, YieldFixture
 
 from tests.common import MockConfigEntry, async_fire_time_changed
-from tests.test_util.aiohttp import AioHttpClientMocker
+from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import ClientSessionGenerator
 
 CODE_CHECK_INTERVAL = 1
@@ -649,7 +649,7 @@ async def test_web_auth_compatibility(
     hass: HomeAssistant,
     current_request_with_host: None,
     mock_code_flow: Mock,
-    aioclient_mock: AioHttpClientMocker,
+    aioclient_mock: AiohttpClientMocker,
     hass_client_no_auth: ClientSessionGenerator,
 ) -> None:
     """Test that we can callback to web auth tokens."""
@@ -728,7 +728,7 @@ async def test_web_reauth_flow(
     hass: HomeAssistant,
     mock_code_flow: Mock,
     mock_exchange: Mock,
-    aioclient_mock: AioHttpClientMocker,
+    aioclient_mock: AiohttpClientMocker,
     hass_client_no_auth: ClientSessionGenerator,
     entry_data: dict[str, Any],
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support to Google Calendar for Web auth credentials. This means that in the future all google integrations that work on personal user data can use the same credentials, opening up the possibility for sharing credentials across integrations. This is follow up discussion from https://github.com/home-assistant/core/pull/102629#discussion_r1370332276

The approach is to try attempt device auth and if it fails with `invalid_client` then attempt web auth. This requires minimal changes to short circuit and use the default web auth behavior with a couple of overrides in a few places in the config flow and auth implementation.

This was manually tested with web auth credentials.

We can explore actually sharing application credentials in the future. One challenge, though, is that it is difficult to tell the credential type without actually attempting to use them. For now, we record the credential type in the config entry -- this has no use now, but may be needed later to know what type of credential we have.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29792

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
