### PR TITLE
Add zwave_js.set_lock_configuration service

### DIFF
--- a/homeassistant/components/zwave_js/const.py
+++ b/homeassistant/components/zwave_js/const.py
@@ -123,14 +123,8 @@ ATTR_PARAMETERS = "parameters"
 ATTR_AUTO_RELOCK_TIME = "auto_relock_time"
 ATTR_BLOCK_TO_BLOCK = "block_to_block"
 ATTR_HOLD_AND_RELEASE_TIME = "hold_and_release_time"
-ATTR_INSIDE_HANDLES_CAN_OPEN_DOOR_CONFIGURATION = (
-    "inside_handles_can_open_door_configuration"
-)
 ATTR_LOCK_TIMEOUT = "lock_timeout"
 ATTR_OPERATION_TYPE = "operation_type"
-ATTR_OUTSIDE_HANDLES_CAN_OPEN_DOOR_CONFIGURATION = (
-    "outside_handles_can_open_door_configuration"
-)
 ATTR_TWIST_ASSIST = "twist_assist"
 
 ADDON_SLUG = "core_zwave_js"

--- a/homeassistant/components/zwave_js/const.py
+++ b/homeassistant/components/zwave_js/const.py
@@ -99,6 +99,7 @@ SERVICE_REFRESH_VALUE = "refresh_value"
 SERVICE_RESET_METER = "reset_meter"
 SERVICE_SET_CONFIG_PARAMETER = "set_config_parameter"
 SERVICE_SET_LOCK_USERCODE = "set_lock_usercode"
+SERVICE_SET_LOCK_CONFIGURATION = "set_lock_configuration"
 SERVICE_SET_VALUE = "set_value"
 
 ATTR_NODES = "nodes"
@@ -118,6 +119,19 @@ ATTR_METER_TYPE_NAME = "meter_type_name"
 # invoke CC API
 ATTR_METHOD_NAME = "method_name"
 ATTR_PARAMETERS = "parameters"
+# lock set configuration
+ATTR_AUTO_RELOCK_TIME = "auto_relock_time"
+ATTR_BLOCK_TO_BLOCK = "block_to_block"
+ATTR_HOLD_AND_RELEASE_TIME = "hold_and_release_time"
+ATTR_INSIDE_HANDLES_CAN_OPEN_DOOR_CONFIGURATION = (
+    "inside_handles_can_open_door_configuration"
+)
+ATTR_LOCK_TIMEOUT = "lock_timeout"
+ATTR_OPERATION_TYPE = "operation_type"
+ATTR_OUTSIDE_HANDLES_CAN_OPEN_DOOR_CONFIGURATION = (
+    "outside_handles_can_open_door_configuration"
+)
+ATTR_TWIST_ASSIST = "twist_assist"
 
 ADDON_SLUG = "core_zwave_js"
 

--- a/homeassistant/components/zwave_js/lock.py
+++ b/homeassistant/components/zwave_js/lock.py
@@ -230,5 +230,5 @@ class ZWaveLock(ZWaveBaseEntity, LockEntity):
             return
         msg = f"Result status is {result.status}"
         if result.remaining_duration is not None:
-            msg += f"and remaining duration is {str(result.remaining_duration)}"
+            msg += f" and remaining duration is {str(result.remaining_duration)}"
         LOGGER.info("%s after setting lock configuration for %s", msg, self.entity_id)

