### PR TITLE
Add helper method to get matter device info

### DIFF
--- a/homeassistant/components/matter/__init__.py
+++ b/homeassistant/components/matter/__init__.py
@@ -33,7 +33,7 @@ from .helpers import (
     MatterEntryData,
     get_matter,
     get_node_from_device_entry,
-    node_id_from_ha_device_id,
+    node_from_ha_device_id,
 )
 from .models import MatterDeviceInfo
 
@@ -47,10 +47,7 @@ def get_matter_device_info(
     hass: HomeAssistant, device_id: str
 ) -> MatterDeviceInfo | None:
     """Return Matter device info or None if device does not exist."""
-    if not (node_id := node_id_from_ha_device_id(hass, device_id)):
-        return None
-
-    if not (node := get_matter(hass).matter_client.get_node(node_id)):
+    if not (node := node_from_ha_device_id(hass, device_id)):
         return None
 
     return MatterDeviceInfo(
@@ -246,9 +243,9 @@ def _async_init_services(hass: HomeAssistant) -> None:
 
     async def open_commissioning_window(call: ServiceCall) -> None:
         """Open commissioning window on specific node."""
-        node_id = node_id_from_ha_device_id(hass, call.data["device_id"])
+        node = node_from_ha_device_id(hass, call.data["device_id"])
 
-        if node_id is None:
+        if node is None:
             raise HomeAssistantError("This is not a Matter device")
 
         matter_client = get_matter(hass).matter_client
@@ -256,7 +253,7 @@ def _async_init_services(hass: HomeAssistant) -> None:
         # We are sending device ID .
 
         try:
-            await matter_client.open_commissioning_window(node_id)
+            await matter_client.open_commissioning_window(node.node_id)
         except NodeCommissionFailed as err:
             raise HomeAssistantError(str(err)) from err
 

--- a/homeassistant/components/matter/__init__.py
+++ b/homeassistant/components/matter/__init__.py
@@ -47,15 +47,17 @@ def get_matter_device_info(
     hass: HomeAssistant, device_id: str
 ) -> MatterDeviceInfo | None:
     """Return Matter device info or None if device does not exist."""
-    matter_client = get_matter(hass).matter_client
-    if node_id := node_id_from_ha_device_id(hass, device_id):
-        if node := matter_client.get_node(node_id):
-            return MatterDeviceInfo(
-                unique_id=node.device_info.uniqueID,
-                vendor_id=hex(node.device_info.vendorID),
-                product_id=hex(node.device_info.productID),
-            )
-    return None
+    if not (node_id := node_id_from_ha_device_id(hass, device_id)):
+        return None
+
+    if not (node := get_matter(hass).matter_client.get_node(node_id)):
+        return None
+
+    return MatterDeviceInfo(
+        unique_id=node.device_info.uniqueID,
+        vendor_id=hex(node.device_info.vendorID),
+        product_id=hex(node.device_info.productID),
+    )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/matter/diagnostics.py
+++ b/homeassistant/components/matter/diagnostics.py
@@ -58,7 +58,7 @@ async def async_get_device_diagnostics(
     """Return diagnostics for a device."""
     matter = get_matter(hass)
     server_diagnostics = await matter.matter_client.get_diagnostics()
-    node = await get_node_from_device_entry(hass, device)
+    node = get_node_from_device_entry(hass, device)
 
     return {
         "server_info": dataclass_to_dict(server_diagnostics.info),

--- a/homeassistant/components/matter/helpers.py
+++ b/homeassistant/components/matter/helpers.py
@@ -67,15 +67,13 @@ def get_device_id(
 
 
 @callback
-def node_id_from_ha_device_id(hass: HomeAssistant, ha_device_id: str) -> int | None:
+def node_from_ha_device_id(hass: HomeAssistant, ha_device_id: str) -> MatterNode | None:
     """Get node id from ha device id."""
     dev_reg = dr.async_get(hass)
     device = dev_reg.async_get(ha_device_id)
     if device is None:
-        return None
-    if node := get_node_from_device_entry(hass, device):
-        return node.node_id
-    return None
+        raise ValueError("Invalid device ID")
+    return get_node_from_device_entry(hass, device)
 
 
 @callback

--- a/homeassistant/components/matter/helpers.py
+++ b/homeassistant/components/matter/helpers.py
@@ -66,20 +66,20 @@ def get_device_id(
     return f"{operational_instance_id}-{postfix}"
 
 
-async def node_id_from_ha_device_id(
-    hass: HomeAssistant, ha_device_id: str
-) -> int | None:
+@callback
+def node_id_from_ha_device_id(hass: HomeAssistant, ha_device_id: str) -> int | None:
     """Get node id from ha device id."""
     dev_reg = dr.async_get(hass)
     device = dev_reg.async_get(ha_device_id)
     if device is None:
         return None
-    if node := await get_node_from_device_entry(hass, device):
+    if node := get_node_from_device_entry(hass, device):
         return node.node_id
     return None
 
 
-async def get_node_from_device_entry(
+@callback
+def get_node_from_device_entry(
     hass: HomeAssistant, device: dr.DeviceEntry
 ) -> MatterNode | None:
     """Return MatterNode from device entry."""

--- a/homeassistant/components/matter/helpers.py
+++ b/homeassistant/components/matter/helpers.py
@@ -66,6 +66,19 @@ def get_device_id(
     return f"{operational_instance_id}-{postfix}"
 
 
+async def node_id_from_ha_device_id(
+    hass: HomeAssistant, ha_device_id: str
+) -> int | None:
+    """Get node id from ha device id."""
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get(ha_device_id)
+    if device is None:
+        return None
+    if node := await get_node_from_device_entry(hass, device):
+        return node.node_id
+    return None
+
+
 async def get_node_from_device_entry(
     hass: HomeAssistant, device: dr.DeviceEntry
 ) -> MatterNode | None:

--- a/homeassistant/components/matter/models.py
+++ b/homeassistant/components/matter/models.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TypedDict
 
 from chip.clusters import Objects as clusters
 from chip.clusters.Objects import ClusterAttributeDescriptor
@@ -14,6 +15,20 @@ from homeassistant.helpers.entity import EntityDescription
 SensorValueTypes = type[
     clusters.uint | int | clusters.Nullable | clusters.float32 | float
 ]
+
+
+class MatterDeviceInfo(TypedDict):
+    """Dictionary with Matter Device info.
+
+    Used to send to other Matter controllers,
+    such as Google Home to prevent duplicated devices.
+
+    Reference: https://developers.home.google.com/matter/device-deduplication
+    """
+
+    unique_id: str
+    vendor_id: str  # vendorId hex string
+    product_id: str  # productId hex string
 
 
 @dataclass

--- a/tests/components/matter/test_helpers.py
+++ b/tests/components/matter/test_helpers.py
@@ -56,7 +56,7 @@ async def test_get_node_from_device_entry(
         device_registry, config_entry.entry_id
     )[0]
     assert device_entry
-    node_from_device_entry = await get_node_from_device_entry(hass, device_entry)
+    node_from_device_entry = get_node_from_device_entry(hass, device_entry)
 
     assert node_from_device_entry is node
 


### PR DESCRIPTION
## Proposed change

Add small helper method to get some basic matter device info for a HA device id.
This can then be used to deduplicate devices in other matter controllers such as Google Home as those ecosystems have direct access to the matter devices as well and if HA is connected, the user might end up with duplicated devices.

NOTE: This also needs an implementation in the various (cloud) platforms such as Google Home, Alexa (and maybe Homekit as well?).

## Type of change


- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
