### PR TITLE
Update nut sensor tests to use parametrize

### DIFF
--- a/tests/components/nut/test_sensor.py
+++ b/tests/components/nut/test_sensor.py
@@ -20,28 +20,35 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    "model",
+    ("model", "unique_id"),
     [
-        "PR3000RT2U",
-        "CP1350C",
-        "5E850I",
-        "5E650I",
-        "BACKUPSES600M1",
-        "CP1500PFCLCD",
-        "DL650ELCD",
-        "EATON5P1550",
-        "blazer_usb",
+        ("PR3000RT2U", "CPS_PR3000RT2U_PYVJO2000034_battery.charge"),
+        ("CP1350C", ""),
+        ("5E850I", ""),
+        ("5E650I", ""),
+        (
+            "BACKUPSES600M1",
+            "American Power Conversion_Back-UPS ES 600M1_4B1713P32195 _battery.charge",
+        ),
+        ("CP1500PFCLCD", ""),
+        ("DL650ELCD", ""),
+        ("EATON5P1550", ""),
+        ("blazer_usb", ""),
     ],
 )
 async def test_devices(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, model: str
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, model: str, unique_id: str
 ) -> None:
     """Test creation of device sensors."""
 
     config_entry = await async_init_integration(hass, model)
     entry = entity_registry.async_get("sensor.ups1_battery_charge")
     assert entry
-    assert entry.config_entry_id == config_entry.entry_id
+
+    if unique_id:
+        assert entry.unique_id == unique_id
+    else:
+        assert entry.unique_id == f"{config_entry.entry_id}_battery.charge"
 
     state = hass.states.get("sensor.ups1_battery_charge")
     assert state.state == "100"

