### PR TITLE
Media player entity for SmartThings

### DIFF
--- a/homeassistant/components/smartthings/const.py
+++ b/homeassistant/components/smartthings/const.py
@@ -39,6 +39,7 @@ PLATFORMS = [
     Platform.LIGHT,
     Platform.LOCK,
     Platform.COVER,
+    Platform.MEDIA_PLAYER,
     Platform.SWITCH,
     Platform.BINARY_SENSOR,
     Platform.SENSOR,

--- a/homeassistant/components/smartthings/media_player.py
+++ b/homeassistant/components/smartthings/media_player.py
@@ -1,0 +1,228 @@
+"""Support for media players through the SmartThings cloud API."""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from pysmartthings import Capability, DeviceEntity
+
+from homeassistant.components.media_player import (
+    DOMAIN as MEDIA_PLAYER_DOMAIN,
+    MediaPlayerEntity,
+    MediaPlayerEntityFeature,
+    MediaPlayerState,
+    RepeatMode,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import SmartThingsEntity
+from .const import DATA_BROKERS, DOMAIN
+
+VALUE_TO_STATE = {
+    "buffering": MediaPlayerState.BUFFERING,
+    "pause": MediaPlayerState.PAUSED,
+    "paused": MediaPlayerState.PAUSED,
+    "play": MediaPlayerState.PLAYING,
+    "playing": MediaPlayerState.PLAYING,
+    "stop": MediaPlayerState.IDLE,
+    "stopped": MediaPlayerState.IDLE,
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Add media players for a config entry."""
+    broker = hass.data[DOMAIN][DATA_BROKERS][config_entry.entry_id]
+    async_add_entities(
+        [
+            SmartThingsMediaPlayer(device)
+            for device in broker.devices.values()
+            if broker.any_assigned(device.device_id, MEDIA_PLAYER_DOMAIN)
+        ]
+    )
+
+
+def get_capabilities(capabilities: Sequence[str]) -> Sequence[str] | None:
+    """Return all capabilities supported if minimum required are present."""
+    supported = [
+        Capability.audio_mute,
+        Capability.audio_volume,
+        Capability.media_input_source,
+        Capability.media_playback,
+        Capability.media_playback_repeat,
+        Capability.media_playback_shuffle,
+        Capability.switch,
+    ]
+    # Must have one of these.
+    media_player_capabilities = [
+        Capability.audio_mute,
+        Capability.audio_volume,
+        Capability.media_input_source,
+        Capability.media_playback,
+        Capability.media_playback_repeat,
+        Capability.media_playback_shuffle,
+    ]
+    if any(capability in capabilities for capability in media_player_capabilities):
+        return supported
+    return None
+
+
+class SmartThingsMediaPlayer(SmartThingsEntity, MediaPlayerEntity):
+    """Define a SmartThings media player."""
+
+    def __init__(self, device: DeviceEntity) -> None:
+        """Initialize the media_player class."""
+        super().__init__(device)
+        self._state = None
+        self._state_attrs = None
+        self._supported_features = (
+            MediaPlayerEntityFeature.PLAY
+            | MediaPlayerEntityFeature.PAUSE
+            | MediaPlayerEntityFeature.STOP
+        )
+        if Capability.audio_volume in device.capabilities:
+            self._supported_features |= (
+                MediaPlayerEntityFeature.VOLUME_SET
+                | MediaPlayerEntityFeature.VOLUME_STEP
+            )
+        if Capability.audio_mute in device.capabilities:
+            self._supported_features |= MediaPlayerEntityFeature.VOLUME_MUTE
+        if Capability.switch in device.capabilities:
+            self._supported_features |= (
+                MediaPlayerEntityFeature.TURN_ON | MediaPlayerEntityFeature.TURN_OFF
+            )
+        if Capability.media_input_source in device.capabilities:
+            self._supported_features |= MediaPlayerEntityFeature.SELECT_SOURCE
+        if Capability.media_playback_shuffle in device.capabilities:
+            self._supported_features |= MediaPlayerEntityFeature.SHUFFLE_SET
+        if Capability.media_playback_repeat in device.capabilities:
+            self._supported_features |= MediaPlayerEntityFeature.REPEAT_SET
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the media player off."""
+        await self._device.switch_off(set_status=True)
+        self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the media player on."""
+        await self._device.switch_on(set_status=True)
+        self.async_write_ha_state()
+
+    async def async_mute_volume(self, mute: bool) -> None:
+        """Mute volume."""
+        if mute:
+            await self._device.mute(set_status=True)
+        else:
+            await self._device.unmute(set_status=True)
+        self.async_write_ha_state()
+
+    async def async_set_volume_level(self, volume: float) -> None:
+        """Set volume level."""
+        await self._device.set_volume(int(volume * 100), set_status=True)
+        self.async_write_ha_state()
+
+    async def async_volume_up(self) -> None:
+        """Increase volume."""
+        await self._device.volume_up(set_status=True)
+        self.async_write_ha_state()
+
+    async def async_volume_down(self) -> None:
+        """Decrease volume."""
+        await self._device.volume_down(set_status=True)
+        self.async_write_ha_state()
+
+    async def async_media_play(self) -> None:
+        """Play media."""
+        await self._device.play(set_status=True)
+        self.async_write_ha_state()
+
+    async def async_media_pause(self) -> None:
+        """Pause media."""
+        await self._device.pause(set_status=True)
+        self.async_write_ha_state()
+
+    async def async_media_stop(self) -> None:
+        """Stop media."""
+        await self._device.stop(set_status=True)
+        self.async_write_ha_state()
+
+    async def async_select_source(self, source: str) -> None:
+        """Select source."""
+        await self._device.set_input_source(source, set_status=True)
+        self.async_write_ha_state()
+
+    async def async_set_shuffle(self, shuffle: bool) -> None:
+        """Set shuffle mode."""
+        await self._device.set_playback_shuffle(shuffle, set_status=True)
+        self.async_write_ha_state()
+
+    async def async_set_repeat(self, repeat: RepeatMode) -> None:
+        """Set repeat mode."""
+        await self._device.set_repeat(repeat, set_status=True)
+        self.async_write_ha_state()
+
+    @property
+    def supported_features(self) -> MediaPlayerEntityFeature:
+        """Supported features."""
+        return self._supported_features
+
+    @property
+    def media_title(self) -> str | None:
+        """Title of the current media."""
+        return self._device.status.media_title
+
+    @property
+    def state(self) -> MediaPlayerState | None:
+        """State of the media player."""
+        if not self._device.status.switch:
+            return MediaPlayerState.OFF
+        if self._device.status.playback_status in VALUE_TO_STATE:
+            return VALUE_TO_STATE[self._device.status.playback_status]
+        return MediaPlayerState.ON
+
+    @property
+    def is_volume_muted(self) -> bool | None:
+        """Returns if the volume is muted."""
+        if self.supported_features & MediaPlayerEntityFeature.VOLUME_MUTE:
+            return self._device.status.mute
+        return None
+
+    @property
+    def volume_level(self) -> float | None:
+        """Volume level."""
+        if self.supported_features & MediaPlayerEntityFeature.VOLUME_SET:
+            return self._device.status.volume / 100
+        return None
+
+    @property
+    def source(self) -> str | None:
+        """Input source."""
+        if self.supported_features & MediaPlayerEntityFeature.SELECT_SOURCE:
+            return self._device.status.input_source
+        return None
+
+    @property
+    def source_list(self) -> list[str] | None:
+        """List of input sources."""
+        if self.supported_features & MediaPlayerEntityFeature.SELECT_SOURCE:
+            return self._device.status.supported_input_sources
+        return None
+
+    @property
+    def shuffle(self) -> bool | None:
+        """Returns if shuffle mode is set."""
+        if self.supported_features & MediaPlayerEntityFeature.SHUFFLE_SET:
+            return self._device.status.playback_shuffle
+        return None
+
+    @property
+    def repeat(self) -> RepeatMode | None:
+        """Returns if repeat mode is set."""
+        if self.supported_features & MediaPlayerEntityFeature.REPEAT_SET:
+            return self._device.status.playback_repeat_mode
+        return None

--- a/tests/components/smartthings/test_media_player.py
+++ b/tests/components/smartthings/test_media_player.py
@@ -1,0 +1,228 @@
+"""Support for media players through the SmartThings cloud API."""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from pysmartthings import Capability, DeviceEntity
+
+from homeassistant.components.media_player import (
+    DOMAIN as MEDIA_PLAYER_DOMAIN,
+    MediaPlayerEntity,
+    MediaPlayerEntityFeature,
+    MediaPlayerState,
+    RepeatMode,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import SmartThingsEntity
+from .const import DATA_BROKERS, DOMAIN
+
+VALUE_TO_STATE = {
+    "buffering": MediaPlayerState.BUFFERING,
+    "pause": MediaPlayerState.PAUSED,
+    "paused": MediaPlayerState.PAUSED,
+    "play": MediaPlayerState.PLAYING,
+    "playing": MediaPlayerState.PLAYING,
+    "stop": MediaPlayerState.IDLE,
+    "stopped": MediaPlayerState.IDLE,
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Add media players for a config entry."""
+    broker = hass.data[DOMAIN][DATA_BROKERS][config_entry.entry_id]
+    async_add_entities(
+        [
+            SmartThingsMediaPlayer(device)
+            for device in broker.devices.values()
+            if broker.any_assigned(device.device_id, MEDIA_PLAYER_DOMAIN)
+        ]
+    )
+
+
+def get_capabilities(capabilities: Sequence[str]) -> Sequence[str] | None:
+    """Return all capabilities supported if minimum required are present."""
+    supported = [
+        Capability.audio_mute,
+        Capability.audio_volume,
+        Capability.media_input_source,
+        Capability.media_playback,
+        Capability.media_playback_repeat,
+        Capability.media_playback_shuffle,
+        Capability.switch,
+    ]
+    # Must have one of these.
+    media_player_capabilities = [
+        Capability.audio_mute,
+        Capability.audio_volume,
+        Capability.media_input_source,
+        Capability.media_playback,
+        Capability.media_playback_repeat,
+        Capability.media_playback_shuffle,
+    ]
+    if any(capability in capabilities for capability in media_player_capabilities):
+        return supported
+    return None
+
+
+class SmartThingsMediaPlayer(SmartThingsEntity, MediaPlayerEntity):
+    """Define a SmartThings media player."""
+
+    def __init__(self, device: DeviceEntity) -> None:
+        """Initialize the media_player class."""
+        super().__init__(device)
+        self._state = None
+        self._state_attrs = None
+        self._supported_features = (
+            MediaPlayerEntityFeature.PLAY
+            | MediaPlayerEntityFeature.PAUSE
+            | MediaPlayerEntityFeature.STOP
+        )
+        if Capability.audio_volume in device.capabilities:
+            self._supported_features |= (
+                MediaPlayerEntityFeature.VOLUME_SET
+                | MediaPlayerEntityFeature.VOLUME_STEP
+            )
+        if Capability.audio_mute in device.capabilities:
+            self._supported_features |= MediaPlayerEntityFeature.VOLUME_MUTE
+        if Capability.switch in device.capabilities:
+            self._supported_features |= (
+                MediaPlayerEntityFeature.TURN_ON | MediaPlayerEntityFeature.TURN_OFF
+            )
+        if Capability.media_input_source in device.capabilities:
+            self._supported_features |= MediaPlayerEntityFeature.SELECT_SOURCE
+        if Capability.media_playback_shuffle in device.capabilities:
+            self._supported_features |= MediaPlayerEntityFeature.SHUFFLE_SET
+        if Capability.media_playback_repeat in device.capabilities:
+            self._supported_features |= MediaPlayerEntityFeature.REPEAT_SET
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the media player off."""
+        await self._device.switch_off(set_status=True)
+        self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the media player on."""
+        await self._device.switch_on(set_status=True)
+        self.async_write_ha_state()
+
+    async def async_mute_volume(self, mute: bool) -> None:
+        """Mute volume."""
+        if mute:
+            await self._device.mute(set_status=True)
+        else:
+            await self._device.unmute(set_status=True)
+        self.async_write_ha_state()
+
+    async def async_set_volume_level(self, volume: float) -> None:
+        """Set volume level."""
+        await self._device.set_volume(int(volume * 100), set_status=True)
+        self.async_write_ha_state()
+
+    async def async_volume_up(self) -> None:
+        """Increase volume."""
+        await self._device.volume_up(set_status=True)
+        self.async_write_ha_state()
+
+    async def async_volume_down(self) -> None:
+        """Decrease volume."""
+        await self._device.volume_down(set_status=True)
+        self.async_write_ha_state()
+
+    async def async_media_play(self) -> None:
+        """Play media."""
+        await self._device.play(set_status=True)
+        self.async_write_ha_state()
+
+    async def async_media_pause(self) -> None:
+        """Pause media."""
+        await self._device.pause(set_status=True)
+        self.async_write_ha_state()
+
+    async def async_media_stop(self) -> None:
+        """Stop media."""
+        await self._device.stop(set_status=True)
+        self.async_write_ha_state()
+
+    async def async_select_source(self, source: str) -> None:
+        """Select source."""
+        await self._device.set_input_source(source, set_status=True)
+        self.async_write_ha_state()
+
+    async def async_set_shuffle(self, shuffle: bool) -> None:
+        """Set shuffle mode."""
+        await self._device.set_playback_shuffle(shuffle, set_status=True)
+        self.async_write_ha_state()
+
+    async def async_set_repeat(self, repeat: RepeatMode) -> None:
+        """Set repeat mode."""
+        await self._device.set_repeat(repeat, set_status=True)
+        self.async_write_ha_state()
+
+    @property
+    def supported_features(self) -> MediaPlayerEntityFeature:
+        """Supported features."""
+        return self._supported_features
+
+    @property
+    def media_title(self) -> str | None:
+        """Title of the current media."""
+        return self._device.status.media_title
+
+    @property
+    def state(self) -> MediaPlayerState | None:
+        """State of the media player."""
+        if not self._device.status.switch:
+            return MediaPlayerState.OFF
+        if self._device.status.playback_status in VALUE_TO_STATE:
+            return VALUE_TO_STATE[self._device.status.playback_status]
+        return MediaPlayerState.ON
+
+    @property
+    def is_volume_muted(self) -> bool | None:
+        """Returns if the volume is muted."""
+        if self.supported_features & MediaPlayerEntityFeature.VOLUME_MUTE:
+            return self._device.status.mute
+        return None
+
+    @property
+    def volume_level(self) -> float | None:
+        """Volume level."""
+        if self.supported_features & MediaPlayerEntityFeature.VOLUME_SET:
+            return self._device.status.volume / 100
+        return None
+
+    @property
+    def source(self) -> str | None:
+        """Input source."""
+        if self.supported_features & MediaPlayerEntityFeature.SELECT_SOURCE:
+            return self._device.status.input_source
+        return None
+
+    @property
+    def source_list(self) -> list[str] | None:
+        """List of input sources."""
+        if self.supported_features & MediaPlayerEntityFeature.SELECT_SOURCE:
+            return self._device.status.supported_input_sources
+        return None
+
+    @property
+    def shuffle(self) -> bool | None:
+        """Returns if shuffle mode is set."""
+        if self.supported_features & MediaPlayerEntityFeature.SHUFFLE_SET:
+            return self._device.status.playback_shuffle
+        return None
+
+    @property
+    def repeat(self) -> RepeatMode | None:
+        """Returns if repeat mode is set."""
+        if self.supported_features & MediaPlayerEntityFeature.REPEAT_SET:
+            return self._device.status.playback_repeat_mode
+        return None


### PR DESCRIPTION
First of all, this is a repost of https://github.com/home-assistant/core/pull/95692 because I removed my HA core fork, forgetting I had this ongoing PR, which was then closed automatically. So please check the history there. Second, I must be honest and tell I have pretty negative feelings about the way my work has been left without any answer since July 18th. This PR is not rocket science at all but come on, isn't it ridiculous to not have Media player entities in the SmartThings integration? Last time I heard, Samsung was still selling a few soundbars here and there. Starting to think there's a reason why there are so many third-party custom integrations! Anyways... rant off.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
SmartThings media players (TVs, sound bars, ...) now have their media player entity. The devices already set in your installation will loose the switch entity, because it's now included in the media_player entity, as well as some sensor entities.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SmartThings integration was quite limited for TVs and sound bars because you could only switch them on or off and gather some information. Now you can do many more things, depending on your device supported capabilities: select source, mute, increase volume, decrease volume, set volume...

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

There are quite a few custom integrations for SmartThings media players, but quite outdated in regards to HA evolution (good old YAML instead of config flow), not always good (some just create entities without devices) and frankly, it seemed a lot better to me to integrate it directly into core. Moreover I saw on https://github.com/PiotrMachowski/Home-Assistant-test-components-SmartThings that the media_player might have been in core in the beginning, or that it might have been considered at a time. Anyways, it provided a starting point, and I went with Piotr's media_player.py, updated the code, tested it, changed a few things and voilà!

This is a start. There's plenty more to do. I'm certain a lot of things in this PR can be fine-grained with time. As is, this version is ready a huge improvement for me regarding my home automation. I have a Samsung QE7580B TV and a Samsung Q990B soundbar. It just works flawlessly.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]: https://github.com/home-assistant/home-assistant.io/pull/28031

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
