### PR TITLE
Update h* tests to use entity & device registry fixtures

### DIFF
--- a/tests/components/heos/test_media_player.py
+++ b/tests/components/heos/test_media_player.py
@@ -249,6 +249,8 @@ async def test_updates_from_players_changed(
 
 async def test_updates_from_players_changed_new_ids(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
     config_entry,
     config,
     controller,
@@ -257,8 +259,6 @@ async def test_updates_from_players_changed_new_ids(
 ) -> None:
     """Test player updates from changes to available players."""
     await setup_platform(hass, config_entry, config)
-    device_registry = dr.async_get(hass)
-    entity_registry = er.async_get(hass)
     player = controller.players[1]
     event = asyncio.Event()
 

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -1664,7 +1664,9 @@ async def test_history_stats_handles_floored_timestamps(
     assert last_times == (start_time, start_time + timedelta(hours=2))
 
 
-async def test_unique_id(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_unique_id(
+    recorder_mock: Recorder, hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test unique_id property."""
 
     config = {
@@ -1682,5 +1684,7 @@ async def test_unique_id(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     assert await async_setup_component(hass, "sensor", config)
     await hass.async_block_till_done()
 
-    registry = er.async_get(hass)
-    assert registry.async_get("sensor.test").unique_id == "some_history_stats_unique_id"
+    assert (
+        entity_registry.async_get("sensor.test").unique_id
+        == "some_history_stats_unique_id"
+    )

--- a/tests/components/homeassistant/triggers/test_numeric_state.py
+++ b/tests/components/homeassistant/triggers/test_numeric_state.py
@@ -141,11 +141,10 @@ async def test_if_fires_on_entity_change_below(
     "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
 )
 async def test_if_fires_on_entity_change_below_uuid(
-    hass: HomeAssistant, calls, below
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls, below
 ) -> None:
     """Test the firing with changed entity specified by registry entry id."""
-    registry = er.async_get(hass)
-    entry = registry.async_get_or_create(
+    entry = entity_registry.async_get_or_create(
         "test", "hue", "1234", suggested_object_id="entity"
     )
     assert entry.entity_id == "test.entity"

--- a/tests/components/homeassistant/triggers/test_state.py
+++ b/tests/components/homeassistant/triggers/test_state.py
@@ -89,12 +89,13 @@ async def test_if_fires_on_entity_change(hass: HomeAssistant, calls) -> None:
     assert len(calls) == 1
 
 
-async def test_if_fires_on_entity_change_uuid(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_entity_change_uuid(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls
+) -> None:
     """Test for firing on entity change."""
     context = Context()
 
-    registry = er.async_get(hass)
-    entry = registry.async_get_or_create(
+    entry = entity_registry.async_get_or_create(
         "test", "hue", "1234", suggested_object_id="beer"
     )
 

--- a/tests/components/homekit/test_aidmanager.py
+++ b/tests/components/homekit/test_aidmanager.py
@@ -622,9 +622,9 @@ async def test_aid_generation_no_unique_ids_handles_collision(
 
 async def test_handle_unique_id_change(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test handling unique id changes."""
-    entity_registry = er.async_get(hass)
     light = entity_registry.async_get_or_create("light", "demo", "old_unique")
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)

--- a/tests/components/homekit/test_type_covers.py
+++ b/tests/components/homekit/test_type_covers.py
@@ -607,20 +607,18 @@ async def test_windowcovering_open_close_with_position_and_stop(
 
 
 async def test_windowcovering_basic_restore(
-    hass: HomeAssistant, hk_driver, events
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver, events
 ) -> None:
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
-    registry = er.async_get(hass)
-
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         "cover",
         "generic",
         "1234",
         suggested_object_id="simple",
     )
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         "cover",
         "generic",
         "9012",
@@ -646,19 +644,19 @@ async def test_windowcovering_basic_restore(
     assert acc.char_position_state is not None
 
 
-async def test_windowcovering_restore(hass: HomeAssistant, hk_driver, events) -> None:
-    """Test setting up an entity from state in the event registry."""
+async def test_windowcovering_restore(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver, events
+) -> None:
+    """Test setting up an entity from state in the event entity_registry."""
     hass.state = CoreState.not_running
 
-    registry = er.async_get(hass)
-
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         "cover",
         "generic",
         "1234",
         suggested_object_id="simple",
     )
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         "cover",
         "generic",
         "9012",

--- a/tests/components/homekit/test_type_fans.py
+++ b/tests/components/homekit/test_type_fans.py
@@ -553,19 +553,19 @@ async def test_fan_set_all_one_shot(hass: HomeAssistant, hk_driver, events) -> N
     assert len(call_set_direction) == 2
 
 
-async def test_fan_restore(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_fan_restore(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver, events
+) -> None:
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
-    registry = er.async_get(hass)
-
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         "fan",
         "generic",
         "1234",
         suggested_object_id="simple",
     )
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         "fan",
         "generic",
         "9012",

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -576,14 +576,16 @@ async def test_light_rgb_color(
     assert events[-1].data[ATTR_VALUE] == "set color at (145, 75)"
 
 
-async def test_light_restore(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_light_restore(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver, events
+) -> None:
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
-    registry = er.async_get(hass)
-
-    registry.async_get_or_create("light", "hue", "1234", suggested_object_id="simple")
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
+        "light", "hue", "1234", suggested_object_id="simple"
+    )
+    entity_registry.async_get_or_create(
         "light",
         "hue",
         "9012",

--- a/tests/components/homekit/test_type_media_players.py
+++ b/tests/components/homekit/test_type_media_players.py
@@ -428,20 +428,20 @@ async def test_media_player_television_supports_source_select_no_sources(
     assert acc.support_select_source is False
 
 
-async def test_tv_restore(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_tv_restore(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver, events
+) -> None:
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
-    registry = er.async_get(hass)
-
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         "media_player",
         "generic",
         "1234",
         suggested_object_id="simple",
         original_device_class=MediaPlayerDeviceClass.TV,
     )
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         "media_player",
         "generic",
         "9012",

--- a/tests/components/homekit/test_type_sensors.py
+++ b/tests/components/homekit/test_type_sensors.py
@@ -541,20 +541,20 @@ async def test_binary_device_classes(hass: HomeAssistant, hk_driver) -> None:
         assert acc.char_detected.display_name == char
 
 
-async def test_sensor_restore(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_sensor_restore(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver, events
+) -> None:
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
-    registry = er.async_get(hass)
-
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         "sensor",
         "generic",
         "1234",
         suggested_object_id="temperature",
         original_device_class="temperature",
     )
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         "sensor",
         "generic",
         "12345",

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -964,16 +964,16 @@ async def test_thermostat_temperature_step_whole(
     assert acc.char_target_temp.properties[PROP_MIN_STEP] == 0.1
 
 
-async def test_thermostat_restore(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_thermostat_restore(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver, events
+) -> None:
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
-    registry = er.async_get(hass)
-
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         "climate", "generic", "1234", suggested_object_id="simple"
     )
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         "climate",
         "generic",
         "9012",
@@ -1794,16 +1794,16 @@ async def test_water_heater_get_temperature_range(
     assert acc.get_temperature_range(state) == (15.5, 21.0)
 
 
-async def test_water_heater_restore(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_water_heater_restore(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver, events
+) -> None:
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
-    registry = er.async_get(hass)
-
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         "water_heater", "generic", "1234", suggested_object_id="simple"
     )
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         "water_heater",
         "generic",
         "9012",

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -142,7 +142,9 @@ async def test_ecobee3_setup(hass: HomeAssistant) -> None:
 
 
 async def test_ecobee3_setup_from_cache(
-    hass: HomeAssistant, hass_storage: dict[str, Any]
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_storage: dict[str, Any],
 ) -> None:
     """Test that Ecbobee can be correctly setup from its cached entity map."""
     accessories = await setup_accessories_from_file(hass, "ecobee3.json")
@@ -163,8 +165,6 @@ async def test_ecobee3_setup_from_cache(
 
     await setup_test_accessories(hass, accessories)
 
-    entity_registry = er.async_get(hass)
-
     climate = entity_registry.async_get("climate.homew")
     assert climate.unique_id == "00:00:00:00:00:00_1_16"
 
@@ -178,11 +178,11 @@ async def test_ecobee3_setup_from_cache(
     assert occ3.unique_id == "00:00:00:00:00:00_4_56"
 
 
-async def test_ecobee3_setup_connection_failure(hass: HomeAssistant) -> None:
+async def test_ecobee3_setup_connection_failure(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test that Ecbobee can be correctly setup from its cached entity map."""
     accessories = await setup_accessories_from_file(hass, "ecobee3.json")
-
-    entity_registry = er.async_get(hass)
 
     # Test that the connection fails during initial setup.
     # No entities should be created.
@@ -218,9 +218,10 @@ async def test_ecobee3_setup_connection_failure(hass: HomeAssistant) -> None:
     assert occ3.unique_id == "00:00:00:00:00:00_4_56"
 
 
-async def test_ecobee3_add_sensors_at_runtime(hass: HomeAssistant) -> None:
+async def test_ecobee3_add_sensors_at_runtime(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test that new sensors are automatically added."""
-    entity_registry = er.async_get(hass)
 
     # Set up a base Ecobee 3 with no additional sensors.
     # There shouldn't be any entities but climate visible.
@@ -254,9 +255,10 @@ async def test_ecobee3_add_sensors_at_runtime(hass: HomeAssistant) -> None:
     assert occ3.unique_id == "00:00:00:00:00:00_4_56"
 
 
-async def test_ecobee3_remove_sensors_at_runtime(hass: HomeAssistant) -> None:
+async def test_ecobee3_remove_sensors_at_runtime(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test that sensors are automatically removed."""
-    entity_registry = er.async_get(hass)
 
     # Set up a base Ecobee 3 with additional sensors.
     accessories = await setup_accessories_from_file(hass, "ecobee3.json")
@@ -307,10 +309,9 @@ async def test_ecobee3_remove_sensors_at_runtime(hass: HomeAssistant) -> None:
 
 
 async def test_ecobee3_services_and_chars_removed(
-    hass: HomeAssistant,
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test handling removal of some services and chars."""
-    entity_registry = er.async_get(hass)
 
     # Set up a base Ecobee 3 with additional sensors.
     accessories = await setup_accessories_from_file(hass, "ecobee3.json")

--- a/tests/components/homekit_controller/specific_devices/test_fan_that_changes_features.py
+++ b/tests/components/homekit_controller/specific_devices/test_fan_that_changes_features.py
@@ -13,9 +13,10 @@ from ..common import (
 )
 
 
-async def test_fan_add_feature_at_runtime(hass: HomeAssistant) -> None:
+async def test_fan_add_feature_at_runtime(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test that new features can be added at runtime."""
-    entity_registry = er.async_get(hass)
 
     # Set up a basic fan that does not support oscillation
     accessories = await setup_accessories_from_file(
@@ -55,9 +56,10 @@ async def test_fan_add_feature_at_runtime(hass: HomeAssistant) -> None:
     assert fan_state.attributes[ATTR_SUPPORTED_FEATURES] is FanEntityFeature.SET_SPEED
 
 
-async def test_fan_remove_feature_at_runtime(hass: HomeAssistant) -> None:
+async def test_fan_remove_feature_at_runtime(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test that features can be removed at runtime."""
-    entity_registry = er.async_get(hass)
 
     # Set up a basic fan that does not support oscillation
     accessories = await setup_accessories_from_file(
@@ -97,9 +99,11 @@ async def test_fan_remove_feature_at_runtime(hass: HomeAssistant) -> None:
     assert fan_state.attributes[ATTR_SUPPORTED_FEATURES] is FanEntityFeature.SET_SPEED
 
 
-async def test_bridge_with_two_fans_one_removed(hass: HomeAssistant) -> None:
+async def test_bridge_with_two_fans_one_removed(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test a bridge with two fans and one gets removed."""
-    entity_registry = er.async_get(hass)
 
     # Set up a basic fan that does not support oscillation
     accessories = await setup_accessories_from_file(

--- a/tests/components/homekit_controller/specific_devices/test_vocolinc_vp3.py
+++ b/tests/components/homekit_controller/specific_devices/test_vocolinc_vp3.py
@@ -14,10 +14,12 @@ from ..common import (
 )
 
 
-async def test_vocolinc_vp3_setup(hass: HomeAssistant) -> None:
+async def test_vocolinc_vp3_setup(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test that a VOCOlinc VP3 can be correctly setup in HA."""
 
-    entity_registry = er.async_get(hass)
     outlet = entity_registry.async_get_or_create(
         "switch",
         "homekit_controller",

--- a/tests/components/homekit_controller/test_alarm_control_panel.py
+++ b/tests/components/homekit_controller/test_alarm_control_panel.py
@@ -124,9 +124,10 @@ async def test_switch_read_alarm_state(hass: HomeAssistant, utcnow) -> None:
     assert state.state == "triggered"
 
 
-async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
+async def test_migrate_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+) -> None:
     """Test a we can migrate a alarm_control_panel unique id."""
-    entity_registry = er.async_get(hass)
     aid = get_next_aid()
     alarm_control_panel_entry = entity_registry.async_get_or_create(
         "alarm_control_panel",

--- a/tests/components/homekit_controller/test_binary_sensor.py
+++ b/tests/components/homekit_controller/test_binary_sensor.py
@@ -173,9 +173,10 @@ async def test_leak_sensor_read_state(hass: HomeAssistant, utcnow) -> None:
     assert state.attributes["device_class"] == BinarySensorDeviceClass.MOISTURE
 
 
-async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
+async def test_migrate_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+) -> None:
     """Test a we can migrate a binary_sensor unique id."""
-    entity_registry = er.async_get(hass)
     aid = get_next_aid()
     binary_sensor_entry = entity_registry.async_get_or_create(
         "binary_sensor",

--- a/tests/components/homekit_controller/test_button.py
+++ b/tests/components/homekit_controller/test_button.py
@@ -94,9 +94,10 @@ async def test_ecobee_clear_hold_press_button(hass: HomeAssistant) -> None:
     )
 
 
-async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
+async def test_migrate_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+) -> None:
     """Test a we can migrate a button unique id."""
-    entity_registry = er.async_get(hass)
     aid = get_next_aid()
     button_entry = entity_registry.async_get_or_create(
         "button",

--- a/tests/components/homekit_controller/test_camera.py
+++ b/tests/components/homekit_controller/test_camera.py
@@ -16,9 +16,10 @@ def create_camera(accessory):
     accessory.add_service(ServicesTypes.CAMERA_RTP_STREAM_MANAGEMENT)
 
 
-async def test_migrate_unique_ids(hass: HomeAssistant, utcnow) -> None:
+async def test_migrate_unique_ids(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+) -> None:
     """Test migrating entity unique ids."""
-    entity_registry = er.async_get(hass)
     aid = get_next_aid()
     camera = entity_registry.async_get_or_create(
         "camera",

--- a/tests/components/homekit_controller/test_climate.py
+++ b/tests/components/homekit_controller/test_climate.py
@@ -1112,9 +1112,10 @@ async def test_heater_cooler_turn_off(hass: HomeAssistant, utcnow) -> None:
     assert state.attributes["hvac_action"] == "off"
 
 
-async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
+async def test_migrate_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+) -> None:
     """Test a we can migrate a switch unique id."""
-    entity_registry = er.async_get(hass)
     aid = get_next_aid()
     climate_entry = entity_registry.async_get_or_create(
         "climate",

--- a/tests/components/homekit_controller/test_connection.py
+++ b/tests/components/homekit_controller/test_connection.py
@@ -90,7 +90,9 @@ DEVICE_MIGRATION_TESTS = [
 
 @pytest.mark.parametrize("variant", DEVICE_MIGRATION_TESTS)
 async def test_migrate_device_id_no_serial_skip_if_other_owner(
-    hass: HomeAssistant, variant: DeviceMigrationTest
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    variant: DeviceMigrationTest,
 ) -> None:
     """Don't migrate unrelated devices.
 
@@ -99,7 +101,6 @@ async def test_migrate_device_id_no_serial_skip_if_other_owner(
     """
     entry = MockConfigEntry()
     entry.add_to_hass(hass)
-    device_registry = dr.async_get(hass)
 
     bridge = device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
@@ -122,11 +123,11 @@ async def test_migrate_device_id_no_serial_skip_if_other_owner(
 
 @pytest.mark.parametrize("variant", DEVICE_MIGRATION_TESTS)
 async def test_migrate_device_id_no_serial(
-    hass: HomeAssistant, variant: DeviceMigrationTest
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    variant: DeviceMigrationTest,
 ) -> None:
     """Test that a Ryse smart bridge with four shades can be migrated correctly in HA."""
-    device_registry = dr.async_get(hass)
-
     accessories = await setup_accessories_from_file(hass, variant.fixture)
 
     fake_controller = await setup_platform(hass)

--- a/tests/components/homekit_controller/test_cover.py
+++ b/tests/components/homekit_controller/test_cover.py
@@ -398,9 +398,10 @@ async def test_read_door_state(hass: HomeAssistant, utcnow) -> None:
     assert state.attributes["obstruction-detected"] is True
 
 
-async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
+async def test_migrate_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+) -> None:
     """Test a we can migrate a cover unique id."""
-    entity_registry = er.async_get(hass)
     aid = get_next_aid()
     cover_entry = entity_registry.async_get_or_create(
         "cover",

--- a/tests/components/homekit_controller/test_device_trigger.py
+++ b/tests/components/homekit_controller/test_device_trigger.py
@@ -83,11 +83,12 @@ def create_doorbell(accessory):
     battery.add_char(CharacteristicsTypes.BATTERY_LEVEL)
 
 
-async def test_enumerate_remote(hass: HomeAssistant, utcnow) -> None:
+async def test_enumerate_remote(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+) -> None:
     """Test that remote is correctly enumerated."""
     await setup_test_component(hass, create_remote)
 
-    entity_registry = er.async_get(hass)
     bat_sensor = entity_registry.async_get("sensor.testdevice_battery")
     identify_button = entity_registry.async_get("button.testdevice_identify")
 
@@ -132,11 +133,12 @@ async def test_enumerate_remote(hass: HomeAssistant, utcnow) -> None:
     assert triggers == unordered(expected)
 
 
-async def test_enumerate_button(hass: HomeAssistant, utcnow) -> None:
+async def test_enumerate_button(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+) -> None:
     """Test that a button is correctly enumerated."""
     await setup_test_component(hass, create_button)
 
-    entity_registry = er.async_get(hass)
     bat_sensor = entity_registry.async_get("sensor.testdevice_battery")
     identify_button = entity_registry.async_get("button.testdevice_identify")
 
@@ -180,11 +182,12 @@ async def test_enumerate_button(hass: HomeAssistant, utcnow) -> None:
     assert triggers == unordered(expected)
 
 
-async def test_enumerate_doorbell(hass: HomeAssistant, utcnow) -> None:
+async def test_enumerate_doorbell(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+) -> None:
     """Test that a button is correctly enumerated."""
     await setup_test_component(hass, create_doorbell)
 
-    entity_registry = er.async_get(hass)
     bat_sensor = entity_registry.async_get("sensor.testdevice_battery")
     identify_button = entity_registry.async_get("button.testdevice_identify")
 
@@ -228,11 +231,12 @@ async def test_enumerate_doorbell(hass: HomeAssistant, utcnow) -> None:
     assert triggers == unordered(expected)
 
 
-async def test_handle_events(hass: HomeAssistant, utcnow, calls) -> None:
+async def test_handle_events(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow, calls
+) -> None:
     """Test that events are handled."""
     helper = await setup_test_component(hass, create_remote)
 
-    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get("sensor.testdevice_battery")
 
     device_registry = dr.async_get(hass)
@@ -345,11 +349,12 @@ async def test_handle_events(hass: HomeAssistant, utcnow, calls) -> None:
     assert len(calls) == 2
 
 
-async def test_handle_events_late_setup(hass: HomeAssistant, utcnow, calls) -> None:
+async def test_handle_events_late_setup(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow, calls
+) -> None:
     """Test that events are handled when setup happens after startup."""
     helper = await setup_test_component(hass, create_remote)
 
-    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get("sensor.testdevice_battery")
 
     device_registry = dr.async_get(hass)

--- a/tests/components/homekit_controller/test_device_trigger.py
+++ b/tests/components/homekit_controller/test_device_trigger.py
@@ -84,7 +84,10 @@ def create_doorbell(accessory):
 
 
 async def test_enumerate_remote(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    utcnow,
 ) -> None:
     """Test that remote is correctly enumerated."""
     await setup_test_component(hass, create_remote)
@@ -92,7 +95,6 @@ async def test_enumerate_remote(
     bat_sensor = entity_registry.async_get("sensor.testdevice_battery")
     identify_button = entity_registry.async_get("button.testdevice_identify")
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(bat_sensor.device_id)
 
     expected = [
@@ -134,7 +136,10 @@ async def test_enumerate_remote(
 
 
 async def test_enumerate_button(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    utcnow,
 ) -> None:
     """Test that a button is correctly enumerated."""
     await setup_test_component(hass, create_button)
@@ -142,7 +147,6 @@ async def test_enumerate_button(
     bat_sensor = entity_registry.async_get("sensor.testdevice_battery")
     identify_button = entity_registry.async_get("button.testdevice_identify")
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(bat_sensor.device_id)
 
     expected = [
@@ -183,7 +187,10 @@ async def test_enumerate_button(
 
 
 async def test_enumerate_doorbell(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    utcnow,
 ) -> None:
     """Test that a button is correctly enumerated."""
     await setup_test_component(hass, create_doorbell)
@@ -191,7 +198,6 @@ async def test_enumerate_doorbell(
     bat_sensor = entity_registry.async_get("sensor.testdevice_battery")
     identify_button = entity_registry.async_get("button.testdevice_identify")
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(bat_sensor.device_id)
 
     expected = [
@@ -232,14 +238,17 @@ async def test_enumerate_doorbell(
 
 
 async def test_handle_events(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow, calls
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    utcnow,
+    calls,
 ) -> None:
     """Test that events are handled."""
     helper = await setup_test_component(hass, create_remote)
 
     entry = entity_registry.async_get("sensor.testdevice_battery")
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert await async_setup_component(
@@ -350,14 +359,17 @@ async def test_handle_events(
 
 
 async def test_handle_events_late_setup(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow, calls
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    utcnow,
+    calls,
 ) -> None:
     """Test that events are handled when setup happens after startup."""
     helper = await setup_test_component(hass, create_remote)
 
     entry = entity_registry.async_get("sensor.testdevice_battery")
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     await hass.config_entries.async_unload(helper.config_entry.entry_id)

--- a/tests/components/homekit_controller/test_diagnostics.py
+++ b/tests/components/homekit_controller/test_diagnostics.py
@@ -290,14 +290,16 @@ async def test_config_entry(
 
 
 async def test_device(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, utcnow
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    device_registry: dr.DeviceRegistry,
+    utcnow,
 ) -> None:
     """Test generating diagnostics for a device entry."""
     accessories = await setup_accessories_from_file(hass, "koogeek_ls1.json")
     config_entry, _ = await setup_test_accessories(hass, accessories)
 
     connection = hass.data[KNOWN_DEVICES]["00:00:00:00:00:00"]
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(connection.devices[1])
 
     diag = await get_diagnostics_for_device(hass, hass_client, config_entry, device)

--- a/tests/components/homekit_controller/test_event.py
+++ b/tests/components/homekit_controller/test_event.py
@@ -64,7 +64,9 @@ def create_doorbell(accessory):
     battery.add_char(CharacteristicsTypes.BATTERY_LEVEL)
 
 
-async def test_remote(hass: HomeAssistant, utcnow) -> None:
+async def test_remote(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+) -> None:
     """Test that remote is supported."""
     helper = await setup_test_component(hass, create_remote)
 
@@ -74,8 +76,6 @@ async def test_remote(hass: HomeAssistant, utcnow) -> None:
         ("event.testdevice_button_3", "Button 3"),
         ("event.testdevice_button_4", "Button 4"),
     ]
-
-    entity_registry = er.async_get(hass)
 
     for entity_id, service in entities:
         button = entity_registry.async_get(entity_id)
@@ -109,12 +109,13 @@ async def test_remote(hass: HomeAssistant, utcnow) -> None:
         assert state.attributes["event_type"] == "long_press"
 
 
-async def test_button(hass: HomeAssistant, utcnow) -> None:
+async def test_button(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+) -> None:
     """Test that a button is correctly enumerated."""
     helper = await setup_test_component(hass, create_button)
     entity_id = "event.testdevice_button_1"
 
-    entity_registry = er.async_get(hass)
     button = entity_registry.async_get(entity_id)
 
     assert button.original_device_class == EventDeviceClass.BUTTON
@@ -146,12 +147,13 @@ async def test_button(hass: HomeAssistant, utcnow) -> None:
     assert state.attributes["event_type"] == "long_press"
 
 
-async def test_doorbell(hass: HomeAssistant, utcnow) -> None:
+async def test_doorbell(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+) -> None:
     """Test that doorbell service is handled."""
     helper = await setup_test_component(hass, create_doorbell)
     entity_id = "event.testdevice_doorbell"
 
-    entity_registry = er.async_get(hass)
     doorbell = entity_registry.async_get(entity_id)
 
     assert doorbell.original_device_class == EventDeviceClass.DOORBELL

--- a/tests/components/homekit_controller/test_fan.py
+++ b/tests/components/homekit_controller/test_fan.py
@@ -811,9 +811,10 @@ async def test_v2_set_percentage_non_standard_rotation_range(
     )
 
 
-async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
+async def test_migrate_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+) -> None:
     """Test a we can migrate a fan unique id."""
-    entity_registry = er.async_get(hass)
     aid = get_next_aid()
     fan_entry = entity_registry.async_get_or_create(
         "fan",

--- a/tests/components/homekit_controller/test_humidifier.py
+++ b/tests/components/homekit_controller/test_humidifier.py
@@ -455,11 +455,12 @@ async def test_dehumidifier_target_humidity_modes(hass: HomeAssistant, utcnow) -
     assert state.attributes["current_humidity"] == 51
 
 
-async def test_migrate_entity_ids(hass: HomeAssistant, utcnow) -> None:
+async def test_migrate_entity_ids(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+) -> None:
     """Test that we can migrate humidifier entity ids."""
     aid = get_next_aid()
 
-    entity_registry = er.async_get(hass)
     humidifier_entry = entity_registry.async_get_or_create(
         "humidifier",
         "homekit_controller",

--- a/tests/components/homekit_controller/test_init.py
+++ b/tests/components/homekit_controller/test_init.py
@@ -17,7 +17,6 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, STATE_OFF, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
@@ -85,7 +84,9 @@ def create_alive_service(accessory):
 
 
 async def test_device_remove_devices(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test we can only remove a device that no longer exists."""
     assert await async_setup_component(hass, "config", {})
@@ -93,8 +94,7 @@ async def test_device_remove_devices(
     config_entry = helper.config_entry
     entry_id = config_entry.entry_id
 
-    registry: EntityRegistry = er.async_get(hass)
-    entity = registry.entities[ALIVE_DEVICE_ENTITY_ID]
+    entity = entity_registry.entities[ALIVE_DEVICE_ENTITY_ID]
     device_registry = dr.async_get(hass)
 
     live_device_entry = device_registry.async_get(entity.device_id)
@@ -231,14 +231,15 @@ async def test_ble_device_only_checks_is_available(
 
 @pytest.mark.parametrize("example", FIXTURES, ids=lambda val: str(val.stem))
 async def test_snapshots(
-    hass: HomeAssistant, snapshot: SnapshotAssertion, example: str
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    snapshot: SnapshotAssertion,
+    example: str,
 ) -> None:
     """Detect regressions in enumerating a homekit accessory database and building entities."""
     accessories = await setup_accessories_from_file(hass, example)
     config_entry, _ = await setup_test_accessories(hass, accessories)
-
-    device_registry = dr.async_get(hass)
-    entity_registry = er.async_get(hass)
 
     registry_devices = dr.async_entries_for_config_entry(
         device_registry, config_entry.entry_id

--- a/tests/components/homekit_controller/test_init.py
+++ b/tests/components/homekit_controller/test_init.py
@@ -85,6 +85,7 @@ def create_alive_service(accessory):
 
 async def test_device_remove_devices(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
@@ -95,7 +96,6 @@ async def test_device_remove_devices(
     entry_id = config_entry.entry_id
 
     entity = entity_registry.entities[ALIVE_DEVICE_ENTITY_ID]
-    device_registry = dr.async_get(hass)
 
     live_device_entry = device_registry.async_get(entity.device_id)
     assert (

--- a/tests/components/homekit_controller/test_light.py
+++ b/tests/components/homekit_controller/test_light.py
@@ -343,9 +343,10 @@ async def test_light_unloaded_removed(hass: HomeAssistant, utcnow) -> None:
     assert hass.states.get(helper.entity_id).state == STATE_UNAVAILABLE
 
 
-async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
+async def test_migrate_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+) -> None:
     """Test a we can migrate a light unique id."""
-    entity_registry = er.async_get(hass)
     aid = get_next_aid()
     light_entry = entity_registry.async_get_or_create(
         "light",
@@ -360,9 +361,10 @@ async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_only_migrate_once(hass: HomeAssistant, utcnow) -> None:
+async def test_only_migrate_once(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+) -> None:
     """Test a we handle migration happening after an upgrade and than a downgrade and then an upgrade."""
-    entity_registry = er.async_get(hass)
     aid = get_next_aid()
     old_light_entry = entity_registry.async_get_or_create(
         "light",

--- a/tests/components/homekit_controller/test_lock.py
+++ b/tests/components/homekit_controller/test_lock.py
@@ -117,9 +117,10 @@ async def test_switch_read_lock_state(hass: HomeAssistant, utcnow) -> None:
     assert state.state == "unlocking"
 
 
-async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
+async def test_migrate_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+) -> None:
     """Test a we can migrate a lock unique id."""
-    entity_registry = er.async_get(hass)
     aid = get_next_aid()
     lock_entry = entity_registry.async_get_or_create(
         "lock",

--- a/tests/components/homekit_controller/test_media_player.py
+++ b/tests/components/homekit_controller/test_media_player.py
@@ -368,9 +368,10 @@ async def test_tv_set_source_fail(hass: HomeAssistant, utcnow) -> None:
     assert state.attributes["source"] == "HDMI 1"
 
 
-async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
+async def test_migrate_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+) -> None:
     """Test a we can migrate a media_player unique id."""
-    entity_registry = er.async_get(hass)
     aid = get_next_aid()
     media_player_entry = entity_registry.async_get_or_create(
         "media_player",

--- a/tests/components/homekit_controller/test_number.py
+++ b/tests/components/homekit_controller/test_number.py
@@ -29,9 +29,10 @@ def create_switch_with_spray_level(accessory):
     return service
 
 
-async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
+async def test_migrate_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+) -> None:
     """Test a we can migrate a number unique id."""
-    entity_registry = er.async_get(hass)
     aid = get_next_aid()
     number = entity_registry.async_get_or_create(
         "number",

--- a/tests/components/homekit_controller/test_select.py
+++ b/tests/components/homekit_controller/test_select.py
@@ -33,9 +33,10 @@ def create_service_with_temperature_units(accessory: Accessory):
     return service
 
 
-async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
+async def test_migrate_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+) -> None:
     """Test we can migrate a select unique id."""
-    entity_registry = er.async_get(hass)
     aid = get_next_aid()
     select = entity_registry.async_get_or_create(
         "select",

--- a/tests/components/homekit_controller/test_sensor.py
+++ b/tests/components/homekit_controller/test_sensor.py
@@ -409,12 +409,12 @@ async def test_rssi_sensor(
 
 async def test_migrate_rssi_sensor_unique_id(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     utcnow,
     entity_registry_enabled_by_default: None,
     enable_bluetooth: None,
 ) -> None:
     """Test an rssi sensor unique id migration."""
-    entity_registry = er.async_get(hass)
     rssi_sensor = entity_registry.async_get_or_create(
         "sensor",
         "homekit_controller",

--- a/tests/components/homekit_controller/test_switch.py
+++ b/tests/components/homekit_controller/test_switch.py
@@ -219,9 +219,10 @@ async def test_char_switch_read_state(hass: HomeAssistant, utcnow) -> None:
     assert switch_1.state == "off"
 
 
-async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
+async def test_migrate_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+) -> None:
     """Test a we can migrate a switch unique id."""
-    entity_registry = er.async_get(hass)
     aid = get_next_aid()
     switch_entry = entity_registry.async_get_or_create(
         "switch",

--- a/tests/components/homematicip_cloud/test_device.py
+++ b/tests/components/homematicip_cloud/test_device.py
@@ -29,7 +29,10 @@ async def test_hmip_load_all_supported_devices(
 
 
 async def test_hmip_remove_device(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    default_mock_hap_factory,
 ) -> None:
     """Test Remove of hmip device."""
     entity_id = "light.treppe_ch"
@@ -45,9 +48,6 @@ async def test_hmip_remove_device(
 
     assert ha_state.state == STATE_ON
     assert hmip_device
-
-    device_registry = dr.async_get(hass)
-    entity_registry = er.async_get(hass)
 
     pre_device_count = len(device_registry.devices)
     pre_entity_count = len(entity_registry.entities)
@@ -63,7 +63,11 @@ async def test_hmip_remove_device(
 
 
 async def test_hmip_add_device(
-    hass: HomeAssistant, default_mock_hap_factory, hmip_config_entry
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    default_mock_hap_factory,
+    hmip_config_entry,
 ) -> None:
     """Test Remove of hmip device."""
     entity_id = "light.treppe_ch"
@@ -79,9 +83,6 @@ async def test_hmip_add_device(
 
     assert ha_state.state == STATE_ON
     assert hmip_device
-
-    device_registry = dr.async_get(hass)
-    entity_registry = er.async_get(hass)
 
     pre_device_count = len(device_registry.devices)
     pre_entity_count = len(entity_registry.entities)
@@ -112,7 +113,12 @@ async def test_hmip_add_device(
     assert len(new_hap.hmip_device_by_entity_id) == pre_mapping_count
 
 
-async def test_hmip_remove_group(hass: HomeAssistant, default_mock_hap_factory) -> None:
+async def test_hmip_remove_group(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    default_mock_hap_factory,
+) -> None:
     """Test Remove of hmip group."""
     entity_id = "switch.strom_group"
     entity_name = "Strom Group"
@@ -125,9 +131,6 @@ async def test_hmip_remove_group(hass: HomeAssistant, default_mock_hap_factory) 
 
     assert ha_state.state == STATE_ON
     assert hmip_device
-
-    device_registry = dr.async_get(hass)
-    entity_registry = er.async_get(hass)
 
     pre_device_count = len(device_registry.devices)
     pre_entity_count = len(entity_registry.entities)
@@ -254,7 +257,10 @@ async def test_hmip_reset_energy_counter_services(
 
 
 async def test_hmip_multi_area_device(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    default_mock_hap_factory,
 ) -> None:
     """Test multi area device. Check if devices are created and referenced."""
     entity_id = "binary_sensor.wired_eingangsmodul_32_fach_channel5"
@@ -270,12 +276,10 @@ async def test_hmip_multi_area_device(
     assert ha_state
 
     # get the entity
-    entity_registry = er.async_get(hass)
     entity = entity_registry.async_get(ha_state.entity_id)
     assert entity
 
     # get the device
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entity.device_id)
     assert device.name == "Wired Eingangsmodul – 32-fach"
 

--- a/tests/components/honeywell/test_climate.py
+++ b/tests/components/honeywell/test_climate.py
@@ -62,6 +62,7 @@ async def test_no_thermostat_options(
 
 async def test_static_attributes(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     device: MagicMock,
     config_entry: MagicMock,
     snapshot: SnapshotAssertion,
@@ -70,7 +71,7 @@ async def test_static_attributes(
     await init_integration(hass, config_entry)
 
     entity_id = f"climate.{device.name}"
-    entry = er.async_get(hass).async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
 
     state = hass.states.get(entity_id)
@@ -1200,7 +1201,10 @@ async def test_async_update_errors(
 
 
 async def test_aux_heat_off_service_call(
-    hass: HomeAssistant, device: MagicMock, config_entry: MagicMock
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device: MagicMock,
+    config_entry: MagicMock,
 ) -> None:
     """Test aux heat off turns of system when no heat configured."""
     device.raw_ui_data["SwitchHeatAllowed"] = False
@@ -1210,7 +1214,7 @@ async def test_aux_heat_off_service_call(
     await init_integration(hass, config_entry)
 
     entity_id = f"climate.{device.name}"
-    entry = er.async_get(hass).async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
 
     state = hass.states.get(entity_id)

--- a/tests/components/honeywell/test_init.py
+++ b/tests/components/honeywell/test_init.py
@@ -124,6 +124,7 @@ async def test_no_devices(
 async def test_remove_stale_device(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
     location: MagicMock,
     another_device: MagicMock,
     client: MagicMock,
@@ -133,7 +134,6 @@ async def test_remove_stale_device(
 
     config_entry.add_to_hass(hass)
 
-    device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={("OtherDomain", 7654321)},
@@ -146,7 +146,6 @@ async def test_remove_stale_device(
         hass.states.async_entity_ids_count() == 6
     )  # 2 climate entities; 4 sensor entities
 
-    device_registry = dr.async_get(hass)
     device_entry = dr.async_entries_for_config_entry(
         device_registry, config_entry.entry_id
     )

--- a/tests/components/huawei_lte/test_switches.py
+++ b/tests/components/huawei_lte/test_switches.py
@@ -12,7 +12,6 @@ from homeassistant.components.switch import (
 from homeassistant.const import ATTR_ENTITY_ID, CONF_URL, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity_registry import EntityRegistry
 
 from tests.common import MockConfigEntry
 
@@ -42,13 +41,13 @@ def magic_client(multi_basic_settings_value: dict) -> MagicMock:
 async def test_huawei_lte_wifi_guest_network_config_entry_when_network_is_not_present(
     client,
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test switch wifi guest network config entry when network is not present."""
     huawei_lte = MockConfigEntry(domain=DOMAIN, data={CONF_URL: "http://huawei-lte"})
     huawei_lte.add_to_hass(hass)
     await hass.config_entries.async_setup(huawei_lte.entry_id)
     await hass.async_block_till_done()
-    entity_registry: EntityRegistry = er.async_get(hass)
     assert not entity_registry.async_is_registered(SWITCH_WIFI_GUEST_NETWORK)
 
 
@@ -62,13 +61,13 @@ async def test_huawei_lte_wifi_guest_network_config_entry_when_network_is_not_pr
 async def test_huawei_lte_wifi_guest_network_config_entry_when_network_is_present(
     client,
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test switch wifi guest network config entry when network is present."""
     huawei_lte = MockConfigEntry(domain=DOMAIN, data={CONF_URL: "http://huawei-lte"})
     huawei_lte.add_to_hass(hass)
     await hass.config_entries.async_setup(huawei_lte.entry_id)
     await hass.async_block_till_done()
-    entity_registry: EntityRegistry = er.async_get(hass)
     assert entity_registry.async_is_registered(SWITCH_WIFI_GUEST_NETWORK)
 
 
@@ -122,7 +121,9 @@ async def test_turn_off_switch_wifi_guest_network(client, hass: HomeAssistant) -
     return_value=magic_client({"Ssids": {"Ssid": "str"}}),
 )
 async def test_huawei_lte_wifi_guest_network_config_entry_when_ssid_is_str(
-    client, hass: HomeAssistant
+    client,
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test switch wifi guest network config entry when ssid is a str.
 
@@ -132,7 +133,6 @@ async def test_huawei_lte_wifi_guest_network_config_entry_when_ssid_is_str(
     huawei_lte.add_to_hass(hass)
     await hass.config_entries.async_setup(huawei_lte.entry_id)
     await hass.async_block_till_done()
-    entity_registry: EntityRegistry = er.async_get(hass)
     assert not entity_registry.async_is_registered(SWITCH_WIFI_GUEST_NETWORK)
 
 
@@ -142,7 +142,9 @@ async def test_huawei_lte_wifi_guest_network_config_entry_when_ssid_is_str(
     return_value=magic_client({"Ssids": {"Ssid": None}}),
 )
 async def test_huawei_lte_wifi_guest_network_config_entry_when_ssid_is_none(
-    client, hass: HomeAssistant
+    client,
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test switch wifi guest network config entry when ssid is a None.
 
@@ -152,5 +154,4 @@ async def test_huawei_lte_wifi_guest_network_config_entry_when_ssid_is_none(
     huawei_lte.add_to_hass(hass)
     await hass.config_entries.async_setup(huawei_lte.entry_id)
     await hass.async_block_till_done()
-    entity_registry: EntityRegistry = er.async_get(hass)
     assert not entity_registry.async_is_registered(SWITCH_WIFI_GUEST_NETWORK)

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -527,7 +527,10 @@ def _get_schema_default(schema, key_name):
     raise KeyError(f"{key_name} not found in schema")
 
 
-async def test_options_flow_v2(hass: HomeAssistant) -> None:
+async def test_options_flow_v2(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
     """Test options config flow for a V2 bridge."""
     entry = MockConfigEntry(
         domain="hue",
@@ -536,9 +539,8 @@ async def test_options_flow_v2(hass: HomeAssistant) -> None:
     )
     entry.add_to_hass(hass)
 
-    dev_reg = dr.async_get(hass)
     mock_dev_id = "aabbccddee"
-    dev_reg.async_get_or_create(
+    device_registry.async_get_or_create(
         config_entry_id=entry.entry_id, identifiers={(const.DOMAIN, mock_dev_id)}
     )
 

--- a/tests/components/hue/test_light_v1.py
+++ b/tests/components/hue/test_light_v1.py
@@ -275,7 +275,9 @@ async def test_lights_color_mode(hass: HomeAssistant, mock_bridge_v1) -> None:
     ]
 
 
-async def test_groups(hass: HomeAssistant, mock_bridge_v1) -> None:
+async def test_groups(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_bridge_v1
+) -> None:
     """Test the update_lights function with some lights."""
     mock_bridge_v1.mock_light_responses.append({})
     mock_bridge_v1.mock_group_responses.append(GROUP_RESPONSE)
@@ -295,9 +297,8 @@ async def test_groups(hass: HomeAssistant, mock_bridge_v1) -> None:
     assert lamp_2 is not None
     assert lamp_2.state == "on"
 
-    ent_reg = er.async_get(hass)
-    assert ent_reg.async_get("light.group_1").unique_id == "1"
-    assert ent_reg.async_get("light.group_2").unique_id == "2"
+    assert entity_registry.async_get("light.group_1").unique_id == "1"
+    assert entity_registry.async_get("light.group_2").unique_id == "2"
 
 
 async def test_new_group_discovered(hass: HomeAssistant, mock_bridge_v1) -> None:
@@ -764,7 +765,12 @@ def test_hs_color() -> None:
     assert light.hs_color == color.color_xy_to_hs(0.4, 0.5, LIGHT_GAMUT)
 
 
-async def test_group_features(hass: HomeAssistant, mock_bridge_v1) -> None:
+async def test_group_features(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    mock_bridge_v1,
+) -> None:
     """Test group features."""
     color_temp_type = "Color temperature light"
     extended_color_type = "Extended color light"
@@ -948,9 +954,6 @@ async def test_group_features(hass: HomeAssistant, mock_bridge_v1) -> None:
     group_3 = hass.states.get("light.dining_room")
     assert group_3.attributes["supported_color_modes"] == extended_color_mode
     assert group_3.attributes["supported_features"] == extended_color_feature
-
-    entity_registry = er.async_get(hass)
-    device_registry = dr.async_get(hass)
 
     entry = entity_registry.async_get("light.hue_lamp_1")
     device_entry = device_registry.async_get(entry.device_id)

--- a/tests/components/hue/test_light_v2.py
+++ b/tests/components/hue/test_light_v2.py
@@ -350,7 +350,10 @@ async def test_light_availability(
 
 
 async def test_grouped_lights(
-    hass: HomeAssistant, mock_bridge_v2, v2_resources_test_data
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_bridge_v2,
+    v2_resources_test_data,
 ) -> None:
     """Test if all v2 grouped lights get created with correct features."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
@@ -359,8 +362,7 @@ async def test_grouped_lights(
 
     # test if entities for hue groups are created and enabled by default
     for entity_id in ("light.test_zone", "light.test_room"):
-        ent_reg = er.async_get(hass)
-        entity_entry = ent_reg.async_get(entity_id)
+        entity_entry = entity_registry.async_get(entity_id)
 
         assert entity_entry
         # scene entities should have be assigned to the room/zone device/service

--- a/tests/components/hue/test_migration.py
+++ b/tests/components/hue/test_migration.py
@@ -44,21 +44,23 @@ async def test_auto_switchover(hass: HomeAssistant) -> None:
 
 
 async def test_light_entity_migration(
-    hass: HomeAssistant, mock_bridge_v2, mock_config_entry_v2, v2_resources_test_data
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    mock_bridge_v2,
+    mock_config_entry_v2,
+    v2_resources_test_data,
 ) -> None:
     """Test if entity schema for lights migrates from v1 to v2."""
     config_entry = mock_bridge_v2.config_entry = mock_config_entry_v2
     config_entry.add_to_hass(hass)
 
-    ent_reg = er.async_get(hass)
-    dev_reg = dr.async_get(hass)
-
     # create device/entity with V1 schema in registry
-    device = dev_reg.async_get_or_create(
+    device = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(hue.DOMAIN, "00:17:88:01:09:aa:bb:65-0b")},
     )
-    ent_reg.async_get_or_create(
+    entity_registry.async_get_or_create(
         "light",
         hue.DOMAIN,
         "00:17:88:01:09:aa:bb:65-0b",
@@ -77,30 +79,32 @@ async def test_light_entity_migration(
         await hue.migration.handle_v2_migration(hass, config_entry)
 
     # migrated device should now have the new identifier (guid) instead of old style (mac)
-    migrated_device = dev_reg.async_get(device.id)
+    migrated_device = device_registry.async_get(device.id)
     assert migrated_device is not None
     assert migrated_device.identifiers == {
         (hue.DOMAIN, "0b216218-d811-4c95-8c55-bbcda50f9d50")
     }
     # the entity should have the new unique_id (guid)
-    migrated_entity = ent_reg.async_get("light.migrated_light_1")
+    migrated_entity = entity_registry.async_get("light.migrated_light_1")
     assert migrated_entity is not None
     assert migrated_entity.unique_id == "02cba059-9c2c-4d45-97e4-4f79b1bfbaa1"
 
 
 async def test_sensor_entity_migration(
-    hass: HomeAssistant, mock_bridge_v2, mock_config_entry_v2, v2_resources_test_data
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    mock_bridge_v2,
+    mock_config_entry_v2,
+    v2_resources_test_data,
 ) -> None:
     """Test if entity schema for sensors migrates from v1 to v2."""
     config_entry = mock_bridge_v2.config_entry = mock_config_entry_v2
     config_entry.add_to_hass(hass)
 
-    ent_reg = er.async_get(hass)
-    dev_reg = dr.async_get(hass)
-
     # create device with V1 schema in registry for Hue motion sensor
     device_mac = "00:17:aa:bb:cc:09:ac:c3"
-    device = dev_reg.async_get_or_create(
+    device = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id, identifiers={(hue.DOMAIN, device_mac)}
     )
 
@@ -114,7 +118,7 @@ async def test_sensor_entity_migration(
 
     # create entities with V1 schema in registry for Hue motion sensor
     for dev_class, platform, _ in sensor_mappings:
-        ent_reg.async_get_or_create(
+        entity_registry.async_get_or_create(
             platform,
             hue.DOMAIN,
             f"{device_mac}-{dev_class}",
@@ -134,14 +138,14 @@ async def test_sensor_entity_migration(
         await hue.migration.handle_v2_migration(hass, config_entry)
 
     # migrated device should now have the new identifier (guid) instead of old style (mac)
-    migrated_device = dev_reg.async_get(device.id)
+    migrated_device = device_registry.async_get(device.id)
     assert migrated_device is not None
     assert migrated_device.identifiers == {
         (hue.DOMAIN, "2330b45d-6079-4c6e-bba6-1b68afb1a0d6")
     }
     # the entities should have the correct V2 unique_id (guid)
     for dev_class, platform, new_id in sensor_mappings:
-        migrated_entity = ent_reg.async_get(
+        migrated_entity = entity_registry.async_get(
             f"{platform}.hue_migrated_{dev_class}_sensor"
         )
         assert migrated_entity is not None
@@ -149,16 +153,18 @@ async def test_sensor_entity_migration(
 
 
 async def test_group_entity_migration_with_v1_id(
-    hass: HomeAssistant, mock_bridge_v2, mock_config_entry_v2, v2_resources_test_data
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_bridge_v2,
+    mock_config_entry_v2,
+    v2_resources_test_data,
 ) -> None:
     """Test if entity schema for grouped_lights migrates from v1 to v2."""
     config_entry = mock_bridge_v2.config_entry = mock_config_entry_v2
 
-    ent_reg = er.async_get(hass)
-
     # create (deviceless) entity with V1 schema in registry
     # using the legacy style group id as unique id
-    ent_reg.async_get_or_create(
+    entity_registry.async_get_or_create(
         "light",
         hue.DOMAIN,
         "3",
@@ -176,22 +182,24 @@ async def test_group_entity_migration_with_v1_id(
         await hue.migration.handle_v2_migration(hass, config_entry)
 
     # the entity should have the new identifier (guid)
-    migrated_entity = ent_reg.async_get("light.hue_migrated_grouped_light")
+    migrated_entity = entity_registry.async_get("light.hue_migrated_grouped_light")
     assert migrated_entity is not None
     assert migrated_entity.unique_id == "e937f8db-2f0e-49a0-936e-027e60e15b34"
 
 
 async def test_group_entity_migration_with_v2_group_id(
-    hass: HomeAssistant, mock_bridge_v2, mock_config_entry_v2, v2_resources_test_data
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_bridge_v2,
+    mock_config_entry_v2,
+    v2_resources_test_data,
 ) -> None:
     """Test if entity schema for grouped_lights migrates from v1 to v2."""
     config_entry = mock_bridge_v2.config_entry = mock_config_entry_v2
 
-    ent_reg = er.async_get(hass)
-
     # create (deviceless) entity with V1 schema in registry
     # using the V2 group id as unique id
-    ent_reg.async_get_or_create(
+    entity_registry.async_get_or_create(
         "light",
         hue.DOMAIN,
         "6ddc9066-7e7d-4a03-a773-c73937968296",
@@ -209,6 +217,6 @@ async def test_group_entity_migration_with_v2_group_id(
         await hue.migration.handle_v2_migration(hass, config_entry)
 
     # the entity should have the new identifier (guid)
-    migrated_entity = ent_reg.async_get("light.hue_migrated_grouped_light")
+    migrated_entity = entity_registry.async_get("light.hue_migrated_grouped_light")
     assert migrated_entity is not None
     assert migrated_entity.unique_id == "e937f8db-2f0e-49a0-936e-027e60e15b34"

--- a/tests/components/hue/test_scene.py
+++ b/tests/components/hue/test_scene.py
@@ -8,7 +8,10 @@ from .const import FAKE_SCENE
 
 
 async def test_scene(
-    hass: HomeAssistant, mock_bridge_v2, v2_resources_test_data
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_bridge_v2,
+    v2_resources_test_data,
 ) -> None:
     """Test if (config) scenes get created."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
@@ -57,13 +60,12 @@ async def test_scene(
     assert test_entity.attributes["is_active"] is True
 
     # scene entities should have be assigned to the room/zone device/service
-    ent_reg = er.async_get(hass)
     for entity_id in (
         "scene.test_zone_dynamic_test_scene",
         "scene.test_room_regular_test_scene",
         "scene.test_room_smart_test_scene",
     ):
-        entity_entry = ent_reg.async_get(entity_id)
+        entity_entry = entity_registry.async_get(entity_id)
         assert entity_entry
         assert entity_entry.device_id is not None
 

--- a/tests/components/hue/test_sensor_v2.py
+++ b/tests/components/hue/test_sensor_v2.py
@@ -9,7 +9,10 @@ from .const import FAKE_DEVICE, FAKE_SENSOR, FAKE_ZIGBEE_CONNECTIVITY
 
 
 async def test_sensors(
-    hass: HomeAssistant, mock_bridge_v2, v2_resources_test_data
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_bridge_v2,
+    v2_resources_test_data,
 ) -> None:
     """Test if all v2 sensors get created with correct features."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
@@ -51,8 +54,7 @@ async def test_sensors(
 
     # test disabled zigbee_connectivity sensor
     entity_id = "sensor.wall_switch_with_2_controls_zigbee_connectivity"
-    ent_reg = er.async_get(hass)
-    entity_entry = ent_reg.async_get(entity_id)
+    entity_entry = entity_registry.async_get(entity_id)
 
     assert entity_entry
     assert entity_entry.disabled
@@ -60,7 +62,11 @@ async def test_sensors(
 
 
 async def test_enable_sensor(
-    hass: HomeAssistant, mock_bridge_v2, v2_resources_test_data, mock_config_entry_v2
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_bridge_v2,
+    v2_resources_test_data,
+    mock_config_entry_v2,
 ) -> None:
     """Test enabling of the by default disabled zigbee_connectivity sensor."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
@@ -71,15 +77,14 @@ async def test_enable_sensor(
     await hass.config_entries.async_forward_entry_setup(mock_config_entry_v2, "sensor")
 
     entity_id = "sensor.wall_switch_with_2_controls_zigbee_connectivity"
-    ent_reg = er.async_get(hass)
-    entity_entry = ent_reg.async_get(entity_id)
+    entity_entry = entity_registry.async_get(entity_id)
 
     assert entity_entry
     assert entity_entry.disabled
     assert entity_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
     # enable the entity
-    updated_entry = ent_reg.async_update_entity(
+    updated_entry = entity_registry.async_update_entity(
         entity_entry.entity_id, **{"disabled_by": None}
     )
     assert updated_entry != entity_entry

--- a/tests/components/hydrawise/test_device.py
+++ b/tests/components/hydrawise/test_device.py
@@ -9,10 +9,12 @@ from homeassistant.helpers import device_registry as dr
 
 
 def test_zones_in_device_registry(
-    hass: HomeAssistant, mock_added_config_entry: ConfigEntry, mock_pydrawise: Mock
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_added_config_entry: ConfigEntry,
+    mock_pydrawise: Mock,
 ) -> None:
     """Test that devices are added to the device registry."""
-    device_registry = dr.async_get(hass)
 
     device1 = device_registry.async_get_device(identifiers={(DOMAIN, "5965394")})
     assert device1 is not None
@@ -26,10 +28,12 @@ def test_zones_in_device_registry(
 
 
 def test_controller_in_device_registry(
-    hass: HomeAssistant, mock_added_config_entry: ConfigEntry, mock_pydrawise: Mock
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_added_config_entry: ConfigEntry,
+    mock_pydrawise: Mock,
 ) -> None:
     """Test that devices are added to the device registry."""
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(identifiers={(DOMAIN, "52496")})
     assert device is not None
     assert device.name == "Home Controller"

--- a/tests/components/hyperion/test_camera.py
+++ b/tests/components/hyperion/test_camera.py
@@ -177,7 +177,11 @@ async def test_camera_stream_failed_start_stream_call(hass: HomeAssistant) -> No
     assert not client.async_send_image_stream_stop.called
 
 
-async def test_device_info(hass: HomeAssistant) -> None:
+async def test_device_info(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Verify device information includes expected details."""
     client = create_mock_client()
 
@@ -190,7 +194,6 @@ async def test_device_info(hass: HomeAssistant) -> None:
     await setup_test_config_entry(hass, hyperion_client=client)
 
     device_id = get_hyperion_device_id(TEST_SYSINFO_ID, TEST_INSTANCE)
-    device_registry = dr.async_get(hass)
 
     device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
     assert device
@@ -200,7 +203,6 @@ async def test_device_info(hass: HomeAssistant) -> None:
     assert device.model == HYPERION_MODEL_NAME
     assert device.name == TEST_INSTANCE_1["friendly_name"]
 
-    entity_registry = er.async_get(hass)
     entities_from_device = [
         entry.entity_id
         for entry in er.async_entries_for_device(entity_registry, device.id)

--- a/tests/components/hyperion/test_switch.py
+++ b/tests/components/hyperion/test_switch.py
@@ -144,7 +144,11 @@ async def test_switch_has_correct_entities(hass: HomeAssistant) -> None:
         assert entity_state, f"Couldn't find entity: {entity_id}"
 
 
-async def test_device_info(hass: HomeAssistant) -> None:
+async def test_device_info(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Verify device information includes expected details."""
     client = create_mock_client()
     client.components = TEST_COMPONENTS
@@ -162,7 +166,6 @@ async def test_device_info(hass: HomeAssistant) -> None:
     assert hass.states.get(TEST_SWITCH_COMPONENT_ALL_ENTITY_ID) is not None
 
     device_identifer = get_hyperion_device_id(TEST_SYSINFO_ID, TEST_INSTANCE)
-    device_registry = dr.async_get(hass)
 
     device = device_registry.async_get_device(identifiers={(DOMAIN, device_identifer)})
     assert device
@@ -172,7 +175,6 @@ async def test_device_info(hass: HomeAssistant) -> None:
     assert device.model == HYPERION_MODEL_NAME
     assert device.name == TEST_INSTANCE_1["friendly_name"]
 
-    entity_registry = er.async_get(hass)
     entities_from_device = [
         entry.entity_id
         for entry in er.async_entries_for_device(entity_registry, device.id)
@@ -184,13 +186,13 @@ async def test_device_info(hass: HomeAssistant) -> None:
         assert entity_id in entities_from_device
 
 
-async def test_switches_can_be_enabled(hass: HomeAssistant) -> None:
+async def test_switches_can_be_enabled(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Verify switches can be enabled."""
     client = create_mock_client()
     client.components = TEST_COMPONENTS
     await setup_test_config_entry(hass, hyperion_client=client)
-
-    entity_registry = er.async_get(hass)
 
     for component in TEST_COMPONENTS:
         name = slugify(KEY_COMPONENTID_TO_NAME[str(component["name"])])


### PR DESCRIPTION
## Proposed change
Update component tests starting with `h` to use the entity & device registry fixtures.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
