### PR TITLE
Add configflow to Proximity integration

### DIFF
--- a/homeassistant/components/proximity/__init__.py
+++ b/homeassistant/components/proximity/__init__.py
@@ -146,7 +146,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator.async_config_entry_first_refresh()
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
-    if entry.data.get(CONF_NAME):
+    if entry.source == SOURCE_IMPORT:
         await _async_setup_legacy(hass, entry, coordinator)
 
     await hass.config_entries.async_forward_entry_setups(entry, [Platform.SENSOR])

--- a/homeassistant/components/proximity/__init__.py
+++ b/homeassistant/components/proximity/__init__.py
@@ -5,8 +5,6 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.automation import automations_with_entity
-from homeassistant.components.script import scripts_with_entity
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_DEVICES,
@@ -35,6 +33,7 @@ from .const import (
     UNITS,
 )
 from .coordinator import ProximityDataUpdateCoordinator
+from .helpers import entity_used_in
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -68,9 +67,7 @@ async def _async_setup_legacy(
     await proximity.async_added_to_hass()
     proximity.async_write_ha_state()
 
-    used_in = automations_with_entity(hass, f"{DOMAIN}.{friendly_name}")
-    used_in += scripts_with_entity(hass, f"{DOMAIN}.{friendly_name}")
-    if used_in:
+    if used_in := entity_used_in(hass, f"{DOMAIN}.{friendly_name}"):
         async_create_issue(
             hass,
             DOMAIN,

--- a/homeassistant/components/proximity/__init__.py
+++ b/homeassistant/components/proximity/__init__.py
@@ -118,7 +118,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
     )
 
-    await coordinator.async_refresh()
+    await coordinator.async_config_entry_first_refresh()
     hass.data[DOMAIN][entry.unique_id] = coordinator
 
     # legacy proximity entity handling, can be removed in 2024.8

--- a/homeassistant/components/proximity/__init__.py
+++ b/homeassistant/components/proximity/__init__.py
@@ -15,7 +15,10 @@ from homeassistant.const import (
 )
 from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.event import (
+    async_track_entity_registry_updated_event,
+    async_track_state_change,
+)
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -140,6 +143,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass,
             entry.data[CONF_TRACKED_ENTITIES],
             coordinator.async_check_proximity_state_change,
+        )
+    )
+
+    entry.async_on_unload(
+        async_track_entity_registry_updated_event(
+            hass,
+            entry.data[CONF_TRACKED_ENTITIES],
+            coordinator.async_check_tracked_entity_change,
         )
     )
 

--- a/homeassistant/components/proximity/__init__.py
+++ b/homeassistant/components/proximity/__init__.py
@@ -121,33 +121,34 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator.async_config_entry_first_refresh()
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
-    # legacy proximity entity handling, can be removed in 2024.8
-    proximity = Proximity(hass, entry.title, coordinator)
-    await proximity.async_added_to_hass()
-    proximity.async_write_ha_state()
+    async def _asnyc_setup_legacy() -> None:
+        """Legacy proximity entity handling, can be removed in 2024.8."""
+        proximity = Proximity(hass, entry.title, coordinator)
+        await proximity.async_added_to_hass()
+        proximity.async_write_ha_state()
+
+        used_in = automations_with_entity(hass, f"{DOMAIN}.{entry.title}")
+        used_in += scripts_with_entity(hass, f"{DOMAIN}.{entry.title}")
+        if used_in:
+            async_create_issue(
+                hass,
+                DOMAIN,
+                f"deprecated_proximity_entity_{entry.title}",
+                breaks_in_ha_version="2024.8.0",
+                is_fixable=True,
+                is_persistent=True,
+                severity=IssueSeverity.WARNING,
+                translation_key="deprecated_proximity_entity",
+                translation_placeholders={
+                    "entity": f"{DOMAIN}.{entry.title}",
+                    "used_in": "\n- ".join([f"`{x}`" for x in used_in]),
+                },
+            )
+
+    await _asnyc_setup_legacy()
 
     await hass.config_entries.async_forward_entry_setups(entry, [Platform.SENSOR])
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
-
-    # deprecate proximity entity - can be removed in 2024.8
-    used_in = automations_with_entity(hass, f"{DOMAIN}.{entry.title}")
-    used_in += scripts_with_entity(hass, f"{DOMAIN}.{entry.title}")
-    if used_in:
-        async_create_issue(
-            hass,
-            DOMAIN,
-            f"deprecated_proximity_entity_{entry.title}",
-            breaks_in_ha_version="2024.8.0",
-            is_fixable=True,
-            is_persistent=True,
-            severity=IssueSeverity.WARNING,
-            translation_key="deprecated_proximity_entity",
-            translation_placeholders={
-                "entity": f"{DOMAIN}.{entry.title}",
-                "used_in": "\n- ".join([f"`{x}`" for x in used_in]),
-            },
-        )
-
     return True
 
 

--- a/homeassistant/components/proximity/__init__.py
+++ b/homeassistant/components/proximity/__init__.py
@@ -119,7 +119,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     await coordinator.async_config_entry_first_refresh()
-    hass.data[DOMAIN][entry.unique_id] = coordinator
+    hass.data[DOMAIN][entry.entry_id] = coordinator
 
     # legacy proximity entity handling, can be removed in 2024.8
     proximity = Proximity(hass, entry.title, coordinator)
@@ -157,7 +157,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry, [Platform.SENSOR]
     )
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.unique_id)
+        hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
 

--- a/homeassistant/components/proximity/__init__.py
+++ b/homeassistant/components/proximity/__init__.py
@@ -7,15 +7,16 @@ import voluptuous as vol
 
 from homeassistant.components.automation import automations_with_entity
 from homeassistant.components.script import scripts_with_entity
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_DEVICES,
     CONF_NAME,
     CONF_UNIT_OF_MEASUREMENT,
     CONF_ZONE,
