### PR TITLE
Implement Overkiz async_execute_commands

### DIFF
--- a/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_heating_zone.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_heating_zone.py
@@ -117,23 +117,19 @@ class AtlanticPassAPCHeatingZone(OverkizEntity, ClimateEntity):
 
     async def async_set_heating_mode(self, mode: str) -> None:
         """Set new heating mode and refresh states."""
-        await self.executor.async_execute_command(
-            OverkizCommand.SET_PASS_APC_HEATING_MODE, mode
-        )
+        commands: list[list | str] = []
+        commands.append([OverkizCommand.SET_PASS_APC_HEATING_MODE, [mode]])
 
         if self.current_heating_profile == OverkizCommandParam.DEROGATION:
             # If current mode is in derogation, disable it
-            await self.executor.async_execute_command(
-                OverkizCommand.SET_DEROGATION_ON_OFF_STATE, OverkizCommandParam.OFF
+            commands.append(
+                [OverkizCommand.SET_DEROGATION_ON_OFF_STATE, [OverkizCommandParam.OFF]]
             )
 
         # We also needs to execute these 2 commands to make it work correctly
-        await self.executor.async_execute_command(
-            OverkizCommand.REFRESH_PASS_APC_HEATING_MODE
-        )
-        await self.executor.async_execute_command(
-            OverkizCommand.REFRESH_PASS_APC_HEATING_PROFILE
-        )
+        commands.append(OverkizCommand.REFRESH_PASS_APC_HEATING_MODE)
+        commands.append(OverkizCommand.REFRESH_PASS_APC_HEATING_PROFILE)
+        await self.executor.async_execute_commands(commands)
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
@@ -182,32 +178,23 @@ class AtlanticPassAPCHeatingZone(OverkizEntity, ClimateEntity):
         """Set new temperature."""
         temperature = kwargs[ATTR_TEMPERATURE]
 
+        commands: list[list | str] = []
+
         if self.hvac_mode == HVACMode.AUTO:
-            await self.executor.async_execute_command(
-                OverkizCommand.SET_COMFORT_HEATING_TARGET_TEMPERATURE,
-                temperature,
+            commands.append(
+                [OverkizCommand.SET_COMFORT_HEATING_TARGET_TEMPERATURE, [temperature]]
             )
-            await self.executor.async_execute_command(
-                OverkizCommand.REFRESH_COMFORT_HEATING_TARGET_TEMPERATURE
-            )
-            await self.executor.async_execute_command(
-                OverkizCommand.REFRESH_TARGET_TEMPERATURE
-            )
+            commands.append(OverkizCommand.REFRESH_COMFORT_HEATING_TARGET_TEMPERATURE)
+            commands.append(OverkizCommand.REFRESH_TARGET_TEMPERATURE)
         else:
-            await self.executor.async_execute_command(
-                OverkizCommand.SET_DEROGATED_TARGET_TEMPERATURE,
-                temperature,
+            commands.append(
+                [OverkizCommand.SET_DEROGATED_TARGET_TEMPERATURE, [temperature]]
             )
-            await self.executor.async_execute_command(
-                OverkizCommand.SET_DEROGATION_ON_OFF_STATE,
-                OverkizCommandParam.ON,
+            commands.append(
+                [OverkizCommand.SET_DEROGATION_ON_OFF_STATE, [OverkizCommandParam.ON]]
             )
-            await self.executor.async_execute_command(
-                OverkizCommand.REFRESH_TARGET_TEMPERATURE
-            )
-            await self.executor.async_execute_command(
-                OverkizCommand.REFRESH_PASS_APC_HEATING_MODE
-            )
-            await self.executor.async_execute_command(
-                OverkizCommand.REFRESH_PASS_APC_HEATING_PROFILE
-            )
+            commands.append(OverkizCommand.REFRESH_TARGET_TEMPERATURE)
+            commands.append(OverkizCommand.REFRESH_PASS_APC_HEATING_MODE)
+            commands.append(OverkizCommand.REFRESH_PASS_APC_HEATING_PROFILE)
+
+        await self.executor.async_execute_commands(commands)

--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -61,7 +61,7 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
         self.is_stateless = all(
             device.protocol in (Protocol.RTS, Protocol.INTERNAL) for device in devices
         )
-        self.executions: dict[str, dict[str, str]] = {}
+        self.executions: dict[str, Any] = {}
         self.areas = self._places_to_area(places) if places else None
         self.config_entry_id = config_entry_id
 

--- a/homeassistant/components/overkiz/executor.py
+++ b/homeassistant/components/overkiz/executor.py
@@ -83,18 +83,58 @@ class OverkizExecutor:
     async def async_execute_command(self, command_name: str, *args: Any) -> None:
         """Execute device command in async context."""
         parameters = [arg for arg in args if arg is not None]
-        # Set the execution duration to 0 seconds for RTS devices on supported commands
-        # Default execution duration is 30 seconds and will block consecutive commands
-        if (
-            self.device.protocol == Protocol.RTS
-            and command_name not in COMMANDS_WITHOUT_DELAY
-        ):
-            parameters.append(0)
+
+        commands: list[list | str] = [[command_name, parameters]]
+        await self.async_execute_commands(commands)
+
+    # commands accept an array of commands
+    # each command could be :
+    # - a simple string to execute a command without parameter
+    # - a list with command name as first index and parameters list  as second index
+    # Example of usage:
+    # commands: list[list | str] = [
+    #     [
+    #         OverkizCommand.SET_MODE_TEMPERATURE,
+    #         [OverkizCommandParam.MANUAL_MODE, temperature],
+    #     ],
+    #     [
+    #         OverkizCommand.SET_DEROGATION_ON_OFF_STATE,
+    #         [OverkizCommandParam.OFF],
+    #     ],
+    #     OverkizCommand.REFRESH_PASS_APC_HEATING_MODE,
+    #     OverkizCommand.REFRESH_PASS_APC_HEATING_PROFILE,
+    # ]
+    # await self.executor.async_execute_commands(commands)
+    async def async_execute_commands(self, commands: list[list | str]) -> None:
+        """Execute device commands in async context."""
+        command_names = []
+        commands_objects = []
+        for cmd in commands:
+            parameters = []
+            if isinstance(cmd, list):
+                command_name = cmd[0]
+                parameters = cmd[1]
+            else:
+                command_name = cmd
+
+            # Set the execution duration to 0 seconds for RTS devices on supported commands
+            # Default execution duration is 30 seconds and will block consecutive commands
+            if (
+                self.device.protocol == Protocol.RTS
+                and command_name not in COMMANDS_WITHOUT_DELAY
+            ):
+                parameters.append(0)
+
+            command_names.append(command_name)
+            if len(parameters) > 0:
+                commands_objects.append(Command(command_name, parameters))
+            else:
+                commands_objects.append(Command(command_name))
 
         try:
-            exec_id = await self.coordinator.client.execute_command(
+            exec_id = await self.coordinator.client.execute_commands(
                 self.device.device_url,
-                Command(command_name, parameters),
+                commands_objects,
                 "Home Assistant",
             )
         # Catch Overkiz exceptions to support `continue_on_error` functionality
@@ -104,7 +144,7 @@ class OverkizExecutor:
         # ExecutionRegisteredEvent doesn't contain the device_url, thus we need to register it here
         self.coordinator.executions[exec_id] = {
             "device_url": self.device.device_url,
-            "command_name": command_name,
+            "commands": command_names,
         }
 
         await self.coordinator.async_refresh()
@@ -121,8 +161,9 @@ class OverkizExecutor:
                 exec_id
                 # Reverse dictionary to cancel the last added execution
                 for exec_id, execution in reversed(self.coordinator.executions.items())
+                for command in execution.get("commands")
                 if execution.get("device_url") == self.device.device_url
-                and execution.get("command_name") in commands_to_cancel
+                and command in commands_to_cancel
             ),
             None,
         )


### PR DESCRIPTION
## Proposed change
While implementing a new entity in PR https://github.com/home-assistant/core/pull/78659, I noticed multiple commands was always executing one by one.
This is not usually a problem for simple entity because they call one command at once.
But for climate entities in the Atlantic/Somfy world, they usually need multiple commands to work correctly.
Doing only 1 call with multiple commands instead of multiple call for each command is great because:

It only counts at one api CALL for rate limits
it's done this way through the API
the canceling could be done for all commands at once
it only create 1 history log on overkiz side

In this PR, I'm only migrating `AtlanticPassAPCHeatingZone` for the sake of simplicity.  
Once this PR is merged, other will be possible too.

For instance, when I'm stopping an heating zone, here is the history with current dev version:
```
"HistoryExecution(id='b0bc0ed3-0a19-0481-7759-f7a94de9b7fb', event_time=1699477196502, owner=c****@****, source='mobile:tool', end_time=1699477201195, effective_start_time=1699477196502, duration=4693, label='Home Assistant', type='Immediate execution - MANUAL_CONTROL', state=<ExecutionState.COMPLETED: 'COMPLETED'>, failure_type='NO_FAILURE', commands=[HistoryExecutionCommand(device_url=io://****-****-3567/2674179#8, command='refreshPassAPCHeatingProfile', rank=0, dynamic=False, state=<ExecutionState.COMPLETED: 'COMPLETED'>, failure_type='NO_FAILURE', parameters=[])], execution_type=<ExecutionType.IMMEDIATE_EXECUTION: 'Immediate execution'>, execution_sub_type=<ExecutionSubType.MANUAL_CONTROL: 'MANUAL_CONTROL'>)",
"HistoryExecution(id='b0bc0e9d-0a19-0481-7759-f7a9a312cdd2', event_time=1699477196448, owner=c****@****, source='mobile:tool', end_time=1699477200681, effective_start_time=1699477196448, duration=4233, label='Home Assistant', type='Immediate execution - MANUAL_CONTROL', state=<ExecutionState.COMPLETED: 'COMPLETED'>, failure_type='NO_FAILURE', commands=[HistoryExecutionCommand(device_url=io://****-****-3567/2674179#8, command='refreshPassAPCHeatingMode', rank=0, dynamic=False, state=<ExecutionState.COMPLETED: 'COMPLETED'>, failure_type='NO_FAILURE', parameters=[])], execution_type=<ExecutionType.IMMEDIATE_EXECUTION: 'Immediate execution'>, execution_sub_type=<ExecutionSubType.MANUAL_CONTROL: 'MANUAL_CONTROL'>)",
"HistoryExecution(id='b0bc0e65-0a19-0481-7759-f7a901ef4ffc', event_time=1699477196392, owner=c****@****, source='mobile:tool', end_time=1699477197611, effective_start_time=1699477196392, duration=1219, label='Home Assistant', type='Immediate execution - MANUAL_CONTROL', state=<ExecutionState.COMPLETED: 'COMPLETED'>, failure_type='NO_FAILURE', commands=[HistoryExecutionCommand(device_url=io://****-****-3567/2674179#8, command='setPassAPCHeatingMode', rank=0, dynamic=False, state=<ExecutionState.COMPLETED: 'COMPLETED'>, failure_type='NO_FAILURE', parameters=['stop'])], execution_type=<ExecutionType.IMMEDIATE_EXECUTION: 'Immediate execution'>, execution_sub_type=<ExecutionSubType.MANUAL_CONTROL: 'MANUAL_CONTROL'>)",
```

When using the version on this PR for the exact same action, We're only have 1 history item:
```
"HistoryExecution(id='b0b898fe-0a19-0481-7759-f7a96cf40f87', event_time=1699476969729, owner=c****@****, source='mobile:tool', end_time=1699476974603, effective_start_time=1699476969729, duration=4874, label='Home Assistant', type='Immediate execution - MANUAL_CONTROL', state=<ExecutionState.COMPLETED: 'COMPLETED'>, failure_type='NO_FAILURE', commands=[HistoryExecutionCommand(device_url=io://****-****-3567/2674179#8, command='setPassAPCHeatingMode', rank=0, dynamic=False, state=<ExecutionState.COMPLETED: 'COMPLETED'>, failure_type='NO_FAILURE', parameters=['stop']), HistoryExecutionCommand(device_url=io://****-****-3567/2674179#8, command='refreshPassAPCHeatingMode', rank=1, dynamic=False, state=<ExecutionState.COMPLETED: 'COMPLETED'>, failure_type='NO_FAILURE', parameters=None), HistoryExecutionCommand(device_url=io://****-****-3567/2674179#8, command='refreshPassAPCHeatingProfile', rank=2, dynamic=False, state=<ExecutionState.COMPLETED: 'COMPLETED'>, failure_type='NO_FAILURE', parameters=None)], execution_type=<ExecutionType.IMMEDIATE_EXECUTION: 'Immediate execution'>, execution_sub_type=<ExecutionSubType.MANUAL_CONTROL: 'MANUAL_CONTROL'>)",
```

This is also reflected on Thaoma history view:
old version 3 items
new version 1 item

Also note that pyoverkiz already uses the execute_commands in the background.  
This PR uses this existing pyoverkiz execute_commands function directly



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
