### PR TITLE
Update d-e* tests to use entity & device registry fixtures

### DIFF
--- a/tests/components/daikin/test_init.py
+++ b/tests/components/daikin/test_init.py
@@ -50,7 +50,12 @@ DATA = {
 INVALID_DATA = {**DATA, "name": None, "mac": HOST}
 
 
-async def test_duplicate_removal(hass: HomeAssistant, mock_daikin) -> None:
+async def test_duplicate_removal(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    mock_daikin,
+) -> None:
     """Test duplicate device removal."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -59,8 +64,6 @@ async def test_duplicate_removal(hass: HomeAssistant, mock_daikin) -> None:
         data={CONF_HOST: HOST, KEY_MAC: HOST},
     )
     config_entry.add_to_hass(hass)
-    entity_registry = er.async_get(hass)
-    device_registry = dr.async_get(hass)
 
     type(mock_daikin).mac = PropertyMock(return_value=HOST)
     type(mock_daikin).values = PropertyMock(return_value=INVALID_DATA)
@@ -111,7 +114,12 @@ async def test_duplicate_removal(hass: HomeAssistant, mock_daikin) -> None:
     assert entity_registry.async_get("switch.none_zone_1").unique_id.startswith(MAC)
 
 
-async def test_unique_id_migrate(hass: HomeAssistant, mock_daikin) -> None:
+async def test_unique_id_migrate(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    mock_daikin,
+) -> None:
     """Test unique id migration."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -120,8 +128,6 @@ async def test_unique_id_migrate(hass: HomeAssistant, mock_daikin) -> None:
         data={CONF_HOST: HOST, KEY_MAC: HOST},
     )
     config_entry.add_to_hass(hass)
-    entity_registry = er.async_get(hass)
-    device_registry = dr.async_get(hass)
 
     type(mock_daikin).mac = PropertyMock(return_value=HOST)
     type(mock_daikin).values = PropertyMock(return_value=INVALID_DATA)
@@ -171,7 +177,6 @@ async def test_client_update_connection_error(
         data={CONF_HOST: HOST, KEY_MAC: MAC},
     )
     config_entry.add_to_hass(hass)
-    er.async_get(hass)
 
     type(mock_daikin).mac = PropertyMock(return_value=MAC)
     type(mock_daikin).values = PropertyMock(return_value=DATA)

--- a/tests/components/derivative/test_init.py
+++ b/tests/components/derivative/test_init.py
@@ -11,11 +11,11 @@ from tests.common import MockConfigEntry
 @pytest.mark.parametrize("platform", ("sensor",))
 async def test_setup_and_remove_config_entry(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     platform: str,
 ) -> None:
     """Test setting up and removing a config entry."""
     input_sensor_entity_id = "sensor.input"
-    registry = er.async_get(hass)
     derivative_entity_id = f"{platform}.my_derivative"
 
     # Setup the config entry
