### PR TITLE
Add support for shell auto-completion to command line

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -141,8 +141,11 @@ def get_arguments() -> argparse.Namespace:
         "--log-no-color", action="store_true", help="Disable color logs"
     )
     parser.add_argument(
-        "--script", nargs=argparse.REMAINDER, help="Run one of the embedded scripts"
-    ).completer = lambda **kwargs: get_scripts()  # type: ignore[attr-defined]
+        "--script",
+        nargs=argparse.REMAINDER,
+        help="Run one of the embedded scripts",
+        choices=get_scripts(),
+    )
     parser.add_argument(
         "--ignore-os-check",
         action="store_true",

--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -1,4 +1,5 @@
 """Start Home Assistant."""
+# PYTHON_ARGCOMPLETE_OK
 from __future__ import annotations
 
 import argparse
@@ -7,7 +8,10 @@ import os
 import sys
 import threading
 
+import argcomplete
+
 from .const import REQUIRED_PYTHON_VER, RESTART_EXIT_CODE, __version__
+from .scripts import get_scripts
 
 FAULT_LOG_FILENAME = "home-assistant.log.fault"
 
@@ -138,12 +142,14 @@ def get_arguments() -> argparse.Namespace:
     )
     parser.add_argument(
         "--script", nargs=argparse.REMAINDER, help="Run one of the embedded scripts"
-    )
+    ).completer = lambda **kwargs: get_scripts()  # type: ignore[attr-defined]
     parser.add_argument(
         "--ignore-os-check",
         action="store_true",
         help="Skips validation of operating system",
     )
+
+    argcomplete.autocomplete(parser)
 
     arguments = parser.parse_args()
 

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -6,6 +6,7 @@ aiohttp-zlib-ng==0.1.1
 aiohttp==3.8.5;python_version<'3.12'
 aiohttp==3.9.0rc0;python_version>='3.12'
 aiohttp_cors==0.7.0
+argcomplete==3.1.4
 astral==2.2
 async-upnp-client==0.36.2
 atomicwrites-homeassistant==1.4.1

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -6,7 +6,7 @@ aiohttp-zlib-ng==0.1.1
 aiohttp==3.8.5;python_version<'3.12'
 aiohttp==3.9.0rc0;python_version>='3.12'
 aiohttp_cors==0.7.0
-argcomplete==3.1.4
+argcomplete==3.1.6
 astral==2.2
 async-upnp-client==0.36.2
 atomicwrites-homeassistant==1.4.1

--- a/homeassistant/scripts/__init__.py
+++ b/homeassistant/scripts/__init__.py
@@ -18,8 +18,12 @@ from homeassistant.util.package import install_package, is_installed, is_virtual
 # mypy: allow-untyped-defs, disallow-any-generics, no-warn-return-any
 
 
-def run(args: list[str]) -> int:
-    """Run a script."""
+def get_scripts() -> list[str]:
+    """Get all scripts.
+
+    Returns a list of str containing all scripts.
+    **kwargs is to us this method as a completer with argcomplete.
+    """
     scripts = []
     path = os.path.dirname(__file__)
     for fil in os.listdir(path):
@@ -30,6 +34,12 @@ def run(args: list[str]) -> int:
             scripts.append(fil)
         elif fil != "__init__.py" and fil.endswith(".py"):
             scripts.append(fil[:-3])
+    return scripts
+
+
+def run(args: list[str]) -> int:
+    """Run a script."""
+    scripts = get_scripts()
 
     if not args:
         print("Please specify a script to run.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies    = [
     "aiohttp_cors==0.7.0",
     "aiohttp-fast-url-dispatcher==0.1.0",
     "aiohttp-zlib-ng==0.1.1",
+    "argcomplete==3.1.4",
     "astral==2.2",
     "attrs==23.1.0",
     "atomicwrites-homeassistant==1.4.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies    = [
     "aiohttp_cors==0.7.0",
     "aiohttp-fast-url-dispatcher==0.1.0",
     "aiohttp-zlib-ng==0.1.1",
-    "argcomplete==3.1.4",
+    "argcomplete==3.1.6",
     "astral==2.2",
     "attrs==23.1.0",
     "atomicwrites-homeassistant==1.4.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ aiohttp==3.8.5;python_version<'3.12'
 aiohttp_cors==0.7.0
 aiohttp-fast-url-dispatcher==0.1.0
 aiohttp-zlib-ng==0.1.1
+argcomplete==3.1.4
 astral==2.2
 attrs==23.1.0
 atomicwrites-homeassistant==1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ aiohttp==3.8.5;python_version<'3.12'
 aiohttp_cors==0.7.0
 aiohttp-fast-url-dispatcher==0.1.0
 aiohttp-zlib-ng==0.1.1
-argcomplete==3.1.4
+argcomplete==3.1.6
 astral==2.2
 attrs==23.1.0
 atomicwrites-homeassistant==1.4.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for shell auto-completion feature when typing `hass` following to tab twice.
To enable this, in bash, type `eval "$(register-python-argcomplete hass)"` and as soon as the virtual environment in activated or in all cases where it is possible to run Home Assistant CLI, parameter can be completed by Bash or ZSH.
Also provide auto-completion for script names after `--script` is typed.
[argcomplete](https://kislyuk.github.io/argcomplete/) is used to provide this feature and is added in requirements.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#29813

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
