### PR TITLE
Update bond tests to use entity & device registry fixtures

### DIFF
--- a/tests/components/bond/test_button.py
+++ b/tests/components/bond/test_button.py
@@ -6,7 +6,6 @@ from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRE
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity_registry import EntityRegistry
 
 from .common import patch_bond_action, patch_bond_device_state, setup_platform
 
@@ -57,7 +56,10 @@ def light(name: str):
     }
 
 
-async def test_entity_registry(hass: HomeAssistant) -> None:
+async def test_entity_registry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(
         hass,
@@ -67,14 +69,13 @@ async def test_entity_registry(hass: HomeAssistant) -> None:
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = er.async_get(hass)
-    entity = registry.entities["button.name_1_stop_actions"]
+    entity = entity_registry.entities["button.name_1_stop_actions"]
     assert entity.unique_id == "test-hub-id_test-device-id_stop"
-    entity = registry.entities["button.name_1_start_increasing_brightness"]
+    entity = entity_registry.entities["button.name_1_start_increasing_brightness"]
     assert entity.unique_id == "test-hub-id_test-device-id_startincreasingbrightness"
-    entity = registry.entities["button.name_1_start_decreasing_brightness"]
+    entity = entity_registry.entities["button.name_1_start_decreasing_brightness"]
     assert entity.unique_id == "test-hub-id_test-device-id_startdecreasingbrightness"
-    entity = registry.entities["button.name_1_start_dimmer"]
+    entity = entity_registry.entities["button.name_1_start_dimmer"]
     assert entity.unique_id == "test-hub-id_test-device-id_startdimmer"
 
 

--- a/tests/components/bond/test_cover.py
+++ b/tests/components/bond/test_cover.py
@@ -23,7 +23,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.util import utcnow
 
 from .common import (
@@ -72,7 +71,10 @@ def tilt_shades(name: str):
     }
 
 
-async def test_entity_registry(hass: HomeAssistant) -> None:
+async def test_entity_registry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(
         hass,
@@ -82,8 +84,7 @@ async def test_entity_registry(hass: HomeAssistant) -> None:
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = er.async_get(hass)
-    entity = registry.entities["cover.name_1"]
+    entity = entity_registry.entities["cover.name_1"]
     assert entity.unique_id == "test-hub-id_test-device-id"
 
 

--- a/tests/components/bond/test_fan.py
+++ b/tests/components/bond/test_fan.py
@@ -36,7 +36,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.util import utcnow
 
 from .common import (
@@ -81,7 +80,11 @@ async def turn_fan_on(
     await hass.async_block_till_done()
 
 
-async def test_entity_registry(hass: HomeAssistant) -> None:
+async def test_entity_registry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(
         hass,
@@ -91,11 +94,9 @@ async def test_entity_registry(hass: HomeAssistant) -> None:
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = er.async_get(hass)
-    entity = registry.entities["fan.name_1"]
+    entity = entity_registry.entities["fan.name_1"]
     assert entity.unique_id == "test-hub-id_test-device-id"
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entity.device_id)
     assert device.configuration_url == "http://some host"
 
@@ -476,7 +477,11 @@ async def test_fan_available(hass: HomeAssistant) -> None:
     )
 
 
-async def test_setup_smart_by_bond_fan(hass: HomeAssistant) -> None:
+async def test_setup_smart_by_bond_fan(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
     """Test setting up a fan without a hub."""
     config_entry = await setup_platform(
         hass,
@@ -491,10 +496,8 @@ async def test_setup_smart_by_bond_fan(hass: HomeAssistant) -> None:
         },
     )
     assert hass.states.get("fan.name_1") is not None
-    registry = er.async_get(hass)
-    entry = registry.async_get("fan.name_1")
+    entry = entity_registry.async_get("fan.name_1")
     assert entry.device_id is not None
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
     assert device is not None
     assert device.sw_version == "test-version"
@@ -505,7 +508,11 @@ async def test_setup_smart_by_bond_fan(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
 
-async def test_setup_hub_template_fan(hass: HomeAssistant) -> None:
+async def test_setup_hub_template_fan(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
     """Test setting up a fan on a hub created from a template."""
     config_entry = await setup_platform(
         hass,
@@ -521,10 +528,8 @@ async def test_setup_hub_template_fan(hass: HomeAssistant) -> None:
         },
     )
     assert hass.states.get("fan.name_1") is not None
-    registry = er.async_get(hass)
-    entry = registry.async_get("fan.name_1")
+    entry = entity_registry.async_get("fan.name_1")
     assert entry.device_id is not None
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
     assert device is not None
     assert device.sw_version is None

--- a/tests/components/bond/test_init.py
+++ b/tests/components/bond/test_init.py
@@ -12,7 +12,6 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ASSUMED_STATE, CONF_ACCESS_TOKEN, CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.setup import async_setup_component
 
 from .common import (
@@ -82,6 +81,7 @@ async def test_async_setup_raises_fails_if_auth_fails(hass: HomeAssistant) -> No
 
 async def test_async_setup_entry_sets_up_hub_and_supported_domains(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test that configuring entry sets up cover domain."""
     config_entry = MockConfigEntry(
@@ -112,7 +112,6 @@ async def test_async_setup_entry_sets_up_hub_and_supported_domains(
     assert config_entry.unique_id == "ZXXX12345"
 
     # verify hub device is registered correctly
-    device_registry = dr.async_get(hass)
     hub = device_registry.async_get_device(identifiers={(DOMAIN, "ZXXX12345")})
     assert hub.name == "bond-name"
     assert hub.manufacturer == "Olibra"
@@ -153,7 +152,9 @@ async def test_unload_config_entry(hass: HomeAssistant) -> None:
     assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
-async def test_old_identifiers_are_removed(hass: HomeAssistant) -> None:
+async def test_old_identifiers_are_removed(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test we remove the old non-unique identifiers."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -163,7 +164,6 @@ async def test_old_identifiers_are_removed(hass: HomeAssistant) -> None:
 
     old_identifers = (DOMAIN, "device_id")
     new_identifiers = (DOMAIN, "ZXXX12345", "device_id")
-    device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={old_identifers},
@@ -201,7 +201,9 @@ async def test_old_identifiers_are_removed(hass: HomeAssistant) -> None:
     assert device_registry.async_get_device(identifiers={new_identifiers}) is not None
 
 
-async def test_smart_by_bond_device_suggested_area(hass: HomeAssistant) -> None:
+async def test_smart_by_bond_device_suggested_area(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test we can setup a smart by bond device and get the suggested area."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -238,13 +240,14 @@ async def test_smart_by_bond_device_suggested_area(hass: HomeAssistant) -> None:
     assert config_entry.state is ConfigEntryState.LOADED
     assert config_entry.unique_id == "KXXX12345"
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(identifiers={(DOMAIN, "KXXX12345")})
     assert device is not None
     assert device.suggested_area == "Den"
 
 
-async def test_bridge_device_suggested_area(hass: HomeAssistant) -> None:
+async def test_bridge_device_suggested_area(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test we can setup a bridge bond device and get the suggested area."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -284,14 +287,16 @@ async def test_bridge_device_suggested_area(hass: HomeAssistant) -> None:
     assert config_entry.state is ConfigEntryState.LOADED
     assert config_entry.unique_id == "ZXXX12345"
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(identifiers={(DOMAIN, "ZXXX12345")})
     assert device is not None
     assert device.suggested_area == "Office"
 
 
 async def test_device_remove_devices(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test we can only remove a device that no longer exists."""
     assert await async_setup_component(hass, "config", {})
@@ -304,11 +309,9 @@ async def test_device_remove_devices(
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = er.async_get(hass)
-    entity = registry.entities["fan.name_1"]
+    entity = entity_registry.entities["fan.name_1"]
     assert entity.unique_id == "test-hub-id_test-device-id"
 
-    device_registry = dr.async_get(hass)
     device_entry = device_registry.async_get(entity.device_id)
     assert (
         await remove_device(

--- a/tests/components/bond/test_light.py
+++ b/tests/components/bond/test_light.py
@@ -32,7 +32,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.util import utcnow
 
 from .common import (
@@ -153,7 +152,10 @@ def light_brightness_increase_decrease_only(name: str):
     }
 
 
-async def test_fan_entity_registry(hass: HomeAssistant) -> None:
+async def test_fan_entity_registry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Tests that fan with light devices are registered in the entity registry."""
     await setup_platform(
         hass,
@@ -163,12 +165,14 @@ async def test_fan_entity_registry(hass: HomeAssistant) -> None:
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = er.async_get(hass)
-    entity = registry.entities["light.fan_name"]
+    entity = entity_registry.entities["light.fan_name"]
     assert entity.unique_id == "test-hub-id_test-device-id"
 
 
-async def test_fan_up_light_entity_registry(hass: HomeAssistant) -> None:
+async def test_fan_up_light_entity_registry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Tests that fan with up light devices are registered in the entity registry."""
     await setup_platform(
         hass,
@@ -178,12 +182,14 @@ async def test_fan_up_light_entity_registry(hass: HomeAssistant) -> None:
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = er.async_get(hass)
-    entity = registry.entities["light.fan_name_up_light"]
+    entity = entity_registry.entities["light.fan_name_up_light"]
     assert entity.unique_id == "test-hub-id_test-device-id_up_light"
 
 
-async def test_fan_down_light_entity_registry(hass: HomeAssistant) -> None:
+async def test_fan_down_light_entity_registry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Tests that fan with down light devices are registered in the entity registry."""
     await setup_platform(
         hass,
@@ -193,12 +199,14 @@ async def test_fan_down_light_entity_registry(hass: HomeAssistant) -> None:
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = er.async_get(hass)
-    entity = registry.entities["light.fan_name_down_light"]
+    entity = entity_registry.entities["light.fan_name_down_light"]
     assert entity.unique_id == "test-hub-id_test-device-id_down_light"
 
 
-async def test_fireplace_entity_registry(hass: HomeAssistant) -> None:
+async def test_fireplace_entity_registry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Tests that flame fireplace devices are registered in the entity registry."""
     await setup_platform(
         hass,
@@ -208,12 +216,14 @@ async def test_fireplace_entity_registry(hass: HomeAssistant) -> None:
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = er.async_get(hass)
-    entity = registry.entities["light.fireplace_name"]
+    entity = entity_registry.entities["light.fireplace_name"]
     assert entity.unique_id == "test-hub-id_test-device-id"
 
 
-async def test_fireplace_with_light_entity_registry(hass: HomeAssistant) -> None:
+async def test_fireplace_with_light_entity_registry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Tests that flame+light devices are registered in the entity registry."""
     await setup_platform(
         hass,
@@ -223,14 +233,16 @@ async def test_fireplace_with_light_entity_registry(hass: HomeAssistant) -> None
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = er.async_get(hass)
-    entity_flame = registry.entities["light.fireplace_name"]
+    entity_flame = entity_registry.entities["light.fireplace_name"]
     assert entity_flame.unique_id == "test-hub-id_test-device-id"
-    entity_light = registry.entities["light.fireplace_name_light"]
+    entity_light = entity_registry.entities["light.fireplace_name_light"]
     assert entity_light.unique_id == "test-hub-id_test-device-id_light"
 
 
-async def test_light_entity_registry(hass: HomeAssistant) -> None:
+async def test_light_entity_registry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Tests lights are registered in the entity registry."""
     await setup_platform(
         hass,
@@ -240,8 +252,7 @@ async def test_light_entity_registry(hass: HomeAssistant) -> None:
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = er.async_get(hass)
-    entity = registry.entities["light.light_name"]
+    entity = entity_registry.entities["light.light_name"]
     assert entity.unique_id == "test-hub-id_test-device-id"
 
 

--- a/tests/components/bond/test_switch.py
+++ b/tests/components/bond/test_switch.py
@@ -14,7 +14,6 @@ from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_O
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.util import utcnow
 
 from .common import (
@@ -33,7 +32,10 @@ def generic_device(name: str):
     return {"name": name, "type": DeviceType.GENERIC_DEVICE}
 
 
-async def test_entity_registry(hass: HomeAssistant) -> None:
+async def test_entity_registry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(
         hass,
@@ -43,8 +45,7 @@ async def test_entity_registry(hass: HomeAssistant) -> None:
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = er.async_get(hass)
-    entity = registry.entities["switch.name_1"]
+    entity = entity_registry.entities["switch.name_1"]
     assert entity.unique_id == "test-hub-id_test-device-id"
 
 


### PR DESCRIPTION
## Proposed change
SSIA, as I saw it in https://github.com/home-assistant/core/pull/103703 :)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
