### PR TITLE
Fix bug in Fitbit config flow, and switch to prefer display name

### DIFF
--- a/homeassistant/components/fitbit/api.py
+++ b/homeassistant/components/fitbit/api.py
@@ -69,7 +69,7 @@ class FitbitApi(ABC):
             profile = response["user"]
             self._profile = FitbitProfile(
                 encoded_id=profile["encodedId"],
-                full_name=profile["fullName"],
+                display_name=profile["displayName"],
                 locale=profile.get("locale"),
             )
         return self._profile

--- a/homeassistant/components/fitbit/config_flow.py
+++ b/homeassistant/components/fitbit/config_flow.py
@@ -90,7 +90,7 @@ class OAuth2FlowHandler(
 
         await self.async_set_unique_id(profile.encoded_id)
         self._abort_if_unique_id_configured()
-        return self.async_create_entry(title=profile.full_name, data=data)
+        return self.async_create_entry(title=profile.display_name, data=data)
 
     async def async_step_import(self, data: dict[str, Any]) -> FlowResult:
         """Handle import from YAML."""

--- a/homeassistant/components/fitbit/model.py
+++ b/homeassistant/components/fitbit/model.py
@@ -14,8 +14,8 @@ class FitbitProfile:
     encoded_id: str
     """The ID representing the Fitbit user."""
 
-    full_name: str
-    """The first name value specified in the user's account settings."""
+    display_name: str
+    """The name shown when the user's friends look at their Fitbit profile."""
 
     locale: str | None
     """The locale defined in the user's Fitbit account settings."""

--- a/tests/components/fitbit/conftest.py
+++ b/tests/components/fitbit/conftest.py
@@ -32,6 +32,15 @@ PROFILE_USER_ID = "fitbit-api-user-id-1"
 FAKE_ACCESS_TOKEN = "some-access-token"
 FAKE_REFRESH_TOKEN = "some-refresh-token"
 FAKE_AUTH_IMPL = "conftest-imported-cred"
+FULL_NAME = "First Last"
+DISPLAY_NAME = "First L."
+PROFILE_DATA = {
+    "fullName": FULL_NAME,
+    "displayName": DISPLAY_NAME,
+    "displayNameSetting": "name",
+    "firstName": "First",
+    "lastName": "Last",
+}
 
 PROFILE_API_URL = "https://api.fitbit.com/1/user/-/profile.json"
 DEVICES_API_URL = "https://api.fitbit.com/1/user/-/devices.json"
@@ -214,20 +223,34 @@ def mock_profile_locale() -> str:
     return "en_US"
 
 
+@pytest.fixture(name="profile_data")
+def mock_profile_data() -> dict[str, Any]:
+    """Fixture to return other profile data fields."""
+    return PROFILE_DATA
+
+
+@pytest.fixture(name="profile_response")
+def mock_profile_response(
+    profile_id: str, profile_locale: str, profile_data: dict[str, Any]
+) -> dict[str, Any]:
+    """Fixture to construct the fake profile API response."""
+    return {
+        "user": {
+            "encodedId": profile_id,
+            "locale": profile_locale,
+            **profile_data,
+        },
+    }
+
+
 @pytest.fixture(name="profile", autouse=True)
-def mock_profile(requests_mock: Mocker, profile_id: str, profile_locale: str) -> None:
+def mock_profile(requests_mock: Mocker, profile_response: dict[str, Any]) -> None:
     """Fixture to setup fake requests made to Fitbit API during config flow."""
     requests_mock.register_uri(
         "GET",
         PROFILE_API_URL,
         status_code=HTTPStatus.OK,
-        json={
-            "user": {
-                "encodedId": profile_id,
-                "fullName": "My name",
-                "locale": profile_locale,
-            },
-        },
+        json=profile_response,
     )
 
 

--- a/tests/components/fitbit/test_config_flow.py
+++ b/tests/components/fitbit/test_config_flow.py
@@ -17,8 +17,10 @@ from homeassistant.helpers import config_entry_oauth2_flow, issue_registry as ir
 
 from .conftest import (
     CLIENT_ID,
+    DISPLAY_NAME,
     FAKE_AUTH_IMPL,
     PROFILE_API_URL,
+    PROFILE_DATA,
     PROFILE_USER_ID,
     SERVER_ACCESS_TOKEN,
 )
@@ -76,7 +78,7 @@ async def test_full_flow(
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
     config_entry = entries[0]
-    assert config_entry.title == "My name"
+    assert config_entry.title == DISPLAY_NAME
     assert config_entry.unique_id == PROFILE_USER_ID
 
     data = dict(config_entry.data)
@@ -286,7 +288,7 @@ async def test_import_fitbit_config(
 
     # Verify valid profile can be fetched from the API
     config_entry = entries[0]
-    assert config_entry.title == "My name"
+    assert config_entry.title == DISPLAY_NAME
     assert config_entry.unique_id == PROFILE_USER_ID
 
     data = dict(config_entry.data)
@@ -598,3 +600,60 @@ async def test_reauth_wrong_user_id(
     assert result.get("reason") == "wrong_account"
 
     assert len(mock_setup.mock_calls) == 0
+
+
+@pytest.mark.parametrize(
+    ("profile_data", "expected_title"),
+    [
+        (PROFILE_DATA, DISPLAY_NAME),
+        ({"displayName": DISPLAY_NAME}, DISPLAY_NAME),
+    ],
+    ids=("full_profile_data", "display_name_only"),
+)
+async def test_partial_profile_data(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+    profile: None,
+    setup_credentials: None,
+    expected_title: str,
+) -> None:
+    """Check full flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": REDIRECT_URL,
+        },
+    )
+    assert result["type"] == FlowResultType.EXTERNAL_STEP
+    assert result["url"] == (
+        f"{OAUTH2_AUTHORIZE}?response_type=code&client_id={CLIENT_ID}"
+        f"&redirect_uri={REDIRECT_URL}"
+        f"&state={state}"
+        "&scope=activity+heartrate+nutrition+profile+settings+sleep+weight&prompt=consent"
+    )
+
+    client = await hass_client_no_auth()
+    resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
+    assert resp.status == 200
+
+    aioclient_mock.post(
+        OAUTH2_TOKEN,
+        json=SERVER_ACCESS_TOKEN,
+    )
+
+    with patch(
+        "homeassistant.components.fitbit.async_setup_entry", return_value=True
+    ) as mock_setup:
+        await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert len(mock_setup.mock_calls) == 1
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    config_entry = entries[0]
+    assert config_entry.title == expected_title


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix bug in Fitbit config flow, and switch to prefer display name.

The integration previously used `fullName` which turns out not to always be available resulting in `KeyError: 'fullName'`. See https://dev.fitbit.com/build/reference/web-api/user/get-profile/ for the full API documentation. Generally, using the display name seems like a better choice anyway given it is something where the user can indicate a preference of how they'd like their profile to appear.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #29748
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