+    Platform,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType
@@ -27,6 +28,7 @@ from .const import (
     ATTR_NEAREST,
     CONF_IGNORED_ZONES,
     CONF_TOLERANCE,
+    CONF_TRACKED_ENTITIES,
     DEFAULT_PROXIMITY_ZONE,
     DEFAULT_TOLERANCE,
     DOMAIN,
@@ -49,61 +51,120 @@ ZONE_SCHEMA = vol.Schema(
 )
 
 CONFIG_SCHEMA = vol.Schema(
-    {DOMAIN: cv.schema_with_slug_keys(ZONE_SCHEMA)}, extra=vol.ALLOW_EXTRA
+    vol.All(
+        cv.deprecated(DOMAIN),
+        {DOMAIN: cv.schema_with_slug_keys(ZONE_SCHEMA)},
+    ),
+    extra=vol.ALLOW_EXTRA,
 )
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Get the zones and offsets from configuration.yaml."""
-    hass.data.setdefault(DOMAIN, {})
-    for friendly_name, proximity_config in config[DOMAIN].items():
-        _LOGGER.debug("setup %s with config:%s", friendly_name, proximity_config)
-
-        coordinator = ProximityDataUpdateCoordinator(
-            hass, friendly_name, proximity_config
-        )
-
-        async_track_state_change(
-            hass,
-            proximity_config[CONF_DEVICES],
-            coordinator.async_check_proximity_state_change,
-        )
-
-        await coordinator.async_refresh()
-        hass.data[DOMAIN][friendly_name] = coordinator
-
-        proximity = Proximity(hass, friendly_name, coordinator)
-        await proximity.async_added_to_hass()
-        proximity.async_write_ha_state()
-
-        await async_load_platform(
-            hass,
-            "sensor",
-            DOMAIN,
-            {CONF_NAME: friendly_name, **proximity_config},
-            config,
-        )
-
-        # deprecate proximity entity - can be removed in 2024.8
-        used_in = automations_with_entity(hass, f"{DOMAIN}.{friendly_name}")
-        used_in += scripts_with_entity(hass, f"{DOMAIN}.{friendly_name}")
-        if used_in:
-            async_create_issue(
-                hass,
-                DOMAIN,
-                f"deprecated_proximity_entity_{friendly_name}",
-                breaks_in_ha_version="2024.8.0",
-                is_fixable=True,
-                is_persistent=True,
-                severity=IssueSeverity.WARNING,
-                translation_key="deprecated_proximity_entity",
-                translation_placeholders={
-                    "entity": f"{DOMAIN}.{friendly_name}",
-                    "used_in": "\n- ".join([f"`{x}`" for x in used_in]),
-                },
+    if DOMAIN in config:
+        for friendly_name, proximity_config in config[DOMAIN].items():
+            _LOGGER.debug("import %s with config:%s", friendly_name, proximity_config)
+            hass.async_create_task(
+                hass.config_entries.flow.async_init(
+                    DOMAIN,
+                    context={"source": SOURCE_IMPORT},
+                    data={
+                        CONF_NAME: friendly_name,
+                        CONF_ZONE: f"zone.{proximity_config[CONF_ZONE]}",
+                        CONF_TRACKED_ENTITIES: proximity_config[CONF_DEVICES],
+                        CONF_IGNORED_ZONES: [
+                            f"zone.{zone}"
+                            for zone in proximity_config[CONF_IGNORED_ZONES]
+                        ],
+                        CONF_TOLERANCE: proximity_config[CONF_TOLERANCE],
+                        CONF_UNIT_OF_MEASUREMENT: proximity_config.get(
+                            CONF_UNIT_OF_MEASUREMENT, hass.config.units.length_unit
+                        ),
+                    },
+                )
             )
 
+        async_create_issue(
+            hass,
+            HOMEASSISTANT_DOMAIN,
+            f"deprecated_yaml_{DOMAIN}",
+            breaks_in_ha_version="2024.8.0",
+            is_fixable=False,
+            issue_domain=DOMAIN,
+            severity=IssueSeverity.WARNING,
+            translation_key="deprecated_yaml",
+            translation_placeholders={
+                "domain": DOMAIN,
+                "integration_title": "Proximity",
+            },
+        )
+
     return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Proximity from a config entry."""
+    _LOGGER.debug("setup %s with config:%s", entry.title, entry.data)
+
+    hass.data.setdefault(DOMAIN, {})
+
+    coordinator = ProximityDataUpdateCoordinator(hass, entry.title, dict(entry.data))
+
+    entry.async_on_unload(
+        async_track_state_change(
+            hass,
+            entry.data[CONF_TRACKED_ENTITIES],
+            coordinator.async_check_proximity_state_change,
+        )
+    )
+
+    await coordinator.async_refresh()
+    hass.data[DOMAIN][entry.unique_id] = coordinator
+
+    # legacy proximity entity handling, can be removed in 2024.8
+    proximity = Proximity(hass, entry.title, coordinator)
+    await proximity.async_added_to_hass()
+    proximity.async_write_ha_state()
+
+    await hass.config_entries.async_forward_entry_setups(entry, [Platform.SENSOR])
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
+
+    # deprecate proximity entity - can be removed in 2024.8
+    used_in = automations_with_entity(hass, f"{DOMAIN}.{entry.title}")
+    used_in += scripts_with_entity(hass, f"{DOMAIN}.{entry.title}")
+    if used_in:
+        async_create_issue(
+            hass,
+            DOMAIN,
+            f"deprecated_proximity_entity_{entry.title}",
+            breaks_in_ha_version="2024.8.0",
+            is_fixable=True,
+            is_persistent=True,
+            severity=IssueSeverity.WARNING,
+            translation_key="deprecated_proximity_entity",
+            translation_placeholders={
+                "entity": f"{DOMAIN}.{entry.title}",
+                "used_in": "\n- ".join([f"`{x}`" for x in used_in]),
+            },
+        )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(
+        entry, [Platform.SENSOR]
+    )
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.unique_id)
+
+    return unload_ok
+
+
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 class Proximity(CoordinatorEntity[ProximityDataUpdateCoordinator]):

--- a/homeassistant/components/proximity/__init__.py
+++ b/homeassistant/components/proximity/__init__.py
@@ -59,7 +59,7 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-async def _asnyc_setup_legacy(
+async def _async_setup_legacy(
     hass: HomeAssistant, entry: ConfigEntry, coordinator: ProximityDataUpdateCoordinator
 ) -> None:
     """Legacy proximity entity handling, can be removed in 2024.8."""
@@ -150,7 +150,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
     if entry.data.get(CONF_NAME):
-        await _asnyc_setup_legacy(hass, entry, coordinator)
+        await _async_setup_legacy(hass, entry, coordinator)
 
     await hass.config_entries.async_forward_entry_setups(entry, [Platform.SENSOR])
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))

--- a/homeassistant/components/proximity/config_flow.py
+++ b/homeassistant/components/proximity/config_flow.py
@@ -1,0 +1,136 @@
+"""Config flow for AVM FRITZ!SmartHome."""
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
+from homeassistant.components.person import DOMAIN as PERSON_DOMAIN
+from homeassistant.components.zone import DOMAIN as ZONE_DOMAIN
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
+from homeassistant.const import CONF_NAME, CONF_ZONE
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.selector import (
+    EntitySelector,
+    EntitySelectorConfig,
+    NumberSelector,
+    NumberSelectorConfig,
+)
+
+from .const import (
+    CONF_IGNORED_ZONES,
+    CONF_TOLERANCE,
+    CONF_TRACKED_ENTITIES,
+    DEFAULT_PROXIMITY_ZONE,
+    DEFAULT_TOLERANCE,
+    DOMAIN,
+)
+
+RESULT_SUCCESS = "success"
+
+
+def _base_schema(user_input: dict[str, Any]) -> vol.Schema:
+    return {
+        vol.Optional(
+            CONF_TRACKED_ENTITIES, default=user_input.get(CONF_TRACKED_ENTITIES, [])
+        ): EntitySelector(
+            EntitySelectorConfig(
+                domain=[DEVICE_TRACKER_DOMAIN, PERSON_DOMAIN], multiple=True
+            ),
+        ),
+        vol.Optional(
+            CONF_IGNORED_ZONES, default=user_input.get(CONF_IGNORED_ZONES, [])
+        ): EntitySelector(
+            EntitySelectorConfig(domain=ZONE_DOMAIN, multiple=True),
+        ),
+        vol.Required(
+            CONF_TOLERANCE,
+            default=user_input.get(CONF_TOLERANCE, DEFAULT_TOLERANCE),
+        ): NumberSelector(
+            NumberSelectorConfig(min=1, max=100, step=1),
+        ),
+    }
+
+
+class ProximityConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a proximity config flow."""
+
+    VERSION = 1
+
+    def _user_form_schema(self, user_input: dict[str, Any] | None = None) -> vol.Schema:
+        if user_input is None:
+            user_input = {}
+        return vol.Schema(
+            {
+                vol.Required(
+                    CONF_NAME, default=user_input.get(CONF_NAME, "")
+                ): cv.string,
+                vol.Required(
+                    CONF_ZONE,
+                    default=user_input.get(
+                        CONF_ZONE, f"{ZONE_DOMAIN}.{DEFAULT_PROXIMITY_ZONE}"
+                    ),
+                ): EntitySelector(
+                    EntitySelectorConfig(domain=ZONE_DOMAIN),
+                ),
+                **_base_schema(user_input),
+            }
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+        """Get the options flow for this handler."""
+        return ProximityOptionsFlow(config_entry)
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle a flow initialized by the user."""
+        if user_input is not None:
+            title = user_input.pop(CONF_NAME)
+
+            await self.async_set_unique_id(f"{DOMAIN}_{title}")
+            self._abort_if_unique_id_configured()
+
+            return self.async_create_entry(title=title, data=user_input)
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=self._user_form_schema(user_input),
+        )
+
+    async def async_step_import(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Import a yaml config entry."""
+        return await self.async_step_user(user_input)
+
+
+class ProximityOptionsFlow(OptionsFlow):
+    """Handle a option flow."""
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    def _user_form_schema(self, user_input: dict[str, Any]) -> vol.Schema:
+        return vol.Schema(_base_schema(user_input))
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle options flow."""
+        if user_input is not None:
+            self.hass.config_entries.async_update_entry(
+                self.config_entry, data={**self.config_entry.data, **user_input}
+            )
+            return self.async_create_entry(title=self.config_entry.title, data={})
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=self._user_form_schema(dict(self.config_entry.data)),
+        )

