### PR TITLE
Add reauth flow to ring integration

### DIFF
--- a/homeassistant/components/ring/__init__.py
+++ b/homeassistant/components/ring/__init__.py
@@ -283,7 +283,9 @@ class DeviceDataUpdater:
                 _LOGGER.warning(
                     "Ring access token is no longer valid, need to re-authenticate"
                 )
-                self.config_entry.async_start_reauth(self.hass)
+                self.hass.loop.call_soon_threadsafe(
+                    self.config_entry.async_start_reauth, self.hass
+                )
                 return
             except ring_doorbell.RingTimeout:
                 _LOGGER.warning(

--- a/homeassistant/components/ring/config_flow.py
+++ b/homeassistant/components/ring/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for Ring integration."""
+from collections.abc import Mapping
 import logging
 from typing import Any
 
@@ -6,11 +7,18 @@ import ring_doorbell
 import voluptuous as vol
 
 from homeassistant import config_entries, core, exceptions
-from homeassistant.const import __version__ as ha_version
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, __version__ as ha_version
+from homeassistant.data_entry_flow import FlowResult
 
 from . import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
+)
+STEP_REAUTH_DATA_SCHEMA = vol.Schema({vol.Required(CONF_PASSWORD): str})
 
 
 async def validate_input(hass: core.HomeAssistant, data):
@@ -39,6 +47,13 @@ class RingConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
     user_pass: dict[str, Any] = {}
+    reauth_entry: ConfigEntry | None = None
+
+    def _show_user_form(self, errors: dict[str, str]) -> FlowResult:
+        """Show the user form."""
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
@@ -55,7 +70,7 @@ class RingConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except Require2FA:
                 self.user_pass = user_input
 
-                return await self.async_step_2fa()
+                return await self.async_step_2fa_user()
 
             except InvalidAuth:
                 errors["base"] = "invalid_auth"
@@ -63,23 +78,78 @@ class RingConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
 
-        return self.async_show_form(
-            step_id="user",
-            data_schema=vol.Schema(
-                {vol.Required("username"): str, vol.Required("password"): str}
-            ),
-            errors=errors,
-        )
+        return self._show_user_form(errors)
 
-    async def async_step_2fa(self, user_input=None):
+    async def async_step_2fa_user(self, user_input=None):
         """Handle 2fa step."""
         if user_input:
             return await self.async_step_user({**self.user_pass, **user_input})
 
         return self.async_show_form(
-            step_id="2fa",
+            step_id="2fa_user",
             data_schema=vol.Schema({vol.Required("2fa"): str}),
         )
+
+    async def async_step_2fa_reauth(self, user_input=None):
+        """Handle 2fa step."""
+        if user_input:
+            return await self.async_step_reauth_confirm(
+                {**self.user_pass, **user_input}
+            )
+
+        return self.async_show_form(
+            step_id="2fa_reauth",
+            data_schema=vol.Schema({vol.Required("2fa"): str}),
+        )
+
+    def _show_reauth_form(self, errors: dict[str, str]) -> FlowResult:
+        """Show the reauth form."""
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=STEP_REAUTH_DATA_SCHEMA,
+            errors=errors,
+            description_placeholders={
+                CONF_USERNAME: self.reauth_entry.data[CONF_USERNAME]  # type: ignore[union-attr]
+            },
+        )
+
+    async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> FlowResult:
+        """Handle reauth upon an API authentication error."""
+        self.reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Dialog that informs the user that reauth is required."""
+        errors = {}
+        assert self.reauth_entry is not None
+
+        if user_input:
+            user_input[CONF_USERNAME] = self.reauth_entry.data[CONF_USERNAME]
+            try:
+                token = await validate_input(self.hass, user_input)
+                data = {
+                    CONF_USERNAME: user_input[CONF_USERNAME],
+                    "token": token,
+                }
+                self.hass.config_entries.async_update_entry(
+                    self.reauth_entry, data=data
+                )
+                await self.hass.config_entries.async_reload(self.reauth_entry.entry_id)
+                return self.async_abort(reason="reauth_successful")
+            except Require2FA:
+                self.user_pass = user_input
+                return await self.async_step_2fa_reauth()
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        return self._show_reauth_form(errors)
 
 
 class Require2FA(exceptions.HomeAssistantError):

--- a/homeassistant/components/ring/strings.json
+++ b/homeassistant/components/ring/strings.json
@@ -8,7 +8,7 @@
           "password": "[%key:common::config_flow::data::password%]"
         }
       },
