### PR TITLE
Add HassDict implementation

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2035,9 +2035,7 @@ class ConfigEntries:
         Config entries which are created after Home Assistant is started can't be waited
         for, the function will just return if the config entry is loaded or not.
         """
-        setup_done: dict[str, asyncio.Future[bool]] = self.hass.data.get(
-            DATA_SETUP_DONE, {}
-        )
+        setup_done = self.hass.data.get(DATA_SETUP_DONE, {})
         if setup_future := setup_done.get(entry.domain):
             await setup_future
         # The component was not loaded.

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -104,6 +104,7 @@ from .util.async_ import (
 )
 from .util.event_type import EventType
 from .util.executor import InterruptibleThreadPoolExecutor
+from .util.hass_dict import HassDict
 from .util.json import JsonObjectType
 from .util.read_only_dict import ReadOnlyDict
 from .util.timeout import TimeoutManager
@@ -406,7 +407,7 @@ class HomeAssistant:
         from . import loader
 
         # This is a dictionary that any component can store any data on.
-        self.data: dict[str, Any] = {}
+        self.data = HassDict()
         self.loop = asyncio.get_running_loop()
         self._tasks: set[asyncio.Future[Any]] = set()
         self._background_tasks: set[asyncio.Future[Any]] = set()

--- a/homeassistant/helpers/singleton.py
+++ b/homeassistant/helpers/singleton.py
@@ -5,17 +5,26 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 import functools
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar, cast, overload
 
 from homeassistant.core import HomeAssistant
 from homeassistant.loader import bind_hass
+from homeassistant.util.hass_dict import HassKey
 
 _T = TypeVar("_T")
 
 _FuncType = Callable[[HomeAssistant], _T]
 
 
-def singleton(data_key: str) -> Callable[[_FuncType[_T]], _FuncType[_T]]:
+@overload
+def singleton(data_key: HassKey[_T]) -> Callable[[_FuncType[_T]], _FuncType[_T]]: ...
+
+
+@overload
+def singleton(data_key: str) -> Callable[[_FuncType[_T]], _FuncType[_T]]: ...
+
+
+def singleton(data_key: Any) -> Callable[[_FuncType[_T]], _FuncType[_T]]:
     """Decorate a function that should be called once per instance.
 
     Result will be cached and simultaneous calls will be handled.

--- a/homeassistant/util/hass_dict.py
+++ b/homeassistant/util/hass_dict.py
@@ -1,0 +1,31 @@
+"""Implementation for HassDict and custom HassKey types.
+
+Custom for type checking. See stub file.
+"""
+
+from __future__ import annotations
+
+from typing import Generic, TypeVar
+
+_T = TypeVar("_T")
+
+
+class HassKey(str, Generic[_T]):
+    """Generic Hass key type.
+
+    At runtime this is a generic subclass of str.
+    """
+
+    __slots__ = ()
+
+
+class HassEntryKey(str, Generic[_T]):
+    """Key type for integrations with config entries.
+
+    At runtime this is a generic subclass of str.
+    """
+
+    __slots__ = ()
+
+
+HassDict = dict