--- a/homeassistant/components/proximity/config_flow.py
+++ b/homeassistant/components/proximity/config_flow.py
@@ -34,7 +34,7 @@ RESULT_SUCCESS = "success"
 
 def _base_schema(user_input: dict[str, Any]) -> vol.Schema:
     return {
-        vol.Optional(
+        vol.Required(
             CONF_TRACKED_ENTITIES, default=user_input.get(CONF_TRACKED_ENTITIES, [])
         ): EntitySelector(
             EntitySelectorConfig(

--- a/homeassistant/components/proximity/config_flow.py
+++ b/homeassistant/components/proximity/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for AVM FRITZ!SmartHome."""
+"""Config flow for proximity."""
 from __future__ import annotations
 
 from typing import Any

--- a/homeassistant/components/proximity/config_flow.py
+++ b/homeassistant/components/proximity/config_flow.py
@@ -93,8 +93,7 @@ class ProximityConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             title = user_input.pop(CONF_NAME)
 
-            await self.async_set_unique_id(f"{DOMAIN}_{title}")
-            self._abort_if_unique_id_configured()
+            self._async_abort_entries_match(user_input)
 
             return self.async_create_entry(title=title, data=user_input)
 

--- a/homeassistant/components/proximity/const.py
+++ b/homeassistant/components/proximity/const.py
@@ -13,6 +13,7 @@ ATTR_PROXIMITY_DATA: Final = "proximity_data"
 
 CONF_IGNORED_ZONES = "ignored_zones"
 CONF_TOLERANCE = "tolerance"
+CONF_TRACKED_ENTITIES = "tracked_entities"
 
 DEFAULT_DIR_OF_TRAVEL = "not set"
 DEFAULT_DIST_TO_ZONE = "not set"

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -122,21 +122,26 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
             new_tracked_entity_id = data["entity_id"]
 
             entity_reg = er.async_get(self.hass)
-            for rel_ent_id in self.entity_mapping.get(old_tracked_entity_id, []):
-                if (rel_ent := entity_reg.async_get(rel_ent_id)) is None:
+            for related_entity_id in self.entity_mapping.get(old_tracked_entity_id, []):
+                if (rel_ent := entity_reg.async_get(related_entity_id)) is None:
                     continue
-                old_uid = rel_ent.unique_id
-                new_uid = old_uid.replace(old_tracked_entity_id, new_tracked_entity_id)
-                entity_reg.async_update_entity(rel_ent_id, new_unique_id=new_uid)
+                old_unique_id = rel_ent.unique_id
+                new_unique_id = old_unique_id.replace(
+                    old_tracked_entity_id, new_tracked_entity_id
+                )
+                entity_reg.async_update_entity(
+                    related_entity_id, new_unique_id=new_unique_id
+                )
 
             self.hass.config_entries.async_update_entry(
                 self.config_entry,
                 data={
                     **self.config_entry.data,
                     CONF_TRACKED_ENTITIES: [
-                        te
-                        for te in self.tracked_entities + [new_tracked_entity_id]
-                        if te != old_tracked_entity_id
+                        tracked_entity
+                        for tracked_entity in self.tracked_entities
+                        + [new_tracked_entity_id]
+                        if tracked_entity != old_tracked_entity_id
                     ],
                 },
             )

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -99,8 +99,6 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
     @callback
     def async_add_entity_mapping(self, tracked_entity_id: str, entity_id: str) -> None:
         """Add an tracked entity to proximity entity mapping."""
-        if tracked_entity_id not in self.entity_mapping:
-            self.entity_mapping[tracked_entity_id] = []
         self.entity_mapping[tracked_entity_id].append(entity_id)
 
     async def async_check_proximity_state_change(

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -3,11 +3,11 @@
 from dataclasses import dataclass
 import logging
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
     ATTR_NAME,
-    CONF_DEVICES,
     CONF_UNIT_OF_MEASUREMENT,
     CONF_ZONE,
     UnitOfLength,
@@ -25,6 +25,7 @@ from .const import (
     ATTR_NEAREST,
     CONF_IGNORED_ZONES,
     CONF_TOLERANCE,
+    CONF_TRACKED_ENTITIES,
     DEFAULT_DIR_OF_TRAVEL,
     DEFAULT_DIST_TO_ZONE,
     DEFAULT_NEAREST,
@@ -63,12 +64,14 @@ DEFAULT_DATA = ProximityData(
 class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
     """Proximity data update coordinator."""
 
+    config_entry: ConfigEntry
+
     def __init__(
         self, hass: HomeAssistant, friendly_name: str, config: ConfigType
     ) -> None:
         """Initialize the Proximity coordinator."""
         self.ignored_zones: list[str] = config[CONF_IGNORED_ZONES]
-        self.tracked_entities: list[str] = config[CONF_DEVICES]
+        self.tracked_entities: list[str] = config[CONF_TRACKED_ENTITIES]
         self.tolerance: int = config[CONF_TOLERANCE]
         self.proximity_zone: str = config[CONF_ZONE]
         self.unit_of_measurement: str = config.get(

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -120,18 +120,6 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
             old_tracked_entity_id = data["old_entity_id"]
             new_tracked_entity_id = data["entity_id"]
 
-            entity_reg = er.async_get(self.hass)
-            for related_entity_id in self.entity_mapping.get(old_tracked_entity_id, []):
-                if (rel_ent := entity_reg.async_get(related_entity_id)) is None:
-                    continue
-                old_unique_id = rel_ent.unique_id
-                new_unique_id = old_unique_id.replace(
-                    old_tracked_entity_id, new_tracked_entity_id
-                )
-                entity_reg.async_update_entity(
-                    related_entity_id, new_unique_id=new_unique_id
-                )
-
             self.hass.config_entries.async_update_entry(
                 self.config_entry,
                 data={

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -79,7 +79,6 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         self.unit_of_measurement: str = config.get(
             CONF_UNIT_OF_MEASUREMENT, hass.config.units.length_unit
         )
-        self.friendly_name = friendly_name
 
         super().__init__(
             hass,
@@ -121,7 +120,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         if device.state.lower() == self.proximity_zone_name.lower():
             _LOGGER.debug(
                 "%s: %s in zone -> distance=0",
-                self.friendly_name,
+                self.name,
                 device.entity_id,
             )
             return 0
@@ -129,7 +128,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         if latitude is None or longitude is None:
             _LOGGER.debug(
                 "%s: %s has no coordinates -> distance=None",
-                self.friendly_name,
+                self.name,
                 device.entity_id,
             )
             return None
@@ -157,7 +156,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         if device.state.lower() == self.proximity_zone_name.lower():
             _LOGGER.debug(
                 "%s: %s in zone -> direction_of_travel=arrived",
-                self.friendly_name,
+                self.name,
                 device.entity_id,
             )
             return "arrived"
@@ -201,7 +200,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         if (zone_state := self.hass.states.get(self.proximity_zone_id)) is None:
             _LOGGER.debug(
                 "%s: zone %s does not exist -> reset",
-                self.friendly_name,
+                self.name,
                 self.proximity_zone_id,
             )
             return DEFAULT_DATA
@@ -213,12 +212,12 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
             if (tracked_entity_state := self.hass.states.get(entity_id)) is None:
                 if entities_data.pop(entity_id, None) is not None:
                     _LOGGER.debug(
-                        "%s: %s does not exist -> remove", self.friendly_name, entity_id
+                        "%s: %s does not exist -> remove", self.name, entity_id
                     )
                 continue
 
             if entity_id not in entities_data:
-                _LOGGER.debug("%s: %s is new -> add", self.friendly_name, entity_id)
+                _LOGGER.debug("%s: %s is new -> add", self.name, entity_id)
                 entities_data[entity_id] = {
                     ATTR_DIST_TO: None,
                     ATTR_DIR_OF_TRAVEL: None,
@@ -238,7 +237,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
             if entities_data[entity_id][ATTR_DIST_TO] is None:
                 _LOGGER.debug(
                     "%s: %s has unknown distance got -> direction_of_travel=None",
-                    self.friendly_name,
+                    self.name,
                     entity_id,
                 )
                 entities_data[entity_id][ATTR_DIR_OF_TRAVEL] = None
@@ -249,7 +248,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         ) is not None:
             _LOGGER.debug(
                 "%s: calculate direction of travel for %s",
-                self.friendly_name,
+                self.name,
                 state_change_data.entity_id,
             )
 

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -1,5 +1,6 @@
 """Data update coordinator for the Proximity integration."""
 
+from collections import defaultdict
 from dataclasses import dataclass
 import logging
 
@@ -82,7 +83,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         self.unit_of_measurement: str = config.get(
             CONF_UNIT_OF_MEASUREMENT, hass.config.units.length_unit
         )
-        self.entity_mapping: dict[str, list[str]] = {}
+        self.entity_mapping: dict[str, list[str]] = defaultdict(list)
 
         super().__init__(
             hass,

--- a/homeassistant/components/proximity/helpers.py
+++ b/homeassistant/components/proximity/helpers.py
@@ -1,0 +1,11 @@
+"""Helper functions for proximity."""
+from homeassistant.components.automation import automations_with_entity
+from homeassistant.components.script import scripts_with_entity
+from homeassistant.core import HomeAssistant
+
+
+def entity_used_in(hass: HomeAssistant, entity_id: str) -> list[str]:
+    """Get list of related automations and scripts."""
+    used_in = automations_with_entity(hass, entity_id)
+    used_in += scripts_with_entity(hass, entity_id)
+    return used_in

--- a/homeassistant/components/proximity/manifest.json
+++ b/homeassistant/components/proximity/manifest.json
@@ -2,6 +2,7 @@
   "domain": "proximity",
   "name": "Proximity",
   "codeowners": ["@mib1185"],
+  "config_flow": true,
   "dependencies": ["device_tracker", "zone"],
   "documentation": "https://www.home-assistant.io/integrations/proximity",
   "iot_class": "calculated",

--- a/homeassistant/components/proximity/sensor.py
+++ b/homeassistant/components/proximity/sensor.py
@@ -78,7 +78,7 @@ async def async_setup_entry(
             tracked_entity_descriptors.append(
                 {
                     "entity_id": tracked_entity_id,
-                    "identifier": entity.unique_id,
+                    "identifier": entity.id,
                 }
             )
         else:

--- a/homeassistant/components/proximity/sensor.py
+++ b/homeassistant/components/proximity/sensor.py
@@ -132,8 +132,18 @@ class ProximityTrackedEntitySensor(
         self._attr_device_info = _device_info(coordinator)
 
     @property
+    def data(self) -> dict[str, str | int | None] | None:
+        """Get data from coordinator."""
+        return self.coordinator.data.entities.get(self.tracked_entity_id)
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self.data is not None
+
+    @property
     def native_value(self) -> str | float | None:
         """Return native sensor value."""
-        if (data := self.coordinator.data.entities.get(self.tracked_entity_id)) is None:
+        if self.data is None:
             return None
-        return data.get(self.entity_description.key)
+        return self.data.get(self.entity_description.key)

--- a/homeassistant/components/proximity/sensor.py
+++ b/homeassistant/components/proximity/sensor.py
@@ -131,6 +131,13 @@ class ProximityTrackedEntitySensor(
         self._attr_name = f"{tracked_entity_id.split('.')[-1]} {description.name}"
         self._attr_device_info = _device_info(coordinator)
 
+    async def async_added_to_hass(self) -> None:
+        """Register entity mapping."""
+        await super().async_added_to_hass()
+        self.coordinator.async_add_entity_mapping(
+            self.tracked_entity_id, self.entity_id
+        )
+
     @property
     def data(self) -> dict[str, str | int | None] | None:
         """Get data from coordinator."""

--- a/homeassistant/components/proximity/sensor.py
+++ b/homeassistant/components/proximity/sensor.py
@@ -62,7 +62,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the proximity sensors."""
 
-    coordinator: ProximityDataUpdateCoordinator = hass.data[DOMAIN][entry.unique_id]
+    coordinator: ProximityDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     entities: list[ProximitySensor | ProximityTrackedEntitySensor] = [
         ProximitySensor(description, coordinator)
@@ -93,7 +93,7 @@ class ProximitySensor(CoordinatorEntity[ProximityDataUpdateCoordinator], SensorE
 
         self.entity_description = description
 
-        self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{description.key}"
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{description.key}"
         self._attr_device_info = _device_info(coordinator)
 
     @property
@@ -125,7 +125,9 @@ class ProximityTrackedEntitySensor(
         self.entity_description = description
         self.tracked_entity_id = tracked_entity_id
 
-        self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{tracked_entity_id}_{description.key}"
+        self._attr_unique_id = (
+            f"{coordinator.config_entry.entry_id}_{tracked_entity_id}_{description.key}"
+        )
         self._attr_name = f"{tracked_entity_id.split('.')[-1]} {description.name}"
         self._attr_device_info = _device_info(coordinator)
 

--- a/homeassistant/components/proximity/sensor.py
+++ b/homeassistant/components/proximity/sensor.py
@@ -74,11 +74,11 @@ async def async_setup_entry(
 
     entity_reg = er.async_get(hass)
     for tracked_entity_id in coordinator.tracked_entities:
-        if (entity := entity_reg.async_get(tracked_entity_id)) is not None:
+        if (entity_entry := entity_reg.async_get(tracked_entity_id)) is not None:
             tracked_entity_descriptors.append(
                 {
                     "entity_id": tracked_entity_id,
-                    "identifier": entity.id,
+                    "identifier": entity_entry.id,
                 }
             )
         else:

--- a/homeassistant/components/proximity/strings.json
+++ b/homeassistant/components/proximity/strings.json
@@ -9,8 +9,7 @@
           "zone": "Zone to track distance to",
           "ignored_zones": "Zones to ignore",
           "tracked_entities": "Devices or Persons to track",
-          "tolerance": "Tolerance distance",
-          "unit_of_measurement": "Unit of measurement used for tolerance distance"
+          "tolerance": "Tolerance distance"
         }
       }
     },
@@ -26,8 +25,7 @@
           "zone": "Zone to track distance to",
           "ignored_zones": "Zones to ignore",
           "tracked_entities": "Devices or Persons to track",
-          "tolerance": "Tolerance distance",
-          "unit_of_measurement": "Unit of measurement used for tolerance distance"
+          "tolerance": "Tolerance distance"
         }
       }
     }

--- a/homeassistant/components/proximity/strings.json
+++ b/homeassistant/components/proximity/strings.json
@@ -1,5 +1,37 @@
 {
   "title": "Proximity",
+  "config": {
+    "flow_title": "Proximity",
+    "step": {
+      "user": {
+        "data": {
+          "name": "Name",
+          "zone": "Zone to track distance to",
+          "ignored_zones": "Zones to ignore",
+          "tracked_entities": "Devices or Persons to track",
+          "tolerance": "Tolerance distance",
+          "unit_of_measurement": "Unit of measurement used for tolerance distance"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "success": "Changes saved"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "zone": "Zone to track distance to",
+          "ignored_zones": "Zones to ignore",
+          "tracked_entities": "Devices or Persons to track",
+          "tolerance": "Tolerance distance",
+          "unit_of_measurement": "Unit of measurement used for tolerance distance"
+        }
+      }
+    }
+  },
   "entity": {
     "sensor": {
       "dir_of_travel": {

--- a/homeassistant/components/proximity/strings.json
+++ b/homeassistant/components/proximity/strings.json
@@ -54,6 +54,17 @@
           }
         }
       }
+    },
+    "tracked_entity_removed": {
+      "title": "Tracked entity has been removed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "[%key:component::proximity::issues::tracked_entity_removed::title%]",
+            "description": "The entity `{entity_id}` has been removed from HA, but is used in proximity {name}. Please remove `{entity_id}` from the list of tracked entities. Related proximity sensor entites were set to unavailable and can be removed."
+          }
+        }
+      }
     }
   }
 }

