### PR TITLE
Update a-c* tests to use entity & device registry fixtures

### DIFF
--- a/tests/components/asuswrt/test_sensor.py
+++ b/tests/components/asuswrt/test_sensor.py
@@ -30,23 +30,29 @@ SENSORS_ALL_LEGACY = [*SENSORS_DEFAULT, *SENSORS_LOAD_AVG, *SENSORS_TEMPERATURES
 
 
 @pytest.fixture(name="create_device_registry_devices")
-def create_device_registry_devices_fixture(hass: HomeAssistant):
+def create_device_registry_devices_fixture(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+):
     """Create device registry devices so the device tracker entities are enabled when added."""
-    dev_reg = dr.async_get(hass)
     config_entry = MockConfigEntry(domain="something_else")
     config_entry.add_to_hass(hass)
 
     for idx, device in enumerate((MOCK_MACS[2], MOCK_MACS[3])):
-        dev_reg.async_get_or_create(
+        device_registry.async_get_or_create(
             name=f"Device {idx}",
             config_entry_id=config_entry.entry_id,
             connections={(dr.CONNECTION_NETWORK_MAC, dr.format_mac(device))},
         )
 
 
-def _setup_entry(hass: HomeAssistant, config, sensors, unique_id=None):
+def _setup_entry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    config,
+    sensors,
+    unique_id=None,
+):
     """Create mock config entry with enabled sensors."""
-    entity_reg = er.async_get(hass)
 
     # init config entry
     config_entry = MockConfigEntry(
@@ -64,7 +70,7 @@ def _setup_entry(hass: HomeAssistant, config, sensors, unique_id=None):
     # Pre-enable the status sensor
     for sensor_key in sensors:
         sensor_id = slugify(sensor_key)
-        entity_reg.async_get_or_create(
+        entity_registry.async_get_or_create(
             sensor.DOMAIN,
             DOMAIN,
             f"{unique_id_prefix}_{sensor_id}",
@@ -78,6 +84,7 @@ def _setup_entry(hass: HomeAssistant, config, sensors, unique_id=None):
 
 async def _test_sensors(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     mock_devices,
     config,
     entry_unique_id,
@@ -88,13 +95,12 @@ async def _test_sensors(
     )
 
     # Create the first device tracker to test mac conversion
-    entity_reg = er.async_get(hass)
     for mac, name in {
         MOCK_MACS[0]: "test",
         dr.format_mac(MOCK_MACS[1]): "testtwo",
         MOCK_MACS[1]: "testremove",
     }.items():
-        entity_reg.async_get_or_create(
+        entity_registry.async_get_or_create(
             device_tracker.DOMAIN,
             DOMAIN,
             mac,
@@ -274,7 +280,9 @@ async def test_options_reload(hass: HomeAssistant, connect_legacy) -> None:
     assert connect_legacy.return_value.connection.async_connect.call_count == 2
 
 
-async def test_unique_id_migration(hass: HomeAssistant, connect_legacy) -> None:
+async def test_unique_id_migration(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, connect_legacy
+) -> None:
     """Test AsusWRT entities unique id format migration."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -283,9 +291,8 @@ async def test_unique_id_migration(hass: HomeAssistant, connect_legacy) -> None:
     )
     config_entry.add_to_hass(hass)
 
-    entity_reg = er.async_get(hass)
     obj_entity_id = slugify(f"{HOST} Upload")
-    entity_reg.async_get_or_create(
+    entity_registry.async_get_or_create(
         sensor.DOMAIN,
         DOMAIN,
         f"{DOMAIN} {ROUTER_MAC_ADDR} Upload",
@@ -297,6 +304,6 @@ async def test_unique_id_migration(hass: HomeAssistant, connect_legacy) -> None:
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    migr_entity = entity_reg.async_get(f"{sensor.DOMAIN}.{obj_entity_id}")
+    migr_entity = entity_registry.async_get(f"{sensor.DOMAIN}.{obj_entity_id}")
     assert migr_entity is not None
     assert migr_entity.unique_id == slugify(f"{ROUTER_MAC_ADDR}_sensor_tx_bytes")

--- a/tests/components/asuswrt/test_sensor.py
+++ b/tests/components/asuswrt/test_sensor.py
@@ -45,12 +45,7 @@ def create_device_registry_devices_fixture(
         )
 
 
-def _setup_entry(
-    hass: HomeAssistant,
-    config,
-    sensors,
-    unique_id=None,
-):
+def _setup_entry(hass: HomeAssistant, config, sensors, unique_id=None):
     """Create mock config entry with enabled sensors."""
     entity_reg = er.async_get(hass)
 

--- a/tests/components/asuswrt/test_sensor.py
+++ b/tests/components/asuswrt/test_sensor.py
@@ -47,12 +47,12 @@ def create_device_registry_devices_fixture(
 
 def _setup_entry(
     hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
     config,
     sensors,
     unique_id=None,
 ):
     """Create mock config entry with enabled sensors."""
+    entity_reg = er.async_get(hass)
 
     # init config entry
     config_entry = MockConfigEntry(
@@ -70,7 +70,7 @@ def _setup_entry(
     # Pre-enable the status sensor
     for sensor_key in sensors:
         sensor_id = slugify(sensor_key)
-        entity_registry.async_get_or_create(
+        entity_reg.async_get_or_create(
             sensor.DOMAIN,
             DOMAIN,
             f"{unique_id_prefix}_{sensor_id}",
@@ -84,7 +84,6 @@ def _setup_entry(
 
 async def _test_sensors(
     hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
     mock_devices,
     config,
     entry_unique_id,
@@ -95,12 +94,13 @@ async def _test_sensors(
     )
 
     # Create the first device tracker to test mac conversion
+    entity_reg = er.async_get(hass)
     for mac, name in {
         MOCK_MACS[0]: "test",
         dr.format_mac(MOCK_MACS[1]): "testtwo",
         MOCK_MACS[1]: "testremove",
     }.items():
-        entity_registry.async_get_or_create(
+        entity_reg.async_get_or_create(
             device_tracker.DOMAIN,
             DOMAIN,
             mac,

--- a/tests/components/blebox/conftest.py
+++ b/tests/components/blebox/conftest.py
@@ -75,7 +75,7 @@ def feature_fixture(request):
     return request.getfixturevalue(request.param)
 
 
-async def async_setup_entities(hass, entity_ids, entity_registry: er.EntityRegistry):
+async def async_setup_entities(hass, entity_ids):
     """Return configured entries with the given entity ids."""
 
     config_entry = mock_config()
@@ -84,6 +84,7 @@ async def async_setup_entities(hass, entity_ids, entity_registry: er.EntityRegis
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
+    entity_registry = er.async_get(hass)
     return [entity_registry.async_get(entity_id) for entity_id in entity_ids]
 
 

--- a/tests/components/blebox/conftest.py
+++ b/tests/components/blebox/conftest.py
@@ -75,7 +75,7 @@ def feature_fixture(request):
     return request.getfixturevalue(request.param)
 
 
-async def async_setup_entities(hass, entity_ids):
+async def async_setup_entities(hass, entity_ids, entity_registry: er.EntityRegistry):
     """Return configured entries with the given entity ids."""
 
     config_entry = mock_config()
@@ -84,7 +84,6 @@ async def async_setup_entities(hass, entity_ids):
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    entity_registry = er.async_get(hass)
     return [entity_registry.async_get(entity_id) for entity_id in entity_ids]
 
 

--- a/tests/components/blebox/test_binary_sensor.py
+++ b/tests/components/blebox/test_binary_sensor.py
@@ -28,7 +28,9 @@ def airsensor_fixture() -> tuple[AsyncMock, str]:
     return feature, "binary_sensor.windrainsensor_0_rain"
 
 
-async def test_init(rainsensor: AsyncMock, hass: HomeAssistant) -> None:
+async def test_init(
+    rainsensor: AsyncMock, device_registry: dr.DeviceRegistry, hass: HomeAssistant
+) -> None:
     """Test binary_sensor initialisation."""
     _, entity_id = rainsensor
     entry = await async_setup_entity(hass, entity_id)
@@ -40,7 +42,6 @@ async def test_init(rainsensor: AsyncMock, hass: HomeAssistant) -> None:
     assert state.attributes[ATTR_DEVICE_CLASS] == BinarySensorDeviceClass.MOISTURE
     assert state.state == STATE_ON
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My rain sensor"

--- a/tests/components/blebox/test_climate.py
+++ b/tests/components/blebox/test_climate.py
@@ -76,7 +76,9 @@ def thermobox_fixture():
     return (feature, "climate.thermobox_thermostat")
 
 
-async def test_init(saunabox, hass: HomeAssistant) -> None:
+async def test_init(
+    saunabox, hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test default state."""
 
     _, entity_id = saunabox
@@ -102,7 +104,6 @@ async def test_init(saunabox, hass: HomeAssistant) -> None:
 
     assert state.state == STATE_UNKNOWN
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My sauna"

--- a/tests/components/blebox/test_cover.py
+++ b/tests/components/blebox/test_cover.py
@@ -98,7 +98,9 @@ def gate_fixture():
     return (feature, "cover.gatecontroller_position")
 
 
-async def test_init_gatecontroller(gatecontroller, hass: HomeAssistant) -> None:
+async def test_init_gatecontroller(
+    gatecontroller, hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test gateController default state."""
 
     _, entity_id = gatecontroller
@@ -118,7 +120,6 @@ async def test_init_gatecontroller(gatecontroller, hass: HomeAssistant) -> None:
     assert ATTR_CURRENT_POSITION not in state.attributes
     assert state.state == STATE_UNKNOWN
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My gate controller"
@@ -128,7 +129,9 @@ async def test_init_gatecontroller(gatecontroller, hass: HomeAssistant) -> None:
     assert device.sw_version == "1.23"
 
 
-async def test_init_shutterbox(shutterbox, hass: HomeAssistant) -> None:
+async def test_init_shutterbox(
+    shutterbox, hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test gateBox default state."""
 
     _, entity_id = shutterbox
@@ -148,7 +151,6 @@ async def test_init_shutterbox(shutterbox, hass: HomeAssistant) -> None:
     assert ATTR_CURRENT_POSITION not in state.attributes
     assert state.state == STATE_UNKNOWN
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My shutter"
@@ -158,7 +160,9 @@ async def test_init_shutterbox(shutterbox, hass: HomeAssistant) -> None:
     assert device.sw_version == "1.23"
 
 
-async def test_init_gatebox(gatebox, hass: HomeAssistant) -> None:
+async def test_init_gatebox(
+    gatebox, hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test cover default state."""
 
     _, entity_id = gatebox
@@ -180,7 +184,6 @@ async def test_init_gatebox(gatebox, hass: HomeAssistant) -> None:
     assert ATTR_CURRENT_POSITION not in state.attributes
     assert state.state == STATE_UNKNOWN
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My gatebox"

--- a/tests/components/blebox/test_light.py
+++ b/tests/components/blebox/test_light.py
@@ -50,7 +50,9 @@ def dimmer_fixture():
     return (feature, "light.dimmerbox_brightness")
 
 
-async def test_dimmer_init(dimmer, hass: HomeAssistant) -> None:
+async def test_dimmer_init(
+    dimmer, hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test cover default state."""
 
     _, entity_id = dimmer
@@ -66,7 +68,6 @@ async def test_dimmer_init(dimmer, hass: HomeAssistant) -> None:
     assert state.attributes[ATTR_BRIGHTNESS] == 65
     assert state.state == STATE_ON
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My dimmer"
@@ -223,7 +224,9 @@ def wlightboxs_fixture():
     return (feature, "light.wlightboxs_color")
 
 
-async def test_wlightbox_s_init(wlightbox_s, hass: HomeAssistant) -> None:
+async def test_wlightbox_s_init(
+    wlightbox_s, hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test cover default state."""
 
     _, entity_id = wlightbox_s
@@ -239,7 +242,6 @@ async def test_wlightbox_s_init(wlightbox_s, hass: HomeAssistant) -> None:
     assert state.attributes[ATTR_BRIGHTNESS] is None
     assert state.state == STATE_UNKNOWN
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My wLightBoxS"
@@ -326,7 +328,9 @@ def wlightbox_fixture():
     return (feature, "light.wlightbox_color")
 
 
-async def test_wlightbox_init(wlightbox, hass: HomeAssistant) -> None:
+async def test_wlightbox_init(
+    wlightbox, hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test cover default state."""
 
     _, entity_id = wlightbox
@@ -343,7 +347,6 @@ async def test_wlightbox_init(wlightbox, hass: HomeAssistant) -> None:
     assert state.attributes[ATTR_RGBW_COLOR] is None
     assert state.state == STATE_UNKNOWN
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My wLightBox"

--- a/tests/components/blebox/test_sensor.py
+++ b/tests/components/blebox/test_sensor.py
@@ -56,7 +56,9 @@ def tempsensor_fixture():
     return (feature, "sensor.tempsensor_0_temperature")
 
 
-async def test_init(tempsensor, hass: HomeAssistant) -> None:
+async def test_init(
+    tempsensor, hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test sensor default state."""
 
     _, entity_id = tempsensor
@@ -70,7 +72,6 @@ async def test_init(tempsensor, hass: HomeAssistant) -> None:
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfTemperature.CELSIUS
     assert state.state == STATE_UNKNOWN
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My temperature sensor"
@@ -110,7 +111,9 @@ async def test_update_failure(
     assert f"Updating '{feature_mock.full_name}' failed: " in caplog.text
 
 
-async def test_airsensor_init(airsensor, hass: HomeAssistant) -> None:
+async def test_airsensor_init(
+    airsensor, hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test airSensor default state."""
 
     _, entity_id = airsensor
@@ -123,7 +126,6 @@ async def test_airsensor_init(airsensor, hass: HomeAssistant) -> None:
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.PM1
     assert state.state == STATE_UNKNOWN
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My air sensor"

--- a/tests/components/blebox/test_switch.py
+++ b/tests/components/blebox/test_switch.py
@@ -44,7 +44,9 @@ def switchbox_fixture():
     return (feature, "switch.switchbox_0_relay")
 
 
-async def test_switchbox_init(switchbox, hass: HomeAssistant, config) -> None:
+async def test_switchbox_init(
+    switchbox, hass: HomeAssistant, device_registry: dr.DeviceRegistry, config
+) -> None:
     """Test switch default state."""
 
     feature_mock, entity_id = switchbox
@@ -60,7 +62,6 @@ async def test_switchbox_init(switchbox, hass: HomeAssistant, config) -> None:
 
     assert state.state == STATE_OFF
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My switch box"
@@ -189,7 +190,9 @@ def switchbox_d_fixture():
     return (features, ["switch.switchboxd_0_relay", "switch.switchboxd_1_relay"])
 
 
-async def test_switchbox_d_init(switchbox_d, hass: HomeAssistant) -> None:
+async def test_switchbox_d_init(
+    switchbox_d, hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test switch default state."""
 
     feature_mocks, entity_ids = switchbox_d
@@ -206,7 +209,6 @@ async def test_switchbox_d_init(switchbox_d, hass: HomeAssistant) -> None:
     assert state.attributes[ATTR_DEVICE_CLASS] == SwitchDeviceClass.SWITCH
     assert state.state == STATE_UNKNOWN
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My relays"
@@ -223,7 +225,6 @@ async def test_switchbox_d_init(switchbox_d, hass: HomeAssistant) -> None:
     assert state.attributes[ATTR_DEVICE_CLASS] == SwitchDeviceClass.SWITCH
     assert state.state == STATE_UNKNOWN
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My relays"

--- a/tests/components/bmw_connected_drive/test_diagnostics.py
+++ b/tests/components/bmw_connected_drive/test_diagnostics.py
@@ -45,6 +45,7 @@ async def test_config_entry_diagnostics(
 async def test_device_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
+    device_registry: dr.DeviceRegistry,
     bmw_fixture,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -56,7 +57,6 @@ async def test_device_diagnostics(
 
     mock_config_entry = await setup_mocked_integration(hass)
 
-    device_registry = dr.async_get(hass)
     reg_device = device_registry.async_get_device(
         identifiers={(DOMAIN, "WBY00000000REXI01")},
     )
@@ -73,6 +73,7 @@ async def test_device_diagnostics(
 async def test_device_diagnostics_vehicle_not_found(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
+    device_registry: dr.DeviceRegistry,
     bmw_fixture,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -84,7 +85,6 @@ async def test_device_diagnostics_vehicle_not_found(
 
     mock_config_entry = await setup_mocked_integration(hass)
 
-    device_registry = dr.async_get(hass)
     reg_device = device_registry.async_get_device(
         identifiers={(DOMAIN, "WBY00000000REXI01")},
     )

--- a/tests/components/bmw_connected_drive/test_init.py
+++ b/tests/components/bmw_connected_drive/test_init.py
@@ -49,12 +49,12 @@ async def test_migrate_unique_ids(
     entitydata: dict,
     old_unique_id: str,
     new_unique_id: str,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test successful migration of entity unique_ids."""
     mock_config_entry = MockConfigEntry(**FIXTURE_CONFIG_ENTRY)
     mock_config_entry.add_to_hass(hass)
 
-    entity_registry = er.async_get(hass)
     entity: er.RegistryEntry = entity_registry.async_get_or_create(
         **entitydata,
         config_entry=mock_config_entry,
@@ -95,12 +95,11 @@ async def test_dont_migrate_unique_ids(
     entitydata: dict,
     old_unique_id: str,
     new_unique_id: str,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test successful migration of entity unique_ids."""
     mock_config_entry = MockConfigEntry(**FIXTURE_CONFIG_ENTRY)
     mock_config_entry.add_to_hass(hass)
-
-    entity_registry = er.async_get(hass)
 
     # create existing entry with new_unique_id
     existing_entity = entity_registry.async_get_or_create(

--- a/tests/components/brother/test_sensor.py
+++ b/tests/components/brother/test_sensor.py
@@ -32,14 +32,12 @@ ATTR_REMAINING_PAGES = "remaining_pages"
 ATTR_COUNTER = "counter"
 
 
-async def test_sensors(hass: HomeAssistant) -> None:
+async def test_sensors(hass: HomeAssistant, entity_registry: er.EntityRegistry) -> None:
     """Test states of the sensors."""
     entry = await init_integration(hass, skip_setup=True)
 
-    registry = er.async_get(hass)
-
     # Pre-create registry entries for disabled by default sensors
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         SENSOR_DOMAIN,
         DOMAIN,
         "0123456789_uptime",
@@ -62,7 +60,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "waiting"
     assert state.attributes.get(ATTR_STATE_CLASS) is None
 
-    entry = registry.async_get("sensor.hl_l2340dw_status")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_status")
     assert entry
     assert entry.unique_id == "0123456789_status"
 
@@ -73,7 +71,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "75"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_black_toner_remaining")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_black_toner_remaining")
     assert entry
     assert entry.unique_id == "0123456789_black_toner_remaining"
 
@@ -84,7 +82,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "10"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_cyan_toner_remaining")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_cyan_toner_remaining")
     assert entry
     assert entry.unique_id == "0123456789_cyan_toner_remaining"
 
@@ -95,7 +93,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "8"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_magenta_toner_remaining")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_magenta_toner_remaining")
     assert entry
     assert entry.unique_id == "0123456789_magenta_toner_remaining"
 
@@ -106,7 +104,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "2"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_yellow_toner_remaining")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_yellow_toner_remaining")
     assert entry
     assert entry.unique_id == "0123456789_yellow_toner_remaining"
 
@@ -117,7 +115,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "92"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_drum_remaining_lifetime")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_drum_remaining_lifetime")
     assert entry
     assert entry.unique_id == "0123456789_drum_remaining_life"
 
@@ -128,7 +126,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "11014"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_drum_remaining_pages")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_drum_remaining_pages")
     assert entry
     assert entry.unique_id == "0123456789_drum_remaining_pages"
 
@@ -139,7 +137,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "986"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_drum_page_counter")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_drum_page_counter")
     assert entry
     assert entry.unique_id == "0123456789_drum_counter"
 
@@ -150,7 +148,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "92"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_black_drum_remaining_lifetime")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_black_drum_remaining_lifetime")
     assert entry
     assert entry.unique_id == "0123456789_black_drum_remaining_life"
 
@@ -161,7 +159,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "16389"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_black_drum_remaining_pages")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_black_drum_remaining_pages")
     assert entry
     assert entry.unique_id == "0123456789_black_drum_remaining_pages"
 
@@ -172,7 +170,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "1611"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_black_drum_page_counter")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_black_drum_page_counter")
     assert entry
     assert entry.unique_id == "0123456789_black_drum_counter"
 
@@ -183,7 +181,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "92"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_cyan_drum_remaining_lifetime")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_cyan_drum_remaining_lifetime")
     assert entry
     assert entry.unique_id == "0123456789_cyan_drum_remaining_life"
 
@@ -194,7 +192,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "16389"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_cyan_drum_remaining_pages")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_cyan_drum_remaining_pages")
     assert entry
     assert entry.unique_id == "0123456789_cyan_drum_remaining_pages"
 
@@ -205,7 +203,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "1611"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_cyan_drum_page_counter")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_cyan_drum_page_counter")
     assert entry
     assert entry.unique_id == "0123456789_cyan_drum_counter"
 
@@ -216,7 +214,9 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "92"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_magenta_drum_remaining_lifetime")
+    entry = entity_registry.async_get(
+        "sensor.hl_l2340dw_magenta_drum_remaining_lifetime"
+    )
     assert entry
     assert entry.unique_id == "0123456789_magenta_drum_remaining_life"
 
@@ -227,7 +227,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "16389"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_magenta_drum_remaining_pages")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_magenta_drum_remaining_pages")
     assert entry
     assert entry.unique_id == "0123456789_magenta_drum_remaining_pages"
 
@@ -238,7 +238,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "1611"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_magenta_drum_page_counter")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_magenta_drum_page_counter")
     assert entry
     assert entry.unique_id == "0123456789_magenta_drum_counter"
 
@@ -249,7 +249,9 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "92"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_yellow_drum_remaining_lifetime")
+    entry = entity_registry.async_get(
+        "sensor.hl_l2340dw_yellow_drum_remaining_lifetime"
+    )
     assert entry
     assert entry.unique_id == "0123456789_yellow_drum_remaining_life"
 
@@ -260,7 +262,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "16389"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_yellow_drum_remaining_pages")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_yellow_drum_remaining_pages")
     assert entry
     assert entry.unique_id == "0123456789_yellow_drum_remaining_pages"
 
@@ -271,7 +273,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "1611"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_yellow_drum_page_counter")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_yellow_drum_page_counter")
     assert entry
     assert entry.unique_id == "0123456789_yellow_drum_counter"
 
@@ -282,7 +284,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "97"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_fuser_remaining_lifetime")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_fuser_remaining_lifetime")
     assert entry
     assert entry.unique_id == "0123456789_fuser_remaining_life"
 
@@ -293,7 +295,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "97"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_belt_unit_remaining_lifetime")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_belt_unit_remaining_lifetime")
     assert entry
     assert entry.unique_id == "0123456789_belt_unit_remaining_life"
 
@@ -304,7 +306,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "98"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_pf_kit_1_remaining_lifetime")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_pf_kit_1_remaining_lifetime")
     assert entry
     assert entry.unique_id == "0123456789_pf_kit_1_remaining_life"
 
@@ -315,7 +317,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "986"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_page_counter")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_page_counter")
     assert entry
     assert entry.unique_id == "0123456789_page_counter"
 
@@ -326,7 +328,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "538"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_duplex_unit_page_counter")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_duplex_unit_page_counter")
     assert entry
     assert entry.unique_id == "0123456789_duplex_unit_pages_counter"
 
@@ -337,7 +339,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "709"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_b_w_pages")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_b_w_pages")
     assert entry
     assert entry.unique_id == "0123456789_bw_counter"
 
@@ -348,7 +350,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "902"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_color_pages")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_color_pages")
     assert entry
     assert entry.unique_id == "0123456789_color_counter"
 
@@ -360,20 +362,21 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "2019-09-24T12:14:56+00:00"
     assert state.attributes.get(ATTR_STATE_CLASS) is None
 
-    entry = registry.async_get("sensor.hl_l2340dw_last_restart")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_last_restart")
     assert entry
     assert entry.unique_id == "0123456789_uptime"
 
 
-async def test_disabled_by_default_sensors(hass: HomeAssistant) -> None:
+async def test_disabled_by_default_sensors(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test the disabled by default Brother sensors."""
     await init_integration(hass)
 
-    registry = er.async_get(hass)
     state = hass.states.get("sensor.hl_l2340dw_last_restart")
     assert state is None
 
-    entry = registry.async_get("sensor.hl_l2340dw_last_restart")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_last_restart")
     assert entry
     assert entry.unique_id == "0123456789_uptime"
     assert entry.disabled
@@ -434,11 +437,12 @@ async def test_manual_update_entity(hass: HomeAssistant) -> None:
         assert len(mock_update.mock_calls) == 1
 
 
-async def test_unique_id_migration(hass: HomeAssistant) -> None:
+async def test_unique_id_migration(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test states of the unique_id migration."""
-    registry = er.async_get(hass)
 
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         SENSOR_DOMAIN,
         DOMAIN,
         "0123456789_b/w_counter",
@@ -448,6 +452,6 @@ async def test_unique_id_migration(hass: HomeAssistant) -> None:
 
     await init_integration(hass)
 
-    entry = registry.async_get("sensor.hl_l2340dw_b_w_counter")
+    entry = entity_registry.async_get("sensor.hl_l2340dw_b_w_counter")
     assert entry
     assert entry.unique_id == "0123456789_bw_counter"

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -367,7 +367,10 @@ async def test_websocket_update_preload_prefs(
 
 
 async def test_websocket_update_orientation_prefs(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, mock_camera
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    entity_registry: er.EntityRegistry,
+    mock_camera,
 ) -> None:
     """Test updating camera preferences."""
     await async_setup_component(hass, "homeassistant", {})
@@ -387,11 +390,10 @@ async def test_websocket_update_orientation_prefs(
     assert not response["success"]
     assert response["error"]["code"] == "update_failed"
 
-    registry = er.async_get(hass)
-    assert not registry.async_get("camera.demo_uniquecamera")
+    assert not entity_registry.async_get("camera.demo_uniquecamera")
     # Since we don't have a unique id, we need to create a registry entry
-    registry.async_get_or_create(DOMAIN, "demo", "uniquecamera")
-    registry.async_update_entity_options(
+    entity_registry.async_get_or_create(DOMAIN, "demo", "uniquecamera")
+    entity_registry.async_update_entity_options(
         "camera.demo_uniquecamera",
         DOMAIN,
         {},
@@ -408,7 +410,9 @@ async def test_websocket_update_orientation_prefs(
     response = await client.receive_json()
     assert response["success"]
 
-    er_camera_prefs = registry.async_get("camera.demo_uniquecamera").options[DOMAIN]
+    er_camera_prefs = entity_registry.async_get("camera.demo_uniquecamera").options[
+        DOMAIN
+    ]
     assert er_camera_prefs[PREF_ORIENTATION] == camera.Orientation.ROTATE_180
     assert response["result"][PREF_ORIENTATION] == er_camera_prefs[PREF_ORIENTATION]
     # Check that the preference was saved

--- a/tests/components/cloud/test_client.py
+++ b/tests/components/cloud/test_client.py
@@ -248,10 +248,12 @@ async def test_webhook_msg(
 
 
 async def test_google_config_expose_entity(
-    hass: HomeAssistant, mock_cloud_setup, mock_cloud_login
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_cloud_setup,
+    mock_cloud_login,
 ) -> None:
     """Test Google config exposing entity method uses latest config."""
-    entity_registry = er.async_get(hass)
 
     # Enable exposing new entities to Google
     exposed_entities: ExposedEntities = hass.data[DATA_EXPOSED_ENTITIES]
@@ -274,10 +276,12 @@ async def test_google_config_expose_entity(
 
 
 async def test_google_config_should_2fa(
-    hass: HomeAssistant, mock_cloud_setup, mock_cloud_login
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_cloud_setup,
+    mock_cloud_login,
 ) -> None:
     """Test Google config disabling 2FA method uses latest config."""
-    entity_registry = er.async_get(hass)
 
     # Register a light entity
     entity_entry = entity_registry.async_get_or_create(

--- a/tests/components/cloud/test_google_config.py
+++ b/tests/components/cloud/test_google_config.py
@@ -120,11 +120,10 @@ async def test_sync_entities(mock_conf, hass: HomeAssistant, cloud_prefs) -> Non
 
 
 async def test_google_update_expose_trigger_sync(
-    hass: HomeAssistant, cloud_prefs
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, cloud_prefs
 ) -> None:
     """Test Google config responds to updating exposed entities."""
     assert await async_setup_component(hass, "homeassistant", {})
-    entity_registry = er.async_get(hass)
 
     # Enable exposing new entities to Google
     expose_new(hass, True)
@@ -176,10 +175,12 @@ async def test_google_update_expose_trigger_sync(
 
 
 async def test_google_entity_registry_sync(
-    hass: HomeAssistant, mock_cloud_login, cloud_prefs
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_cloud_login,
+    cloud_prefs,
 ) -> None:
     """Test Google config responds to entity registry."""
-    entity_registry = er.async_get(hass)
 
     # Enable exposing new entities to Google
     expose_new(hass, True)
@@ -246,19 +247,25 @@ async def test_google_entity_registry_sync(
 
 
 async def test_google_device_registry_sync(
-    hass: HomeAssistant, mock_cloud_login, cloud_prefs
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_cloud_login,
+    cloud_prefs,
 ) -> None:
     """Test Google config responds to device registry."""
     config = CloudGoogleConfig(
         hass, GACTIONS_SCHEMA({}), "mock-user-id", cloud_prefs, hass.data["cloud"]
     )
-    ent_reg = er.async_get(hass)
 
     # Enable exposing new entities to Google
     expose_new(hass, True)
 
-    entity_entry = ent_reg.async_get_or_create("light", "hue", "1234", device_id="1234")
-    entity_entry = ent_reg.async_update_entity(entity_entry.entity_id, area_id="ABCD")
+    entity_entry = entity_registry.async_get_or_create(
+        "light", "hue", "1234", device_id="1234"
+    )
+    entity_entry = entity_registry.async_update_entity(
+        entity_entry.entity_id, area_id="ABCD"
+    )
 
     with patch.object(config, "async_sync_entities_all"):
         await config.async_initialize()
@@ -293,7 +300,7 @@ async def test_google_device_registry_sync(
 
         assert len(mock_sync.mock_calls) == 0
 
-        ent_reg.async_update_entity(entity_entry.entity_id, area_id=None)
+        entity_registry.async_update_entity(entity_entry.entity_id, area_id=None)
 
         # Device registry updated with relevant changes
         # but entity has area ID so not impacted

--- a/tests/components/config/test_automation.py
+++ b/tests/components/config/test_automation.py
@@ -337,13 +337,13 @@ async def test_bad_formatted_automations(
 async def test_delete_automation(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
+    entity_registry: er.EntityRegistry,
     hass_config_store,
     setup_automation,
 ) -> None:
     """Test deleting an automation."""
-    ent_reg = er.async_get(hass)
 
-    assert len(ent_reg.entities) == 2
+    assert len(entity_registry.entities) == 2
 
     with patch.object(config, "SECTIONS", ["automation"]):
         assert await async_setup_component(hass, "config", {})
@@ -371,7 +371,7 @@ async def test_delete_automation(
 
     assert hass_config_store["automations.yaml"] == [{"id": "moon"}]
 
-    assert len(ent_reg.entities) == 1
+    assert len(entity_registry.entities) == 1
 
 
 @pytest.mark.parametrize("automation_config", ({},))

--- a/tests/components/config/test_scene.py
+++ b/tests/components/config/test_scene.py
@@ -184,13 +184,13 @@ async def test_bad_formatted_scene(
 async def test_delete_scene(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
+    entity_registry: er.EntityRegistry,
     hass_config_store,
     setup_scene,
 ) -> None:
     """Test deleting a scene."""
-    ent_reg = er.async_get(hass)
 
-    assert len(ent_reg.entities) == 2
+    assert len(entity_registry.entities) == 2
 
     with patch.object(config, "SECTIONS", ["scene"]):
         assert await async_setup_component(hass, "config", {})
@@ -220,7 +220,7 @@ async def test_delete_scene(
         {"id": "light_off"},
     ]
 
-    assert len(ent_reg.entities) == 1
+    assert len(entity_registry.entities) == 1
 
 
 @pytest.mark.parametrize("scene_config", ({},))

--- a/tests/components/config/test_script.py
+++ b/tests/components/config/test_script.py
@@ -281,7 +281,10 @@ async def test_update_remove_key_script_config(
     ),
 )
 async def test_delete_script(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_config_store
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    entity_registry: er.EntityRegistry,
+    hass_config_store,
 ) -> None:
     """Test deleting a script."""
     with patch.object(config, "SECTIONS", ["script"]):
@@ -292,8 +295,7 @@ async def test_delete_script(
         "script.two",
     ]
 
-    ent_reg = er.async_get(hass)
-    assert len(ent_reg.entities) == 2
+    assert len(entity_registry.entities) == 2
 
     client = await hass_client()
 
@@ -313,7 +315,7 @@ async def test_delete_script(
 
     assert hass_config_store["scripts.yaml"] == {"one": {}}
 
-    assert len(ent_reg.entities) == 1
+    assert len(entity_registry.entities) == 1
 
 
 @pytest.mark.parametrize("script_config", ({},))

--- a/tests/components/counter/test_init.py
+++ b/tests/components/counter/test_init.py
@@ -502,18 +502,20 @@ async def test_ws_list(
 
 
 async def test_ws_delete(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    entity_registry: er.EntityRegistry,
+    storage_setup,
 ) -> None:
     """Test WS delete cleans up entity registry."""
     assert await storage_setup()
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
 
     client = await hass_ws_client(hass)
 
@@ -525,7 +527,7 @@ async def test_ws_delete(
 
     state = hass.states.get(input_entity_id)
     assert state is None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
 
 
 async def test_update_min_max(
@@ -546,7 +548,7 @@ async def test_update_min_max(
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = er.async_get(hass)
+    entity_registry = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None
@@ -554,7 +556,7 @@ async def test_update_min_max(
     assert state.attributes[ATTR_MAXIMUM] == 100
     assert state.attributes[ATTR_MINIMUM] == 10
     assert state.attributes[ATTR_STEP] == 3
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
 
     client = await hass_ws_client(hass)
 
@@ -627,11 +629,11 @@ async def test_create(
 
     counter_id = "new_counter"
     input_entity_id = f"{DOMAIN}.{counter_id}"
-    ent_reg = er.async_get(hass)
+    entity_registry = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, counter_id) is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, counter_id) is None
 
     client = await hass_ws_client(hass)
 

--- a/tests/components/cpuspeed/test_sensor.py
+++ b/tests/components/cpuspeed/test_sensor.py
@@ -25,13 +25,13 @@ from tests.common import MockConfigEntry
 
 async def test_sensor(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     mock_cpuinfo: MagicMock,
     init_integration: MockConfigEntry,
 ) -> None:
     """Test the CPU Speed sensor."""
     await async_setup_component(hass, "homeassistant", {})
-    entity_registry = er.async_get(hass)
-    device_registry = dr.async_get(hass)
 
     entry = entity_registry.async_get("sensor.cpu_speed")
     assert entry


### PR DESCRIPTION
## Proposed change
Update the B-C component tests to use the entity & device registry fixtures. Also update some missed A component tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