--- a/homeassistant/components/zwave_js/lock.py
+++ b/homeassistant/components/zwave_js/lock.py
@@ -31,10 +31,8 @@ from .const import (
     ATTR_AUTO_RELOCK_TIME,
     ATTR_BLOCK_TO_BLOCK,
     ATTR_HOLD_AND_RELEASE_TIME,
-    ATTR_INSIDE_HANDLES_CAN_OPEN_DOOR_CONFIGURATION,
     ATTR_LOCK_TIMEOUT,
     ATTR_OPERATION_TYPE,
-    ATTR_OUTSIDE_HANDLES_CAN_OPEN_DOOR_CONFIGURATION,
     ATTR_TWIST_ASSIST,
     DATA_CLIENT,
     DOMAIN,
@@ -114,12 +112,6 @@ async def async_setup_entry(
                 lambda x: OperationType[x],
             ),
             vol.Optional(ATTR_LOCK_TIMEOUT): UNIT16_SCHEMA,
-            vol.Optional(ATTR_OUTSIDE_HANDLES_CAN_OPEN_DOOR_CONFIGURATION): vol.All(
-                [cv.boolean], vol.Length(4, 4)
-            ),
-            vol.Optional(ATTR_INSIDE_HANDLES_CAN_OPEN_DOOR_CONFIGURATION): vol.All(
-                [cv.boolean], vol.Length(4, 4)
-            ),
             vol.Optional(ATTR_AUTO_RELOCK_TIME): UNIT16_SCHEMA,
             vol.Optional(ATTR_HOLD_AND_RELEASE_TIME): UNIT16_SCHEMA,
             vol.Optional(ATTR_TWIST_ASSIST): vol.Coerce(bool),
@@ -196,8 +188,6 @@ class ZWaveLock(ZWaveBaseEntity, LockEntity):
         self,
         operation_type: OperationType,
         lock_timeout: int | None = None,
-        outside_handles_can_open_door_configuration: list[bool] | None = None,
-        inside_handles_can_open_door_configuration: list[bool] | None = None,
         auto_relock_time: int | None = None,
         hold_and_release_time: int | None = None,
         twist_assist: bool | None = None,
@@ -207,14 +197,6 @@ class ZWaveLock(ZWaveBaseEntity, LockEntity):
         params: dict[str, Any] = {"operation_type": operation_type}
         for attr, val in (
             ("lock_timeout_configuration", lock_timeout),
-            (
-                "outside_handles_can_open_door_configuration",
-                outside_handles_can_open_door_configuration,
-            ),
-            (
-                "inside_handles_can_open_door_configuration",
-                inside_handles_can_open_door_configuration,
-            ),
             ("auto_relock_time", auto_relock_time),
             ("hold_and_release_time", hold_and_release_time),
             ("twist_assist", twist_assist),

--- a/homeassistant/components/zwave_js/lock.py
+++ b/homeassistant/components/zwave_js/lock.py
@@ -58,6 +58,7 @@ STATE_TO_ZWAVE_MAP: dict[int, dict[str, int | bool]] = {
         STATE_LOCKED: True,
     },
 }
+UNIT16_SCHEMA = vol.All(vol.Coerce(int), vol.Range(min=0, max=65535))
 
 
 async def async_setup_entry(
@@ -112,15 +113,15 @@ async def async_setup_entry(
                 vol.In(["TIMED", "CONSTANT"]),
                 lambda x: OperationType[x],
             ),
-            vol.Optional(ATTR_LOCK_TIMEOUT): vol.Coerce(int),
+            vol.Optional(ATTR_LOCK_TIMEOUT): UNIT16_SCHEMA,
             vol.Optional(ATTR_OUTSIDE_HANDLES_CAN_OPEN_DOOR_CONFIGURATION): vol.All(
                 [cv.boolean], vol.Length(4, 4)
             ),
             vol.Optional(ATTR_INSIDE_HANDLES_CAN_OPEN_DOOR_CONFIGURATION): vol.All(
                 [cv.boolean], vol.Length(4, 4)
             ),
-            vol.Optional(ATTR_AUTO_RELOCK_TIME): vol.Coerce(int),
-            vol.Optional(ATTR_HOLD_AND_RELEASE_TIME): vol.Coerce(int),
+            vol.Optional(ATTR_AUTO_RELOCK_TIME): UNIT16_SCHEMA,
+            vol.Optional(ATTR_HOLD_AND_RELEASE_TIME): UNIT16_SCHEMA,
             vol.Optional(ATTR_TWIST_ASSIST): vol.Coerce(bool),
             vol.Optional(ATTR_BLOCK_TO_BLOCK): vol.Coerce(bool),
         },

--- a/homeassistant/components/zwave_js/lock.py
+++ b/homeassistant/components/zwave_js/lock.py
@@ -194,18 +194,18 @@ class ZWaveLock(ZWaveBaseEntity, LockEntity):
     async def async_set_lock_configuration(
         self,
         operation_type: OperationType,
-        lock_timeout: int | None,
-        outside_handles_can_open_door_configuration: list[bool] | None,
-        inside_handles_can_open_door_configuration: list[bool] | None,
-        auto_relock_time: int | None,
-        hold_and_release_time: int | None,
-        twist_assist: bool | None,
-        block_to_block: bool | None,
+        lock_timeout: int | None = None,
+        outside_handles_can_open_door_configuration: list[bool] | None = None,
+        inside_handles_can_open_door_configuration: list[bool] | None = None,
+        auto_relock_time: int | None = None,
+        hold_and_release_time: int | None = None,
+        twist_assist: bool | None = None,
+        block_to_block: bool | None = None,
     ) -> None:
         """Set the lock configuration."""
         params: dict[str, Any] = {"operation_type": operation_type}
         for attr, val in (
-            ("lock_timeout", lock_timeout),
+            ("lock_timeout_configuration", lock_timeout),
             (
                 "outside_handles_can_open_door_configuration",
                 outside_handles_can_open_door_configuration,

--- a/homeassistant/components/zwave_js/services.yaml
+++ b/homeassistant/components/zwave_js/services.yaml
@@ -47,7 +47,10 @@ set_lock_configuration:
       required: false
       example: 1
       selector:
-        text:
+        number:
+          min: 0
+          max: 65535
+          unit_of_measurement: sec
     outside_handles_can_open_door_configuration:
       required: false
       example: [true, true, true, false]
@@ -62,12 +65,18 @@ set_lock_configuration:
       required: false
       example: 1
       selector:
-        text:
+        number:
+          min: 0
+          max: 65535
+          unit_of_measurement: sec
     hold_and_release_time:
       required: false
       example: 1
       selector:
-        text:
+        number:
+          min: 0
+          max: 65535
+          unit_of_measurement: sec
     twist_assist:
       required: false
       example: true

--- a/homeassistant/components/zwave_js/services.yaml
+++ b/homeassistant/components/zwave_js/services.yaml
@@ -29,6 +29,56 @@ set_lock_usercode:
       selector:
         text:
 
+set_lock_configuration:
+  target:
+    entity:
+      domain: lock
+      integration: zwave_js
+  fields:
+    operation_type:
+      required: true
+      example: timed
+      selector:
+        select:
+          options:
+            - constant
+            - timed
+    lock_timeout:
+      required: false
+      example: 1
+      selector:
+        text:
+    outside_handles_can_open_door_configuration:
+      required: false
+      example: [true, true, true, false]
+      selector:
+        object:
+    inside_handles_can_open_door_configuration:
+      required: false
+      example: [true, true, true, false]
+      selector:
+        object:
+    auto_relock_time:
+      required: false
+      example: 1
+      selector:
+        text:
+    hold_and_release_time:
+      required: false
+      example: 1
+      selector:
+        text:
+    twist_assist:
+      required: false
+      example: true
+      selector:
+        boolean:
+    block_to_block:
+      required: false
+      example: true
+      selector:
+        boolean:
+
 set_config_parameter:
   target:
     entity:

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -400,11 +400,11 @@
         },
         "outside_handles_can_open_door_configuration": {
           "name": "Outside handles can open door configuration",
-          "description": "Which outside handles can open the door."
+          "description": "A list of four booleans which indicate which outside handles can open the door."
         },
         "inside_handles_can_open_door_configuration": {
           "name": "Inside handles can open door configuration",
-          "description": "Which inside handles can open the door."
+          "description": "A list of four booleans which indicate which inside handles can open the door."
         },
         "auto_relock_time": {
           "name": "Auto relock time",

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -416,11 +416,11 @@
         },
         "twist_assist": {
           "name": "Twist assist",
-          "description": "Twist Assist enabled."
+          "description": "Enable Twist Assist."
         },
         "block_to_block": {
           "name": "Block to block",
-          "description": "Block-to-block functionality enabled."
+          "description": "Enable block-to-block functionality."
         }
       }
     }

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -385,6 +385,44 @@
           "description": "The Notification Event number as defined in the Z-Wave specs."
         }
       }
