### PR TITLE
Update f-g* tests to use entity & device registry fixtures

### DIFF
--- a/tests/components/fibaro/test_scene.py
+++ b/tests/components/fibaro/test_scene.py
@@ -13,6 +13,7 @@ from tests.common import MockConfigEntry
 
 async def test_entity_attributes(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     mock_fibaro_client: Mock,
     mock_config_entry: MockConfigEntry,
     mock_scene: Mock,
@@ -22,7 +23,6 @@ async def test_entity_attributes(
     # Arrange
     mock_fibaro_client.read_rooms.return_value = [mock_room]
     mock_fibaro_client.read_scenes.return_value = [mock_scene]
-    entity_registry = er.async_get(hass)
     # Act
     await init_integration(hass, mock_config_entry)
     # Assert
@@ -35,6 +35,7 @@ async def test_entity_attributes(
 
 async def test_entity_attributes_without_room(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     mock_fibaro_client: Mock,
     mock_config_entry: MockConfigEntry,
     mock_scene: Mock,
@@ -45,7 +46,6 @@ async def test_entity_attributes_without_room(
     mock_room.name = None
     mock_fibaro_client.read_rooms.return_value = [mock_room]
     mock_fibaro_client.read_scenes.return_value = [mock_scene]
-    entity_registry = er.async_get(hass)
     # Act
     await init_integration(hass, mock_config_entry)
     # Assert

--- a/tests/components/filter/test_sensor.py
+++ b/tests/components/filter/test_sensor.py
@@ -249,7 +249,9 @@ async def test_history_time(recorder_mock: Recorder, hass: HomeAssistant) -> Non
         assert state.state == "18.0"
 
 
-async def test_setup(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_setup(
+    recorder_mock: Recorder, hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test if filter attributes are inherited."""
     config = {
         "sensor": {
@@ -284,8 +286,7 @@ async def test_setup(recorder_mock: Recorder, hass: HomeAssistant) -> None:
         assert state.attributes[ATTR_STATE_CLASS] is SensorStateClass.TOTAL_INCREASING
         assert state.state == "1.0"
 
-        entity_reg = er.async_get(hass)
-        entity_id = entity_reg.async_get_entity_id(
+        entity_id = entity_registry.async_get_entity_id(
             "sensor", DOMAIN, "uniqueid_sensor_test"
         )
         assert entity_id == "sensor.test"

--- a/tests/components/fitbit/test_sensor.py
+++ b/tests/components/fitbit/test_sensor.py
@@ -279,7 +279,6 @@ async def test_device_battery(
         "type": "scale",
     }
 
-    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get("sensor.aria_air_battery")
     assert entry
     assert entry.unique_id == f"{PROFILE_USER_ID}_devices/battery_016713257"

--- a/tests/components/flic/test_binary_sensor.py
+++ b/tests/components/flic/test_binary_sensor.py
@@ -29,7 +29,9 @@ class _MockFlicClient:
         self.channel = channel
 
 
-async def test_button_uid(hass: HomeAssistant) -> None:
+async def test_button_uid(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test UID assignment for Flic buttons."""
     address_to_name = {
         "80:e4:da:78:6e:11": "binary_sensor.flic_80e4da786e11",
@@ -53,7 +55,6 @@ async def test_button_uid(hass: HomeAssistant) -> None:
 
         await hass.async_block_till_done()
 
-        entity_registry = er.async_get(hass)
         for address, name in address_to_name.items():
             state = hass.states.get(name)
             assert state

--- a/tests/components/flux_led/test_init.py
+++ b/tests/components/flux_led/test_init.py
@@ -139,7 +139,7 @@ async def test_config_entry_retry_right_away_on_discovery(hass: HomeAssistant) -
 
 
 async def test_coordinator_retry_right_away_on_discovery_already_setup(
-    hass: HomeAssistant,
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test discovery makes the coordinator force poll if its already setup."""
     config_entry = MockConfigEntry(
@@ -156,7 +156,6 @@ async def test_coordinator_retry_right_away_on_discovery_already_setup(
     assert config_entry.state == ConfigEntryState.LOADED
 
     entity_id = "light.bulb_rgbcw_ddeeff"
-    entity_registry = er.async_get(hass)
     assert entity_registry.async_get(entity_id).unique_id == MAC_ADDRESS
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
@@ -241,7 +240,9 @@ async def test_time_sync_startup_and_next_day(hass: HomeAssistant) -> None:
     assert len(bulb.async_set_time.mock_calls) == 2
 
 
-async def test_unique_id_migrate_when_mac_discovered(hass: HomeAssistant) -> None:
+async def test_unique_id_migrate_when_mac_discovered(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test unique id migrated when mac discovered."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -260,7 +261,6 @@ async def test_unique_id_migrate_when_mac_discovered(hass: HomeAssistant) -> Non
         await hass.async_block_till_done()
 
     assert not config_entry.unique_id
-    entity_registry = er.async_get(hass)
     assert (
         entity_registry.async_get("light.bulb_rgbcw_ddeeff").unique_id
         == config_entry.entry_id
@@ -285,7 +285,7 @@ async def test_unique_id_migrate_when_mac_discovered(hass: HomeAssistant) -> Non
 
 
 async def test_unique_id_migrate_when_mac_discovered_via_discovery(
-    hass: HomeAssistant,
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test unique id migrated when mac discovered via discovery and the mac address from dhcp was one off."""
     config_entry = MockConfigEntry(
@@ -306,7 +306,6 @@ async def test_unique_id_migrate_when_mac_discovered_via_discovery(
         await hass.async_block_till_done()
 
     assert config_entry.unique_id == MAC_ADDRESS_ONE_OFF
-    entity_registry = er.async_get(hass)
     assert (
         entity_registry.async_get("light.bulb_rgbcw_ddeeff").unique_id
         == MAC_ADDRESS_ONE_OFF

--- a/tests/components/flux_led/test_light.py
+++ b/tests/components/flux_led/test_light.py
@@ -81,7 +81,9 @@ from . import (
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_light_unique_id(hass: HomeAssistant) -> None:
+async def test_light_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test a light unique id."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -95,13 +97,14 @@ async def test_light_unique_id(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     entity_id = "light.bulb_rgbcw_ddeeff"
-    entity_registry = er.async_get(hass)
     assert entity_registry.async_get(entity_id).unique_id == MAC_ADDRESS
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
 
 
-async def test_light_goes_unavailable_and_recovers(hass: HomeAssistant) -> None:
+async def test_light_goes_unavailable_and_recovers(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test a light goes unavailable and then recovers."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -115,7 +118,6 @@ async def test_light_goes_unavailable_and_recovers(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     entity_id = "light.bulb_rgbcw_ddeeff"
-    entity_registry = er.async_get(hass)
     assert entity_registry.async_get(entity_id).unique_id == MAC_ADDRESS
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
@@ -135,7 +137,9 @@ async def test_light_goes_unavailable_and_recovers(hass: HomeAssistant) -> None:
     assert state.state == STATE_ON
 
 
-async def test_light_mac_address_not_found(hass: HomeAssistant) -> None:
+async def test_light_mac_address_not_found(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test a light when we cannot discover the mac address."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: IP_ADDRESS, CONF_NAME: DEFAULT_ENTRY_TITLE}
@@ -147,7 +151,6 @@ async def test_light_mac_address_not_found(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     entity_id = "light.bulb_rgbcw_ddeeff"
-    entity_registry = er.async_get(hass)
     assert entity_registry.async_get(entity_id).unique_id == config_entry.entry_id
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
@@ -161,7 +164,12 @@ async def test_light_mac_address_not_found(hass: HomeAssistant) -> None:
     ],
 )
 async def test_light_device_registry(
-    hass: HomeAssistant, protocol: str, sw_version: int, model_num: int, model: str
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    protocol: str,
+    sw_version: int,
+    model_num: int,
+    model: str,
 ) -> None:
     """Test a light device registry entry."""
     config_entry = MockConfigEntry(
@@ -180,7 +188,6 @@ async def test_light_device_registry(
         await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
         await hass.async_block_till_done()
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, MAC_ADDRESS)}
     )

--- a/tests/components/flux_led/test_number.py
+++ b/tests/components/flux_led/test_number.py
@@ -41,7 +41,9 @@ from . import (
 from tests.common import MockConfigEntry
 
 
-async def test_effects_speed_unique_id(hass: HomeAssistant) -> None:
+async def test_effects_speed_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test a number unique id."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -55,11 +57,12 @@ async def test_effects_speed_unique_id(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     entity_id = "number.bulb_rgbcw_ddeeff_effect_speed"
-    entity_registry = er.async_get(hass)
     assert entity_registry.async_get(entity_id).unique_id == MAC_ADDRESS
 
 
-async def test_effects_speed_unique_id_no_discovery(hass: HomeAssistant) -> None:
+async def test_effects_speed_unique_id_no_discovery(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test a number unique id."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -72,7 +75,6 @@ async def test_effects_speed_unique_id_no_discovery(hass: HomeAssistant) -> None
         await hass.async_block_till_done()
 
     entity_id = "number.bulb_rgbcw_ddeeff_effect_speed"
-    entity_registry = er.async_get(hass)
     assert entity_registry.async_get(entity_id).unique_id == config_entry.entry_id
 
 

--- a/tests/components/flux_led/test_select.py
+++ b/tests/components/flux_led/test_select.py
@@ -68,7 +68,9 @@ async def test_switch_power_restore_state(hass: HomeAssistant) -> None:
     )
 
 
-async def test_power_restored_unique_id(hass: HomeAssistant) -> None:
+async def test_power_restored_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test a select unique id."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -82,14 +84,15 @@ async def test_power_restored_unique_id(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     entity_id = "select.bulb_rgbcw_ddeeff_power_restored"
-    entity_registry = er.async_get(hass)
     assert (
         entity_registry.async_get(entity_id).unique_id
         == f"{MAC_ADDRESS}_power_restored"
     )
 
 
-async def test_power_restored_unique_id_no_discovery(hass: HomeAssistant) -> None:
+async def test_power_restored_unique_id_no_discovery(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test a select unique id."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -102,7 +105,6 @@ async def test_power_restored_unique_id_no_discovery(hass: HomeAssistant) -> Non
         await hass.async_block_till_done()
 
     entity_id = "select.bulb_rgbcw_ddeeff_power_restored"
-    entity_registry = er.async_get(hass)
     assert (
         entity_registry.async_get(entity_id).unique_id
         == f"{config_entry.entry_id}_power_restored"

--- a/tests/components/flux_led/test_switch.py
+++ b/tests/components/flux_led/test_switch.py
@@ -71,7 +71,9 @@ async def test_switch_on_off(hass: HomeAssistant) -> None:
     assert hass.states.get(entity_id).state == STATE_ON
 
 
-async def test_remote_access_unique_id(hass: HomeAssistant) -> None:
+async def test_remote_access_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test a remote access switch unique id."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -91,13 +93,14 @@ async def test_remote_access_unique_id(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     entity_id = "switch.bulb_rgbcw_ddeeff_remote_access"
-    entity_registry = er.async_get(hass)
     assert (
         entity_registry.async_get(entity_id).unique_id == f"{MAC_ADDRESS}_remote_access"
     )
 
 
-async def test_effects_speed_unique_id_no_discovery(hass: HomeAssistant) -> None:
+async def test_effects_speed_unique_id_no_discovery(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test a remote access switch unique id when discovery fails."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -116,7 +119,6 @@ async def test_effects_speed_unique_id_no_discovery(hass: HomeAssistant) -> None
         await hass.async_block_till_done()
 
     entity_id = "switch.bulb_rgbcw_ddeeff_remote_access"
-    entity_registry = er.async_get(hass)
     assert (
         entity_registry.async_get(entity_id).unique_id
         == f"{config_entry.entry_id}_remote_access"

--- a/tests/components/forecast_solar/test_sensor.py
+++ b/tests/components/forecast_solar/test_sensor.py
@@ -26,12 +26,12 @@ from tests.common import MockConfigEntry
 
 async def test_sensors(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
     init_integration: MockConfigEntry,
 ) -> None:
     """Test the Forecast.Solar sensors."""
     entry_id = init_integration.entry_id
-    entity_registry = er.async_get(hass)
-    device_registry = dr.async_get(hass)
 
     state = hass.states.get("sensor.energy_production_today")
     entry = entity_registry.async_get("sensor.energy_production_today")
@@ -173,11 +173,12 @@ async def test_sensors(
     ),
 )
 async def test_disabled_by_default(
-    hass: HomeAssistant, init_integration: MockConfigEntry, entity_id: str
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    init_integration: MockConfigEntry,
+    entity_id: str,
 ) -> None:
     """Test the Forecast.Solar sensors that are disabled by default."""
-    entity_registry = er.async_get(hass)
-
     state = hass.states.get(entity_id)
     assert state is None
 
@@ -209,6 +210,7 @@ async def test_disabled_by_default(
 )
 async def test_enabling_disable_by_default(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
     mock_forecast_solar: MagicMock,
     key: str,
@@ -218,7 +220,6 @@ async def test_enabling_disable_by_default(
     """Test the Forecast.Solar sensors that are disabled by default."""
     entry_id = mock_config_entry.entry_id
     entity_id = f"{SENSOR_DOMAIN}.{key}"
-    entity_registry = er.async_get(hass)
 
     # Pre-create registry entry for disabled by default sensor
     entity_registry.async_get_or_create(

--- a/tests/components/freedompro/test_binary_sensor.py
+++ b/tests/components/freedompro/test_binary_sensor.py
@@ -45,6 +45,8 @@ from tests.common import async_fire_time_changed
 )
 async def test_binary_sensor_get_state(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
     init_integration,
     entity_id: str,
     uid: str,
@@ -53,10 +55,8 @@ async def test_binary_sensor_get_state(
 ) -> None:
     """Test states of the binary_sensor."""
     init_integration
-    registry = er.async_get(hass)
-    registry_device = dr.async_get(hass)
 
-    device = registry_device.async_get_device(identifiers={("freedompro", uid)})
+    device = device_registry.async_get_device(identifiers={("freedompro", uid)})
     assert device is not None
     assert device.identifiers == {("freedompro", uid)}
     assert device.manufacturer == "Freedompro"
@@ -67,7 +67,7 @@ async def test_binary_sensor_get_state(
     assert state
     assert state.attributes.get("friendly_name") == name
 
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == uid
 
@@ -84,7 +84,7 @@ async def test_binary_sensor_get_state(
         assert state
         assert state.attributes.get("friendly_name") == name
 
-        entry = registry.async_get(entity_id)
+        entry = entity_registry.async_get(entity_id)
         assert entry
         assert entry.unique_id == uid
 
@@ -110,7 +110,7 @@ async def test_binary_sensor_get_state(
         assert state
         assert state.attributes.get("friendly_name") == name
 
-        entry = registry.async_get(entity_id)
+        entry = entity_registry.async_get(entity_id)
         assert entry
         assert entry.unique_id == uid
 

--- a/tests/components/freedompro/test_climate.py
+++ b/tests/components/freedompro/test_climate.py
@@ -28,11 +28,13 @@ from tests.common import async_fire_time_changed
 uid = "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*TWMYQKL3UVED4HSIIB9GXJWJZBQCXG-9VE-N2IUAIWI"
 
 
-async def test_climate_get_state(hass: HomeAssistant, init_integration) -> None:
+async def test_climate_get_state(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    init_integration,
+) -> None:
     """Test states of the climate."""
-    entity_registry = er.async_get(hass)
-    device_registry = dr.async_get(hass)
-
     device = device_registry.async_get_device(identifiers={("freedompro", uid)})
     assert device is not None
     assert device.identifiers == {("freedompro", uid)}
@@ -84,10 +86,11 @@ async def test_climate_get_state(hass: HomeAssistant, init_integration) -> None:
         assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 20
 
 
-async def test_climate_set_off(hass: HomeAssistant, init_integration) -> None:
+async def test_climate_set_off(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, init_integration
+) -> None:
     """Test set off climate."""
     init_integration
-    entity_registry = er.async_get(hass)
 
     entity_id = "climate.thermostat"
     state = hass.states.get(entity_id)
@@ -115,11 +118,10 @@ async def test_climate_set_off(hass: HomeAssistant, init_integration) -> None:
 
 
 async def test_climate_set_unsupported_hvac_mode(
-    hass: HomeAssistant, init_integration
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, init_integration
 ) -> None:
     """Test set unsupported hvac mode climate."""
     init_integration
-    entity_registry = er.async_get(hass)
 
     entity_id = "climate.thermostat"
     state = hass.states.get(entity_id)
@@ -139,10 +141,11 @@ async def test_climate_set_unsupported_hvac_mode(
         )
 
 
-async def test_climate_set_temperature(hass: HomeAssistant, init_integration) -> None:
+async def test_climate_set_temperature(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, init_integration
+) -> None:
     """Test set temperature climate."""
     init_integration
-    entity_registry = er.async_get(hass)
 
     entity_id = "climate.thermostat"
     state = hass.states.get(entity_id)
@@ -185,11 +188,10 @@ async def test_climate_set_temperature(hass: HomeAssistant, init_integration) ->
 
 
 async def test_climate_set_temperature_unsupported_hvac_mode(
-    hass: HomeAssistant, init_integration
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, init_integration
 ) -> None:
     """Test set temperature climate unsupported hvac mode."""
     init_integration
-    entity_registry = er.async_get(hass)
 
     entity_id = "climate.thermostat"
     state = hass.states.get(entity_id)

--- a/tests/components/freedompro/test_cover.py
+++ b/tests/components/freedompro/test_cover.py
@@ -36,6 +36,8 @@ from tests.common import async_fire_time_changed
 )
 async def test_cover_get_state(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
     init_integration,
     entity_id: str,
     uid: str,
@@ -44,10 +46,8 @@ async def test_cover_get_state(
 ) -> None:
     """Test states of the cover."""
     init_integration
-    registry = er.async_get(hass)
-    registry_device = dr.async_get(hass)
 
-    device = registry_device.async_get_device(identifiers={("freedompro", uid)})
+    device = device_registry.async_get_device(identifiers={("freedompro", uid)})
     assert device is not None
     assert device.identifiers == {("freedompro", uid)}
     assert device.manufacturer == "Freedompro"
@@ -59,7 +59,7 @@ async def test_cover_get_state(
     assert state.state == STATE_CLOSED
     assert state.attributes.get("friendly_name") == name
 
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == uid
 
@@ -76,7 +76,7 @@ async def test_cover_get_state(
         assert state
         assert state.attributes.get("friendly_name") == name
 
-        entry = registry.async_get(entity_id)
+        entry = entity_registry.async_get(entity_id)
         assert entry
         assert entry.unique_id == uid
 
@@ -96,6 +96,7 @@ async def test_cover_get_state(
 )
 async def test_cover_set_position(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     init_integration,
     entity_id: str,
     uid: str,
@@ -104,14 +105,13 @@ async def test_cover_set_position(
 ) -> None:
     """Test set position of the cover."""
     init_integration
-    registry = er.async_get(hass)
 
     state = hass.states.get(entity_id)
     assert state
     assert state.state == STATE_CLOSED
     assert state.attributes.get("friendly_name") == name
 
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == uid
 
@@ -151,6 +151,7 @@ async def test_cover_set_position(
 )
 async def test_cover_close(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     init_integration,
     entity_id: str,
     uid: str,
@@ -159,7 +160,6 @@ async def test_cover_close(
 ) -> None:
     """Test close cover."""
     init_integration
-    registry = er.async_get(hass)
 
     states_response = get_states_response_for_uid(uid)
     states_response[0]["state"]["position"] = 100
@@ -176,7 +176,7 @@ async def test_cover_close(
     assert state.state == STATE_OPEN
     assert state.attributes.get("friendly_name") == name
 
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == uid
 
@@ -214,6 +214,7 @@ async def test_cover_close(
 )
 async def test_cover_open(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     init_integration,
     entity_id: str,
     uid: str,
@@ -222,14 +223,13 @@ async def test_cover_open(
 ) -> None:
     """Test open cover."""
     init_integration
-    registry = er.async_get(hass)
 
     state = hass.states.get(entity_id)
     assert state
     assert state.state == STATE_CLOSED
     assert state.attributes.get("friendly_name") == name
 
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == uid
 

--- a/tests/components/freedompro/test_fan.py
+++ b/tests/components/freedompro/test_fan.py
@@ -21,13 +21,16 @@ from tests.common import async_fire_time_changed
 uid = "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*ILYH1E3DWZOVMNEUIMDYMNLOW-LFRQFDPWWJOVHVDOS"
 
 
-async def test_fan_get_state(hass: HomeAssistant, init_integration) -> None:
+async def test_fan_get_state(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    init_integration,
+) -> None:
     """Test states of the fan."""
     init_integration
-    registry = er.async_get(hass)
-    registry_device = dr.async_get(hass)
 
-    device = registry_device.async_get_device(identifiers={("freedompro", uid)})
+    device = device_registry.async_get_device(identifiers={("freedompro", uid)})
     assert device is not None
     assert device.identifiers == {("freedompro", uid)}
     assert device.manufacturer == "Freedompro"
@@ -41,7 +44,7 @@ async def test_fan_get_state(hass: HomeAssistant, init_integration) -> None:
     assert state.attributes[ATTR_PERCENTAGE] == 0
     assert state.attributes.get("friendly_name") == "bedroom"
 
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == uid
 
@@ -59,7 +62,7 @@ async def test_fan_get_state(hass: HomeAssistant, init_integration) -> None:
         assert state
         assert state.attributes.get("friendly_name") == "bedroom"
 
-        entry = registry.async_get(entity_id)
+        entry = entity_registry.async_get(entity_id)
         assert entry
         assert entry.unique_id == uid
 
@@ -67,10 +70,11 @@ async def test_fan_get_state(hass: HomeAssistant, init_integration) -> None:
         assert state.attributes[ATTR_PERCENTAGE] == 50
 
 
-async def test_fan_set_off(hass: HomeAssistant, init_integration) -> None:
+async def test_fan_set_off(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, init_integration
+) -> None:
     """Test turn off the fan."""
     init_integration
-    registry = er.async_get(hass)
 
     entity_id = "fan.bedroom"
 
@@ -91,7 +95,7 @@ async def test_fan_set_off(hass: HomeAssistant, init_integration) -> None:
     assert state.attributes[ATTR_PERCENTAGE] == 50
     assert state.attributes.get("friendly_name") == "bedroom"
 
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == uid
 
@@ -120,10 +124,11 @@ async def test_fan_set_off(hass: HomeAssistant, init_integration) -> None:
     assert state.state == STATE_OFF
 
 
-async def test_fan_set_on(hass: HomeAssistant, init_integration) -> None:
+async def test_fan_set_on(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, init_integration
+) -> None:
     """Test turn on the fan."""
     init_integration
-    registry = er.async_get(hass)
 
     entity_id = "fan.bedroom"
     state = hass.states.get(entity_id)
@@ -132,7 +137,7 @@ async def test_fan_set_on(hass: HomeAssistant, init_integration) -> None:
     assert state.attributes[ATTR_PERCENTAGE] == 0
     assert state.attributes.get("friendly_name") == "bedroom"
 
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == uid
 
@@ -160,10 +165,11 @@ async def test_fan_set_on(hass: HomeAssistant, init_integration) -> None:
     assert state.state == STATE_ON
 
 
-async def test_fan_set_percent(hass: HomeAssistant, init_integration) -> None:
+async def test_fan_set_percent(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, init_integration
+) -> None:
     """Test turn on the fan."""
     init_integration
-    registry = er.async_get(hass)
 
     entity_id = "fan.bedroom"
     state = hass.states.get(entity_id)
@@ -172,7 +178,7 @@ async def test_fan_set_percent(hass: HomeAssistant, init_integration) -> None:
     assert state.attributes[ATTR_PERCENTAGE] == 0
     assert state.attributes.get("friendly_name") == "bedroom"
 
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == uid
 

--- a/tests/components/freedompro/test_light.py
+++ b/tests/components/freedompro/test_light.py
@@ -21,10 +21,11 @@ def mock_freedompro_put_state():
         yield
 
 
-async def test_light_get_state(hass: HomeAssistant, init_integration) -> None:
+async def test_light_get_state(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, init_integration
+) -> None:
     """Test states of the light."""
     init_integration
-    registry = er.async_get(hass)
 
     entity_id = "light.lightbulb"
     state = hass.states.get(entity_id)
@@ -32,7 +33,7 @@ async def test_light_get_state(hass: HomeAssistant, init_integration) -> None:
     assert state.state == STATE_ON
     assert state.attributes.get("friendly_name") == "lightbulb"
 
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert (
         entry.unique_id
@@ -40,10 +41,11 @@ async def test_light_get_state(hass: HomeAssistant, init_integration) -> None:
     )
 
 
-async def test_light_set_on(hass: HomeAssistant, init_integration) -> None:
+async def test_light_set_on(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, init_integration
+) -> None:
     """Test set on of the light."""
     init_integration
-    registry = er.async_get(hass)
 
     entity_id = "light.lightbulb"
     state = hass.states.get(entity_id)
@@ -51,7 +53,7 @@ async def test_light_set_on(hass: HomeAssistant, init_integration) -> None:
     assert state.state == STATE_ON
     assert state.attributes.get("friendly_name") == "lightbulb"
 
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert (
         entry.unique_id
@@ -70,10 +72,11 @@ async def test_light_set_on(hass: HomeAssistant, init_integration) -> None:
     assert state.state == STATE_ON
 
 
-async def test_light_set_off(hass: HomeAssistant, init_integration) -> None:
+async def test_light_set_off(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, init_integration
+) -> None:
     """Test set off of the light."""
     init_integration
-    registry = er.async_get(hass)
 
     entity_id = "light.bedroomlight"
     state = hass.states.get(entity_id)
@@ -81,7 +84,7 @@ async def test_light_set_off(hass: HomeAssistant, init_integration) -> None:
     assert state.state == STATE_OFF
     assert state.attributes.get("friendly_name") == "bedroomlight"
 
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert (
         entry.unique_id
@@ -100,10 +103,11 @@ async def test_light_set_off(hass: HomeAssistant, init_integration) -> None:
     assert state.state == STATE_OFF
 
 
-async def test_light_set_brightness(hass: HomeAssistant, init_integration) -> None:
+async def test_light_set_brightness(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, init_integration
+) -> None:
     """Test set brightness of the light."""
     init_integration
-    registry = er.async_get(hass)
 
     entity_id = "light.lightbulb"
     state = hass.states.get(entity_id)
@@ -111,7 +115,7 @@ async def test_light_set_brightness(hass: HomeAssistant, init_integration) -> No
     assert state.state == STATE_ON
     assert state.attributes.get("friendly_name") == "lightbulb"
 
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert (
         entry.unique_id
@@ -131,10 +135,11 @@ async def test_light_set_brightness(hass: HomeAssistant, init_integration) -> No
     assert int(state.attributes[ATTR_BRIGHTNESS]) == 0
 
 
-async def test_light_set_hue(hass: HomeAssistant, init_integration) -> None:
+async def test_light_set_hue(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, init_integration
+) -> None:
     """Test set brightness of the light."""
     init_integration
-    registry = er.async_get(hass)
 
     entity_id = "light.lightbulb"
     state = hass.states.get(entity_id)
@@ -142,7 +147,7 @@ async def test_light_set_hue(hass: HomeAssistant, init_integration) -> None:
     assert state.state == STATE_ON
     assert state.attributes.get("friendly_name") == "lightbulb"
 
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert (
         entry.unique_id

--- a/tests/components/freedompro/test_lock.py
+++ b/tests/components/freedompro/test_lock.py
@@ -20,13 +20,16 @@ from tests.common import async_fire_time_changed
 uid = "2WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*2VAS3HTWINNZ5N6HVEIPDJ6NX85P2-AM-GSYWUCNPU0"
 
 
-async def test_lock_get_state(hass: HomeAssistant, init_integration) -> None:
+async def test_lock_get_state(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    init_integration,
+) -> None:
     """Test states of the lock."""
     init_integration
-    registry = er.async_get(hass)
-    registry_device = dr.async_get(hass)
 
-    device = registry_device.async_get_device(identifiers={("freedompro", uid)})
+    device = device_registry.async_get_device(identifiers={("freedompro", uid)})
     assert device is not None
     assert device.identifiers == {("freedompro", uid)}
     assert device.manufacturer == "Freedompro"
@@ -39,7 +42,7 @@ async def test_lock_get_state(hass: HomeAssistant, init_integration) -> None:
     assert state.state == STATE_UNLOCKED
     assert state.attributes.get("friendly_name") == "lock"
 
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == uid
 
@@ -56,17 +59,18 @@ async def test_lock_get_state(hass: HomeAssistant, init_integration) -> None:
         assert state
         assert state.attributes.get("friendly_name") == "lock"
 
-        entry = registry.async_get(entity_id)
+        entry = entity_registry.async_get(entity_id)
         assert entry
         assert entry.unique_id == uid
 
         assert state.state == STATE_LOCKED
 
 
-async def test_lock_set_unlock(hass: HomeAssistant, init_integration) -> None:
+async def test_lock_set_unlock(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, init_integration
+) -> None:
     """Test set on of the lock."""
     init_integration
-    registry = er.async_get(hass)
 
     entity_id = "lock.lock"
 
@@ -85,7 +89,7 @@ async def test_lock_set_unlock(hass: HomeAssistant, init_integration) -> None:
     assert state.state == STATE_LOCKED
     assert state.attributes.get("friendly_name") == "lock"
 
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == uid
 
@@ -111,10 +115,11 @@ async def test_lock_set_unlock(hass: HomeAssistant, init_integration) -> None:
     assert state.state == STATE_UNLOCKED
 
 
-async def test_lock_set_lock(hass: HomeAssistant, init_integration) -> None:
+async def test_lock_set_lock(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, init_integration
+) -> None:
     """Test set on of the lock."""
     init_integration
-    registry = er.async_get(hass)
 
     entity_id = "lock.lock"
     state = hass.states.get(entity_id)
@@ -122,7 +127,7 @@ async def test_lock_set_lock(hass: HomeAssistant, init_integration) -> None:
     assert state.state == STATE_UNLOCKED
     assert state.attributes.get("friendly_name") == "lock"
 
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == uid
 

--- a/tests/components/freedompro/test_sensor.py
+++ b/tests/components/freedompro/test_sensor.py
@@ -34,17 +34,21 @@ from tests.common import async_fire_time_changed
     ],
 )
 async def test_sensor_get_state(
-    hass: HomeAssistant, init_integration, entity_id: str, uid: str, name: str
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    init_integration,
+    entity_id: str,
+    uid: str,
+    name: str,
 ) -> None:
     """Test states of the sensor."""
     init_integration
-    registry = er.async_get(hass)
 
     state = hass.states.get(entity_id)
     assert state
     assert state.attributes.get("friendly_name") == name
 
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == uid
 
@@ -68,7 +72,7 @@ async def test_sensor_get_state(
         assert state
         assert state.attributes.get("friendly_name") == name
 
-        entry = registry.async_get(entity_id)
+        entry = entity_registry.async_get(entity_id)
         assert entry
         assert entry.unique_id == uid
 

--- a/tests/components/freedompro/test_switch.py
+++ b/tests/components/freedompro/test_switch.py
@@ -16,10 +16,11 @@ from tests.common import async_fire_time_changed
 uid = "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*1JKU1MVWHQL-Z9SCUS85VFXMRGNDCDNDDUVVDKBU31W"
 
 
-async def test_switch_get_state(hass: HomeAssistant, init_integration) -> None:
+async def test_switch_get_state(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, init_integration
+) -> None:
     """Test states of the switch."""
     init_integration
-    registry = er.async_get(hass)
 
     entity_id = "switch.irrigation_switch"
     state = hass.states.get(entity_id)
@@ -27,7 +28,7 @@ async def test_switch_get_state(hass: HomeAssistant, init_integration) -> None:
     assert state.state == STATE_OFF
     assert state.attributes.get("friendly_name") == "Irrigation switch"
 
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == uid
 
@@ -44,17 +45,18 @@ async def test_switch_get_state(hass: HomeAssistant, init_integration) -> None:
         assert state
         assert state.attributes.get("friendly_name") == "Irrigation switch"
 
-        entry = registry.async_get(entity_id)
+        entry = entity_registry.async_get(entity_id)
         assert entry
         assert entry.unique_id == uid
 
         assert state.state == STATE_ON
 
 
-async def test_switch_set_off(hass: HomeAssistant, init_integration) -> None:
+async def test_switch_set_off(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, init_integration
+) -> None:
     """Test set off of the switch."""
     init_integration
-    registry = er.async_get(hass)
 
     entity_id = "switch.irrigation_switch"
 
@@ -73,7 +75,7 @@ async def test_switch_set_off(hass: HomeAssistant, init_integration) -> None:
     assert state.state == STATE_ON
     assert state.attributes.get("friendly_name") == "Irrigation switch"
 
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == uid
 
@@ -101,10 +103,11 @@ async def test_switch_set_off(hass: HomeAssistant, init_integration) -> None:
     assert state.state == STATE_OFF
 
 
-async def test_switch_set_on(hass: HomeAssistant, init_integration) -> None:
+async def test_switch_set_on(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, init_integration
+) -> None:
     """Test set on of the switch."""
     init_integration
-    registry = er.async_get(hass)
 
     entity_id = "switch.irrigation_switch"
     state = hass.states.get(entity_id)
@@ -112,7 +115,7 @@ async def test_switch_set_on(hass: HomeAssistant, init_integration) -> None:
     assert state.state == STATE_OFF
     assert state.attributes.get("friendly_name") == "Irrigation switch"
 
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == uid
 

--- a/tests/components/fritzbox/test_init.py
+++ b/tests/components/fritzbox/test_init.py
@@ -72,6 +72,7 @@ async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
 )
 async def test_update_unique_id(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     fritz: Mock,
     entitydata: dict,
     old_unique_id: str,
@@ -85,7 +86,6 @@ async def test_update_unique_id(
     )
     entry.add_to_hass(hass)
 
-    entity_registry = er.async_get(hass)
     entity: er.RegistryEntry = entity_registry.async_get_or_create(
         **entitydata,
         config_entry=entry,
@@ -131,6 +131,7 @@ async def test_update_unique_id(
 )
 async def test_update_unique_id_no_change(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     fritz: Mock,
     entitydata: dict,
     unique_id: str,
@@ -143,7 +144,6 @@ async def test_update_unique_id_no_change(
     )
     entry.add_to_hass(hass)
 
-    entity_registry = er.async_get(hass)
     entity = entity_registry.async_get_or_create(
         **entitydata,
         config_entry=entry,

--- a/tests/components/fritzbox/test_sensor.py
+++ b/tests/components/fritzbox/test_sensor.py
@@ -26,7 +26,9 @@ from tests.common import async_fire_time_changed
 ENTITY_ID = f"{DOMAIN}.{CONF_FAKE_NAME}"
 
 
-async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
+async def test_setup(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, fritz: Mock
+) -> None:
     """Test setup of platform."""
     device = FritzDeviceSensorMock()
     assert await setup_config_entry(
@@ -61,7 +63,6 @@ async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
         ],
     )
 
-    entity_registry = er.async_get(hass)
     for sensor in sensors:
         state = hass.states.get(sensor[0])
         assert state

--- a/tests/components/fritzbox/test_switch.py
+++ b/tests/components/fritzbox/test_switch.py
@@ -39,7 +39,9 @@ from tests.common import async_fire_time_changed
 ENTITY_ID = f"{DOMAIN}.{CONF_FAKE_NAME}"
 
 
-async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
+async def test_setup(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, fritz: Mock
+) -> None:
     """Test setup of platform."""
     device = FritzDeviceSwitchMock()
     assert await setup_config_entry(
@@ -98,7 +100,6 @@ async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
         ],
     )
 
-    entity_registry = er.async_get(hass)
     for sensor in sensors:
         state = hass.states.get(sensor[0])
         assert state

--- a/tests/components/fronius/test_init.py
+++ b/tests/components/fronius/test_init.py
@@ -60,7 +60,9 @@ async def test_inverter_error(
 
 
 async def test_inverter_night_rescan(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test dynamic adding of an inverter discovered automatically after a Home Assistant reboot during the night."""
     mock_responses(aioclient_mock, fixture_set="igplus_v2", night=True)
@@ -79,7 +81,6 @@ async def test_inverter_night_rescan(
     await hass.async_block_till_done()
 
     # We expect our inverter to be present now
-    device_registry = dr.async_get(hass)
     inverter_1 = device_registry.async_get_device(identifiers={(DOMAIN, "203200")})
     assert inverter_1.manufacturer == "Fronius"
 
@@ -93,13 +94,14 @@ async def test_inverter_night_rescan(
 
 
 async def test_inverter_rescan_interruption(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test interruption of re-scan during runtime to process further."""
     mock_responses(aioclient_mock, fixture_set="igplus_v2", night=True)
     config_entry = await setup_fronius_integration(hass, is_logger=True)
     assert config_entry.state is ConfigEntryState.LOADED
-    device_registry = dr.async_get(hass)
     # Expect 1 devices during the night, logger
     assert (
         len(dr.async_entries_for_config_entry(device_registry, config_entry.entry_id))

--- a/tests/components/fully_kiosk/test_binary_sensor.py
+++ b/tests/components/fully_kiosk/test_binary_sensor.py
@@ -22,14 +22,13 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 async def test_binary_sensors(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
     freezer: FrozenDateTimeFactory,
     mock_fully_kiosk: MagicMock,
     init_integration: MockConfigEntry,
 ) -> None:
     """Test standard Fully Kiosk binary sensors."""
-    entity_registry = er.async_get(hass)
-    device_registry = dr.async_get(hass)
-
     state = hass.states.get("binary_sensor.amazon_fire_plugged_in")
     assert state
     assert state.state == STATE_ON

--- a/tests/components/fully_kiosk/test_button.py
+++ b/tests/components/fully_kiosk/test_button.py
@@ -12,13 +12,12 @@ from tests.common import MockConfigEntry
 
 async def test_buttons(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
     mock_fully_kiosk: MagicMock,
     init_integration: MockConfigEntry,
 ) -> None:
     """Test standard Fully Kiosk buttons."""
-    entity_registry = er.async_get(hass)
-    device_registry = dr.async_get(hass)
-
     entry = entity_registry.async_get("button.amazon_fire_restart_browser")
     assert entry
     assert entry.unique_id == "abcdef-123456-restartApp"

--- a/tests/components/fully_kiosk/test_diagnostics.py
+++ b/tests/components/fully_kiosk/test_diagnostics.py
@@ -17,13 +17,12 @@ from tests.typing import ClientSessionGenerator
 
 async def test_diagnostics(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     hass_client: ClientSessionGenerator,
     mock_fully_kiosk: MagicMock,
     init_integration: MockConfigEntry,
 ) -> None:
     """Test Fully Kiosk diagnostics."""
-
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(identifiers={(DOMAIN, "abcdef-123456")})
 
     diagnostics = await get_diagnostics_for_device(

--- a/tests/components/fully_kiosk/test_init.py
+++ b/tests/components/fully_kiosk/test_init.py
@@ -81,11 +81,10 @@ async def _load_config(
 
 async def test_multiple_kiosk_with_empty_mac(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test that multiple kiosk devices with empty MAC don't get merged."""
-    entity_registry = er.async_get(hass)
-    device_registry = dr.async_get(hass)
-
     config_entry1 = MockConfigEntry(
         title="Test device 1",
         domain=DOMAIN,

--- a/tests/components/fully_kiosk/test_media_player.py
+++ b/tests/components/fully_kiosk/test_media_player.py
@@ -15,13 +15,12 @@ from tests.typing import WebSocketGenerator
 
 async def test_media_player(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
     mock_fully_kiosk: MagicMock,
     init_integration: MockConfigEntry,
 ) -> None:
     """Test standard Fully Kiosk media player."""
-    entity_registry = er.async_get(hass)
-    device_registry = dr.async_get(hass)
-
     state = hass.states.get("media_player.amazon_fire")
     assert state
 

--- a/tests/components/fully_kiosk/test_number.py
+++ b/tests/components/fully_kiosk/test_number.py
@@ -13,13 +13,12 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 async def test_numbers(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
     mock_fully_kiosk: MagicMock,
     init_integration: MockConfigEntry,
 ) -> None:
     """Test standard Fully Kiosk numbers."""
-    entity_registry = er.async_get(hass)
-    device_registry = dr.async_get(hass)
-
     state = hass.states.get("number.amazon_fire_screensaver_timer")
     assert state
     assert state.state == "900"

--- a/tests/components/fully_kiosk/test_sensor.py
+++ b/tests/components/fully_kiosk/test_sensor.py
@@ -26,14 +26,13 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 async def test_sensors_sensors(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
     freezer: FrozenDateTimeFactory,
     mock_fully_kiosk: MagicMock,
     init_integration: MockConfigEntry,
 ) -> None:
     """Test standard Fully Kiosk sensors."""
-    entity_registry = er.async_get(hass)
-    device_registry = dr.async_get(hass)
-
     state = hass.states.get("sensor.amazon_fire_battery")
     assert state
     assert state.state == "100"

--- a/tests/components/fully_kiosk/test_services.py
+++ b/tests/components/fully_kiosk/test_services.py
@@ -23,11 +23,11 @@ from tests.common import MockConfigEntry
 
 async def test_services(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_fully_kiosk: MagicMock,
     init_integration: MockConfigEntry,
 ) -> None:
     """Test the Fully Kiosk Browser services."""
-    device_registry = dr.async_get(hass)
     device_entry = device_registry.async_get_device(
         identifiers={(DOMAIN, "abcdef-123456")}
     )
@@ -103,13 +103,13 @@ async def test_services(
 
 async def test_service_unloaded_entry(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_fully_kiosk: MagicMock,
     init_integration: MockConfigEntry,
 ) -> None:
     """Test service not called when config entry unloaded."""
     await init_integration.async_unload(hass)
 
-    device_registry = dr.async_get(hass)
     device_entry = device_registry.async_get_device(
         identifiers={(DOMAIN, "abcdef-123456")}
     )
@@ -156,12 +156,11 @@ async def test_service_bad_device_id(
 
 async def test_service_called_with_non_fkb_target_devices(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_fully_kiosk: MagicMock,
     init_integration: MockConfigEntry,
 ) -> None:
     """Services raise exception when no valid devices provided."""
-    device_registry = dr.async_get(hass)
-
     other_domain = "NotFullyKiosk"
     other_config_id = "555"
     await hass.config_entries.async_add(

--- a/tests/components/fully_kiosk/test_switch.py
+++ b/tests/components/fully_kiosk/test_switch.py
@@ -11,12 +11,13 @@ from tests.common import MockConfigEntry
 
 
 async def test_switches(
-    hass: HomeAssistant, mock_fully_kiosk: MagicMock, init_integration: MockConfigEntry
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    mock_fully_kiosk: MagicMock,
+    init_integration: MockConfigEntry,
 ) -> None:
     """Test Fully Kiosk switches."""
-    entity_registry = er.async_get(hass)
-    device_registry = dr.async_get(hass)
-
     entity = hass.states.get("switch.amazon_fire_screensaver")
     assert entity
     assert entity.state == "off"

--- a/tests/components/gardena_bluetooth/test_init.py
+++ b/tests/components/gardena_bluetooth/test_init.py
@@ -20,6 +20,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 async def test_setup(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_entry: MockConfigEntry,
     mock_read_char_raw: dict[str, bytes],
     snapshot: SnapshotAssertion,
@@ -34,7 +35,6 @@ async def test_setup(
 
     assert mock_entry.state is ConfigEntryState.LOADED
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(
         identifiers={(DOMAIN, WATER_TIMER_SERVICE_INFO.address)}
     )

--- a/tests/components/gdacs/test_geo_location.py
+++ b/tests/components/gdacs/test_geo_location.py
@@ -44,7 +44,7 @@ from tests.common import async_fire_time_changed
 CONFIG = {gdacs.DOMAIN: {CONF_RADIUS: 200}}
 
 
-async def test_setup(hass: HomeAssistant) -> None:
+async def test_setup(hass: HomeAssistant, entity_registry: er.EntityRegistry) -> None:
     """Test the general setup of the integration."""
     # Set up some mock feed entries for this test.
     mock_entry_1 = _generate_mock_feed_entry(
@@ -106,7 +106,6 @@ async def test_setup(hass: HomeAssistant) -> None:
             + len(hass.states.async_entity_ids("sensor"))
             == 4
         )
-        entity_registry = er.async_get(hass)
         assert len(entity_registry.entities) == 4
 
         state = hass.states.get("geo_location.drought_name_1")

--- a/tests/components/generic_hygrostat/test_humidifier.py
+++ b/tests/components/generic_hygrostat/test_humidifier.py
@@ -170,7 +170,9 @@ async def test_humidifier_switch(
     assert hass.states.get(ENTITY).attributes.get("action") == "humidifying"
 
 
-async def test_unique_id(hass: HomeAssistant, setup_comp_1) -> None:
+async def test_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, setup_comp_1
+) -> None:
     """Test setting a unique ID."""
     unique_id = "some_unique_id"
     _setup_sensor(hass, 18)
@@ -189,8 +191,6 @@ async def test_unique_id(hass: HomeAssistant, setup_comp_1) -> None:
         },
     )
     await hass.async_block_till_done()
-
-    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get(ENTITY)
     assert entry

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -173,7 +173,9 @@ async def test_heater_switch(
     assert hass.states.get(heater_switch).state == STATE_ON
 
 
-async def test_unique_id(hass: HomeAssistant, setup_comp_1) -> None:
+async def test_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, setup_comp_1
+) -> None:
     """Test setting a unique ID."""
     unique_id = "some_unique_id"
     _setup_sensor(hass, 18)
@@ -192,8 +194,6 @@ async def test_unique_id(hass: HomeAssistant, setup_comp_1) -> None:
         },
     )
     await hass.async_block_till_done()
-
-    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get(ENTITY)
     assert entry

--- a/tests/components/geofency/test_init.py
+++ b/tests/components/geofency/test_init.py
@@ -184,7 +184,11 @@ async def test_data_validation(geofency_client, webhook_id) -> None:
 
 
 async def test_gps_enter_and_exit_home(
-    hass: HomeAssistant, geofency_client, webhook_id
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    geofency_client,
+    webhook_id,
 ) -> None:
     """Test GPS based zone enter and exit."""
     url = f"/api/webhook/{webhook_id}"
@@ -223,11 +227,8 @@ async def test_gps_enter_and_exit_home(
     ]
     assert current_longitude == NOT_HOME_LONGITUDE
 
-    dev_reg = dr.async_get(hass)
-    assert len(dev_reg.devices) == 1
-
-    ent_reg = er.async_get(hass)
-    assert len(ent_reg.entities) == 1
+    assert len(device_registry.devices) == 1
+    assert len(entity_registry.entities) == 1
 
 
 async def test_beacon_enter_and_exit_home(

--- a/tests/components/geonetnz_quakes/test_geo_location.py
+++ b/tests/components/geonetnz_quakes/test_geo_location.py
@@ -38,7 +38,7 @@ from tests.common import async_fire_time_changed
 CONFIG = {geonetnz_quakes.DOMAIN: {CONF_RADIUS: 200}}
 
 
-async def test_setup(hass: HomeAssistant) -> None:
+async def test_setup(hass: HomeAssistant, entity_registry: er.EntityRegistry) -> None:
     """Test the general setup of the integration."""
     # Set up some mock feed entries for this test.
     mock_entry_1 = _generate_mock_feed_entry(
@@ -80,7 +80,6 @@ async def test_setup(hass: HomeAssistant) -> None:
             + len(hass.states.async_entity_ids("sensor"))
             == 4
         )
-        entity_registry = er.async_get(hass)
         assert len(entity_registry.entities) == 4
 
         state = hass.states.get("geo_location.title_1")

--- a/tests/components/gios/test_init.py
+++ b/tests/components/gios/test_init.py
@@ -100,11 +100,11 @@ async def test_migrate_device_and_config_entry(
         assert device_entry.id == migrated_device_entry.id
 
 
-async def test_remove_air_quality_entities(hass: HomeAssistant) -> None:
+async def test_remove_air_quality_entities(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test remove air_quality entities from registry."""
-    registry = er.async_get(hass)
-
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         AIR_QUALITY_PLATFORM,
         DOMAIN,
         "123",
@@ -114,5 +114,5 @@ async def test_remove_air_quality_entities(hass: HomeAssistant) -> None:
 
     await init_integration(hass)
 
-    entry = registry.async_get("air_quality.home")
+    entry = entity_registry.async_get("air_quality.home")
     assert entry is None

--- a/tests/components/gios/test_sensor.py
+++ b/tests/components/gios/test_sensor.py
@@ -30,10 +30,9 @@ from . import init_integration
 from tests.common import async_fire_time_changed, load_fixture
 
 
-async def test_sensor(hass: HomeAssistant) -> None:
+async def test_sensor(hass: HomeAssistant, entity_registry: er.EntityRegistry) -> None:
     """Test states of the sensor."""
     await init_integration(hass)
-    registry = er.async_get(hass)
 
     state = hass.states.get("sensor.home_benzene")
     assert state
@@ -46,7 +45,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     )
     assert state.attributes.get(ATTR_ICON) == "mdi:molecule"
 
-    entry = registry.async_get("sensor.home_benzene")
+    entry = entity_registry.async_get("sensor.home_benzene")
     assert entry
     assert entry.unique_id == "123-c6h6"
 
@@ -61,7 +60,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get("sensor.home_carbon_monoxide")
+    entry = entity_registry.async_get("sensor.home_carbon_monoxide")
     assert entry
     assert entry.unique_id == "123-co"
 
@@ -76,7 +75,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get("sensor.home_nitrogen_dioxide")
+    entry = entity_registry.async_get("sensor.home_nitrogen_dioxide")
     assert entry
     assert entry.unique_id == "123-no2"
 
@@ -94,7 +93,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         "very_good",
     ]
 
-    entry = registry.async_get("sensor.home_nitrogen_dioxide_index")
+    entry = entity_registry.async_get("sensor.home_nitrogen_dioxide_index")
     assert entry
     assert entry.unique_id == "123-no2-index"
 
@@ -109,7 +108,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get("sensor.home_ozone")
+    entry = entity_registry.async_get("sensor.home_ozone")
     assert entry
     assert entry.unique_id == "123-o3"
 
@@ -127,7 +126,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         "very_good",
     ]
 
-    entry = registry.async_get("sensor.home_ozone_index")
+    entry = entity_registry.async_get("sensor.home_ozone_index")
     assert entry
     assert entry.unique_id == "123-o3-index"
 
@@ -142,7 +141,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get("sensor.home_pm10")
+    entry = entity_registry.async_get("sensor.home_pm10")
     assert entry
     assert entry.unique_id == "123-pm10"
 
@@ -160,7 +159,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         "very_good",
     ]
 
-    entry = registry.async_get("sensor.home_pm10_index")
+    entry = entity_registry.async_get("sensor.home_pm10_index")
     assert entry
     assert entry.unique_id == "123-pm10-index"
 
@@ -175,7 +174,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get("sensor.home_pm2_5")
+    entry = entity_registry.async_get("sensor.home_pm2_5")
     assert entry
     assert entry.unique_id == "123-pm25"
 
@@ -193,7 +192,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         "very_good",
     ]
 
-    entry = registry.async_get("sensor.home_pm2_5_index")
+    entry = entity_registry.async_get("sensor.home_pm2_5_index")
     assert entry
     assert entry.unique_id == "123-pm25-index"
 
@@ -208,7 +207,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get("sensor.home_sulphur_dioxide")
+    entry = entity_registry.async_get("sensor.home_sulphur_dioxide")
     assert entry
     assert entry.unique_id == "123-so2"
 
@@ -226,7 +225,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         "very_good",
     ]
 
-    entry = registry.async_get("sensor.home_sulphur_dioxide_index")
+    entry = entity_registry.async_get("sensor.home_sulphur_dioxide_index")
     assert entry
     assert entry.unique_id == "123-so2-index"
 
@@ -245,7 +244,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         "very_good",
     ]
 
-    entry = registry.async_get("sensor.home_air_quality_index")
+    entry = entity_registry.async_get("sensor.home_air_quality_index")
     assert entry
     assert entry.unique_id == "123-aqi"
 
@@ -365,11 +364,11 @@ async def test_invalid_indexes(hass: HomeAssistant) -> None:
     assert state is None
 
 
-async def test_unique_id_migration(hass: HomeAssistant) -> None:
+async def test_unique_id_migration(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test states of the unique_id migration."""
-    registry = er.async_get(hass)
-
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         PLATFORM,
         DOMAIN,
         "123-pm2.5",
@@ -379,6 +378,6 @@ async def test_unique_id_migration(hass: HomeAssistant) -> None:
 
     await init_integration(hass)
 
-    entry = registry.async_get("sensor.home_pm2_5")
+    entry = entity_registry.async_get("sensor.home_pm2_5")
     assert entry
     assert entry.unique_id == "123-pm25"

--- a/tests/components/github/test_init.py
+++ b/tests/components/github/test_init.py
@@ -15,6 +15,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 @pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_device_registry_cleanup(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_config_entry: MockConfigEntry,
     aioclient_mock: AiohttpClientMocker,
     caplog: pytest.LogCaptureFixture,
@@ -23,7 +24,6 @@ async def test_device_registry_cleanup(
     mock_config_entry.options = {CONF_REPOSITORIES: ["home-assistant/core"]}
     await setup_github_integration(hass, mock_config_entry, aioclient_mock)
 
-    device_registry = dr.async_get(hass)
     devices = dr.async_entries_for_config_entry(
         registry=device_registry,
         config_entry_id=mock_config_entry.entry_id,

--- a/tests/components/glances/test_sensor.py
+++ b/tests/components/glances/test_sensor.py
@@ -61,16 +61,18 @@ async def test_sensor_states(hass: HomeAssistant) -> None:
     ],
 )
 async def test_migrate_unique_id(
-    hass: HomeAssistant, object_id: str, old_unique_id: str, new_unique_id: str
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    object_id: str,
+    old_unique_id: str,
+    new_unique_id: str,
 ) -> None:
     """Test unique id migration."""
     old_config_data = {**MOCK_USER_INPUT, "name": "Glances"}
     entry = MockConfigEntry(domain=DOMAIN, data=old_config_data)
     entry.add_to_hass(hass)
 
-    ent_reg = er.async_get(hass)
-
-    entity: er.RegistryEntry = ent_reg.async_get_or_create(
+    entity: er.RegistryEntry = entity_registry.async_get_or_create(
         suggested_object_id=object_id,
         disabled_by=None,
         domain=SENSOR_DOMAIN,
@@ -83,6 +85,6 @@ async def test_migrate_unique_id(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    entity_migrated = ent_reg.async_get(entity.entity_id)
+    entity_migrated = entity_registry.async_get(entity.entity_id)
     assert entity_migrated
     assert entity_migrated.unique_id == f"{entry.entry_id}-{new_unique_id}"

--- a/tests/components/goalzero/test_init.py
+++ b/tests/components/goalzero/test_init.py
@@ -66,11 +66,12 @@ async def test_update_failed(
 
 
 async def test_device_info(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test device info."""
     entry = await async_init_integration(hass, aioclient_mock)
-    device_registry = dr.async_get(hass)
 
     device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
 

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -653,6 +653,7 @@ async def test_future_event_offset_update_behavior(
 
 async def test_unique_id(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     mock_events_list_items,
     component_setup,
     config_entry,
@@ -661,7 +662,6 @@ async def test_unique_id(
     mock_events_list_items([])
     assert await component_setup()
 
-    entity_registry = er.async_get(hass)
     registry_entries = er.async_entries_for_config_entry(
         entity_registry, config_entry.entry_id
     )
@@ -675,14 +675,13 @@ async def test_unique_id(
 )
 async def test_unique_id_migration(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     mock_events_list_items,
     component_setup,
     config_entry,
     old_unique_id,
 ) -> None:
     """Test that old unique id format is migrated to the new format that supports multiple accounts."""
-    entity_registry = er.async_get(hass)
-
     # Create an entity using the old unique id format
     entity_registry.async_get_or_create(
         DOMAIN,
@@ -730,14 +729,13 @@ async def test_unique_id_migration(
 )
 async def test_invalid_unique_id_cleanup(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     mock_events_list_items,
     component_setup,
     config_entry,
     mock_calendars_yaml,
 ) -> None:
     """Test that old unique id format that is not actually unique is removed."""
-    entity_registry = er.async_get(hass)
-
     # Create an entity using the old unique id format
     entity_registry.async_get_or_create(
         DOMAIN,

--- a/tests/components/google_mail/test_init.py
+++ b/tests/components/google_mail/test_init.py
@@ -121,11 +121,12 @@ async def test_expired_token_refresh_client_error(
 
 
 async def test_device_info(
-    hass: HomeAssistant, setup_integration: ComponentSetup
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    setup_integration: ComponentSetup,
 ) -> None:
     """Test device info."""
     await setup_integration()
-    device_registry = dr.async_get(hass)
 
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})

--- a/tests/components/gpslogger/test_init.py
+++ b/tests/components/gpslogger/test_init.py
@@ -100,7 +100,11 @@ async def test_missing_data(hass: HomeAssistant, gpslogger_client, webhook_id) -
 
 
 async def test_enter_and_exit(
-    hass: HomeAssistant, gpslogger_client, webhook_id
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    gpslogger_client,
+    webhook_id,
 ) -> None:
     """Test when there is a known zone."""
     url = f"/api/webhook/{webhook_id}"
@@ -131,11 +135,8 @@ async def test_enter_and_exit(
     state_name = hass.states.get(f"{DEVICE_TRACKER_DOMAIN}.{data['device']}").state
     assert state_name == STATE_NOT_HOME
 
-    dev_reg = dr.async_get(hass)
-    assert len(dev_reg.devices) == 1
-
-    ent_reg = er.async_get(hass)
-    assert len(ent_reg.entities) == 1
+    assert len(device_registry.devices) == 1
+    assert len(entity_registry.entities) == 1
 
 
 async def test_enter_with_attrs(

--- a/tests/components/group/test_binary_sensor.py
+++ b/tests/components/group/test_binary_sensor.py
@@ -13,7 +13,9 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 
-async def test_default_state(hass: HomeAssistant) -> None:
+async def test_default_state(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test binary_sensor group default state."""
     hass.states.async_set("binary_sensor.kitchen", "on")
     hass.states.async_set("binary_sensor.bedroom", "on")
@@ -42,7 +44,6 @@ async def test_default_state(hass: HomeAssistant) -> None:
         "binary_sensor.bedroom",
     ]
 
-    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get("binary_sensor.bedroom_group")
     assert entry
     assert entry.unique_id == "unique_identifier"
@@ -145,7 +146,9 @@ async def test_state_reporting_all(hass: HomeAssistant) -> None:
     )
 
 
-async def test_state_reporting_any(hass: HomeAssistant) -> None:
+async def test_state_reporting_any(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test the state reporting in 'any' mode.
 
     The group state is unavailable if all group members are unavailable.
@@ -171,7 +174,6 @@ async def test_state_reporting_any(hass: HomeAssistant) -> None:
     await hass.async_start()
     await hass.async_block_till_done()
 
-    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get("binary_sensor.binary_sensor_group")
     assert entry
     assert entry.unique_id == "unique_identifier"

--- a/tests/components/group/test_config_flow.py
+++ b/tests/components/group/test_config_flow.py
@@ -144,18 +144,22 @@ async def test_config_flow(
     ),
 )
 async def test_config_flow_hides_members(
-    hass: HomeAssistant, group_type, extra_input, hide_members, hidden_by
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    group_type,
+    extra_input,
+    hide_members,
+    hidden_by,
 ) -> None:
     """Test the config flow hides members if requested."""
     fake_uuid = "a266a680b608c32770e6c45bfe6b8411"
-    registry = er.async_get(hass)
-    entry = registry.async_get_or_create(
+    entry = entity_registry.async_get_or_create(
         group_type, "test", "unique", suggested_object_id="one"
     )
     assert entry.entity_id == f"{group_type}.one"
     assert entry.hidden_by is None
 
-    entry = registry.async_get_or_create(
+    entry = entity_registry.async_get_or_create(
         group_type, "test", "unique3", suggested_object_id="three"
     )
     assert entry.entity_id == f"{group_type}.three"
@@ -188,8 +192,8 @@ async def test_config_flow_hides_members(
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
 
-    assert registry.async_get(f"{group_type}.one").hidden_by == hidden_by
-    assert registry.async_get(f"{group_type}.three").hidden_by == hidden_by
+    assert entity_registry.async_get(f"{group_type}.one").hidden_by == hidden_by
+    assert entity_registry.async_get(f"{group_type}.three").hidden_by == hidden_by
 
 
 def get_suggested(schema, key):
@@ -402,6 +406,7 @@ async def test_all_options(
 )
 async def test_options_flow_hides_members(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     group_type,
     extra_input,
     hide_members,
@@ -410,8 +415,7 @@ async def test_options_flow_hides_members(
 ) -> None:
     """Test the options flow hides or unhides members if requested."""
     fake_uuid = "a266a680b608c32770e6c45bfe6b8411"
-    registry = er.async_get(hass)
-    entry = registry.async_get_or_create(
+    entry = entity_registry.async_get_or_create(
         group_type,
         "test",
         "unique1",
@@ -420,7 +424,7 @@ async def test_options_flow_hides_members(
     )
     assert entry.entity_id == f"{group_type}.one"
 
-    entry = registry.async_get_or_create(
+    entry = entity_registry.async_get_or_create(
         group_type,
         "test",
         "unique3",
@@ -462,8 +466,8 @@ async def test_options_flow_hides_members(
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
 
-    assert registry.async_get(f"{group_type}.one").hidden_by == hidden_by
-    assert registry.async_get(f"{group_type}.three").hidden_by == hidden_by
+    assert entity_registry.async_get(f"{group_type}.one").hidden_by == hidden_by
+    assert entity_registry.async_get(f"{group_type}.three").hidden_by == hidden_by
 
 
 COVER_ATTRS = [{"supported_features": 0}, {}]

--- a/tests/components/group/test_cover.py
+++ b/tests/components/group/test_cover.py
@@ -249,7 +249,9 @@ async def test_state(hass: HomeAssistant, setup_comp) -> None:
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ATTRIBUTES, 1)])
-async def test_attributes(hass: HomeAssistant, setup_comp) -> None:
+async def test_attributes(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, setup_comp
+) -> None:
     """Test handling of state attributes."""
     state = hass.states.get(COVER_GROUP)
     assert state.state == STATE_UNAVAILABLE
@@ -407,7 +409,6 @@ async def test_attributes(hass: HomeAssistant, setup_comp) -> None:
     assert ATTR_ASSUMED_STATE not in state.attributes
 
     # Test entity registry integration
-    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get(COVER_GROUP)
     assert entry
     assert entry.unique_id == "unique_identifier"

--- a/tests/components/group/test_event.py
+++ b/tests/components/group/test_event.py
@@ -16,7 +16,9 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 
-async def test_default_state(hass: HomeAssistant) -> None:
+async def test_default_state(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test event group default state."""
     await async_setup_component(
         hass,
@@ -132,7 +134,6 @@ async def test_default_state(hass: HomeAssistant) -> None:
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
-    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get("event.remote_control")
     assert entry
     assert entry.unique_id == "unique_identifier"

--- a/tests/components/group/test_fan.py
+++ b/tests/components/group/test_fan.py
@@ -112,7 +112,9 @@ async def setup_comp(hass, config_count):
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ATTRIBUTES, 1)])
-async def test_state(hass: HomeAssistant, setup_comp) -> None:
+async def test_state(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, setup_comp
+) -> None:
     """Test handling of state.
 
     The group state is on if at least one group member is on.
@@ -201,7 +203,6 @@ async def test_state(hass: HomeAssistant, setup_comp) -> None:
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
 
     # Test entity registry integration
-    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get(FAN_GROUP)
     assert entry
     assert entry.unique_id == "unique_identifier"

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -1641,13 +1641,12 @@ async def test_plant_group(hass: HomeAssistant) -> None:
 )
 async def test_setup_and_remove_config_entry(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     group_type: str,
     member_state: str,
     extra_options: dict[str, Any],
 ) -> None:
     """Test removing a config entry."""
-    registry = er.async_get(hass)
-
     members1 = [f"{group_type}.one", f"{group_type}.two"]
 
     for member in members1:
@@ -1672,7 +1671,7 @@ async def test_setup_and_remove_config_entry(
     # Check the state and entity registry entry are present
     state = hass.states.get(f"{group_type}.bed_room")
     assert state.attributes["entity_id"] == members1
-    assert registry.async_get(f"{group_type}.bed_room") is not None
+    assert entity_registry.async_get(f"{group_type}.bed_room") is not None
 
     # Remove the config entry
     assert await hass.config_entries.async_remove(group_config_entry.entry_id)
@@ -1680,7 +1679,7 @@ async def test_setup_and_remove_config_entry(
 
     # Check the state and entity registry entry are removed
     assert hass.states.get(f"{group_type}.bed_room") is None
-    assert registry.async_get(f"{group_type}.bed_room") is None
+    assert entity_registry.async_get(f"{group_type}.bed_room") is None
 
 
 @pytest.mark.parametrize(
@@ -1706,6 +1705,7 @@ async def test_setup_and_remove_config_entry(
 )
 async def test_unhide_members_on_remove(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     group_type: str,
     extra_options: dict[str, Any],
     hide_members: bool,
@@ -1713,10 +1713,7 @@ async def test_unhide_members_on_remove(
     hidden_by: str,
 ) -> None:
     """Test removing a config entry."""
-    registry = er.async_get(hass)
-
-    registry = er.async_get(hass)
-    entry1 = registry.async_get_or_create(
+    entry1 = entity_registry.async_get_or_create(
         group_type,
         "test",
         "unique1",
@@ -1725,7 +1722,7 @@ async def test_unhide_members_on_remove(
     )
     assert entry1.entity_id == f"{group_type}.one"
 
-    entry3 = registry.async_get_or_create(
+    entry3 = entity_registry.async_get_or_create(
         group_type,
         "test",
         "unique3",
@@ -1734,7 +1731,7 @@ async def test_unhide_members_on_remove(
     )
     assert entry3.entity_id == f"{group_type}.three"
 
-    entry4 = registry.async_get_or_create(
+    entry4 = entity_registry.async_get_or_create(
         group_type,
         "test",
         "unique4",
@@ -1766,12 +1763,12 @@ async def test_unhide_members_on_remove(
 
     # Remove one entity registry entry, to make sure this does not trip up config entry
     # removal
-    registry.async_remove(entry4.entity_id)
+    entity_registry.async_remove(entry4.entity_id)
 
     # Remove the config entry
     assert await hass.config_entries.async_remove(group_config_entry.entry_id)
     await hass.async_block_till_done()
 
     # Check the group members are unhidden
-    assert registry.async_get(f"{group_type}.one").hidden_by == hidden_by
-    assert registry.async_get(f"{group_type}.three").hidden_by == hidden_by
+    assert entity_registry.async_get(f"{group_type}.one").hidden_by == hidden_by
+    assert entity_registry.async_get(f"{group_type}.three").hidden_by == hidden_by

--- a/tests/components/group/test_light.py
+++ b/tests/components/group/test_light.py
@@ -49,7 +49,9 @@ from homeassistant.setup import async_setup_component
 from tests.common import async_capture_events, get_fixture_path
 
 
-async def test_default_state(hass: HomeAssistant) -> None:
+async def test_default_state(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test light group default state."""
     hass.states.async_set("light.kitchen", "on")
     await async_setup_component(
@@ -80,7 +82,6 @@ async def test_default_state(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_EFFECT_LIST) is None
     assert state.attributes.get(ATTR_EFFECT) is None
 
-    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get("light.bedroom_group")
     assert entry
     assert entry.unique_id == "unique_identifier"

--- a/tests/components/group/test_lock.py
+++ b/tests/components/group/test_lock.py
@@ -31,7 +31,9 @@ from homeassistant.setup import async_setup_component
 from tests.common import get_fixture_path
 
 
-async def test_default_state(hass: HomeAssistant) -> None:
+async def test_default_state(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test lock group default state."""
     hass.states.async_set("lock.front", "locked")
     await async_setup_component(
@@ -55,7 +57,6 @@ async def test_default_state(hass: HomeAssistant) -> None:
     assert state.state == STATE_LOCKED
     assert state.attributes.get(ATTR_ENTITY_ID) == ["lock.front", "lock.back"]
 
-    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get("lock.door_group")
     assert entry
     assert entry.unique_id == "unique_identifier"

--- a/tests/components/group/test_media_player.py
+++ b/tests/components/group/test_media_player.py
@@ -58,7 +58,9 @@ def media_player_media_seek_fixture():
         yield seek
 
 
-async def test_default_state(hass: HomeAssistant) -> None:
+async def test_default_state(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test media group default state."""
     hass.states.async_set("media_player.player_1", "on")
     await async_setup_component(
@@ -86,7 +88,6 @@ async def test_default_state(hass: HomeAssistant) -> None:
         "media_player.player_2",
     ]
 
-    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get("media_player.media_group")
     assert entry
     assert entry.unique_id == "unique_identifier"

--- a/tests/components/group/test_sensor.py
+++ b/tests/components/group/test_sensor.py
@@ -64,6 +64,7 @@ PRODUCT_VALUE = prod(VALUES)
 )
 async def test_sensors(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     sensor_type: str,
     result: str,
     attributes: dict[str, Any],
@@ -107,8 +108,7 @@ async def test_sensors(
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "L"
 
-    entity_reg = er.async_get(hass)
-    entity = entity_reg.async_get(f"sensor.sensor_group_{sensor_type}")
+    entity = entity_registry.async_get(f"sensor.sensor_group_{sensor_type}")
     assert entity.unique_id == "very_unique_id"
 
 

--- a/tests/components/group/test_switch.py
+++ b/tests/components/group/test_switch.py
@@ -24,7 +24,9 @@ from homeassistant.setup import async_setup_component
 from tests.common import get_fixture_path
 
 
-async def test_default_state(hass: HomeAssistant) -> None:
+async def test_default_state(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test switch group default state."""
     hass.states.async_set("switch.tv", "on")
     await async_setup_component(
@@ -49,7 +51,6 @@ async def test_default_state(hass: HomeAssistant) -> None:
     assert state.state == STATE_ON
     assert state.attributes.get(ATTR_ENTITY_ID) == ["switch.tv", "switch.soundbar"]
 
-    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get("switch.multimedia_group")
     assert entry
     assert entry.unique_id == "unique_identifier"


### PR DESCRIPTION
## Proposed change
Update the component tests starting with `f` or `g` to use the entity & device registry fixtures

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
