### PR TITLE
Ensure large payloads are compressed in the executor with aiohttp 3.9.0

### DIFF
--- a/homeassistant/components/api/__init__.py
+++ b/homeassistant/components/api/__init__.py
@@ -41,6 +41,7 @@ from homeassistant.exceptions import (
     Unauthorized,
 )
 from homeassistant.helpers import config_validation as cv, template
+from homeassistant.helpers.aiohttp_compat import enable_compression
 from homeassistant.helpers.event import EventStateChangedData
 from homeassistant.helpers.json import json_dumps
 from homeassistant.helpers.service import async_get_all_descriptions
@@ -219,7 +220,7 @@ class APIStatesView(HomeAssistantView):
         response = web.Response(
             body=f'[{",".join(states)}]', content_type=CONTENT_TYPE_JSON
         )
-        response.enable_compression()
+        enable_compression(response)
         return response
 
 

--- a/homeassistant/components/hassio/ingress.py
+++ b/homeassistant/components/hassio/ingress.py
@@ -17,6 +17,7 @@ from yarl import URL
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.aiohttp_compat import enable_compression
 from homeassistant.helpers.typing import UNDEFINED
 
 from .const import X_HASS_SOURCE, X_INGRESS_PATH
@@ -191,7 +192,7 @@ class HassIOIngress(HomeAssistantView):
                 if content_length_int > MIN_COMPRESSED_SIZE and should_compress(
                     content_type or simple_response.content_type
                 ):
-                    simple_response.enable_compression()
+                    enable_compression(simple_response)
                 await simple_response.prepare(request)
                 return simple_response
 

--- a/homeassistant/components/http/view.py
+++ b/homeassistant/components/http/view.py
@@ -20,6 +20,7 @@ import voluptuous as vol
 from homeassistant import exceptions
 from homeassistant.const import CONTENT_TYPE_JSON
 from homeassistant.core import Context, HomeAssistant, is_callback
+from homeassistant.helpers.aiohttp_compat import enable_compression
 from homeassistant.helpers.json import (
     find_paths_unserializable_data,
     json_bytes,
@@ -72,7 +73,7 @@ class HomeAssistantView:
             status=int(status_code),
             headers=headers,
         )
-        response.enable_compression()
+        enable_compression(response)
         return response
 
     def json_message(

--- a/homeassistant/helpers/aiohttp_compat.py
+++ b/homeassistant/helpers/aiohttp_compat.py
@@ -32,7 +32,10 @@ def enable_compression(response: web.Response) -> None:
     # aiohttp < 3.9.0 is dropped
     #
     # We want large zlib payloads to be compressed in the executor
-    # to avoid blocking the event loop, 5192 bytes was chosen because
-    # its also the value used by python-zlib-ng to release the gil
-    response._zlib_executor_size = 5192  # pylint: disable=protected-access
+    # to avoid blocking the event loop.
+    #
+    # 32KiB was chosen based on testing in production.
+    # aiohttp will generate a warning for payloads larger than 1MiB
+    #
+    response._zlib_executor_size = 32768  # pylint: disable=protected-access
     response.enable_compression()

--- a/homeassistant/helpers/aiohttp_compat.py
+++ b/homeassistant/helpers/aiohttp_compat.py
@@ -1,7 +1,7 @@
 """Helper to restore old aiohttp behavior."""
 from __future__ import annotations
 
-from aiohttp import web_protocol, web_server
+from aiohttp import web, web_protocol, web_server
 
 
 class CancelOnDisconnectRequestHandler(web_protocol.RequestHandler):
@@ -23,3 +23,16 @@ def restore_original_aiohttp_cancel_behavior() -> None:
     """
     web_protocol.RequestHandler = CancelOnDisconnectRequestHandler  # type: ignore[misc]
     web_server.RequestHandler = CancelOnDisconnectRequestHandler  # type: ignore[misc]
+
+
+def enable_compression(response: web.Response) -> None:
+    """Enable compression on the response."""
+    #
+    # Set _zlib_executor_size in the constructor once support for
+    # aiohttp < 3.9.0 is dropped
+    #
+    # We want large zlib payloads to be compressed in the executor
+    # to avoid blocking the event loop, 5192 bytes was chosen because
+    # its also the value used by python-zlib-ng to release the gil
+    response._zlib_executor_size = 5192  # pylint: disable=protected-access
+    response.enable_compression()


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure large payloads are compressed in the executor with aiohttp 3.9.0+

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