+    },
+    "set_lock_configuration": {
+      "name": "Set lock configuration",
+      "description": "Sets the configuration for a lock.",
+      "fields": {
+        "operation_type": {
+          "name": "Operation Type",
+          "description": "The operation type of the lock."
+        },
+        "lock_timeout": {
+          "name": "Lock timeout",
+          "description": "Seconds until lock mode times out. Should only be used if operation type is `timed`."
+        },
+        "outside_handles_can_open_door_configuration": {
+          "name": "Outside handles can open door configuration",
+          "description": "Which outside handles can open the door."
+        },
+        "inside_handles_can_open_door_configuration": {
+          "name": "Inside handles can open door configuration",
+          "description": "Which inside handles can open the door."
+        },
+        "auto_relock_time": {
+          "name": "Auto relock time",
+          "description": "Duration in seconds until lock returns to secure state. Only enforced when operation type is `constant`."
+        },
+        "hold_and_release_time": {
+          "name": "Hold and release time",
+          "description": "Duration in seconds the latch stays retracted."
+        },
+        "twist_assist": {
+          "name": "Twist assist",
+          "description": "Twist Assist enabled."
+        },
+        "block_to_block": {
+          "name": "Block to block",
+          "description": "Block-to-block functionality enabled."
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Proposed change
Adds new service to set the configuration of a lock for zwave_js. Needed for Z-Wave certification: https://github.com/zwave-js/certification-backlog/issues/21


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/zwave-js/certification-backlog/issues/21
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29768

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
