### PR TITLE
Update i-j* tests to use entity & device registry fixtures

### DIFF
--- a/tests/components/ibeacon/test_init.py
+++ b/tests/components/ibeacon/test_init.py
@@ -33,7 +33,9 @@ async def remove_device(ws_client, device_id, config_entry_id):
 
 
 async def test_device_remove_devices(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test we can only remove a device that no longer exists."""
     entry = MockConfigEntry(
@@ -46,7 +48,6 @@ async def test_device_remove_devices(
     await hass.async_block_till_done()
     inject_bluetooth_service_info(hass, BLUECHARM_BEACON_SERVICE_INFO)
     await hass.async_block_till_done()
-    device_registry = dr.async_get(hass)
 
     device_entry = device_registry.async_get_device(
         identifiers={

--- a/tests/components/input_boolean/test_init.py
+++ b/tests/components/input_boolean/test_init.py
@@ -195,10 +195,11 @@ async def test_input_boolean_context(
     assert state2.context.user_id == hass_admin_user.id
 
 
-async def test_reload(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
+async def test_reload(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, hass_admin_user: MockUser
+) -> None:
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
-    ent_reg = er.async_get(hass)
 
     _LOGGER.debug("ENTITIES @ start: %s", hass.states.async_entity_ids())
 
@@ -226,9 +227,9 @@ async def test_reload(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
     assert state_3 is None
     assert state_2.state == STATE_ON
 
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_1") is not None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_2") is not None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_1") is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_2") is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is None
 
     with patch(
         "homeassistant.config.load_yaml_config_file",
@@ -261,9 +262,9 @@ async def test_reload(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
     assert state_2 is not None
     assert state_3 is not None
 
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_1") is None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_2") is not None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_1") is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_2") is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is not None
 
     assert state_2.state == STATE_ON  # reload is not supposed to change entity state
     assert state_2.attributes.get(ATTR_FRIENDLY_NAME) == "Hello World reloaded"
@@ -316,18 +317,20 @@ async def test_ws_list(
 
 
 async def test_ws_delete(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+    storage_setup,
 ) -> None:
     """Test WS delete cleans up entity registry."""
     assert await storage_setup()
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
 
     client = await hass_ws_client(hass)
 
@@ -339,11 +342,14 @@ async def test_ws_delete(
 
     state = hass.states.get(input_entity_id)
     assert state is None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
 
 
 async def test_ws_update(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+    storage_setup,
 ) -> None:
     """Test update WS."""
 
@@ -355,12 +361,11 @@ async def test_ws_update(
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None
     assert state.state
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
 
     client = await hass_ws_client(hass)
 
@@ -400,18 +405,20 @@ async def test_ws_update(
 
 
 async def test_ws_create(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+    storage_setup,
 ) -> None:
     """Test create WS."""
     assert await storage_setup(items=[])
 
     input_id = "new_input"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
 
     client = await hass_ws_client(hass)
 

--- a/tests/components/input_button/test_init.py
+++ b/tests/components/input_button/test_init.py
@@ -133,10 +133,11 @@ async def test_input_button_context(
     assert state2.context.user_id == hass_admin_user.id
 
 
-async def test_reload(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
+async def test_reload(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, hass_admin_user: MockUser
+) -> None:
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
-    ent_reg = er.async_get(hass)
 
     _LOGGER.debug("ENTITIES @ start: %s", hass.states.async_entity_ids())
 
@@ -163,9 +164,9 @@ async def test_reload(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
     assert state_2 is not None
     assert state_3 is None
 
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_1") is not None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_2") is not None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_1") is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_2") is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is None
 
     with patch(
         "homeassistant.config.load_yaml_config_file",
@@ -197,9 +198,9 @@ async def test_reload(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
     assert state_2 is not None
     assert state_3 is not None
 
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_1") is None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_2") is not None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_1") is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_2") is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is not None
 
 
 async def test_reload_not_changing_state(hass: HomeAssistant, storage_setup) -> None:
@@ -288,7 +289,10 @@ async def test_ws_list(
 
 
 async def test_ws_create_update(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+    storage_setup,
 ) -> None:
     """Test creating and updating via WS."""
     assert await storage_setup(config={DOMAIN: {}})
@@ -304,8 +308,7 @@ async def test_ws_create_update(
     assert state.state == STATE_UNKNOWN
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == "new"
 
-    ent_reg = er.async_get(hass)
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "new") is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "new") is not None
 
     await client.send_json(
         {"id": 8, "type": f"{DOMAIN}/update", f"{DOMAIN}_id": "new", "name": "newer"}
@@ -319,22 +322,24 @@ async def test_ws_create_update(
     assert state.state == STATE_UNKNOWN
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == "newer"
 
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "new") is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "new") is not None
 
 
 async def test_ws_delete(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+    storage_setup,
 ) -> None:
     """Test WS delete cleans up entity registry."""
     assert await storage_setup()
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
 
     client = await hass_ws_client(hass)
 
@@ -346,7 +351,7 @@ async def test_ws_delete(
 
     state = hass.states.get(input_entity_id)
     assert state is None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
 
 
 async def test_setup_no_config(hass: HomeAssistant, hass_admin_user: MockUser) -> None:

--- a/tests/components/input_datetime/test_init.py
+++ b/tests/components/input_datetime/test_init.py
@@ -423,11 +423,13 @@ async def test_input_datetime_context(
 
 
 async def test_reload(
-    hass: HomeAssistant, hass_admin_user: MockUser, hass_read_only_user: MockUser
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_admin_user: MockUser,
+    hass_read_only_user: MockUser,
 ) -> None:
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
-    ent_reg = er.async_get(hass)
 
     assert await async_setup_component(
         hass,
@@ -451,9 +453,9 @@ async def test_reload(
     assert state_2 is None
     assert state_3 is not None
     assert dt_obj.strftime(FORMAT_DATE) == state_1.state
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "dt1") == f"{DOMAIN}.dt1"
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "dt2") is None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "dt3") == f"{DOMAIN}.dt3"
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "dt1") == f"{DOMAIN}.dt1"
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "dt2") is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "dt3") == f"{DOMAIN}.dt3"
 
     with patch(
         "homeassistant.config.load_yaml_config_file",
@@ -493,9 +495,9 @@ async def test_reload(
         datetime.date.today(), DEFAULT_TIME
     ).strftime(FORMAT_DATETIME)
 
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "dt1") == f"{DOMAIN}.dt1"
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "dt2") == f"{DOMAIN}.dt2"
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "dt3") is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "dt1") == f"{DOMAIN}.dt1"
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "dt2") == f"{DOMAIN}.dt2"
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "dt3") is None
 
 
 async def test_load_from_storage(hass: HomeAssistant, storage_setup) -> None:
@@ -553,18 +555,22 @@ async def test_ws_list(
 
 
 async def test_ws_delete(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+    storage_setup,
 ) -> None:
     """Test WS delete cleans up entity registry."""
     assert await storage_setup()
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.datetime_from_storage"
-    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) == input_entity_id
+    assert (
+        entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) == input_entity_id
+    )
 
     client = await hass_ws_client(hass)
 
@@ -576,11 +582,14 @@ async def test_ws_delete(
 
     state = hass.states.get(input_entity_id)
     assert state is None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
 
 
 async def test_update(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+    storage_setup,
 ) -> None:
     """Test updating min/max updates the state."""
 
@@ -588,12 +597,13 @@ async def test_update(
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.datetime_from_storage"
-    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state.attributes[ATTR_FRIENDLY_NAME] == "datetime from storage"
     assert state.state == INITIAL_DATETIME
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) == input_entity_id
+    assert (
+        entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) == input_entity_id
+    )
 
     client = await hass_ws_client(hass)
 
@@ -621,18 +631,20 @@ async def test_update(
 
 
 async def test_ws_create(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+    storage_setup,
 ) -> None:
     """Test create WS."""
     assert await storage_setup(items=[])
 
     input_id = "new_datetime"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
 
     client = await hass_ws_client(hass)
 

--- a/tests/components/input_number/test_init.py
+++ b/tests/components/input_number/test_init.py
@@ -343,11 +343,13 @@ async def test_input_number_context(
 
 
 async def test_reload(
-    hass: HomeAssistant, hass_admin_user: MockUser, hass_read_only_user: MockUser
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_admin_user: MockUser,
+    hass_read_only_user: MockUser,
 ) -> None:
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
-    ent_reg = er.async_get(hass)
 
     assert await async_setup_component(
         hass,
@@ -371,9 +373,9 @@ async def test_reload(
     assert state_3 is not None
     assert float(state_1.state) == 50
     assert float(state_3.state) == 10
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_1") is not None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_2") is None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_1") is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_2") is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is not None
 
     with patch(
         "homeassistant.config.load_yaml_config_file",
@@ -411,9 +413,9 @@ async def test_reload(
     assert state_3 is None
     assert float(state_1.state) == 50
     assert float(state_2.state) == 20
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_1") is not None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_2") is not None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_1") is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_2") is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is None
 
 
 async def test_load_from_storage(hass: HomeAssistant, storage_setup) -> None:
@@ -486,18 +488,20 @@ async def test_ws_list(
 
 
 async def test_ws_delete(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+    storage_setup,
 ) -> None:
     """Test WS delete cleans up entity registry."""
     assert await storage_setup()
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
 
     client = await hass_ws_client(hass)
 
@@ -509,11 +513,14 @@ async def test_ws_delete(
 
     state = hass.states.get(input_entity_id)
     assert state is None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
 
 
 async def test_update_min_max(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+    storage_setup,
 ) -> None:
     """Test updating min/max updates the state."""
 
@@ -529,12 +536,11 @@ async def test_update_min_max(
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None
     assert state.state
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
 
     client = await hass_ws_client(hass)
 
@@ -572,18 +578,20 @@ async def test_update_min_max(
 
 
 async def test_ws_create(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+    storage_setup,
 ) -> None:
     """Test create WS."""
     assert await storage_setup(items=[])
 
     input_id = "new_input"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
 
     client = await hass_ws_client(hass)
 

--- a/tests/components/input_select/test_init.py
+++ b/tests/components/input_select/test_init.py
@@ -447,11 +447,13 @@ async def test_input_select_context(
 
 
 async def test_reload(
-    hass: HomeAssistant, hass_admin_user: MockUser, hass_read_only_user: MockUser
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_admin_user: MockUser,
+    hass_read_only_user: MockUser,
 ) -> None:
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
-    ent_reg = er.async_get(hass)
 
     assert await async_setup_component(
         hass,
@@ -481,9 +483,9 @@ async def test_reload(
     assert state_3 is None
     assert state_1.state == "middle option"
     assert state_2.state == "an option"
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_1") is not None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_2") is not None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_1") is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_2") is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is None
 
     with patch(
         "homeassistant.config.load_yaml_config_file",
@@ -526,9 +528,9 @@ async def test_reload(
     assert state_3 is not None
     assert state_2.state == "an option"
     assert state_3.state == "newer option"
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_1") is None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_2") is not None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_1") is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_2") is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is not None
 
 
 async def test_load_from_storage(hass: HomeAssistant, storage_setup) -> None:
@@ -611,18 +613,20 @@ async def test_ws_list(
 
 
 async def test_ws_delete(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+    storage_setup,
 ) -> None:
     """Test WS delete cleans up entity registry."""
     assert await storage_setup()
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
 
     client = await hass_ws_client(hass)
 
@@ -634,11 +638,14 @@ async def test_ws_delete(
 
     state = hass.states.get(input_entity_id)
     assert state is None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
 
 
 async def test_update(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+    storage_setup,
 ) -> None:
     """Test updating options updates the state."""
 
@@ -651,11 +658,10 @@ async def test_update(
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state.attributes[ATTR_OPTIONS] == ["yaml update 1", "yaml update 2"]
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
 
     client = await hass_ws_client(hass)
 
@@ -697,6 +703,7 @@ async def test_update(
 
 async def test_update_duplicates(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     hass_ws_client: WebSocketGenerator,
     storage_setup,
     caplog: pytest.LogCaptureFixture,
@@ -712,11 +719,10 @@ async def test_update_duplicates(
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state.attributes[ATTR_OPTIONS] == ["yaml update 1", "yaml update 2"]
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
 
     client = await hass_ws_client(hass)
 
@@ -742,18 +748,20 @@ async def test_update_duplicates(
 
 
 async def test_ws_create(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+    storage_setup,
 ) -> None:
     """Test create WS."""
     assert await storage_setup(items=[])
 
     input_id = "new_input"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
 
     client = await hass_ws_client(hass)
 
@@ -776,6 +784,7 @@ async def test_ws_create(
 
 async def test_ws_create_duplicates(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     hass_ws_client: WebSocketGenerator,
     storage_setup,
     caplog: pytest.LogCaptureFixture,
@@ -785,11 +794,10 @@ async def test_ws_create_duplicates(
 
     input_id = "new_input"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
 
     client = await hass_ws_client(hass)
 

--- a/tests/components/input_text/test_init.py
+++ b/tests/components/input_text/test_init.py
@@ -397,18 +397,20 @@ async def test_ws_list(
 
 
 async def test_ws_delete(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+    storage_setup,
 ) -> None:
     """Test WS delete cleans up entity registry."""
     assert await storage_setup()
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
 
     client = await hass_ws_client(hass)
 
@@ -420,11 +422,14 @@ async def test_ws_delete(
 
     state = hass.states.get(input_entity_id)
     assert state is None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
 
 
 async def test_update(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+    storage_setup,
 ) -> None:
     """Test updating min/max updates the state."""
 
@@ -432,13 +437,12 @@ async def test_update(
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state.attributes[ATTR_FRIENDLY_NAME] == "from storage"
     assert state.attributes[ATTR_MODE] == MODE_TEXT
     assert state.state == "loaded from storage"
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
 
     client = await hass_ws_client(hass)
 
@@ -470,18 +474,20 @@ async def test_update(
 
 
 async def test_ws_create(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+    storage_setup,
 ) -> None:
     """Test create WS."""
     assert await storage_setup(items=[])
 
     input_id = "new_input"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is None
-    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
 
     client = await hass_ws_client(hass)
 

--- a/tests/components/insteon/test_api_device.py
+++ b/tests/components/insteon/test_api_device.py
@@ -87,7 +87,9 @@ async def test_no_ha_device(
 
 
 async def test_no_insteon_device(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test response when no Insteon device exists."""
     config_entry = MockConfigEntry(
@@ -103,15 +105,14 @@ async def test_no_insteon_device(
     devices = MockDevices()
     await devices.async_load()
 
-    dev_reg = dr.async_get(hass)
     # Create device registry entry for a Insteon device not in the Insteon devices list
-    ha_device_1 = dev_reg.async_get_or_create(
+    ha_device_1 = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, "AA.BB.CC")},
         name="HA Device Only",
     )
     # Create device registry entry for a non-Insteon device
-    ha_device_2 = dev_reg.async_get_or_create(
+    ha_device_2 = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={("other_domain", "no address")},
         name="HA Device Only",

--- a/tests/components/insteon/test_lock.py
+++ b/tests/components/insteon/test_lock.py
@@ -57,18 +57,20 @@ async def mock_connection(*args, **kwargs):
     return True
 
 
-async def test_lock_lock(hass: HomeAssistant) -> None:
+async def test_lock_lock(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test locking an Insteon lock device."""
 
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT_PLM)
     config_entry.add_to_hass(hass)
-    registry_entity = er.async_get(hass)
 
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
     try:
-        lock = registry_entity.async_get("lock.device_55_55_55_55_55_55")
+        lock = entity_registry.async_get("lock.device_55_55_55_55_55_55")
         state = hass.states.get(lock.entity_id)
         assert state.state is STATE_UNLOCKED
 
@@ -82,19 +84,21 @@ async def test_lock_lock(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
 
-async def test_lock_unlock(hass: HomeAssistant) -> None:
+async def test_lock_unlock(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test locking an Insteon lock device."""
 
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT_PLM)
     config_entry.add_to_hass(hass)
-    registry_entity = er.async_get(hass)
 
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
     devices["55.55.55"].groups[1].set_value(255)
 
     try:
-        lock = registry_entity.async_get("lock.device_55_55_55_55_55_55")
+        lock = entity_registry.async_get("lock.device_55_55_55_55_55_55")
         state = hass.states.get(lock.entity_id)
 
         assert state.state is STATE_LOCKED

--- a/tests/components/integration/test_init.py
+++ b/tests/components/integration/test_init.py
@@ -11,11 +11,11 @@ from tests.common import MockConfigEntry
 @pytest.mark.parametrize("platform", ("sensor",))
 async def test_setup_and_remove_config_entry(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     platform: str,
 ) -> None:
     """Test setting up and removing a config entry."""
     input_sensor_entity_id = "sensor.input"
-    registry = er.async_get(hass)
     integration_entity_id = f"{platform}.my_integration"
 
     # Setup the config entry
@@ -37,7 +37,7 @@ async def test_setup_and_remove_config_entry(
     await hass.async_block_till_done()
 
     # Check the entity is registered in the entity registry
-    assert registry.async_get(integration_entity_id) is not None
+    assert entity_registry.async_get(integration_entity_id) is not None
 
     # Check the platform is setup correctly
     state = hass.states.get(integration_entity_id)
@@ -58,4 +58,4 @@ async def test_setup_and_remove_config_entry(
 
     # Check the state and entity registry entry are removed
     assert hass.states.get(integration_entity_id) is None
-    assert registry.async_get(integration_entity_id) is None
+    assert entity_registry.async_get(integration_entity_id) is None

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -679,11 +679,12 @@ async def test_calc_errors(hass: HomeAssistant, method) -> None:
     assert round(float(state.state)) == 0 if method != "right" else 1
 
 
-async def test_device_id(hass: HomeAssistant) -> None:
+async def test_device_id(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test for source entity device for Riemann sum integral."""
-    device_registry = dr.async_get(hass)
-    entity_registry = er.async_get(hass)
-
     source_config_entry = MockConfigEntry()
     source_config_entry.add_to_hass(hass)
     source_device_entry = device_registry.async_get_or_create(

--- a/tests/components/intent/test_init.py
+++ b/tests/components/intent/test_init.py
@@ -119,14 +119,14 @@ async def test_turn_on_intent(hass: HomeAssistant) -> None:
     assert call.data == {"entity_id": ["light.test_light"]}
 
 
-async def test_translated_turn_on_intent(hass: HomeAssistant) -> None:
+async def test_translated_turn_on_intent(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test HassTurnOn intent on domains which don't have the intent."""
     result = await async_setup_component(hass, "homeassistant", {})
     result = await async_setup_component(hass, "intent", {})
     await hass.async_block_till_done()
     assert result
-
-    entity_registry = er.async_get(hass)
 
     cover = entity_registry.async_get_or_create("cover", "test", "cover_uid")
     lock = entity_registry.async_get_or_create("lock", "test", "lock_uid")

--- a/tests/components/ipp/test_sensor.py
+++ b/tests/components/ipp/test_sensor.py
@@ -79,15 +79,14 @@ async def test_sensors(
 
 async def test_disabled_by_default_sensors(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     init_integration: MockConfigEntry,
 ) -> None:
     """Test the disabled by default IPP sensors."""
-    registry = er.async_get(hass)
-
     state = hass.states.get("sensor.test_ha_1000_series_uptime")
     assert state is None
 
-    entry = registry.async_get("sensor.test_ha_1000_series_uptime")
+    entry = entity_registry.async_get("sensor.test_ha_1000_series_uptime")
     assert entry
     assert entry.disabled
     assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
@@ -95,6 +94,7 @@ async def test_disabled_by_default_sensors(
 
 async def test_missing_entry_unique_id(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
     mock_ipp: AsyncMock,
 ) -> None:
@@ -105,8 +105,6 @@ async def test_missing_entry_unique_id(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    registry = er.async_get(hass)
-
-    entity = registry.async_get("sensor.test_ha_1000_series")
+    entity = entity_registry.async_get("sensor.test_ha_1000_series")
     assert entity
     assert entity.unique_id == f"{mock_config_entry.entry_id}_printer"

--- a/tests/components/islamic_prayer_times/test_init.py
+++ b/tests/components/islamic_prayer_times/test_init.py
@@ -154,15 +154,16 @@ async def test_update_failed(hass: HomeAssistant) -> None:
     ],
 )
 async def test_migrate_unique_id(
-    hass: HomeAssistant, object_id: str, old_unique_id: str
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    object_id: str,
+    old_unique_id: str,
 ) -> None:
     """Test unique id migration."""
     entry = MockConfigEntry(domain=islamic_prayer_times.DOMAIN, data={})
     entry.add_to_hass(hass)
 
-    ent_reg = er.async_get(hass)
-
-    entity: er.RegistryEntry = ent_reg.async_get_or_create(
+    entity: er.RegistryEntry = entity_registry.async_get_or_create(
         suggested_object_id=object_id,
         domain=SENSOR_DOMAIN,
         platform=islamic_prayer_times.DOMAIN,
@@ -178,6 +179,6 @@ async def test_migrate_unique_id(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    entity_migrated = ent_reg.async_get(entity.entity_id)
+    entity_migrated = entity_registry.async_get(entity.entity_id)
     assert entity_migrated
     assert entity_migrated.unique_id == f"{entry.entry_id}-{old_unique_id}"

--- a/tests/components/jellyfin/test_media_player.py
+++ b/tests/components/jellyfin/test_media_player.py
@@ -41,14 +41,13 @@ from tests.typing import WebSocketGenerator
 
 async def test_media_player(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     init_integration: MockConfigEntry,
     mock_jellyfin: MagicMock,
     mock_api: MagicMock,
 ) -> None:
     """Test the Jellyfin media player."""
-    device_registry = dr.async_get(hass)
-    entity_registry = er.async_get(hass)
-
     state = hass.states.get("media_player.jellyfin_device")
 
     assert state
@@ -97,13 +96,12 @@ async def test_media_player(
 
 async def test_media_player_music(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     init_integration: MockConfigEntry,
     mock_jellyfin: MagicMock,
     mock_api: MagicMock,
 ) -> None:
     """Test the Jellyfin media player."""
-    entity_registry = er.async_get(hass)
-
     state = hass.states.get("media_player.jellyfin_device_four")
 
     assert state

--- a/tests/components/jellyfin/test_sensor.py
+++ b/tests/components/jellyfin/test_sensor.py
@@ -17,13 +17,12 @@ from tests.common import MockConfigEntry
 
 async def test_watching(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     init_integration: MockConfigEntry,
     mock_jellyfin: MagicMock,
 ) -> None:
     """Test the Jellyfin watching sensor."""
-    device_registry = dr.async_get(hass)
-    entity_registry = er.async_get(hass)
-
     state = hass.states.get("sensor.jellyfin_server")
     assert state
     assert state.attributes.get(ATTR_DEVICE_CLASS) is None

--- a/tests/components/jewish_calendar/test_binary_sensor.py
+++ b/tests/components/jewish_calendar/test_binary_sensor.py
@@ -169,6 +169,7 @@ MELACHA_TEST_IDS = [
 )
 async def test_issur_melacha_sensor(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     now,
     candle_lighting,
     havdalah,
@@ -185,8 +186,6 @@ async def test_issur_melacha_sensor(
     hass.config.set_time_zone(tzname)
     hass.config.latitude = latitude
     hass.config.longitude = longitude
-
-    registry = er.async_get(hass)
 
     with alter_time(test_time):
         assert await async_setup_component(
@@ -208,7 +207,7 @@ async def test_issur_melacha_sensor(
             hass.states.get("binary_sensor.test_issur_melacha_in_effect").state
             == result["state"]
         )
-        entity = registry.async_get("binary_sensor.test_issur_melacha_in_effect")
+        entity = entity_registry.async_get("binary_sensor.test_issur_melacha_in_effect")
         target_uid = "_".join(
             map(
                 str,

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -496,6 +496,7 @@ SHABBAT_TEST_IDS = [
 )
 async def test_shabbat_times_sensor(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     language,
     now,
     candle_lighting,
@@ -513,8 +514,6 @@ async def test_shabbat_times_sensor(
     hass.config.set_time_zone(tzname)
     hass.config.latitude = latitude
     hass.config.longitude = longitude
-
-    registry = er.async_get(hass)
 
     with alter_time(test_time):
         assert await async_setup_component(
@@ -552,7 +551,7 @@ async def test_shabbat_times_sensor(
             result_value
         ), f"Value for {sensor_type}"
 
-        entity = registry.async_get(f"sensor.test_{sensor_type}")
+        entity = entity_registry.async_get(f"sensor.test_{sensor_type}")
         target_sensor_type = sensor_type.replace("parshat_hashavua", "weekly_portion")
         target_uid = "_".join(
             map(

--- a/tests/components/jvc_projector/test_init.py
+++ b/tests/components/jvc_projector/test_init.py
@@ -16,11 +16,11 @@ from tests.common import MockConfigEntry
 
 async def test_init(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_device: AsyncMock,
     mock_integration: MockConfigEntry,
 ) -> None:
     """Test initialization."""
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(identifiers={(DOMAIN, MOCK_MAC)})
     assert device is not None
     assert device.identifiers == {(DOMAIN, MOCK_MAC)}

--- a/tests/components/jvc_projector/test_remote.py
+++ b/tests/components/jvc_projector/test_remote.py
@@ -21,13 +21,14 @@ ENTITY_ID = "remote.jvc_projector"
 
 async def test_entity_state(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     mock_device: MagicMock,
     mock_integration: MockConfigEntry,
 ) -> None:
     """Tests entity state is registered."""
     entity = hass.states.get(ENTITY_ID)
     assert entity
-    assert er.async_get(hass).async_get(entity.entity_id)
+    assert entity_registry.async_get(entity.entity_id)
 
 
 async def test_commands(


### PR DESCRIPTION
## Proposed change
Update the component tests starting with `i` or `j` to use the entity & device registry fixtures.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
