### PR TITLE
Add `release_url` property of Shelly update entities

### DIFF
--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -189,3 +189,9 @@ OTA_SUCCESS = "ota_success"
 
 GEN1_RELEASE_URL = "https://shelly-api-docs.shelly.cloud/gen1/#changelog"
 GEN2_RELEASE_URL = "https://shelly-api-docs.shelly.cloud/gen2/changelog/"
+DEVICES_WITHOUT_FIRMWARE_CHANGELOG = (
+    "SAWD-0A1XX10EU1",
+    "SHMOS-01",
+    "SHMOS-02",
+    "SHTRV-01",
+)

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -186,3 +186,6 @@ OTA_BEGIN = "ota_begin"
 OTA_ERROR = "ota_error"
 OTA_PROGRESS = "ota_progress"
 OTA_SUCCESS = "ota_success"
+
+GEN1_RELEASE_URL = "https://shelly-api-docs.shelly.cloud/gen1/#changelog"
+GEN2_RELEASE_URL = "https://shelly-api-docs.shelly.cloud/gen2/changelog/"

--- a/homeassistant/components/shelly/update.py
+++ b/homeassistant/components/shelly/update.py
@@ -175,7 +175,6 @@ class RestUpdateEntity(ShellyRestAttributeEntity, UpdateEntity):
         """Initialize update entity."""
         super().__init__(block_coordinator, attribute, description)
         self._in_progress_old_version: str | None = None
-        self._attr_release_url = description.release_url
 
     @property
     def installed_version(self) -> str | None:
@@ -225,6 +224,14 @@ class RestUpdateEntity(ShellyRestAttributeEntity, UpdateEntity):
             self.coordinator.entry.async_start_reauth(self.hass)
         else:
             LOGGER.debug("Result of OTA update call: %s", result)
+
+    @property
+    def release_url(self) -> str | None:
+        """URL to the full release notes."""
+        if self.coordinator.model in ("SHMOS-01", "SHMOS-02", "SHTRV-01"):
+            return None
+
+        return self.entity_description.release_url
 
 
 class RpcUpdateEntity(ShellyRpcAttributeEntity, UpdateEntity):

--- a/homeassistant/components/shelly/update.py
+++ b/homeassistant/components/shelly/update.py
@@ -162,7 +162,7 @@ class RestUpdateEntity(ShellyRestAttributeEntity, UpdateEntity):
         super().__init__(block_coordinator, attribute, description)
         self._attr_release_url = get_release_url(
             block_coordinator.device.gen,
-            block_coordinator.device.model,
+            block_coordinator.model,
             description.beta,
         )
         self._in_progress_old_version: str | None = None
@@ -236,7 +236,7 @@ class RpcUpdateEntity(ShellyRpcAttributeEntity, UpdateEntity):
         super().__init__(coordinator, key, attribute, description)
         self._ota_in_progress: bool = False
         self._attr_release_url = get_release_url(
-            coordinator.device.gen, coordinator.device.model, description.beta
+            coordinator.device.gen, coordinator.model, description.beta
         )
 
     async def async_added_to_hass(self) -> None:
@@ -353,6 +353,6 @@ class RpcSleepingUpdateEntity(
 
         return get_release_url(
             self.coordinator.device.gen,
-            self.coordinator.device.model,
+            self.coordinator.model,
             self.entity_description.beta,
         )

--- a/homeassistant/components/shelly/update.py
+++ b/homeassistant/components/shelly/update.py
@@ -23,7 +23,15 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import CONF_SLEEP_PERIOD, OTA_BEGIN, OTA_ERROR, OTA_PROGRESS, OTA_SUCCESS
+from .const import (
+    CONF_SLEEP_PERIOD,
+    GEN1_RELEASE_URL,
+    GEN2_RELEASE_URL,
+    OTA_BEGIN,
+    OTA_ERROR,
+    OTA_PROGRESS,
+    OTA_SUCCESS,
+)
 from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator
 from .entity import (
     RestEntityDescription,
@@ -82,7 +90,7 @@ REST_UPDATES: Final = {
         device_class=UpdateDeviceClass.FIRMWARE,
         entity_category=EntityCategory.CONFIG,
         entity_registry_enabled_default=False,
-        release_url="https://shelly-api-docs.shelly.cloud/gen1/#changelog",
+        release_url=GEN1_RELEASE_URL,
     ),
     "fwupdate_beta": RestUpdateDescription(
         name="Beta firmware update",
@@ -104,7 +112,7 @@ RPC_UPDATES: Final = {
         beta=False,
         device_class=UpdateDeviceClass.FIRMWARE,
         entity_category=EntityCategory.CONFIG,
-        release_url="https://shelly-api-docs.shelly.cloud/gen2/changelog/",
+        release_url=GEN2_RELEASE_URL,
     ),
     "fwupdate_beta": RpcUpdateDescription(
         name="Beta firmware update",

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -27,6 +27,8 @@ from .const import (
     CONF_COAP_PORT,
     DEFAULT_COAP_PORT,
     DOMAIN,
+    GEN1_RELEASE_URL,
+    GEN2_RELEASE_URL,
     LOGGER,
     RPC_INPUTS_EVENTS_TYPES,
     SHBTN_INPUTS_EVENTS_TYPES,
@@ -408,3 +410,14 @@ def mac_address_from_name(name: str) -> str | None:
     """Convert a name to a mac address."""
     mac = name.partition(".")[0].partition("-")[-1]
     return mac.upper() if len(mac) == 12 else None
+
+
+def get_release_url(gen: int, model: str, beta: bool) -> str | None:
+    """Return release URL or None."""
+    if model in ("SAWD-0A1XX10EU1", "SHMOS-01", "SHMOS-02", "SHTRV-01"):
+        return None
+
+    if beta:
+        return None
+
+    return GEN1_RELEASE_URL if gen == 1 else GEN2_RELEASE_URL

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -26,6 +26,7 @@ from .const import (
     BASIC_INPUTS_EVENTS_TYPES,
     CONF_COAP_PORT,
     DEFAULT_COAP_PORT,
+    DEVICES_WITHOUT_FIRMWARE_CHANGELOG,
     DOMAIN,
     GEN1_RELEASE_URL,
     GEN2_RELEASE_URL,
@@ -414,7 +415,7 @@ def mac_address_from_name(name: str) -> str | None:
 
 def get_release_url(gen: int, model: str, beta: bool) -> str | None:
     """Return release URL or None."""
-    if model in ("SAWD-0A1XX10EU1", "SHMOS-01", "SHMOS-02", "SHTRV-01"):
+    if model in DEVICES_WITHOUT_FIRMWARE_CHANGELOG:
         return None
 
     if beta:

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -415,10 +415,7 @@ def mac_address_from_name(name: str) -> str | None:
 
 def get_release_url(gen: int, model: str, beta: bool) -> str | None:
     """Return release URL or None."""
-    if model in DEVICES_WITHOUT_FIRMWARE_CHANGELOG:
-        return None
-
-    if beta:
+    if beta or model in DEVICES_WITHOUT_FIRMWARE_CHANGELOG:
         return None
 
     return GEN1_RELEASE_URL if gen == 1 else GEN2_RELEASE_URL

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -281,6 +281,7 @@ async def mock_block_device():
             firmware_version="some fw string",
             initialized=True,
             model="SHSW-1",
+            gen=1,
         )
         type(device).name = PropertyMock(return_value="Test name")
         block_device_mock.return_value = device

--- a/tests/components/shelly/test_update.py
+++ b/tests/components/shelly/test_update.py
@@ -5,7 +5,11 @@ from aioshelly.exceptions import DeviceConnectionError, InvalidAuthError, RpcCal
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
-from homeassistant.components.shelly.const import DOMAIN
+from homeassistant.components.shelly.const import (
+    DOMAIN,
+    GEN1_RELEASE_URL,
+    GEN2_RELEASE_URL,
+)
 from homeassistant.components.update import (
     ATTR_IN_PROGRESS,
     ATTR_INSTALLED_VERSION,
@@ -76,10 +80,7 @@ async def test_block_update(
     assert state.attributes[ATTR_INSTALLED_VERSION] == "1"
     assert state.attributes[ATTR_LATEST_VERSION] == "2"
     assert state.attributes[ATTR_IN_PROGRESS] is True
-    assert (
-        state.attributes[ATTR_RELEASE_URL]
-        == "https://shelly-api-docs.shelly.cloud/gen1/#changelog"
-    )
+    assert state.attributes[ATTR_RELEASE_URL] == GEN1_RELEASE_URL
 
     monkeypatch.setitem(mock_block_device.status["update"], "old_version", "2")
     await mock_rest_update(hass, freezer)
@@ -276,10 +277,7 @@ async def test_rpc_update(hass: HomeAssistant, mock_rpc_device, monkeypatch) -> 
     assert state.attributes[ATTR_INSTALLED_VERSION] == "1"
     assert state.attributes[ATTR_LATEST_VERSION] == "2"
     assert state.attributes[ATTR_IN_PROGRESS] == 0
-    assert (
-        state.attributes[ATTR_RELEASE_URL]
-        == "https://shelly-api-docs.shelly.cloud/gen2/changelog/"
-    )
+    assert state.attributes[ATTR_RELEASE_URL] == GEN2_RELEASE_URL
 
     inject_rpc_device_event(
         monkeypatch,
@@ -351,10 +349,7 @@ async def test_rpc_sleeping_update(
     assert state.attributes[ATTR_LATEST_VERSION] == "2"
     assert state.attributes[ATTR_IN_PROGRESS] is False
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == UpdateEntityFeature(0)
-    assert (
-        state.attributes[ATTR_RELEASE_URL]
-        == "https://shelly-api-docs.shelly.cloud/gen2/changelog/"
-    )
+    assert state.attributes[ATTR_RELEASE_URL] == GEN2_RELEASE_URL
 
     monkeypatch.setitem(mock_rpc_device.shelly, "ver", "2")
     mock_rpc_device.mock_update()

--- a/tests/components/shelly/test_update.py
+++ b/tests/components/shelly/test_update.py
@@ -10,6 +10,7 @@ from homeassistant.components.update import (
     ATTR_IN_PROGRESS,
     ATTR_INSTALLED_VERSION,
     ATTR_LATEST_VERSION,
+    ATTR_RELEASE_URL,
     DOMAIN as UPDATE_DOMAIN,
     SERVICE_INSTALL,
     UpdateEntityFeature,
@@ -75,6 +76,10 @@ async def test_block_update(
     assert state.attributes[ATTR_INSTALLED_VERSION] == "1"
     assert state.attributes[ATTR_LATEST_VERSION] == "2"
     assert state.attributes[ATTR_IN_PROGRESS] is True
+    assert (
+        state.attributes[ATTR_RELEASE_URL]
+        == "https://shelly-api-docs.shelly.cloud/gen1/#changelog"
+    )
 
     monkeypatch.setitem(mock_block_device.status["update"], "old_version", "2")
     await mock_rest_update(hass, freezer)
@@ -117,6 +122,7 @@ async def test_block_beta_update(
     assert state.attributes[ATTR_INSTALLED_VERSION] == "1"
     assert state.attributes[ATTR_LATEST_VERSION] == "2b"
     assert state.attributes[ATTR_IN_PROGRESS] is False
+    assert state.attributes[ATTR_RELEASE_URL] is None
 
     await hass.services.async_call(
         UPDATE_DOMAIN,
@@ -270,6 +276,10 @@ async def test_rpc_update(hass: HomeAssistant, mock_rpc_device, monkeypatch) -> 
     assert state.attributes[ATTR_INSTALLED_VERSION] == "1"
     assert state.attributes[ATTR_LATEST_VERSION] == "2"
     assert state.attributes[ATTR_IN_PROGRESS] == 0
+    assert (
+        state.attributes[ATTR_RELEASE_URL]
+        == "https://shelly-api-docs.shelly.cloud/gen2/changelog/"
+    )
 
     inject_rpc_device_event(
         monkeypatch,
@@ -341,6 +351,10 @@ async def test_rpc_sleeping_update(
     assert state.attributes[ATTR_LATEST_VERSION] == "2"
     assert state.attributes[ATTR_IN_PROGRESS] is False
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == UpdateEntityFeature(0)
+    assert (
+        state.attributes[ATTR_RELEASE_URL]
+        == "https://shelly-api-docs.shelly.cloud/gen2/changelog/"
+    )
 
     monkeypatch.setitem(mock_rpc_device.shelly, "ver", "2")
     mock_rpc_device.mock_update()
@@ -467,6 +481,7 @@ async def test_rpc_beta_update(
     assert state.attributes[ATTR_INSTALLED_VERSION] == "1"
     assert state.attributes[ATTR_LATEST_VERSION] == "1"
     assert state.attributes[ATTR_IN_PROGRESS] is False
+    assert state.attributes[ATTR_RELEASE_URL] is None
 
     monkeypatch.setitem(
         mock_rpc_device.status["sys"],

--- a/tests/components/shelly/test_utils.py
+++ b/tests/components/shelly/test_utils.py
@@ -1,6 +1,7 @@
 """Tests for Shelly utils."""
 import pytest
 
+from homeassistant.components.shelly.const import GEN1_RELEASE_URL, GEN2_RELEASE_URL
 from homeassistant.components.shelly.utils import (
     get_block_channel_name,
     get_block_device_sleep_period,
@@ -227,8 +228,21 @@ async def test_get_rpc_input_triggers(mock_rpc_device, monkeypatch) -> None:
     assert not get_rpc_input_triggers(mock_rpc_device)
 
 
-def test_get_release_url() -> None:
+@pytest.mark.parametrize(
+    ("gen", "model", "beta", "expected"),
+    [
+        (1, "SHMOS-01", False, None),
+        (1, "SHSW-1", False, GEN1_RELEASE_URL),
+        (1, "SHSW-1", True, None),
+        (2, "SAWD-0A1XX10EU1", False, None),
+        (2, "SNSW-102P16EU", False, GEN2_RELEASE_URL),
+        (2, "SNSW-102P16EU", True, None),
+    ],
+)
+def test_get_release_url(
+    gen: int, model: str, beta: bool, expected: str | None
+) -> None:
     """Test get_release_url() with a device without a release note URL."""
-    result = get_release_url(1, "SHMOS-01", False)
+    result = get_release_url(gen, model, beta)
 
-    assert result is None
+    assert result is expected

--- a/tests/components/shelly/test_utils.py
+++ b/tests/components/shelly/test_utils.py
@@ -7,6 +7,7 @@ from homeassistant.components.shelly.utils import (
     get_block_input_triggers,
     get_device_uptime,
     get_number_of_channels,
+    get_release_url,
     get_rpc_channel_name,
     get_rpc_input_triggers,
     is_block_momentary_input,
@@ -224,3 +225,10 @@ async def test_get_rpc_input_triggers(mock_rpc_device, monkeypatch) -> None:
 
     monkeypatch.setattr(mock_rpc_device, "config", {"input:0": {"type": "switch"}})
     assert not get_rpc_input_triggers(mock_rpc_device)
+
+
+def test_get_release_url() -> None:
+    """Test get_release_url() with a device without a release note URL."""
+    result = get_release_url(1, "SHMOS-01", False)
+
+    assert result is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds values for `release_url` property of Shelly update entities. 
Changelogs are only available for stable firmware, so beta update entities return `None` as `release_url`.
Changelogs are not available for those devices: `SAWD-0A1XX10EU1`, `SHMOS-01`, `SHMOS-02`, `SHTRV-01`, they use a different firmware line.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