-      "2fa_user": {
+      "2fa": {
         "title": "Two-factor authentication",
         "data": {
           "2fa": "Two-factor code"
@@ -19,12 +19,6 @@
         "description": "The Ring integration needs to re-authenticate your account {username}",
         "data": {
           "password": "[%key:common::config_flow::data::password%]"
-        }
-      },
-      "2fa_reauth": {
-        "title": "Two-factor authentication",
-        "data": {
-          "2fa": "Two-factor code"
         }
       }
     },

--- a/homeassistant/components/ring/strings.json
+++ b/homeassistant/components/ring/strings.json
@@ -8,7 +8,20 @@
           "password": "[%key:common::config_flow::data::password%]"
         }
       },
-      "2fa": {
+      "2fa_user": {
+        "title": "Two-factor authentication",
+        "data": {
+          "2fa": "Two-factor code"
+        }
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "The Ring integration needs to re-authenticate your account {username}",
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      },
+      "2fa_reauth": {
         "title": "Two-factor authentication",
         "data": {
           "2fa": "Two-factor code"
@@ -20,7 +33,8 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
   "entity": {

--- a/tests/components/ring/test_config_flow.py
+++ b/tests/components/ring/test_config_flow.py
@@ -12,8 +12,6 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry
 
-pytestmark = pytest.mark.usefixtures("mock_setup_entry")
-
 
 async def test_form(
     hass: HomeAssistant,

--- a/tests/components/ring/test_config_flow.py
+++ b/tests/components/ring/test_config_flow.py
@@ -1,5 +1,5 @@
 """Test the Ring config flow."""
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 import ring_doorbell
@@ -9,6 +9,10 @@ from homeassistant.components.ring import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
 
 async def test_form(
@@ -90,7 +94,7 @@ async def test_form_2fa(
     )
 
     assert result2["type"] == FlowResultType.FORM
-    assert result2["step_id"] == "2fa"
+    assert result2["step_id"] == "2fa_user"
     mock_ring_auth.fetch_token.reset_mock(side_effect=True)
     mock_ring_auth.fetch_token.return_value = "new-foobar"
     result3 = await hass.config_entries.flow.async_configure(
@@ -108,3 +112,91 @@ async def test_form_2fa(
         "token": "new-foobar",
     }
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_reauth(
+    hass: HomeAssistant,
+    mock_added_config_entry: MockConfigEntry,
+    mock_setup_entry: AsyncMock,
+    mock_ring_auth: Mock,
+) -> None:
+    """Test reauth flow."""
+    mock_added_config_entry.async_start_reauth(hass)
+    await hass.async_block_till_done()
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    [result] = flows
+    assert result["step_id"] == "reauth_confirm"
+
+    mock_ring_auth.fetch_token.side_effect = ring_doorbell.Requires2FAError
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_PASSWORD: "other_fake_password",
+        },
+    )
+
+    mock_ring_auth.fetch_token.assert_called_once_with(
+        "foo@bar.com", "other_fake_password", None
+    )
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "2fa_reauth"
+    mock_ring_auth.fetch_token.reset_mock(side_effect=True)
+    mock_ring_auth.fetch_token.return_value = "new-foobar"
+    result3 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"],
+        user_input={"2fa": "123456"},
+    )
+
+    mock_ring_auth.fetch_token.assert_called_once_with(
+        "foo@bar.com", "other_fake_password", "123456"
+    )
+    assert result3["type"] == FlowResultType.ABORT
+    assert result3["reason"] == "reauth_successful"
+    assert mock_added_config_entry.data == {
+        "username": "foo@bar.com",
+        "token": "new-foobar",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("error_type", "errors_msg"),
+    [
+        (ring_doorbell.AuthenticationError, "invalid_auth"),
+        (Exception, "unknown"),
+    ],
+    ids=["invalid-auth", "unknown-error"],
+)
+async def test_reauth_error(
+    hass: HomeAssistant,
+    mock_added_config_entry: MockConfigEntry,
+    mock_setup_entry: AsyncMock,
+    mock_ring_auth: Mock,
+    error_type,
+    errors_msg,
+) -> None:
+    """Test reauth flow."""
+    mock_added_config_entry.async_start_reauth(hass)
+    await hass.async_block_till_done()
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    [result] = flows
+    assert result["step_id"] == "reauth_confirm"
+
+    mock_ring_auth.fetch_token.side_effect = error_type
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_PASSWORD: "other_fake_password",
+        },
+    )
+    await hass.async_block_till_done()
+
+    mock_ring_auth.fetch_token.assert_called_once_with(
+        "foo@bar.com", "other_fake_password", None
+    )
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": errors_msg}

--- a/tests/components/ring/test_init.py
+++ b/tests/components/ring/test_init.py
@@ -9,7 +9,7 @@ from ring_doorbell import AuthenticationError, RingError, RingTimeout
 
 import homeassistant.components.ring as ring
 from homeassistant.components.ring import DOMAIN
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -46,7 +46,6 @@ async def test_auth_failed_on_setup(
     hass: HomeAssistant,
     requests_mock: requests_mock.Mocker,
     mock_config_entry: MockConfigEntry,
-    caplog,
 ) -> None:
     """Test auth failure on setup entry."""
     mock_config_entry.add_to_hass(hass)
@@ -54,14 +53,10 @@ async def test_auth_failed_on_setup(
         "ring_doorbell.Ring.update_data",
         side_effect=AuthenticationError,
     ):
-        result = await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        assert not any(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
-        assert result is False
-        assert "Access token is no longer valid. Please set up Ring again" in [
-            record.message for record in caplog.records if record.levelname == "ERROR"
-        ]
-
-        assert DOMAIN not in hass.data
+        assert any(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
         assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
@@ -75,7 +70,7 @@ async def test_auth_failure_on_global_update(
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
-
+    assert not any(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
     with patch(
         "ring_doorbell.Ring.update_devices",
         side_effect=AuthenticationError,
@@ -83,11 +78,11 @@ async def test_auth_failure_on_global_update(
         async_fire_time_changed(hass, dt_util.now() + timedelta(minutes=20))
         await hass.async_block_till_done()
 
-        assert "Ring access token is no longer valid. Set up Ring again" in [
-            record.message for record in caplog.records if record.levelname == "ERROR"
+        assert "Ring access token is no longer valid, need to re-authenticate" in [
+            record.message for record in caplog.records if record.levelname == "WARNING"
         ]
 
-        assert mock_config_entry.entry_id not in hass.data[DOMAIN]
+        assert any(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
 
 
 async def test_auth_failure_on_device_update(
@@ -100,7 +95,7 @@ async def test_auth_failure_on_device_update(
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
-
+    assert not any(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
     with patch(
         "ring_doorbell.RingDoorBell.history",
         side_effect=AuthenticationError,
@@ -108,11 +103,11 @@ async def test_auth_failure_on_device_update(
         async_fire_time_changed(hass, dt_util.now() + timedelta(minutes=20))
         await hass.async_block_till_done()
 
-        assert "Ring access token is no longer valid. Set up Ring again" in [
-            record.message for record in caplog.records if record.levelname == "ERROR"
+        assert "Ring access token is no longer valid, need to re-authenticate" in [
+            record.message for record in caplog.records if record.levelname == "WARNING"
         ]
 
-        assert mock_config_entry.entry_id not in hass.data[DOMAIN]
+        assert any(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
 
 
 @pytest.mark.parametrize(
@@ -170,8 +165,7 @@ async def test_error_on_global_update(
     ],
     ids=["timeout-error", "other-error"],
 )
-async def test_error_on_device_update(
-    hass: HomeAssistant,
+async def test_error_on_device_update(hass: HomeAssistant,
     requests_mock: requests_mock.Mocker,
     mock_config_entry: MockConfigEntry,
     caplog,
@@ -194,3 +188,4 @@ async def test_error_on_device_update(
             record.message for record in caplog.records if record.levelname == "WARNING"
         ]
         assert mock_config_entry.entry_id in hass.data[DOMAIN]
+

--- a/tests/components/ring/test_init.py
+++ b/tests/components/ring/test_init.py
@@ -165,7 +165,8 @@ async def test_error_on_global_update(
     ],
     ids=["timeout-error", "other-error"],
 )
-async def test_error_on_device_update(hass: HomeAssistant,
+async def test_error_on_device_update(
+    hass: HomeAssistant,
     requests_mock: requests_mock.Mocker,
     mock_config_entry: MockConfigEntry,
     caplog,
@@ -188,4 +189,3 @@ async def test_error_on_device_update(hass: HomeAssistant,
             record.message for record in caplog.records if record.levelname == "WARNING"
         ]
         assert mock_config_entry.entry_id in hass.data[DOMAIN]
-


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add reauthorisation flow to the ring integration.  Currently token expiry requires users to delete and re-create the ring integration which is undesirable.

In order for this to work the ring_doorbell library that this integration uses has some new error types that need to be caught and handled by the integration.  Hence it depended on PR [Bump ring_doorbell to 0.8.0 and handle new exceptions](https://github.com/home-assistant/core/pull/103904) which has now been merged.

N.B. I based these changes heavily on PR https://github.com/home-assistant/core/pull/103351 so many thanks to @dknowles2 and the reviewers on that PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