--- a/homeassistant/components/proximity/strings.json
+++ b/homeassistant/components/proximity/strings.json
@@ -5,7 +5,6 @@
     "step": {
       "user": {
         "data": {
-          "name": "Name",
           "zone": "Zone to track distance to",
           "ignored_zones": "Zones to ignore",
           "tracked_entities": "Devices or Persons to track",

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -392,6 +392,7 @@ FLOWS = {
         "profiler",
         "progettihwsw",
         "prosegur",
+        "proximity",
         "prusalink",
         "ps4",
         "pure_energie",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -4551,7 +4551,7 @@
     },
     "proximity": {
       "integration_type": "hub",
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "calculated"
     },
     "proxmoxve": {

--- a/tests/components/proximity/conftest.py
+++ b/tests/components/proximity/conftest.py
@@ -1,0 +1,20 @@
+"""Config test for proximity."""
+import pytest
+
+from homeassistant.core import HomeAssistant
+
+
+@pytest.fixture
+def config_zones(hass: HomeAssistant):
+    """Set up zones for test."""
+    hass.config.components.add("zone")
+    hass.states.async_set(
+        "zone.home",
+        "zoning",
+        {"name": "home", "latitude": 2.1, "longitude": 1.1, "radius": 10},
+    )
+    hass.states.async_set(
+        "zone.work",
+        "zoning",
+        {"name": "work", "latitude": 2.3, "longitude": 1.3, "radius": 10},
+    )

--- a/tests/components/proximity/conftest.py
+++ b/tests/components/proximity/conftest.py
@@ -4,17 +4,17 @@ import pytest
 from homeassistant.core import HomeAssistant
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def config_zones(hass: HomeAssistant):
     """Set up zones for test."""
     hass.config.components.add("zone")
     hass.states.async_set(
         "zone.home",
         "zoning",
-        {"name": "home", "latitude": 2.1, "longitude": 1.1, "radius": 10},
+        {"name": "Home", "latitude": 2.1, "longitude": 1.1, "radius": 10},
     )
     hass.states.async_set(
         "zone.work",
         "zoning",
-        {"name": "work", "latitude": 2.3, "longitude": 1.3, "radius": 10},
+        {"name": "Work", "latitude": 2.3, "longitude": 1.3, "radius": 10},
     )

--- a/tests/components/proximity/test_config_flow.py
+++ b/tests/components/proximity/test_config_flow.py
@@ -22,7 +22,6 @@ from tests.common import MockConfigEntry
     [
         (
             {
-                CONF_NAME: "home",
                 CONF_ZONE: "zone.home",
                 CONF_TRACKED_ENTITIES: ["device_tracker.test1"],
             },
@@ -35,7 +34,6 @@ from tests.common import MockConfigEntry
         ),
         (
             {
-                CONF_NAME: "home",
                 CONF_ZONE: "zone.home",
                 CONF_TRACKED_ENTITIES: ["device_tracker.test1"],
                 CONF_IGNORED_ZONES: ["zone.work"],
@@ -51,7 +49,7 @@ from tests.common import MockConfigEntry
     ],
 )
 async def test_user_flow(
-    hass: HomeAssistant, user_input: dict, expected_result: dict, config_zones
+    hass: HomeAssistant, user_input: dict, expected_result: dict
 ) -> None:
     """Test starting a flow by user."""
     result = await hass.config_entries.flow.async_init(
@@ -69,6 +67,9 @@ async def test_user_flow(
         )
         assert result["type"] == FlowResultType.CREATE_ENTRY
         assert result["data"] == expected_result
+
+        zone = hass.states.get(user_input[CONF_ZONE])
+        assert result["title"] == zone.name
 
         await hass.async_block_till_done()
 
@@ -118,7 +119,7 @@ async def test_options_flow(hass: HomeAssistant) -> None:
     }
 
 
-async def test_import_flow(hass: HomeAssistant, config_zones) -> None:
+async def test_import_flow(hass: HomeAssistant) -> None:
     """Test import of yaml configuration."""
     with patch(
         "homeassistant.components.proximity.async_setup_entry", return_value=True
@@ -138,12 +139,16 @@ async def test_import_flow(hass: HomeAssistant, config_zones) -> None:
 
         assert result["type"] == FlowResultType.CREATE_ENTRY
         assert result["data"] == {
+            CONF_NAME: "home",
             CONF_ZONE: "zone.home",
             CONF_TRACKED_ENTITIES: ["device_tracker.test1"],
             CONF_IGNORED_ZONES: ["zone.work"],
             CONF_TOLERANCE: 10,
             CONF_UNIT_OF_MEASUREMENT: "km",
         }
+
+        zone = hass.states.get("zone.home")
+        assert result["title"] == zone.name
 
         await hass.async_block_till_done()
 

--- a/tests/components/proximity/test_config_flow.py
+++ b/tests/components/proximity/test_config_flow.py
@@ -1,0 +1,150 @@
+"""Test proximity config flow."""
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.proximity.const import (
+    CONF_IGNORED_ZONES,
+    CONF_TOLERANCE,
+    CONF_TRACKED_ENTITIES,
+    DOMAIN,
+)
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.const import CONF_NAME, CONF_UNIT_OF_MEASUREMENT, CONF_ZONE
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.parametrize(
+    ("user_input", "expected_result"),
+    [
+        (
+            {
+                CONF_NAME: "home",
+                CONF_ZONE: "zone.home",
+                CONF_TRACKED_ENTITIES: ["device_tracker.test1"],
+            },
+            {
+                CONF_ZONE: "zone.home",
+                CONF_TRACKED_ENTITIES: ["device_tracker.test1"],
+                CONF_IGNORED_ZONES: [],
+                CONF_TOLERANCE: 1,
+            },
+        ),
+        (
+            {
+                CONF_NAME: "home",
+                CONF_ZONE: "zone.home",
+                CONF_TRACKED_ENTITIES: ["device_tracker.test1"],
+                CONF_IGNORED_ZONES: ["zone.work"],
+                CONF_TOLERANCE: 10,
+            },
+            {
+                CONF_ZONE: "zone.home",
+                CONF_TRACKED_ENTITIES: ["device_tracker.test1"],
+                CONF_IGNORED_ZONES: ["zone.work"],
+                CONF_TOLERANCE: 10,
+            },
+        ),
+    ],
+)
+async def test_user_flow(
+    hass: HomeAssistant, user_input: dict, expected_result: dict, config_zones
+) -> None:
+    """Test starting a flow by user."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with patch(
+        "homeassistant.components.proximity.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input=user_input,
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"] == expected_result
+
+        await hass.async_block_till_done()
+
+    assert mock_setup_entry.called
+
+
+async def test_options_flow(hass: HomeAssistant) -> None:
+    """Test options flow."""
+
+    mock_config = MockConfigEntry(
+        domain=DOMAIN,
+        title="home",
+        data={
+            CONF_ZONE: "zone.home",
+            CONF_TRACKED_ENTITIES: ["device_tracker.test1"],
+            CONF_IGNORED_ZONES: ["zone.work"],
+            CONF_TOLERANCE: 10,
+        },
+        unique_id=f"{DOMAIN}_home",
+    )
+    mock_config.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.proximity.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        await hass.config_entries.async_setup(mock_config.entry_id)
+        await hass.async_block_till_done()
+        assert mock_setup_entry.called
+
+        result = await hass.config_entries.options.async_init(mock_config.entry_id)
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "init"
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_TRACKED_ENTITIES: ["device_tracker.test2"],
+            CONF_IGNORED_ZONES: [],
+            CONF_TOLERANCE: 1,
+        },
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert mock_config.data == {
+        CONF_ZONE: "zone.home",
+        CONF_TRACKED_ENTITIES: ["device_tracker.test2"],
+        CONF_IGNORED_ZONES: [],
+        CONF_TOLERANCE: 1,
+    }
+
+
+async def test_import_flow(hass: HomeAssistant, config_zones) -> None:
+    """Test import of yaml configuration."""
+    with patch(
+        "homeassistant.components.proximity.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data={
+                CONF_NAME: "home",
+                CONF_ZONE: "zone.home",
+                CONF_TRACKED_ENTITIES: ["device_tracker.test1"],
+                CONF_IGNORED_ZONES: ["zone.work"],
+                CONF_TOLERANCE: 10,
+                CONF_UNIT_OF_MEASUREMENT: "km",
+            },
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"] == {
+            CONF_ZONE: "zone.home",
+            CONF_TRACKED_ENTITIES: ["device_tracker.test1"],
+            CONF_IGNORED_ZONES: ["zone.work"],
+            CONF_TOLERANCE: 10,
+            CONF_UNIT_OF_MEASUREMENT: "km",
+        }
+
+        await hass.async_block_till_done()
+
+    assert mock_setup_entry.called

--- a/tests/components/proximity/test_init.py
+++ b/tests/components/proximity/test_init.py
@@ -50,7 +50,7 @@ async def test_proximities(hass: HomeAssistant, friendly_name: str) -> None:
     assert state.state == "0"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{friendly_name}_nearest_device")
+    state = hass.states.get(f"sensor.{friendly_name}_nearest")
     assert state.state == STATE_UNKNOWN
 
     for device in config["proximity"][friendly_name]["devices"]:
@@ -105,7 +105,7 @@ async def test_device_tracker_test1_in_zone(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "arrived"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest_device")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -143,7 +143,7 @@ async def test_device_tracker_test1_away(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest_device")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -184,7 +184,7 @@ async def test_device_tracker_test1_awayfurther(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest_device")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -206,7 +206,7 @@ async def test_device_tracker_test1_awayfurther(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "away_from"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest_device")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -246,7 +246,7 @@ async def test_device_tracker_test1_awaycloser(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest_device")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -268,7 +268,7 @@ async def test_device_tracker_test1_awaycloser(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "towards"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest_device")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -302,7 +302,7 @@ async def test_all_device_trackers_in_ignored_zone(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "not set"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest_device")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == STATE_UNKNOWN
 
     entity_base_name = "sensor.home_test1"
@@ -337,7 +337,7 @@ async def test_device_tracker_test1_no_coordinates(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "not set"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest_device")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == STATE_UNKNOWN
 
     entity_base_name = "sensor.home_test1"
@@ -377,7 +377,7 @@ async def test_device_tracker_test1_awayfurther_a_bit(hass: HomeAssistant) -> No
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest_device")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -399,7 +399,7 @@ async def test_device_tracker_test1_awayfurther_a_bit(hass: HomeAssistant) -> No
     assert state.attributes.get("dir_of_travel") == "stationary"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest_device")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -445,7 +445,7 @@ async def test_device_trackers_in_zone(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "arrived"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest_device")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1, test2"
 
     for device in ["test1", "test2"]:
@@ -500,7 +500,7 @@ async def test_device_tracker_test1_awayfurther_than_test2_first_test1(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest_device")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -528,7 +528,7 @@ async def test_device_tracker_test1_awayfurther_than_test2_first_test1(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest_device")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -586,7 +586,7 @@ async def test_device_tracker_test1_awayfurther_than_test2_first_test2(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest_device")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test2"
 
     entity_base_name = "sensor.home_test1"
@@ -614,7 +614,7 @@ async def test_device_tracker_test1_awayfurther_than_test2_first_test2(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest_device")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -667,7 +667,7 @@ async def test_device_tracker_test1_awayfurther_test2_in_ignored_zone(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest_device")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -750,7 +750,7 @@ async def test_device_tracker_test1_awayfurther_test2_first(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest_device")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test2"
 
     entity_base_name = "sensor.home_test1"
@@ -809,7 +809,7 @@ async def test_device_tracker_test1_nearest_after_test2_in_ignored_zone(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest_device")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -837,7 +837,7 @@ async def test_device_tracker_test1_nearest_after_test2_in_ignored_zone(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest_device")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test2"
 
     entity_base_name = "sensor.home_test1"
@@ -865,7 +865,7 @@ async def test_device_tracker_test1_nearest_after_test2_in_ignored_zone(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest_device")
+    state = hass.states.get("sensor.home_nearest")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"

--- a/tests/components/proximity/test_init.py
+++ b/tests/components/proximity/test_init.py
@@ -50,7 +50,7 @@ async def test_proximities(hass: HomeAssistant, friendly_name: str) -> None:
     assert state.state == "0"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{friendly_name}_nearest")
+    state = hass.states.get(f"sensor.{friendly_name}_nearest_device")
     assert state.state == STATE_UNKNOWN
 
     for device in config["proximity"][friendly_name]["devices"]:
@@ -105,7 +105,7 @@ async def test_device_tracker_test1_in_zone(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "arrived"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -143,7 +143,7 @@ async def test_device_tracker_test1_away(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -184,7 +184,7 @@ async def test_device_tracker_test1_awayfurther(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -206,7 +206,7 @@ async def test_device_tracker_test1_awayfurther(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "away_from"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -246,7 +246,7 @@ async def test_device_tracker_test1_awaycloser(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -268,7 +268,7 @@ async def test_device_tracker_test1_awaycloser(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "towards"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -302,7 +302,7 @@ async def test_all_device_trackers_in_ignored_zone(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "not set"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == STATE_UNKNOWN
 
     entity_base_name = "sensor.home_test1"
@@ -337,7 +337,7 @@ async def test_device_tracker_test1_no_coordinates(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "not set"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == STATE_UNKNOWN
 
     entity_base_name = "sensor.home_test1"
@@ -377,7 +377,7 @@ async def test_device_tracker_test1_awayfurther_a_bit(hass: HomeAssistant) -> No
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -399,7 +399,7 @@ async def test_device_tracker_test1_awayfurther_a_bit(hass: HomeAssistant) -> No
     assert state.attributes.get("dir_of_travel") == "stationary"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -445,7 +445,7 @@ async def test_device_trackers_in_zone(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "arrived"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1, test2"
 
     for device in ["test1", "test2"]:
@@ -500,7 +500,7 @@ async def test_device_tracker_test1_awayfurther_than_test2_first_test1(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -528,7 +528,7 @@ async def test_device_tracker_test1_awayfurther_than_test2_first_test1(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -586,7 +586,7 @@ async def test_device_tracker_test1_awayfurther_than_test2_first_test2(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test2"
 
     entity_base_name = "sensor.home_test1"
@@ -614,7 +614,7 @@ async def test_device_tracker_test1_awayfurther_than_test2_first_test2(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -667,7 +667,7 @@ async def test_device_tracker_test1_awayfurther_test2_in_ignored_zone(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -750,7 +750,7 @@ async def test_device_tracker_test1_awayfurther_test2_first(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test2"
 
     entity_base_name = "sensor.home_test1"
@@ -809,7 +809,7 @@ async def test_device_tracker_test1_nearest_after_test2_in_ignored_zone(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -837,7 +837,7 @@ async def test_device_tracker_test1_nearest_after_test2_in_ignored_zone(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test2"
 
     entity_base_name = "sensor.home_test1"
@@ -865,7 +865,7 @@ async def test_device_tracker_test1_nearest_after_test2_in_ignored_zone(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
     entity_base_name = "sensor.home_test1"
@@ -946,7 +946,7 @@ async def test_create_issue(
     )
 
 
-def config_zones(hass):
+def config_zones(hass: HomeAssistant):
     """Set up zones for test."""
     hass.config.components.add("zone")
     hass.states.async_set(

--- a/tests/components/proximity/test_init.py
+++ b/tests/components/proximity/test_init.py
@@ -13,30 +13,42 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util import slugify
 
 
-@pytest.mark.parametrize(("friendly_name"), ["home", "home_test2", "work"])
-async def test_proximities(hass: HomeAssistant, friendly_name: str) -> None:
-    """Test a list of proximities."""
-    config = {
-        "proximity": {
-            "home": {
+@pytest.mark.parametrize(
+    ("friendly_name", "config"),
+    [
+        (
+            "home",
+            {
                 "ignored_zones": ["work"],
                 "devices": ["device_tracker.test1", "device_tracker.test2"],
                 "tolerance": "1",
             },
-            "home_test2": {
+        ),
+        (
+            "home_test2",
+            {
                 "ignored_zones": ["work"],
                 "devices": ["device_tracker.test1", "device_tracker.test2"],
                 "tolerance": "1",
             },
-            "work": {
+        ),
+        (
+            "work",
+            {
                 "devices": ["device_tracker.test1"],
                 "tolerance": "1",
                 "zone": "work",
             },
-        }
-    }
-
-    assert await async_setup_component(hass, DOMAIN, config)
+        ),
+    ],
+)
+async def test_proximities(
+    hass: HomeAssistant, friendly_name: str, config: dict
+) -> None:
+    """Test a list of proximities."""
+    assert await async_setup_component(
+        hass, DOMAIN, {"proximity": {friendly_name: config}}
+    )
     await hass.async_block_till_done()
 
     # proximity entity
@@ -53,7 +65,7 @@ async def test_proximities(hass: HomeAssistant, friendly_name: str) -> None:
     state = hass.states.get(f"sensor.{friendly_name}_nearest_device")
     assert state.state == STATE_UNKNOWN
 
-    for device in config["proximity"][friendly_name]["devices"]:
+    for device in config["devices"]:
         entity_base_name = f"sensor.{friendly_name}_{slugify(device.split('.')[-1])}"
         state = hass.states.get(f"{entity_base_name}_distance")
         assert state.state == STATE_UNKNOWN

--- a/tests/components/proximity/test_init.py
+++ b/tests/components/proximity/test_init.py
@@ -50,11 +50,11 @@ async def test_proximities(hass: HomeAssistant, friendly_name: str) -> None:
     assert state.state == "0"
 
     # sensor entities
-    state = hass.states.get(f"sensor.{friendly_name}_nearest")
+    state = hass.states.get(f"sensor.{friendly_name}_nearest_device")
     assert state.state == STATE_UNKNOWN
 
     for device in config["proximity"][friendly_name]["devices"]:
-        entity_base_name = f"sensor.{friendly_name}_{slugify(device)}"
+        entity_base_name = f"sensor.{friendly_name}_{slugify(device.split('.')[-1])}"
         state = hass.states.get(f"{entity_base_name}_distance")
         assert state.state == STATE_UNKNOWN
         state = hass.states.get(f"{entity_base_name}_direction_of_travel")
@@ -105,10 +105,10 @@ async def test_device_tracker_test1_in_zone(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "arrived"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
+    entity_base_name = "sensor.home_test1"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "0"
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
@@ -143,10 +143,10 @@ async def test_device_tracker_test1_away(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
+    entity_base_name = "sensor.home_test1"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "11912010"
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
@@ -184,10 +184,10 @@ async def test_device_tracker_test1_awayfurther(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
+    entity_base_name = "sensor.home_test1"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "2218752"
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
@@ -206,10 +206,10 @@ async def test_device_tracker_test1_awayfurther(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "away_from"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
+    entity_base_name = "sensor.home_test1"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "4625264"
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
@@ -246,10 +246,10 @@ async def test_device_tracker_test1_awaycloser(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
+    entity_base_name = "sensor.home_test1"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "4625264"
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
@@ -268,10 +268,10 @@ async def test_device_tracker_test1_awaycloser(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "towards"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
+    entity_base_name = "sensor.home_test1"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "2218752"
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
@@ -302,10 +302,10 @@ async def test_all_device_trackers_in_ignored_zone(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "not set"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == STATE_UNKNOWN
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
+    entity_base_name = "sensor.home_test1"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == STATE_UNKNOWN
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
@@ -337,10 +337,10 @@ async def test_device_tracker_test1_no_coordinates(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "not set"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == STATE_UNKNOWN
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
+    entity_base_name = "sensor.home_test1"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == STATE_UNKNOWN
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
@@ -377,10 +377,10 @@ async def test_device_tracker_test1_awayfurther_a_bit(hass: HomeAssistant) -> No
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
+    entity_base_name = "sensor.home_test1"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "11912010"
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
@@ -399,10 +399,10 @@ async def test_device_tracker_test1_awayfurther_a_bit(hass: HomeAssistant) -> No
     assert state.attributes.get("dir_of_travel") == "stationary"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
+    entity_base_name = "sensor.home_test1"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "11912010"
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
@@ -445,11 +445,11 @@ async def test_device_trackers_in_zone(hass: HomeAssistant) -> None:
     assert state.attributes.get("dir_of_travel") == "arrived"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1, test2"
 
-    for device in ["device_tracker.test1", "device_tracker.test2"]:
-        entity_base_name = f"sensor.home_{slugify(device)}"
+    for device in ["test1", "test2"]:
+        entity_base_name = f"sensor.home_{device}"
         state = hass.states.get(f"{entity_base_name}_distance")
         assert state.state == "0"
         state = hass.states.get(f"{entity_base_name}_direction_of_travel")
@@ -500,16 +500,16 @@ async def test_device_tracker_test1_awayfurther_than_test2_first_test1(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
+    entity_base_name = "sensor.home_test1"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "2218752"
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
+    entity_base_name = "sensor.home_test2"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == STATE_UNKNOWN
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
@@ -528,16 +528,16 @@ async def test_device_tracker_test1_awayfurther_than_test2_first_test1(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
+    entity_base_name = "sensor.home_test1"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "2218752"
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
+    entity_base_name = "sensor.home_test2"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "4625264"
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
@@ -586,16 +586,16 @@ async def test_device_tracker_test1_awayfurther_than_test2_first_test2(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test2"
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
+    entity_base_name = "sensor.home_test1"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == STATE_UNKNOWN
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
+    entity_base_name = "sensor.home_test2"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "4625264"
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
@@ -614,16 +614,16 @@ async def test_device_tracker_test1_awayfurther_than_test2_first_test2(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
+    entity_base_name = "sensor.home_test1"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "2218752"
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
+    entity_base_name = "sensor.home_test2"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "4625264"
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
@@ -667,16 +667,16 @@ async def test_device_tracker_test1_awayfurther_test2_in_ignored_zone(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
+    entity_base_name = "sensor.home_test1"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "11912010"
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
+    entity_base_name = "sensor.home_test2"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == STATE_UNKNOWN
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
@@ -750,16 +750,16 @@ async def test_device_tracker_test1_awayfurther_test2_first(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test2"
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
+    entity_base_name = "sensor.home_test1"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == STATE_UNKNOWN
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
+    entity_base_name = "sensor.home_test2"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "2218752"
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
@@ -809,16 +809,16 @@ async def test_device_tracker_test1_nearest_after_test2_in_ignored_zone(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
+    entity_base_name = "sensor.home_test1"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "2218752"
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
+    entity_base_name = "sensor.home_test2"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == STATE_UNKNOWN
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
@@ -837,16 +837,16 @@ async def test_device_tracker_test1_nearest_after_test2_in_ignored_zone(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test2"
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
+    entity_base_name = "sensor.home_test1"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "2218752"
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
+    entity_base_name = "sensor.home_test2"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "989156"
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
@@ -865,16 +865,16 @@ async def test_device_tracker_test1_nearest_after_test2_in_ignored_zone(
     assert state.attributes.get("dir_of_travel") == "unknown"
 
     # sensor entities
-    state = hass.states.get("sensor.home_nearest")
+    state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1"
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test1')}"
+    entity_base_name = "sensor.home_test1"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "2218752"
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")
     assert state.state == STATE_UNKNOWN
 
-    entity_base_name = f"sensor.home_{slugify('device_tracker.test2')}"
+    entity_base_name = "sensor.home_test2"
     state = hass.states.get(f"{entity_base_name}_distance")
     assert state.state == "1364567"
     state = hass.states.get(f"{entity_base_name}_direction_of_travel")

--- a/tests/components/proximity/test_init.py
+++ b/tests/components/proximity/test_init.py
@@ -153,10 +153,11 @@ async def test_device_tracker_test1_away(hass: HomeAssistant) -> None:
     assert state.state == STATE_UNKNOWN
 
 
-async def test_device_tracker_test1_awayfurther(hass: HomeAssistant) -> None:
+async def test_device_tracker_test1_awayfurther(
+    hass: HomeAssistant, config_zones
+) -> None:
     """Test for tracker state away further."""
 
-    config_zones(hass)
     await hass.async_block_till_done()
 
     config = {
@@ -216,9 +217,10 @@ async def test_device_tracker_test1_awayfurther(hass: HomeAssistant) -> None:
     assert state.state == "away_from"
 
 
-async def test_device_tracker_test1_awaycloser(hass: HomeAssistant) -> None:
+async def test_device_tracker_test1_awaycloser(
+    hass: HomeAssistant, config_zones
+) -> None:
     """Test for tracker state away closer."""
-    config_zones(hass)
     await hass.async_block_till_done()
 
     config = {
@@ -457,10 +459,9 @@ async def test_device_trackers_in_zone(hass: HomeAssistant) -> None:
 
 
 async def test_device_tracker_test1_awayfurther_than_test2_first_test1(
-    hass: HomeAssistant,
+    hass: HomeAssistant, config_zones
 ) -> None:
     """Test for tracker ordering."""
-    config_zones(hass)
     await hass.async_block_till_done()
 
     hass.states.async_set(
@@ -545,10 +546,9 @@ async def test_device_tracker_test1_awayfurther_than_test2_first_test1(
 
 
 async def test_device_tracker_test1_awayfurther_than_test2_first_test2(
-    hass: HomeAssistant,
+    hass: HomeAssistant, config_zones
 ) -> None:
     """Test for tracker ordering."""
-    config_zones(hass)
     await hass.async_block_till_done()
 
     hass.states.async_set(
@@ -684,10 +684,9 @@ async def test_device_tracker_test1_awayfurther_test2_in_ignored_zone(
 
 
 async def test_device_tracker_test1_awayfurther_test2_first(
-    hass: HomeAssistant,
+    hass: HomeAssistant, config_zones
 ) -> None:
     """Test for tracker state."""
-    config_zones(hass)
     await hass.async_block_till_done()
 
     hass.states.async_set(
@@ -767,10 +766,9 @@ async def test_device_tracker_test1_awayfurther_test2_first(
 
 
 async def test_device_tracker_test1_nearest_after_test2_in_ignored_zone(
-    hass: HomeAssistant,
+    hass: HomeAssistant, config_zones
 ) -> None:
     """Test for tracker states."""
-    config_zones(hass)
     await hass.async_block_till_done()
 
     hass.states.async_set(
@@ -943,19 +941,4 @@ async def test_create_issue(
 
     assert not issue_registry.async_get_issue(
         DOMAIN, "deprecated_proximity_entity_work"
-    )
-
-
-def config_zones(hass: HomeAssistant):
-    """Set up zones for test."""
-    hass.config.components.add("zone")
-    hass.states.async_set(
-        "zone.home",
-        "zoning",
-        {"name": "home", "latitude": 2.1, "longitude": 1.1, "radius": 10},
-    )
-    hass.states.async_set(
-        "zone.work",
-        "zoning",
-        {"name": "work", "latitude": 2.3, "longitude": 1.3, "radius": 10},
     )

--- a/tests/components/proximity/test_init.py
+++ b/tests/components/proximity/test_init.py
@@ -1057,7 +1057,7 @@ async def test_track_renamed_tracked_entity(
 
     entity = entity_registry.async_get(sensor_t1)
     assert entity
-    assert entity.unique_id == f"{mock_config.entry_id}_{t1.unique_id}_dist_to_zone"
+    assert entity.unique_id == f"{mock_config.entry_id}_{t1.id}_dist_to_zone"
 
     entity_registry.async_update_entity(
         t1.entity_id, new_entity_id=f"{t1.entity_id}_renamed"
@@ -1066,7 +1066,7 @@ async def test_track_renamed_tracked_entity(
 
     entity = entity_registry.async_get(sensor_t1)
     assert entity
-    assert entity.unique_id == f"{mock_config.entry_id}_{t1.unique_id}_dist_to_zone"
+    assert entity.unique_id == f"{mock_config.entry_id}_{t1.id}_dist_to_zone"
 
     entry = hass.config_entries.async_get_entry(mock_config.entry_id)
     assert entry
@@ -1104,7 +1104,7 @@ async def test_sensor_unique_ids(
     sensor_t1 = f"sensor.home_{t1.entity_id.split('.')[-1]}_distance"
     entity = entity_registry.async_get(sensor_t1)
     assert entity
-    assert entity.unique_id == f"{mock_config.entry_id}_{t1.unique_id}_dist_to_zone"
+    assert entity.unique_id == f"{mock_config.entry_id}_{t1.id}_dist_to_zone"
 
     entity = entity_registry.async_get("sensor.home_test2_distance")
     assert entity


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Configuring Proximity using YAML is being removed in 2024.8.
Your existing YAML configuration has been imported into the UI automatically.
Remove the proximity configuration from your `configuration.yaml` file.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Config flow

![image](https://github.com/home-assistant/core/assets/35783820/6dfb6be8-98ab-442d-83c9-d61e24352193)


Options flow

![image](https://github.com/home-assistant/core/assets/35783820/1c1442af-1151-4908-83e1-4cd23b5481a0)



open todos:
- [x] needs rebase after #101497 is merged
- [x] add tests for config flow att all

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29965

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
