### PR TITLE
Handle BaseException from asyncio gather

### DIFF
--- a/homeassistant/components/elkm1/discovery.py
+++ b/homeassistant/components/elkm1/discovery.py
@@ -63,6 +63,8 @@ async def async_discover_devices(
         if isinstance(discovered, Exception):
             _LOGGER.debug("Scanning %s failed with error: %s", targets[idx], discovered)
             continue
+        if isinstance(discovered, BaseException):
+            raise discovered from None
         for device in discovered:
             assert isinstance(device, ElkSystem)
             combined_discoveries[device.ip_address] = device

--- a/homeassistant/components/notion/__init__.py
+++ b/homeassistant/components/notion/__init__.py
@@ -189,6 +189,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 raise UpdateFailed(
                     f"There was an unknown error while updating {attr}: {result}"
                 ) from result
+            if isinstance(result, BaseException):
+                raise result from None
 
             data.update_data_from_response(result)
 

--- a/homeassistant/components/wiz/discovery.py
+++ b/homeassistant/components/wiz/discovery.py
@@ -33,6 +33,8 @@ async def async_discover_devices(
         if isinstance(discovered, Exception):
             _LOGGER.debug("Scanning %s failed with error: %s", targets[idx], discovered)
             continue
+        if isinstance(discovered, BaseException):
+            raise discovered from None
         for device in discovered:
             assert isinstance(device, DiscoveredBulb)
             combined_discoveries[device.ip_address] = device

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -885,7 +885,7 @@ async def entity_service_call(
 
     # Use asyncio.gather here to ensure the returned results
     # are in the same order as the entities list
-    results: list[ServiceResponse] = await asyncio.gather(
+    results: list[ServiceResponse | BaseException] = await asyncio.gather(
         *[
             entity.async_request_call(
                 _handle_entity_call(hass, entity, func, data, call.context)
@@ -897,8 +897,8 @@ async def entity_service_call(
 
     response_data: EntityServiceResponse = {}
     for entity, result in zip(entities, results):
-        if isinstance(result, Exception):
-            raise result
+        if isinstance(result, BaseException):
+            raise result from None
         response_data[entity.entity_id] = result
 
     tasks: list[asyncio.Task[None]] = []

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -305,7 +305,7 @@ async def async_initialize_triggers(
     variables: TemplateVarsType = None,
 ) -> CALLBACK_TYPE | None:
     """Initialize triggers."""
-    triggers = []
+    triggers: list[Coroutine[Any, Any, CALLBACK_TYPE]] = []
     for idx, conf in enumerate(trigger_config):
         # Skip triggers that are not enabled
         if not conf.get(CONF_ENABLED, True):
@@ -338,6 +338,8 @@ async def async_initialize_triggers(
             log_cb(logging.ERROR, f"Got error '{result}' when setting up triggers for")
         elif isinstance(result, Exception):
             log_cb(logging.ERROR, "Error setting up trigger", exc_info=result)
+        elif isinstance(result, BaseException):
+            raise result from None
         elif result is None:
             log_cb(
                 logging.ERROR, "Unknown error while setting up trigger (empty result)"


### PR DESCRIPTION
## Proposed change
If `asyncio.gather` is used with `return_exceptions=True`, `BaseExceptions` are caught as well.
It's probably best to just re-raise them.

https://docs.python.org/3/library/asyncio-task.html#asyncio.gather

Required for:
- #103800

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
