### PR TITLE
Fix Reolink DHCP IP update

### DIFF
--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -113,7 +113,7 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 raise AbortFlow("already_configured")
 
             # check if the camera is reachable at the new IP
-            new_config = existing_entry.data
+            new_config = dict(existing_entry.data)
             new_config[CONF_HOST] = discovery_info.ip
             host = ReolinkHost(self.hass, new_config, existing_entry.options)
             try:

--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -113,7 +113,9 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 raise AbortFlow("already_configured")
 
             # check if the camera is reachable at the new IP
-            host = ReolinkHost(self.hass, existing_entry.data, existing_entry.options)
+            new_config = existing_entry.data
+            new_config[CONF_HOST] = discovery_info.ip
+            host = ReolinkHost(self.hass, new_config, existing_entry.options)
             try:
                 await host.api.get_state("GetLocalLink")
                 await host.api.logout()

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -34,8 +34,10 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def reolink_connect(mock_get_source_ip: None) -> Generator[MagicMock, None, None]:
-    """Mock reolink connection."""
+def reolink_connect_class(
+    mock_get_source_ip: None,
+) -> Generator[tuple[MagicMock, MagicMock], None, None]:
+    """Mock reolink connection and return both the host_mock and host_mock_class."""
     with patch(
         "homeassistant.components.reolink.host.webhook.async_register",
         return_value=True,
@@ -65,7 +67,15 @@ def reolink_connect(mock_get_source_ip: None) -> Generator[MagicMock, None, None
         host_mock.session_active = True
         host_mock.timeout = 60
         host_mock.renewtimer.return_value = 600
-        yield host_mock
+        yield (host_mock, host_mock_class)
+
+
+@pytest.fixture
+def reolink_connect(
+    reolink_connect_class: tuple[MagicMock, MagicMock]
+) -> Generator[MagicMock, None, None]:
+    """Mock reolink connection."""
+    return reolink_connect_class[0]
 
 
 @pytest.fixture

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -36,7 +36,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 @pytest.fixture
 def reolink_connect_class(
     mock_get_source_ip: None,
-) -> Generator[tuple[MagicMock, MagicMock], None, None]:
+) -> Generator[MagicMock, None, None]:
     """Mock reolink connection and return both the host_mock and host_mock_class."""
     with patch(
         "homeassistant.components.reolink.host.webhook.async_register",
@@ -67,15 +67,15 @@ def reolink_connect_class(
         host_mock.session_active = True
         host_mock.timeout = 60
         host_mock.renewtimer.return_value = 600
-        yield (host_mock, host_mock_class)
+        yield host_mock_class
 
 
 @pytest.fixture
 def reolink_connect(
-    reolink_connect_class: tuple[MagicMock, MagicMock]
+    reolink_connect_class: MagicMock,
 ) -> Generator[MagicMock, None, None]:
     """Mock reolink connection."""
-    return reolink_connect_class[0]
+    return reolink_connect_class.return_value
 
 
 @pytest.fixture

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -411,16 +411,14 @@ async def test_dhcp_flow(hass: HomeAssistant, mock_setup_entry: MagicMock) -> No
 )
 async def test_dhcp_ip_update(
     hass: HomeAssistant,
-    reolink_connect_class: tuple[MagicMock, MagicMock],
+    reolink_connect_class: MagicMock,
+    reolink_connect: MagicMock,
     last_update_success: bool,
     attr: str,
     value: Any,
     expected: str,
 ) -> None:
     """Test dhcp discovery aborts if already configured where the IP is updated if appropriate."""
-    reolink_connect = reolink_connect_class[0]
-    reolink_class_mock = reolink_connect_class[1]
-
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,
         unique_id=format_mac(TEST_MAC),
@@ -442,7 +440,7 @@ async def test_dhcp_ip_update(
     await hass.async_block_till_done()
     assert config_entry.state == ConfigEntryState.LOADED
 
-    reolink_class_mock.assert_called_with(
+    reolink_connect_class.assert_called_with(
         TEST_HOST,
         TEST_USERNAME,
         TEST_PASSWORD,
@@ -474,7 +472,7 @@ async def test_dhcp_ip_update(
     )
 
     if not last_update_success:
-        reolink_class_mock.assert_called_with(
+        reolink_connect_class.assert_called_with(
             TEST_HOST2,
             TEST_USERNAME,
             TEST_PASSWORD,

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -445,16 +445,6 @@ async def test_dhcp_ip_update(
     await hass.async_block_till_done()
     assert config_entry.state == ConfigEntryState.LOADED
 
-    reolink_connect_class.assert_called_with(
-        TEST_HOST,
-        TEST_USERNAME,
-        TEST_PASSWORD,
-        port=TEST_PORT,
-        use_https=TEST_USE_HTTPS,
-        protocol=DEFAULT_PROTOCOL,
-        timeout=DEFAULT_TIMEOUT,
-    )
-
     if not last_update_success:
         # ensure the last_update_succes is False for the device_coordinator.
         reolink_connect.get_states = AsyncMock(side_effect=ReolinkError("Test error"))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When DHCP indicates the IP adress of a Reolink camera has changed, first a connection is attempted to confirm the new IP actually works.
Unfortunetly the old IP is used in this attempt instead of the newly discovered IP, sorry my mistake when writing that code...
This fixes that mistake.

Tested in my production enviroment (changed the IP to some random value in core.config_entries file and let the DHCP set it back correctly).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
