### PR TITLE
Hydrawise: Explicitly set switch state on toggle

### DIFF
--- a/homeassistant/components/hydrawise/switch.py
+++ b/homeassistant/components/hydrawise/switch.py
@@ -114,6 +114,8 @@ class HydrawiseSwitch(HydrawiseEntity, SwitchEntity):
             self.coordinator.api.run_zone(self._default_watering_timer, zone_number)
         elif self.entity_description.key == "auto_watering":
             self.coordinator.api.suspend_zone(0, zone_number)
+        self._attr_is_on = True
+        self.async_write_ha_state()
 
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
@@ -122,6 +124,8 @@ class HydrawiseSwitch(HydrawiseEntity, SwitchEntity):
             self.coordinator.api.run_zone(0, zone_number)
         elif self.entity_description.key == "auto_watering":
             self.coordinator.api.suspend_zone(365, zone_number)
+        self._attr_is_on = False
+        self.async_write_ha_state()
 
     def _update_attrs(self) -> None:
         """Update state attributes."""

--- a/tests/components/hydrawise/test_switch.py
+++ b/tests/components/hydrawise/test_switch.py
@@ -45,6 +45,9 @@ async def test_manual_watering_services(
         blocking=True,
     )
     mock_pydrawise.run_zone.assert_called_once_with(15, 1)
+    state = hass.states.get("switch.zone_one_manual_watering")
+    assert state is not None
+    assert state.state == "on"
     mock_pydrawise.reset_mock()
 
     await hass.services.async_call(
@@ -54,6 +57,9 @@ async def test_manual_watering_services(
         blocking=True,
     )
     mock_pydrawise.run_zone.assert_called_once_with(0, 1)
+    state = hass.states.get("switch.zone_one_manual_watering")
+    assert state is not None
+    assert state.state == "off"
 
 
 async def test_auto_watering_services(
@@ -67,6 +73,9 @@ async def test_auto_watering_services(
         blocking=True,
     )
     mock_pydrawise.suspend_zone.assert_called_once_with(365, 1)
+    state = hass.states.get("switch.zone_one_automatic_watering")
+    assert state is not None
+    assert state.state == "off"
     mock_pydrawise.reset_mock()
 
     await hass.services.async_call(
@@ -76,3 +85,6 @@ async def test_auto_watering_services(
         blocking=True,
     )
     mock_pydrawise.suspend_zone.assert_called_once_with(0, 1)
+    state = hass.states.get("switch.zone_one_automatic_watering")
+    assert state is not None
+    assert state.state == "on"


### PR DESCRIPTION
## Proposed change
Explicitly set `self._attr_is_on` when a Hydrawise switch is toggled.

This prevents the switch bouncing that users have reported in #103629 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #103629
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