--- a/tests/components/nut/test_sensor.py
+++ b/tests/components/nut/test_sensor.py
@@ -1,6 +1,8 @@
 """The sensor tests for the nut platform."""
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant.components.nut.const import DOMAIN
 from homeassistant.const import (
     CONF_HOST,
@@ -17,210 +19,28 @@ from .util import _get_mock_pynutclient, async_init_integration
 from tests.common import MockConfigEntry
 
 
-async def test_pr3000rt2u(hass: HomeAssistant) -> None:
-    """Test creation of PR3000RT2U sensors."""
+@pytest.mark.parametrize(
+    "model",
+    [
+        "PR3000RT2U",
+        "CP1350C",
+        "5E850I",
+        "5E650I",
+        "BACKUPSES600M1",
+        "DL650ELCD",
+        "EATON5P1550",
+        "blazer_usb",
+    ],
+)
+async def test_devices(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, model: str
+) -> None:
+    """Test creation of device sensors."""
 
-    await async_init_integration(hass, "PR3000RT2U")
-    registry = er.async_get(hass)
-    entry = registry.async_get("sensor.ups1_battery_charge")
+    config_entry = await async_init_integration(hass, model)
+    entry = entity_registry.async_get("sensor.ups1_battery_charge")
     assert entry
-    assert entry.unique_id == "CPS_PR3000RT2U_PYVJO2000034_battery.charge"
-
-    state = hass.states.get("sensor.ups1_battery_charge")
-    assert state.state == "100"
-
-    expected_attributes = {
-        "device_class": "battery",
-        "friendly_name": "Ups1 Battery charge",
-        "unit_of_measurement": PERCENTAGE,
-    }
-    # Only test for a subset of attributes in case
-    # HA changes the implementation and a new one appears
-    assert all(
-        state.attributes[key] == attr for key, attr in expected_attributes.items()
-    )
-
-
-async def test_cp1350c(hass: HomeAssistant) -> None:
-    """Test creation of CP1350C sensors."""
-
-    config_entry = await async_init_integration(hass, "CP1350C")
-
-    registry = er.async_get(hass)
-    entry = registry.async_get("sensor.ups1_battery_charge")
-    assert entry
-    assert entry.unique_id == f"{config_entry.entry_id}_battery.charge"
-
-    state = hass.states.get("sensor.ups1_battery_charge")
-    assert state.state == "100"
-
-    expected_attributes = {
-        "device_class": "battery",
-        "friendly_name": "Ups1 Battery charge",
-        "unit_of_measurement": PERCENTAGE,
-    }
-    # Only test for a subset of attributes in case
-    # HA changes the implementation and a new one appears
-    assert all(
-        state.attributes[key] == attr for key, attr in expected_attributes.items()
-    )
-
-
-async def test_5e850i(hass: HomeAssistant) -> None:
-    """Test creation of 5E850I sensors."""
-
-    config_entry = await async_init_integration(hass, "5E850I")
-    registry = er.async_get(hass)
-    entry = registry.async_get("sensor.ups1_battery_charge")
-    assert entry
-    assert entry.unique_id == f"{config_entry.entry_id}_battery.charge"
-
-    state = hass.states.get("sensor.ups1_battery_charge")
-    assert state.state == "100"
-
-    expected_attributes = {
-        "device_class": "battery",
-        "friendly_name": "Ups1 Battery charge",
-        "unit_of_measurement": PERCENTAGE,
-    }
-    # Only test for a subset of attributes in case
-    # HA changes the implementation and a new one appears
-    assert all(
-        state.attributes[key] == attr for key, attr in expected_attributes.items()
-    )
-
-
-async def test_5e650i(hass: HomeAssistant) -> None:
-    """Test creation of 5E650I sensors."""
-
-    config_entry = await async_init_integration(hass, "5E650I")
-    registry = er.async_get(hass)
-    entry = registry.async_get("sensor.ups1_battery_charge")
-    assert entry
-    assert entry.unique_id == f"{config_entry.entry_id}_battery.charge"
-
-    state = hass.states.get("sensor.ups1_battery_charge")
-    assert state.state == "100"
-
-    expected_attributes = {
-        "device_class": "battery",
-        "friendly_name": "Ups1 Battery charge",
-        "unit_of_measurement": PERCENTAGE,
-    }
-    # Only test for a subset of attributes in case
-    # HA changes the implementation and a new one appears
-    assert all(
-        state.attributes[key] == attr for key, attr in expected_attributes.items()
-    )
-
-
-async def test_backupsses600m1(hass: HomeAssistant) -> None:
-    """Test creation of BACKUPSES600M1 sensors."""
-
-    await async_init_integration(hass, "BACKUPSES600M1")
-    registry = er.async_get(hass)
-    entry = registry.async_get("sensor.ups1_battery_charge")
-    assert entry
-    assert (
-        entry.unique_id
-        == "American Power Conversion_Back-UPS ES 600M1_4B1713P32195 _battery.charge"
-    )
-
-    state = hass.states.get("sensor.ups1_battery_charge")
-    assert state.state == "100"
-
-    expected_attributes = {
-        "device_class": "battery",
-        "friendly_name": "Ups1 Battery charge",
-        "unit_of_measurement": PERCENTAGE,
-    }
-    # Only test for a subset of attributes in case
-    # HA changes the implementation and a new one appears
-    assert all(
-        state.attributes[key] == attr for key, attr in expected_attributes.items()
-    )
-
-
-async def test_cp1500pfclcd(hass: HomeAssistant) -> None:
-    """Test creation of CP1500PFCLCD sensors."""
-
-    config_entry = await async_init_integration(hass, "CP1500PFCLCD")
-    registry = er.async_get(hass)
-    entry = registry.async_get("sensor.ups1_battery_charge")
-    assert entry
-    assert entry.unique_id == f"{config_entry.entry_id}_battery.charge"
-
-    state = hass.states.get("sensor.ups1_battery_charge")
-    assert state.state == "100"
-
-    expected_attributes = {
-        "device_class": "battery",
-        "friendly_name": "Ups1 Battery charge",
-        "unit_of_measurement": PERCENTAGE,
-    }
-    # Only test for a subset of attributes in case
-    # HA changes the implementation and a new one appears
-    assert all(
-        state.attributes[key] == attr for key, attr in expected_attributes.items()
-    )
-
-
-async def test_dl650elcd(hass: HomeAssistant) -> None:
-    """Test creation of DL650ELCD sensors."""
-
-    config_entry = await async_init_integration(hass, "DL650ELCD")
-    registry = er.async_get(hass)
-    entry = registry.async_get("sensor.ups1_battery_charge")
-    assert entry
-    assert entry.unique_id == f"{config_entry.entry_id}_battery.charge"
-
-    state = hass.states.get("sensor.ups1_battery_charge")
-    assert state.state == "100"
-
-    expected_attributes = {
-        "device_class": "battery",
-        "friendly_name": "Ups1 Battery charge",
-        "unit_of_measurement": PERCENTAGE,
-    }
-    # Only test for a subset of attributes in case
-    # HA changes the implementation and a new one appears
-    assert all(
-        state.attributes[key] == attr for key, attr in expected_attributes.items()
-    )
-
-
-async def test_eaton5p1550(hass: HomeAssistant) -> None:
-    """Test creation of EATON5P1550 sensors."""
-
-    config_entry = await async_init_integration(hass, "EATON5P1550")
-    registry = er.async_get(hass)
-    entry = registry.async_get("sensor.ups1_battery_charge")
-    assert entry
-    assert entry.unique_id == f"{config_entry.entry_id}_battery.charge"
-
-    state = hass.states.get("sensor.ups1_battery_charge")
-    assert state.state == "100"
-
-    expected_attributes = {
-        "device_class": "battery",
-        "friendly_name": "Ups1 Battery charge",
-        "unit_of_measurement": PERCENTAGE,
-    }
-    # Only test for a subset of attributes in case
-    # HA changes the implementation and a new one appears
-    assert all(
-        state.attributes[key] == attr for key, attr in expected_attributes.items()
-    )
-
-
-async def test_blazer_usb(hass: HomeAssistant) -> None:
-    """Test creation of blazer_usb sensors."""
-
-    config_entry = await async_init_integration(hass, "blazer_usb")
-    registry = er.async_get(hass)
-    entry = registry.async_get("sensor.ups1_battery_charge")
-    assert entry
-    assert entry.unique_id == f"{config_entry.entry_id}_battery.charge"
+    assert entry.config_entry_id == config_entry.entry_id
 
     state = hass.states.get("sensor.ups1_battery_charge")
     assert state.state == "100"

--- a/tests/components/nut/test_sensor.py
+++ b/tests/components/nut/test_sensor.py
@@ -27,6 +27,7 @@ from tests.common import MockConfigEntry
         "5E850I",
         "5E650I",
         "BACKUPSES600M1",
+        "CP1500PFCLCD",
         "DL650ELCD",
         "EATON5P1550",
         "blazer_usb",


### PR DESCRIPTION
## Proposed change
Cleanup the nut sensor tests and use `pytest.mark.parametrize`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