--- a/homeassistant/util/hass_dict.pyi
+++ b/homeassistant/util/hass_dict.pyi
@@ -1,0 +1,176 @@
+"""Stub file for hass_dict. Provide overload for type checking."""
+# ruff: noqa: PYI021  # Allow docstrings
+
+from typing import Any, Generic, TypeVar, assert_type, overload
+
+__all__ = [
+    "HassDict",
+    "HassEntryKey",
+    "HassKey",
+]
+
+_T = TypeVar("_T")
+_U = TypeVar("_U")
+
+class _Key(Generic[_T]):
+    """Base class for Hass key types. At runtime delegated to str."""
+
+    def __init__(self, value: str, /) -> None: ...
+    def __len__(self) -> int: ...
+    def __hash__(self) -> int: ...
+    def __eq__(self, other: object) -> bool: ...
+    def __getitem__(self, index: int) -> str: ...
+
+class HassEntryKey(_Key[_T]):
+    """Key type for integrations with config entries."""
+
+class HassKey(_Key[_T]):
+    """Generic Hass key type."""
+
+class HassDict(dict[_Key[Any] | str, Any]):
+    """Custom dict type to provide better value type hints for Hass key types."""
+
+    @overload  # type: ignore[override]
+    def __getitem__(self, key: HassEntryKey[_T], /) -> dict[str, _T]: ...
+    @overload
+    def __getitem__(self, key: HassKey[_T], /) -> _T: ...
+    @overload
+    def __getitem__(self, key: str, /) -> Any: ...
+
+    # ------
+    @overload  # type: ignore[override]
+    def __setitem__(self, key: HassEntryKey[_T], value: dict[str, _T], /) -> None: ...
+    @overload
+    def __setitem__(self, key: HassKey[_T], value: _T, /) -> None: ...
+    @overload
+    def __setitem__(self, key: str, value: Any, /) -> None: ...
+
+    # ------
+    @overload  # type: ignore[override]
+    def setdefault(
+        self, key: HassEntryKey[_T], default: dict[str, _T], /
+    ) -> dict[str, _T]: ...
+    @overload
+    def setdefault(self, key: HassKey[_T], default: _T, /) -> _T: ...
+    @overload
+    def setdefault(self, key: str, default: None = None, /) -> Any | None: ...
+    @overload
+    def setdefault(self, key: str, default: Any, /) -> Any: ...
+
+    # ------
+    @overload  # type: ignore[override]
+    def get(self, key: HassEntryKey[_T], /) -> dict[str, _T] | None: ...
+    @overload
+    def get(self, key: HassEntryKey[_T], default: _U, /) -> dict[str, _T] | _U: ...
+    @overload
+    def get(self, key: HassKey[_T], /) -> _T | None: ...
+    @overload
+    def get(self, key: HassKey[_T], default: _U, /) -> _T | _U: ...
+    @overload
+    def get(self, key: str, /) -> Any | None: ...
+    @overload
+    def get(self, key: str, default: Any, /) -> Any: ...
+
+    # ------
+    @overload  # type: ignore[override]
+    def pop(self, key: HassEntryKey[_T], /) -> dict[str, _T]: ...
+    @overload
+    def pop(
+        self, key: HassEntryKey[_T], default: dict[str, _T], /
+    ) -> dict[str, _T]: ...
+    @overload
+    def pop(self, key: HassEntryKey[_T], default: _U, /) -> dict[str, _T] | _U: ...
+    @overload
+    def pop(self, key: HassKey[_T], /) -> _T: ...
+    @overload
+    def pop(self, key: HassKey[_T], default: _T, /) -> _T: ...
+    @overload
+    def pop(self, key: HassKey[_T], default: _U, /) -> _T | _U: ...
+    @overload
+    def pop(self, key: str, /) -> Any: ...
+    @overload
+    def pop(self, key: str, default: _U, /) -> Any | _U: ...
+
+def _test_hass_dict_typing() -> None:  # noqa: PYI048
+    """Test HassDict overloads work as intended.
+
+    This is tested during the mypy run. Do not move it to 'tests'!
+    """
+    d = HassDict()
+    entry_key = HassEntryKey[int]("entry_key")
+    key = HassKey[int]("key")
+    key2 = HassKey[dict[int, bool]]("key2")
+    key3 = HassKey[set[str]]("key3")
+    other_key = "domain"
+
+    # __getitem__
+    assert_type(d[entry_key], dict[str, int])
+    assert_type(d[entry_key]["entry_id"], int)
+    assert_type(d[key], int)
+    assert_type(d[key2], dict[int, bool])
+
+    # __setitem__
+    d[entry_key] = {}
+    d[entry_key] = 2  # type: ignore[call-overload]
+    d[entry_key]["entry_id"] = 2
+    d[entry_key]["entry_id"] = "Hello World"  # type: ignore[assignment]
+    d[key] = 2
+    d[key] = "Hello World"  # type: ignore[misc]
+    d[key] = {}  # type: ignore[misc]
+    d[key2] = {}
+    d[key2] = 2  # type: ignore[misc]
+    d[key3] = set()
+    d[key3] = 2  # type: ignore[misc]
+    d[other_key] = 2
+    d[other_key] = "Hello World"
+
+    # get
+    assert_type(d.get(entry_key), dict[str, int] | None)
+    assert_type(d.get(entry_key, True), dict[str, int] | bool)
+    assert_type(d.get(key), int | None)
+    assert_type(d.get(key, True), int | bool)
+    assert_type(d.get(key2), dict[int, bool] | None)
+    assert_type(d.get(key2, {}), dict[int, bool])
+    assert_type(d.get(key3), set[str] | None)
+    assert_type(d.get(key3, set()), set[str])
+    assert_type(d.get(other_key), Any | None)
+    assert_type(d.get(other_key, True), Any)
+    assert_type(d.get(other_key, {})["id"], Any)
+
+    # setdefault
+    assert_type(d.setdefault(entry_key, {}), dict[str, int])
+    assert_type(d.setdefault(entry_key, {})["entry_id"], int)
+    assert_type(d.setdefault(key, 2), int)
+    assert_type(d.setdefault(key2, {}), dict[int, bool])
+    assert_type(d.setdefault(key2, {})[2], bool)
+    assert_type(d.setdefault(key3, set()), set[str])
+    assert_type(d.setdefault(other_key, 2), Any)
+    assert_type(d.setdefault(other_key), Any | None)
+    d.setdefault(entry_key, {})["entry_id"] = 2
+    d.setdefault(entry_key, {})["entry_id"] = "Hello World"  # type: ignore[assignment]
+    d.setdefault(key, 2)
+    d.setdefault(key, "Error")  # type: ignore[misc]
+    d.setdefault(key2, {})[2] = True
+    d.setdefault(key2, {})[2] = "Error"  # type: ignore[assignment]
+    d.setdefault(key3, set()).add("Hello World")
+    d.setdefault(key3, set()).add(2)  # type: ignore[arg-type]
+    d.setdefault(other_key, {})["id"] = 2
+    d.setdefault(other_key, {})["id"] = "Hello World"
+    d.setdefault(entry_key)  # type: ignore[call-overload]
+    d.setdefault(key)  # type: ignore[call-overload]
+    d.setdefault(key2)  # type: ignore[call-overload]
+
+    # pop
+    assert_type(d.pop(entry_key), dict[str, int])
+    assert_type(d.pop(entry_key, {}), dict[str, int])
+    assert_type(d.pop(entry_key, 2), dict[str, int] | int)
+    assert_type(d.pop(key), int)
+    assert_type(d.pop(key, 2), int)
+    assert_type(d.pop(key, "Hello World"), int | str)
+    assert_type(d.pop(key2), dict[int, bool])
+    assert_type(d.pop(key2, {}), dict[int, bool])
+    assert_type(d.pop(key2, 2), dict[int, bool] | int)
+    assert_type(d.pop(key3), set[str])
+    assert_type(d.pop(key3, set()), set[str])
+    assert_type(d.pop(other_key), Any)
+    assert_type(d.pop(other_key, True), Any | bool)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -739,7 +739,6 @@ async def test_integration_only_setup_entry(hass: HomeAssistant) -> None:
 async def test_async_start_setup_running(hass: HomeAssistant) -> None:
     """Test setup started context manager does nothing when running."""
     assert hass.state is CoreState.running
