### PR TITLE
Update nibe heatpump to 2.5.0

### DIFF
--- a/homeassistant/components/nibe_heatpump/climate.py
+++ b/homeassistant/components/nibe_heatpump/climate.py
@@ -1,6 +1,7 @@
 """The Nibe Heat Pump climate."""
 from __future__ import annotations
 
+from datetime import date
 from typing import Any
 
 from nibe.coil import Coil
@@ -124,7 +125,7 @@ class NibeClimateEntity(CoordinatorEntity[Coordinator], ClimateEntity):
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        def _get_value(coil: Coil) -> int | str | float | None:
+        def _get_value(coil: Coil) -> int | str | float | date | None:
             return self.coordinator.get_coil_value(coil)
 
         def _get_float(coil: Coil) -> float | None:

--- a/homeassistant/components/nibe_heatpump/coordinator.py
+++ b/homeassistant/components/nibe_heatpump/coordinator.py
@@ -132,10 +132,7 @@ class Coordinator(ContextCoordinator[dict[int, CoilData], int]):
     def get_coil_float(self, coil: Coil) -> float | None:
         """Return a coil with float and check for validity."""
         if value := self.get_coil_value(coil):
-            try:
-                return float(value)  # type: ignore[arg-type]
-            except ValueError:
-                return None
+            return float(value)  # type: ignore[arg-type]
         return None
 
     async def async_write_coil(self, coil: Coil, value: int | float | str) -> None:

--- a/homeassistant/components/nibe_heatpump/coordinator.py
+++ b/homeassistant/components/nibe_heatpump/coordinator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections import defaultdict
 from collections.abc import Callable, Iterable
-from datetime import timedelta
+from datetime import date, timedelta
 from typing import Any, Generic, TypeVar
 
 from nibe.coil import Coil, CoilData
@@ -123,7 +123,7 @@ class Coordinator(ContextCoordinator[dict[int, CoilData], int]):
         """Return device information for the main device."""
         return DeviceInfo(identifiers={(DOMAIN, self.unique_id)})
 
-    def get_coil_value(self, coil: Coil) -> int | str | float | None:
+    def get_coil_value(self, coil: Coil) -> int | str | float | date | None:
         """Return a coil with data and check for validity."""
         if coil_with_data := self.data.get(coil.address):
             return coil_with_data.value
@@ -132,7 +132,10 @@ class Coordinator(ContextCoordinator[dict[int, CoilData], int]):
     def get_coil_float(self, coil: Coil) -> float | None:
         """Return a coil with float and check for validity."""
         if value := self.get_coil_value(coil):
-            return float(value)
+            try:
+                return float(value)  # type: ignore[arg-type]
+            except ValueError:
+                return None
         return None
 
     async def async_write_coil(self, coil: Coil, value: int | float | str) -> None:

--- a/homeassistant/components/nibe_heatpump/manifest.json
+++ b/homeassistant/components/nibe_heatpump/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/nibe_heatpump",
   "iot_class": "local_polling",
-  "requirements": ["nibe==2.4.0"]
+  "requirements": ["nibe==2.5.0"]
 }

--- a/homeassistant/components/nibe_heatpump/number.py
+++ b/homeassistant/components/nibe_heatpump/number.py
@@ -66,7 +66,7 @@ class Number(CoilEntity, NumberEntity):
             return
 
         try:
-            self._attr_native_value = float(data.value)
+            self._attr_native_value = float(data.value)  # type: ignore[arg-type]
         except ValueError:
             self._attr_native_value = None
 

--- a/homeassistant/components/nibe_heatpump/water_heater.py
+++ b/homeassistant/components/nibe_heatpump/water_heater.py
@@ -1,6 +1,8 @@
 """The Nibe Heat Pump sensors."""
 from __future__ import annotations
 
+from datetime import date
+
 from nibe.coil import Coil
 from nibe.coil_groups import WATER_HEATER_COILGROUPS, WaterHeaterCoilGroup
 from nibe.exceptions import CoilNotFoundException
@@ -132,7 +134,7 @@ class WaterHeater(CoordinatorEntity[Coordinator], WaterHeaterEntity):
                 return None
             return self.coordinator.get_coil_float(coil)
 
-        def _get_value(coil: Coil | None) -> int | str | float | None:
+        def _get_value(coil: Coil | None) -> int | str | float | date | None:
             if coil is None:
                 return None
             return self.coordinator.get_coil_value(coil)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1311,7 +1311,7 @@ nextcord==2.0.0a8
 nextdns==2.0.1
 
 # homeassistant.components.nibe_heatpump
-nibe==2.4.0
+nibe==2.5.0
 
 # homeassistant.components.niko_home_control
 niko-home-control==0.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1025,7 +1025,7 @@ nextcord==2.0.0a8
 nextdns==2.0.1
 
 # homeassistant.components.nibe_heatpump
-nibe==2.4.0
+nibe==2.5.0
 
 # homeassistant.components.nfandroidtv
 notifications-android-tv==0.1.5


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

S-Series entities priority-3102,  hot-water-demand-mode-40057 and oper-mode-40238 is changed from a number entity to a select entity with mapping values for the possible choices.

If you have the old number entities enabled, you can delete them since they will no longer be provided by the integration.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Upgrade nibe heatpump to 2.5.0

https://github.com/yozik04/nibe/releases/tag/2.5.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: #103397, #101774

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
