### PR TITLE
Remove logic converting empty or falsy YAML to empty dict

### DIFF
--- a/homeassistant/components/blueprint/models.py
+++ b/homeassistant/components/blueprint/models.py
@@ -215,7 +215,7 @@ class DomainBlueprints:
     def _load_blueprint(self, blueprint_path) -> Blueprint:
         """Load a blueprint."""
         try:
-            blueprint_data = yaml.load_yaml(self.blueprint_folder / blueprint_path)
+            blueprint_data = yaml.load_yaml_dict(self.blueprint_folder / blueprint_path)
         except FileNotFoundError as err:
             raise FailedToLoad(
                 self.domain,
@@ -225,7 +225,6 @@ class DomainBlueprints:
         except HomeAssistantError as err:
             raise FailedToLoad(self.domain, blueprint_path, err) from err
 
-        assert isinstance(blueprint_data, dict)
         return Blueprint(
             blueprint_data, expected_domain=self.domain, path=blueprint_path
         )

--- a/homeassistant/components/lovelace/dashboard.py
+++ b/homeassistant/components/lovelace/dashboard.py
@@ -14,7 +14,7 @@ from homeassistant.const import CONF_FILENAME
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import collection, storage
-from homeassistant.util.yaml import Secrets, load_yaml
+from homeassistant.util.yaml import Secrets, load_yaml_dict
 
 from .const import (
     CONF_ICON,
@@ -201,7 +201,9 @@ class LovelaceYAML(LovelaceConfig):
         is_updated = self._cache is not None
 
         try:
-            config = load_yaml(self.path, Secrets(Path(self.hass.config.config_dir)))
+            config = load_yaml_dict(
+                self.path, Secrets(Path(self.hass.config.config_dir))
+            )
         except FileNotFoundError:
             raise ConfigNotFound from None
 

--- a/homeassistant/components/notify/legacy.py
+++ b/homeassistant/components/notify/legacy.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.loader import async_get_integration, bind_hass
 from homeassistant.setup import async_prepare_setup_platform, async_start_setup
 from homeassistant.util import slugify
-from homeassistant.util.yaml import load_yaml
+from homeassistant.util.yaml import load_yaml_dict
 
 from .const import (
     ATTR_DATA,
@@ -280,8 +280,8 @@ class BaseNotificationService:
         # Load service descriptions from notify/services.yaml
         integration = await async_get_integration(hass, DOMAIN)
         services_yaml = integration.file_path / "services.yaml"
-        self.services_dict = cast(
-            dict, await hass.async_add_executor_job(load_yaml, str(services_yaml))
+        self.services_dict = await hass.async_add_executor_job(
+            load_yaml_dict, str(services_yaml)
         )
 
     async def async_register_services(self) -> None:

--- a/homeassistant/components/python_script/__init__.py
+++ b/homeassistant/components/python_script/__init__.py
@@ -27,7 +27,7 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 from homeassistant.util import raise_if_invalid_filename
 import homeassistant.util.dt as dt_util
-from homeassistant.util.yaml.loader import load_yaml
+from homeassistant.util.yaml.loader import load_yaml_dict
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -120,7 +120,7 @@ def discover_scripts(hass):
     # Load user-provided service descriptions from python_scripts/services.yaml
     services_yaml = os.path.join(path, "services.yaml")
     if os.path.exists(services_yaml):
-        services_dict = load_yaml(services_yaml)
+        services_dict = load_yaml_dict(services_yaml)
     else:
         services_dict = {}
 

--- a/homeassistant/components/tts/legacy.py
+++ b/homeassistant/components/tts/legacy.py
@@ -6,7 +6,7 @@ from collections.abc import Coroutine, Mapping
 from functools import partial
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 
@@ -31,7 +31,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.service import async_set_service_schema
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.setup import async_prepare_setup_platform
-from homeassistant.util.yaml import load_yaml
+from homeassistant.util.yaml import load_yaml_dict
 
 from .const import (
     ATTR_CACHE,
@@ -104,8 +104,8 @@ async def async_setup_legacy(
 
     # Load service descriptions from tts/services.yaml
     services_yaml = Path(__file__).parent / "services.yaml"
-    services_dict = cast(
-        dict, await hass.async_add_executor_job(load_yaml, str(services_yaml))
+    services_dict = await hass.async_add_executor_job(
+        load_yaml_dict, str(services_yaml)
     )
 
     async def async_setup_platform(

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -464,6 +464,8 @@ def load_yaml_config_file(
     This method needs to run in an executor.
     """
     conf_dict = load_yaml(config_path, secrets)
+    if conf_dict is None:
+        conf_dict = {}
 
     if not isinstance(conf_dict, dict):
         msg = (

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -66,7 +66,7 @@ from .loader import ComponentProtocol, Integration, IntegrationNotFound
 from .requirements import RequirementsNotFound, async_get_integration_with_requirements
 from .util.package import is_docker_env
 from .util.unit_system import get_unit_system, validate_unit_system
-from .util.yaml import SECRET_YAML, Secrets, load_yaml
+from .util.yaml import SECRET_YAML, Secrets, YamlTypeError, load_yaml_dict
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -463,17 +463,15 @@ def load_yaml_config_file(
 
     This method needs to run in an executor.
     """
-    conf_dict = load_yaml(config_path, secrets)
-    if conf_dict is None:
-        conf_dict = {}
-
-    if not isinstance(conf_dict, dict):
+    try:
+        conf_dict = load_yaml_dict(config_path, secrets)
+    except YamlTypeError as exc:
         msg = (
             f"The configuration file {os.path.basename(config_path)} "
             "does not contain a dictionary"
         )
         _LOGGER.error(msg)
-        raise HomeAssistantError(msg)
+        raise HomeAssistantError(msg) from exc
 
     # Convert values to dictionaries if they are None
     for key, value in conf_dict.items():

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -42,7 +42,7 @@ from homeassistant.exceptions import (
     UnknownUser,
 )
 from homeassistant.loader import Integration, async_get_integrations, bind_hass
-from homeassistant.util.yaml import load_yaml
+from homeassistant.util.yaml import load_yaml_dict
 from homeassistant.util.yaml.loader import JSON_TYPE
 
 from . import (
@@ -542,7 +542,9 @@ def _load_services_file(hass: HomeAssistant, integration: Integration) -> JSON_T
     try:
         return cast(
             JSON_TYPE,
-            _SERVICES_SCHEMA(load_yaml(str(integration.file_path / "services.yaml"))),
+            _SERVICES_SCHEMA(
+                load_yaml_dict(str(integration.file_path / "services.yaml"))
+            ),
         )
     except FileNotFoundError:
         _LOGGER.warning(

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -32,7 +32,7 @@ REQUIREMENTS = ("colorlog==6.7.0",)
 _LOGGER = logging.getLogger(__name__)
 MOCKS: dict[str, tuple[str, Callable]] = {
     "load": ("homeassistant.util.yaml.loader.load_yaml", yaml_loader.load_yaml),
-    "load*": ("homeassistant.config.load_yaml", yaml_loader.load_yaml),
+    "load*": ("homeassistant.config.load_yaml_dict", yaml_loader.load_yaml_dict),
     "secrets": ("homeassistant.util.yaml.loader.secret_yaml", yaml_loader.secret_yaml),
 }
 

--- a/homeassistant/util/yaml/__init__.py
+++ b/homeassistant/util/yaml/__init__.py
@@ -2,7 +2,14 @@
 from .const import SECRET_YAML
 from .dumper import dump, save_yaml
 from .input import UndefinedSubstitution, extract_inputs, substitute
-from .loader import Secrets, load_yaml, parse_yaml, secret_yaml
+from .loader import (
+    Secrets,
+    YamlTypeError,
+    load_yaml,
+    load_yaml_dict,
+    parse_yaml,
+    secret_yaml,
+)
 from .objects import Input
 
 __all__ = [
@@ -11,7 +18,9 @@ __all__ = [
     "dump",
     "save_yaml",
     "Secrets",
+    "YamlTypeError",
     "load_yaml",
+    "load_yaml_dict",
     "secret_yaml",
     "parse_yaml",
     "UndefinedSubstitution",

--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -205,10 +205,10 @@ def _parse_yaml(
     """Load a YAML file."""
     # If configuration file is empty YAML returns None
     # We convert that to an empty dict
-    return (
-        yaml.load(content, Loader=lambda stream: loader(stream, secrets))  # type: ignore[arg-type]
-        or NodeDictClass()
-    )
+    result = yaml.load(content, Loader=lambda stream: loader(stream, secrets))  # type: ignore[arg-type]
+    if result is None:
+        return NodeDictClass()
+    return result
 
 
 @overload

--- a/script/hassfest/services.py
+++ b/script/hassfest/services.py
@@ -13,7 +13,7 @@ from voluptuous.humanize import humanize_error
 from homeassistant.const import CONF_SELECTOR
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, selector, service
-from homeassistant.util.yaml import load_yaml
+from homeassistant.util.yaml import load_yaml_dict
 
 from .model import Config, Integration
 
@@ -107,7 +107,7 @@ def grep_dir(path: pathlib.Path, glob_pattern: str, search_pattern: str) -> bool
 def validate_services(config: Config, integration: Integration) -> None:
     """Validate services."""
     try:
-        data = load_yaml(str(integration.path / "services.yaml"))
+        data = load_yaml_dict(str(integration.path / "services.yaml"))
     except FileNotFoundError:
         # Find if integration uses services
         has_services = grep_dir(
@@ -122,7 +122,7 @@ def validate_services(config: Config, integration: Integration) -> None:
             )
         return
     except HomeAssistantError:
-        integration.add_error("services", "Unable to load services.yaml")
+        integration.add_error("services", "Invalid services.yaml")
         return
 
     try:

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -1102,7 +1102,7 @@ async def test_reload_automation_when_blueprint_changes(
             autospec=True,
             return_value=config,
         ), patch(
-            "homeassistant.components.blueprint.models.yaml.load_yaml",
+            "homeassistant.components.blueprint.models.yaml.load_yaml_dict",
             autospec=True,
             return_value=blueprint_config,
         ):

--- a/tests/components/lovelace/test_cast.py
+++ b/tests/components/lovelace/test_cast.py
@@ -44,7 +44,7 @@ async def mock_yaml_dashboard(hass):
     )
 
     with patch(
-        "homeassistant.components.lovelace.dashboard.load_yaml",
+        "homeassistant.components.lovelace.dashboard.load_yaml_dict",
         return_value={
             "title": "YAML Title",
             "views": [

--- a/tests/components/lovelace/test_dashboard.py
+++ b/tests/components/lovelace/test_dashboard.py
@@ -141,7 +141,7 @@ async def test_lovelace_from_yaml(
     events = async_capture_events(hass, const.EVENT_LOVELACE_UPDATED)
 
     with patch(
-        "homeassistant.components.lovelace.dashboard.load_yaml",
+        "homeassistant.components.lovelace.dashboard.load_yaml_dict",
         return_value={"hello": "yo"},
     ):
         await client.send_json({"id": 7, "type": "lovelace/config"})
@@ -154,7 +154,7 @@ async def test_lovelace_from_yaml(
 
     # Fake new data to see we fire event
     with patch(
-        "homeassistant.components.lovelace.dashboard.load_yaml",
+        "homeassistant.components.lovelace.dashboard.load_yaml_dict",
         return_value={"hello": "yo2"},
     ):
         await client.send_json({"id": 8, "type": "lovelace/config", "force": True})
@@ -245,7 +245,7 @@ async def test_dashboard_from_yaml(
     events = async_capture_events(hass, const.EVENT_LOVELACE_UPDATED)
 
     with patch(
-        "homeassistant.components.lovelace.dashboard.load_yaml",
+        "homeassistant.components.lovelace.dashboard.load_yaml_dict",
         return_value={"hello": "yo"},
     ):
         await client.send_json(
@@ -260,7 +260,7 @@ async def test_dashboard_from_yaml(
 
     # Fake new data to see we fire event
     with patch(
-        "homeassistant.components.lovelace.dashboard.load_yaml",
+        "homeassistant.components.lovelace.dashboard.load_yaml_dict",
         return_value={"hello": "yo2"},
     ):
         await client.send_json(

--- a/tests/components/lovelace/test_resources.py
+++ b/tests/components/lovelace/test_resources.py
@@ -38,7 +38,7 @@ async def test_yaml_resources_backwards(
 ) -> None:
     """Test defining resources in YAML ll config (legacy)."""
     with patch(
-        "homeassistant.components.lovelace.dashboard.load_yaml",
+        "homeassistant.components.lovelace.dashboard.load_yaml_dict",
         return_value={"resources": RESOURCE_EXAMPLES},
     ):
         assert await async_setup_component(

--- a/tests/components/lovelace/test_system_health.py
+++ b/tests/components/lovelace/test_system_health.py
@@ -39,7 +39,7 @@ async def test_system_health_info_yaml(hass: HomeAssistant) -> None:
     assert await async_setup_component(hass, "lovelace", {"lovelace": {"mode": "YAML"}})
     await hass.async_block_till_done()
     with patch(
-        "homeassistant.components.lovelace.dashboard.load_yaml",
+        "homeassistant.components.lovelace.dashboard.load_yaml_dict",
         return_value={"views": [{"cards": []}]},
     ):
         info = await get_system_health_info(hass, "lovelace")

--- a/tests/components/samsungtv/test_trigger.py
+++ b/tests/components/samsungtv/test_trigger.py
@@ -57,7 +57,7 @@ async def test_turn_on_trigger_device_id(
     assert calls[0].data["some"] == device.id
     assert calls[0].data["id"] == 0
 
-    with patch("homeassistant.config.load_yaml", return_value={}):
+    with patch("homeassistant.config.load_yaml_dict", return_value={}):
         await hass.services.async_call(automation.DOMAIN, SERVICE_RELOAD, blocking=True)
 
     calls.clear()

--- a/tests/components/webostv/test_trigger.py
+++ b/tests/components/webostv/test_trigger.py
@@ -60,7 +60,7 @@ async def test_webostv_turn_on_trigger_device_id(
     assert calls[0].data["some"] == device.id
     assert calls[0].data["id"] == 0
 
-    with patch("homeassistant.config.load_yaml", return_value={}):
+    with patch("homeassistant.config.load_yaml_dict", return_value={}):
         await hass.services.async_call(automation.DOMAIN, SERVICE_RELOAD, blocking=True)
 
     calls.clear()

--- a/tests/components/zwave_js/test_trigger.py
+++ b/tests/components/zwave_js/test_trigger.py
@@ -272,7 +272,7 @@ async def test_zwave_js_value_updated(
 
     clear_events()
 
-    with patch("homeassistant.config.load_yaml", return_value={}):
+    with patch("homeassistant.config.load_yaml_dict", return_value={}):
         await hass.services.async_call(automation.DOMAIN, SERVICE_RELOAD, blocking=True)
 
 
@@ -834,7 +834,7 @@ async def test_zwave_js_event(
 
     clear_events()
 
-    with patch("homeassistant.config.load_yaml", return_value={}):
+    with patch("homeassistant.config.load_yaml_dict", return_value={}):
         await hass.services.async_call(automation.DOMAIN, SERVICE_RELOAD, blocking=True)
 
 

--- a/tests/util/yaml/test_init.py
+++ b/tests/util/yaml/test_init.py
@@ -705,3 +705,20 @@ def test_string_used_as_vol_schema(try_both_loaders) -> None:
     schema({"key_1": "value_1", "key_2": "value_2"})
     with pytest.raises(vol.Invalid):
         schema({"key_1": "value_2", "key_2": "value_1"})
+
+
+@pytest.mark.parametrize(
+    ("hass_config_yaml", "expected_data"), [("", {}), ("bla:", {"bla": None})]
+)
+def test_load_yaml_dict(
+    try_both_loaders, mock_hass_config_yaml: None, expected_data: Any
+) -> None:
+    """Test item without a key."""
+    assert yaml.load_yaml_dict(YAML_CONFIG_FILE) == expected_data
+
+
+@pytest.mark.parametrize("hass_config_yaml", ["abc", "123", "[]"])
+def test_load_yaml_dict_fail(try_both_loaders, mock_hass_config_yaml: None) -> None:
+    """Test item without a key."""
+    with pytest.raises(yaml_loader.YamlTypeError):
+        yaml_loader.load_yaml_dict(YAML_CONFIG_FILE)

--- a/tests/util/yaml/test_init.py
+++ b/tests/util/yaml/test_init.py
@@ -55,26 +55,6 @@ def try_both_dumpers(request):
     importlib.reload(yaml_loader)
 
 
-@pytest.mark.parametrize(
-    ("yaml_content", "expected_output"),
-    [
-        ("", {}),
-        ("~", {}),
-        ("off", False),
-        ("False", False),
-        ("[]", []),
-    ],
-)
-def test_none_to_dict(try_both_loaders, yaml_content, expected_output) -> None:
-    """Test None is converted to an empty dict.
-
-    Also test other falsy values are not created to empty dict.
-    """
-    with io.StringIO(yaml_content) as file:
-        doc = yaml_loader.parse_yaml(file)
-    assert doc == expected_output
-
-
 def test_simple_list(try_both_loaders) -> None:
     """Test simple list."""
     conf = "config:\n  - simple\n  - list"
@@ -154,6 +134,7 @@ def test_include_yaml(
     [
         ({"/test/one.yaml": "one", "/test/two.yaml": "two"}, ["one", "two"]),
         ({"/test/one.yaml": "1", "/test/two.yaml": "2"}, [1, 2]),
+        ({"/test/one.yaml": "1", "/test/two.yaml": None}, [1]),
     ],
 )
 def test_include_dir_list(
@@ -209,6 +190,10 @@ def test_include_dir_list_recursive(
         (
             {"/test/first.yaml": "1", "/test/second.yaml": "2"},
             {"first": 1, "second": 2},
+        ),
+        (
+            {"/test/first.yaml": "1", "/test/second.yaml": None},
+            {"first": 1},
         ),
     ],
 )
@@ -268,6 +253,10 @@ def test_include_dir_named_recursive(
         (
             {"/test/first.yaml": "- 1", "/test/second.yaml": "- 2\n- 3"},
             [1, 2, 3],
+        ),
+        (
+            {"/test/first.yaml": "- 1", "/test/second.yaml": None},
+            [1],
         ),
     ],
 )
@@ -330,6 +319,13 @@ def test_include_dir_merge_list_recursive(
                 "/test/second.yaml": "key2: 2\nkey3: 3",
             },
             {"key1": 1, "key2": 2, "key3": 3},
+        ),
+        (
+            {
+                "/test/first.yaml": "key1: 1",
+                "/test/second.yaml": None,
+            },
+            {"key1": 1},
         ),
     ],
 )

--- a/tests/util/yaml/test_init.py
+++ b/tests/util/yaml/test_init.py
@@ -55,6 +55,26 @@ def try_both_dumpers(request):
     importlib.reload(yaml_loader)
 
 
+@pytest.mark.parametrize(
+    ("yaml_content", "expected_output"),
+    [
+        ("", {}),
+        ("~", {}),
+        ("off", False),
+        ("False", False),
+        ("[]", []),
+    ],
+)
+def test_none_to_dict(try_both_loaders, yaml_content, expected_output) -> None:
+    """Test None is converted to an empty dict.
+
+    Also test other falsy values are not created to empty dict.
+    """
+    with io.StringIO(yaml_content) as file:
+        doc = yaml_loader.parse_yaml(file)
+    assert doc == expected_output
+
+
 def test_simple_list(try_both_loaders) -> None:
     """Test simple list."""
     conf = "config:\n  - simple\n  - list"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove logic from `yaml.loader.load_yaml` converting "falsy" files to empty dict

Rationale: Empty files, or files containing falsy data such as the number 0, False, an empty list etc. are valid yaml and there's no reason why they should be converted to an empty dict.

It's however a common case that we do want to load configuration files which must be dictionaries and which we do allow to be empty.
Add a new helper `yaml.loader.load_yaml_dict` for this case which:
- Returns an empty dict if the file is empty
- Raises if the top level structure is not a dict
- Is typed and guaranteed to return a dict, so the caller does not need to check this



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