-    setup_started: dict[tuple[str, str | None], float]
     setup_started = hass.data.setdefault(setup.DATA_SETUP_STARTED, {})
 
     with setup.async_start_setup(
@@ -753,7 +752,6 @@ async def test_async_start_setup_config_entry(
 ) -> None:
     """Test setup started keeps track of setup times with a config entry."""
     hass.set_state(CoreState.not_running)
-    setup_started: dict[tuple[str, str | None], float]
     setup_started = hass.data.setdefault(setup.DATA_SETUP_STARTED, {})
     setup_time = setup._setup_times(hass)
 
@@ -864,7 +862,6 @@ async def test_async_start_setup_config_entry_late_platform(
 ) -> None:
     """Test setup started tracks config entry time with a late platform load."""
     hass.set_state(CoreState.not_running)
-    setup_started: dict[tuple[str, str | None], float]
     setup_started = hass.data.setdefault(setup.DATA_SETUP_STARTED, {})
     setup_time = setup._setup_times(hass)
 
@@ -919,7 +916,6 @@ async def test_async_start_setup_config_entry_platform_wait(
 ) -> None:
     """Test setup started tracks wait time when a platform loads inside of config entry setup."""
     hass.set_state(CoreState.not_running)
-    setup_started: dict[tuple[str, str | None], float]
     setup_started = hass.data.setdefault(setup.DATA_SETUP_STARTED, {})
     setup_time = setup._setup_times(hass)
 
@@ -962,7 +958,6 @@ async def test_async_start_setup_config_entry_platform_wait(
 async def test_async_start_setup_top_level_yaml(hass: HomeAssistant) -> None:
     """Test setup started context manager keeps track of setup times with modern yaml."""
     hass.set_state(CoreState.not_running)
-    setup_started: dict[tuple[str, str | None], float]
     setup_started = hass.data.setdefault(setup.DATA_SETUP_STARTED, {})
     setup_time = setup._setup_times(hass)
 
@@ -979,7 +974,6 @@ async def test_async_start_setup_top_level_yaml(hass: HomeAssistant) -> None:
 async def test_async_start_setup_platform_integration(hass: HomeAssistant) -> None:
     """Test setup started keeps track of setup times a platform integration."""
     hass.set_state(CoreState.not_running)
-    setup_started: dict[tuple[str, str | None], float]
     setup_started = hass.data.setdefault(setup.DATA_SETUP_STARTED, {})
     setup_time = setup._setup_times(hass)
 
@@ -1014,7 +1008,6 @@ async def test_async_start_setup_legacy_platform_integration(
 ) -> None:
     """Test setup started keeps track of setup times for a legacy platform integration."""
     hass.set_state(CoreState.not_running)
-    setup_started: dict[tuple[str, str | None], float]
     setup_started = hass.data.setdefault(setup.DATA_SETUP_STARTED, {})
     setup_time = setup._setup_times(hass)
 

--- a/tests/util/test_hass_dict.py
+++ b/tests/util/test_hass_dict.py
@@ -1,0 +1,47 @@
+"""Test HassDict and custom HassKey types."""
+
+from homeassistant.util.hass_dict import HassDict, HassEntryKey, HassKey
+
+
+def test_key_comparison() -> None:
+    """Test key comparison with itself and string keys."""
+
+    str_key = "custom-key"
+    key = HassKey[int](str_key)
+    other_key = HassKey[str]("other-key")
+
+    entry_key = HassEntryKey[int](str_key)
+    other_entry_key = HassEntryKey[str]("other-key")
+
+    assert key == str_key
+    assert key != other_key
+    assert key != 2
+
+    assert entry_key == str_key
+    assert entry_key != other_entry_key
+    assert entry_key != 2
+
+    # Only compare name attribute, HassKey(<name>) == HassEntryKey(<name>)
+    assert key == entry_key
+
+
+def test_hass_dict_access() -> None:
+    """Test keys with the same name all access the same value in HassDict."""
+
+    data = HassDict()
+    str_key = "custom-key"
+    key = HassKey[int](str_key)
+    other_key = HassKey[str]("other-key")
+
+    entry_key = HassEntryKey[int](str_key)
+    other_entry_key = HassEntryKey[str]("other-key")
+
+    data[str_key] = True
+    assert data.get(key) is True
+    assert data.get(other_key) is None
+
+    assert data.get(entry_key) is True  # type: ignore[comparison-overlap]
+    assert data.get(other_entry_key) is None
+
+    data[key] = False
+    assert data[str_key] is False


### PR DESCRIPTION
## Proposed change
Alternative approach to typing `hass.data`.
For the previous attempt, see: #96419

Got the idea from `aiohttp`. For `3.9.0`, they've added `AppKey` to solve a similar problem with typing the `app` dict.
https://docs.aiohttp.org/en/latest/web_advanced.html#application-s-config

One of the reasons against the initial change was that ideally integrations shouldn't access `hass.data` directly and the change was to involved for little value.

Even though this diff might look bigger at first, it's actually easier to apply. Most of it are just the correct overloads. If at some point a good design for getter / setter emerges, this change can be easily incorporated or even fully reverted if necessary.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2161

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