@@ -37,7 +37,7 @@ async def test_setup_and_remove_config_entry(
     await hass.async_block_till_done()
 
     # Check the entity is registered in the entity registry
-    assert registry.async_get(derivative_entity_id) is not None
+    assert entity_registry.async_get(derivative_entity_id) is not None
 
     # Check the platform is setup correctly
     state = hass.states.get(derivative_entity_id)
@@ -58,4 +58,4 @@ async def test_setup_and_remove_config_entry(
 
     # Check the state and entity registry entry are removed
     assert hass.states.get(derivative_entity_id) is None
-    assert registry.async_get(derivative_entity_id) is None
+    assert entity_registry.async_get(derivative_entity_id) is None

--- a/tests/components/derivative/test_sensor.py
+++ b/tests/components/derivative/test_sensor.py
@@ -348,11 +348,12 @@ async def test_suffix(hass: HomeAssistant) -> None:
     assert round(float(state.state), config["sensor"]["round"]) == 0.0
 
 
-async def test_device_id(hass: HomeAssistant) -> None:
+async def test_device_id(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
     """Test for source entity device for Derivative."""
-    device_registry = dr.async_get(hass)
-    entity_registry = er.async_get(hass)
-
     source_config_entry = MockConfigEntry()
     source_config_entry.add_to_hass(hass)
     source_device_entry = device_registry.async_get_or_create(

--- a/tests/components/device_tracker/test_entities.py
+++ b/tests/components/device_tracker/test_entities.py
@@ -21,13 +21,15 @@ from tests.common import MockConfigEntry
 
 
 async def test_scanner_entity_device_tracker(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    enable_custom_integrations: None,
 ) -> None:
     """Test ScannerEntity based device tracker."""
     # Make device tied to other integration so device tracker entities get enabled
     other_config_entry = MockConfigEntry(domain="not_fake_integration")
     other_config_entry.add_to_hass(hass)
-    dr.async_get(hass).async_get_or_create(
+    device_registry.async_get_or_create(
         name="Device from other integration",
         config_entry_id=other_config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "ad:de:ef:be:ed:fe")},

--- a/tests/components/devolo_home_control/test_init.py
+++ b/tests/components/devolo_home_control/test_init.py
@@ -65,6 +65,7 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
 async def test_remove_device(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test removing a device."""
     assert await async_setup_component(hass, "config", {})
@@ -77,7 +78,6 @@ async def test_remove_device(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        device_registry = dr.async_get(hass)
         device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "Test")})
         assert device_entry
 

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -213,7 +213,9 @@ async def test_dhcp_renewal_match_hostname_and_macaddress(hass: HomeAssistant) -
     )
 
 
-async def test_registered_devices(hass: HomeAssistant) -> None:
+async def test_registered_devices(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test discovery flows are created for registered devices."""
     integration_matchers = [
         {"domain": "not-matching", "registered_devices": True},
@@ -222,10 +224,9 @@ async def test_registered_devices(hass: HomeAssistant) -> None:
 
     packet = Ether(RAW_DHCP_RENEWAL)
 
-    registry = dr.async_get(hass)
     config_entry = MockConfigEntry(domain="mock-domain", data={})
     config_entry.add_to_hass(hass)
-    registry.async_get_or_create(
+    device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "50147903852c")},
         name="name",
@@ -233,7 +234,7 @@ async def test_registered_devices(hass: HomeAssistant) -> None:
     # Not enabled should not get flows
     config_entry2 = MockConfigEntry(domain="mock-domain-2", data={})
     config_entry2.add_to_hass(hass)
-    registry.async_get_or_create(
+    device_registry.async_get_or_create(
         config_entry_id=config_entry2.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "50147903852c")},
         name="name",

--- a/tests/components/directv/test_media_player.py
+++ b/tests/components/directv/test_media_player.py
@@ -142,12 +142,12 @@ async def test_setup(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -
 
 
 async def test_unique_id(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test unique id."""
     await setup_integration(hass, aioclient_mock)
-
-    entity_registry = er.async_get(hass)
 
     main = entity_registry.async_get(MAIN_ENTITY_ID)
     assert main.original_device_class == MediaPlayerDeviceClass.RECEIVER

--- a/tests/components/directv/test_remote.py
+++ b/tests/components/directv/test_remote.py
@@ -29,12 +29,12 @@ async def test_setup(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -
 
 
 async def test_unique_id(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test unique id."""
     await setup_integration(hass, aioclient_mock)
-
-    entity_registry = er.async_get(hass)
 
     main = entity_registry.async_get(MAIN_ENTITY_ID)
     assert main.unique_id == "028877455858"

--- a/tests/components/dlink/test_init.py
+++ b/tests/components/dlink/test_init.py
@@ -59,13 +59,14 @@ async def test_async_setup_entry_not_ready(
 
 
 async def test_device_info(
-    hass: HomeAssistant, setup_integration: ComponentSetup
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    setup_integration: ComponentSetup,
 ) -> None:
     """Test device info."""
     await setup_integration()
 
     entry = hass.config_entries.async_entries(DOMAIN)[0]
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
 
     assert device.connections == {("mac", "aa:bb:cc:dd:ee:ff")}

--- a/tests/components/dremel_3d_printer/test_init.py
+++ b/tests/components/dremel_3d_printer/test_init.py
@@ -74,12 +74,14 @@ async def test_update_failed(
 
 
 async def test_device_info(
-    hass: HomeAssistant, connection, config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    connection,
+    config_entry: MockConfigEntry,
 ) -> None:
     """Test device info."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     assert await async_setup_component(hass, DOMAIN, {})
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(
         identifiers={(DOMAIN, config_entry.unique_id)}
     )

--- a/tests/components/dsmr/test_init.py
+++ b/tests/components/dsmr/test_init.py
@@ -85,6 +85,7 @@ from tests.common import MockConfigEntry
 )
 async def test_migrate_unique_id(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     dsmr_connection_fixture: tuple[MagicMock, MagicMock, MagicMock],
     dsmr_version: str,
     old_unique_id: str,
@@ -109,7 +110,6 @@ async def test_migrate_unique_id(
 
     mock_entry.add_to_hass(hass)
 
-    entity_registry = er.async_get(hass)
     entity: er.RegistryEntry = entity_registry.async_get_or_create(
         suggested_object_id="my_sensor",
         disabled_by=None,

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -45,7 +45,9 @@ from homeassistant.helpers import entity_registry as er
 from tests.common import MockConfigEntry, patch
 
 
-async def test_default_setup(hass: HomeAssistant, dsmr_connection_fixture) -> None:
+async def test_default_setup(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, dsmr_connection_fixture
+) -> None:
     """Test the default setup."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
@@ -102,13 +104,11 @@ async def test_default_setup(hass: HomeAssistant, dsmr_connection_fixture) -> No
     # after receiving telegram entities need to have the chance to be created
     await hass.async_block_till_done()
 
-    registry = er.async_get(hass)
-
-    entry = registry.async_get("sensor.electricity_meter_power_consumption")
+    entry = entity_registry.async_get("sensor.electricity_meter_power_consumption")
     assert entry
     assert entry.unique_id == "1234_current_electricity_usage"
 
-    entry = registry.async_get("sensor.gas_meter_gas_consumption")
+    entry = entity_registry.async_get("sensor.gas_meter_gas_consumption")
     assert entry
     assert entry.unique_id == "5678_gas_meter_reading"
 
@@ -184,7 +184,9 @@ async def test_default_setup(hass: HomeAssistant, dsmr_connection_fixture) -> No
     )
 
 
-async def test_setup_only_energy(hass: HomeAssistant, dsmr_connection_fixture) -> None:
+async def test_setup_only_energy(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, dsmr_connection_fixture
+) -> None:
     """Test the default setup."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
@@ -232,13 +234,11 @@ async def test_setup_only_energy(hass: HomeAssistant, dsmr_connection_fixture) -
     # after receiving telegram entities need to have the chance to be created
     await hass.async_block_till_done()
 
-    registry = er.async_get(hass)
-
-    entry = registry.async_get("sensor.electricity_meter_power_consumption")
+    entry = entity_registry.async_get("sensor.electricity_meter_power_consumption")
     assert entry
     assert entry.unique_id == "1234_current_electricity_usage"
 
-    entry = registry.async_get("sensor.gas_meter_gas_consumption")
+    entry = entity_registry.async_get("sensor.gas_meter_gas_consumption")
     assert not entry
 
 

--- a/tests/components/dynalite/common.py
+++ b/tests/components/dynalite/common.py
@@ -3,7 +3,6 @@ from unittest.mock import AsyncMock, Mock, call, patch
 
 from homeassistant.components import dynalite
 from homeassistant.const import ATTR_SERVICE
-from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry
 
@@ -23,8 +22,6 @@ def create_mock_device(platform, spec):
 
 async def get_entry_id_from_hass(hass):
     """Get the config entry id from hass."""
-    ent_reg = er.async_get(hass)
-    assert ent_reg
     conf_entries = hass.config_entries.async_entries(dynalite.DOMAIN)
     assert len(conf_entries) == 1
     return conf_entries[0].entry_id

--- a/tests/components/easyenergy/test_sensor.py
+++ b/tests/components/easyenergy/test_sensor.py
@@ -32,12 +32,13 @@ from tests.common import MockConfigEntry
 
 @pytest.mark.freeze_time("2023-01-19 15:00:00")
 async def test_energy_usage_today(
-    hass: HomeAssistant, init_integration: MockConfigEntry
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    init_integration: MockConfigEntry,
 ) -> None:
     """Test the easyEnergy - Energy usage sensors."""
     entry_id = init_integration.entry_id
-    entity_registry = er.async_get(hass)
-    device_registry = dr.async_get(hass)
 
     # Current usage energy price sensor
     state = hass.states.get("sensor.easyenergy_today_energy_usage_current_hour_price")
@@ -146,12 +147,13 @@ async def test_energy_usage_today(
 
 @pytest.mark.freeze_time("2023-01-19 15:00:00")
 async def test_energy_return_today(
-    hass: HomeAssistant, init_integration: MockConfigEntry
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    init_integration: MockConfigEntry,
 ) -> None:
     """Test the easyEnergy - Energy return sensors."""
     entry_id = init_integration.entry_id
-    entity_registry = er.async_get(hass)
-    device_registry = dr.async_get(hass)
 
     # Current return energy price sensor
     state = hass.states.get("sensor.easyenergy_today_energy_return_current_hour_price")
@@ -261,12 +263,13 @@ async def test_energy_return_today(
 
 @pytest.mark.freeze_time("2023-01-19 10:00:00")
 async def test_gas_today(
-    hass: HomeAssistant, init_integration: MockConfigEntry
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    init_integration: MockConfigEntry,
 ) -> None:
     """Test the easyEnergy - Gas sensors."""
     entry_id = init_integration.entry_id
-    entity_registry = er.async_get(hass)
-    device_registry = dr.async_get(hass)
 
     # Current gas price sensor
     state = hass.states.get("sensor.easyenergy_today_gas_current_hour_price")

--- a/tests/components/efergy/test_init.py
+++ b/tests/components/efergy/test_init.py
@@ -47,11 +47,12 @@ async def test_async_setup_entry_auth_failed(hass: HomeAssistant) -> None:
 
 
 async def test_device_info(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test device info."""
     entry = await setup_platform(hass, aioclient_mock, SENSOR_DOMAIN)
-    device_registry = dr.async_get(hass)
 
     device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
 

--- a/tests/components/efergy/test_sensor.py
+++ b/tests/components/efergy/test_sensor.py
@@ -17,7 +17,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity_registry import EntityRegistry
 import homeassistant.util.dt as dt_util
 
 from . import MULTI_SENSOR_TOKEN, mock_responses, setup_platform
@@ -27,13 +26,14 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 async def test_sensor_readings(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test for successfully setting up the Efergy platform."""
     for description in SENSOR_TYPES:
         description.entity_registry_enabled_default = True
     entry = await setup_platform(hass, aioclient_mock, SENSOR_DOMAIN)
-    ent_reg: EntityRegistry = er.async_get(hass)
 
     state = hass.states.get("sensor.efergy_power_usage")
     assert state.state == "1580"
@@ -85,9 +85,9 @@ async def test_sensor_readings(
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.MONETARY
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "EUR"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.TOTAL_INCREASING
-    entity = ent_reg.async_get("sensor.efergy_power_usage_728386")
+    entity = entity_registry.async_get("sensor.efergy_power_usage_728386")
     assert entity.disabled_by is er.RegistryEntryDisabler.INTEGRATION
-    ent_reg.async_update_entity(entity.entity_id, **{"disabled_by": None})
+    entity_registry.async_update_entity(entity.entity_id, **{"disabled_by": None})
     await hass.config_entries.async_reload(entry.entry_id)
     await hass.async_block_till_done()
     state = hass.states.get("sensor.efergy_power_usage_728386")

--- a/tests/components/energy/test_sensor.py
+++ b/tests/components/energy/test_sensor.py
@@ -88,7 +88,10 @@ async def test_cost_sensor_no_states(
 
 
 async def test_cost_sensor_attributes(
-    setup_integration, hass: HomeAssistant, hass_storage: dict[str, Any]
+    setup_integration,
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_storage: dict[str, Any],
 ) -> None:
     """Test sensor attributes."""
     energy_data = data.EnergyManager.default_preferences()
@@ -114,9 +117,8 @@ async def test_cost_sensor_attributes(
     }
     await setup_integration(hass)
 
-    registry = er.async_get(hass)
     cost_sensor_entity_id = "sensor.energy_consumption_cost"
-    entry = registry.async_get(cost_sensor_entity_id)
+    entry = entity_registry.async_get(cost_sensor_entity_id)
     assert entry.entity_category is None
     assert entry.disabled_by is None
     assert entry.hidden_by == er.RegistryEntryHider.INTEGRATION
@@ -145,6 +147,7 @@ async def test_cost_sensor_price_entity_total_increasing(
     hass: HomeAssistant,
     hass_storage: dict[str, Any],
     hass_ws_client: WebSocketGenerator,
+    entity_registry: er.EntityRegistry,
     initial_energy,
     initial_cost,
     price_entity,
@@ -237,7 +240,6 @@ async def test_cost_sensor_price_entity_total_increasing(
     assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.TOTAL
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "EUR"
 
-    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get(cost_sensor_entity_id)
     assert entry
     postfix = "cost" if flow_type == "flow_from" else "compensation"
@@ -357,6 +359,7 @@ async def test_cost_sensor_price_entity_total(
     hass: HomeAssistant,
     hass_storage: dict[str, Any],
     hass_ws_client: WebSocketGenerator,
+    entity_registry: er.EntityRegistry,
     initial_energy,
     initial_cost,
     price_entity,
@@ -451,7 +454,6 @@ async def test_cost_sensor_price_entity_total(
     assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.TOTAL
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "EUR"
 
-    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get(cost_sensor_entity_id)
     assert entry
     postfix = "cost" if flow_type == "flow_from" else "compensation"
@@ -572,6 +574,7 @@ async def test_cost_sensor_price_entity_total_no_reset(
     hass: HomeAssistant,
     hass_storage: dict[str, Any],
     hass_ws_client: WebSocketGenerator,
+    entity_registry: er.EntityRegistry,
     initial_energy,
     initial_cost,
     price_entity,
@@ -665,7 +668,6 @@ async def test_cost_sensor_price_entity_total_no_reset(
     assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.TOTAL
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "EUR"
 
-    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get(cost_sensor_entity_id)
     assert entry
     postfix = "cost" if flow_type == "flow_from" else "compensation"
@@ -1156,7 +1158,10 @@ async def test_cost_sensor_state_class_measurement_no_reset(
 
 
 async def test_inherit_source_unique_id(
-    setup_integration, hass: HomeAssistant, hass_storage: dict[str, Any]
+    setup_integration,
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_storage: dict[str, Any],
 ) -> None:
     """Test sensor inherits unique ID from source."""
     energy_data = data.EnergyManager.default_preferences()
@@ -1175,7 +1180,6 @@ async def test_inherit_source_unique_id(
         "data": energy_data,
     }
 
-    entity_registry = er.async_get(hass)
     source_entry = entity_registry.async_get_or_create(
         "sensor", "test", "123456", suggested_object_id="gas_consumption"
     )

--- a/tests/components/enocean/test_switch.py
+++ b/tests/components/enocean/test_switch.py
@@ -22,15 +22,16 @@ SWITCH_CONFIG = {
 }
 
 
-async def test_unique_id_migration(hass: HomeAssistant) -> None:
+async def test_unique_id_migration(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test EnOcean switch ID migration."""
 
     entity_name = SWITCH_CONFIG["switch"][0]["name"]
     switch_entity_id = f"{SWITCH_DOMAIN}.{entity_name}"
     dev_id = SWITCH_CONFIG["switch"][0]["id"]
     channel = SWITCH_CONFIG["switch"][0]["channel"]
-
-    ent_reg = er.async_get(hass)
 
     old_unique_id = f"{combine_hex(dev_id)}"
 
@@ -39,7 +40,7 @@ async def test_unique_id_migration(hass: HomeAssistant) -> None:
     entry.add_to_hass(hass)
 
     # Add a switch with an old unique_id to the entity registry
-    entity_entry = ent_reg.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         SWITCH_DOMAIN,
         ENOCEAN_DOMAIN,
         old_unique_id,
@@ -63,11 +64,13 @@ async def test_unique_id_migration(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     # Check that new entry has a new unique_id
-    entity_entry = ent_reg.async_get(switch_entity_id)
+    entity_entry = entity_registry.async_get(switch_entity_id)
     new_unique_id = f"{combine_hex(dev_id)}-{channel}"
 
     assert entity_entry.unique_id == new_unique_id
     assert (
-        ent_reg.async_get_entity_id(SWITCH_DOMAIN, ENOCEAN_DOMAIN, old_unique_id)
+        entity_registry.async_get_entity_id(
+            SWITCH_DOMAIN, ENOCEAN_DOMAIN, old_unique_id
+        )
         is None
     )


### PR DESCRIPTION
## Proposed change
Update the component tests starting with `d` or `e` to use the entity & device registry fixtures.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
