### PR TITLE
Introduce target_temperature_range attribute to climate component

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -53,6 +53,7 @@ from .const import (  # noqa: F401
     ATTR_SWING_MODES,
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
+    ATTR_TARGET_TEMP_RANGE,
     ATTR_TARGET_TEMP_STEP,
     DOMAIN,
     FAN_AUTO,
@@ -102,6 +103,7 @@ from .const import (  # noqa: F401
     HVACMode,
 )
 
+DEFAULT_TEMP_RANGE = -16
 DEFAULT_MIN_TEMP = 7
 DEFAULT_MAX_TEMP = 35
 DEFAULT_MIN_HUMIDITY = 30
@@ -110,14 +112,20 @@ DEFAULT_MAX_HUMIDITY = 99
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
 SCAN_INTERVAL = timedelta(seconds=60)
 
-CONVERTIBLE_ATTRIBUTE = [ATTR_TEMPERATURE, ATTR_TARGET_TEMP_LOW, ATTR_TARGET_TEMP_HIGH]
+CONVERTIBLE_ATTRIBUTE = [
+    ATTR_TEMPERATURE,
+    ATTR_TARGET_TEMP_LOW,
+    ATTR_TARGET_TEMP_HIGH,
+]
 
 _LOGGER = logging.getLogger(__name__)
 
 
 SET_TEMPERATURE_SCHEMA = vol.All(
     cv.has_at_least_one_key(
-        ATTR_TEMPERATURE, ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW
+        ATTR_TEMPERATURE,
+        ATTR_TARGET_TEMP_HIGH,
+        ATTR_TARGET_TEMP_LOW,
     ),
     make_entity_service_schema(
         {
@@ -247,6 +255,7 @@ class ClimateEntity(Entity):
     _attr_target_temperature_low: float | None
     _attr_target_temperature_step: float | None = None
     _attr_target_temperature: float | None = None
+    _attr_target_temperature_range: float | None = None
     _attr_temperature_unit: str
 
     @final
@@ -332,6 +341,9 @@ class ClimateEntity(Entity):
             data[ATTR_TARGET_TEMP_LOW] = show_temp(
                 hass, self.target_temperature_low, temperature_unit, precision
             )
+            data[ATTR_TARGET_TEMP_RANGE] = show_temp(
+                hass, self.target_temperature_range, temperature_unit, precision
+            )
 
         if (current_humidity := self.current_humidity) is not None:
             data[ATTR_CURRENT_HUMIDITY] = current_humidity
@@ -416,6 +428,14 @@ class ClimateEntity(Entity):
         Requires ClimateEntityFeature.TARGET_TEMPERATURE_RANGE.
         """
         return self._attr_target_temperature_low
+
+    @property
+    def target_temperature_range(self) -> float | None:
+        """Return the minimum range between target_temperature_low and target_temperature_high.
+
+        Requires ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+        """
+        return self._attr_target_temperature_range
 
     @property
     def preset_mode(self) -> str | None:

--- a/homeassistant/components/climate/const.py
+++ b/homeassistant/components/climate/const.py
@@ -128,6 +128,7 @@ ATTR_SWING_MODE = "swing_mode"
 ATTR_TARGET_TEMP_HIGH = "target_temp_high"
 ATTR_TARGET_TEMP_LOW = "target_temp_low"
 ATTR_TARGET_TEMP_STEP = "target_temp_step"
+ATTR_TARGET_TEMP_RANGE = "target_temp_range"
 
 DEFAULT_MIN_TEMP = 7
 DEFAULT_MAX_TEMP = 35


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
This change introduces the `target_temperature_range` attribute to the base `climate` entity that lives in HA core. As more thermostats add support for a heat/cool mode, more vendors will provide the deadband range between the low and high temperatures. This attribute will be useful in integrations that should send the thermostat device a valid set of low and high temperatures. 

One use case example would be the Nest Thermostat by Google. The minimum setpoint deadband (aka target_temperature_range) is 3°F. If a user provides two temperatures with a range between them that is less than <3°F, the thermostat refuses to accept the set temperature call. Providing 70°F and 72°F as the low and high temperatures would be invalid for this device since it doesn't meet the target_temperature_range.

Currently, the Nest integration automatically handles this logic: https://github.com/home-assistant/core/pull/98238/commits/7af4c523413f6d729b95b4720cdcd79ea9a71e77

In the Nest implementation linked above, if the provided temperature range is invalid, the low and high temperature settings are adjusted to meet the minimum range.

The Matter integration for the Nest Thermostat on the other hand doesn't support correctly handling the deadband (yet). See: https://github.com/home-assistant/core/issues/102491

Supporting the target_temperature_range on a global scale seems like an overall improvement since components are already incorporating it on an individual level.

![image](https://github.com/home-assistant/core/assets/37427166/ac8b351a-bbd2-4666-8968-e4774b7c380f)

Future tasks include:
- Updating the Nest thermostat and the Matter thermostat implementations to refer to this new attribute


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: https://github.com/home-assistant/core/issues/102491
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29815

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]


If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
