### PR TITLE
Update icmplib privilege detection function to be async in ping integration

### DIFF
--- a/homeassistant/components/ping/__init__.py
+++ b/homeassistant/components/ping/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import logging
 
-from icmplib import SocketPermissionError, ping as icmp_ping
+from icmplib import SocketPermissionError, async_ping
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
@@ -30,19 +30,19 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
 
     hass.data[DOMAIN] = PingDomainData(
-        privileged=await hass.async_add_executor_job(_can_use_icmp_lib_with_privilege),
+        privileged=await _can_use_icmp_lib_with_privilege(),
     )
 
     return True
 
 
-def _can_use_icmp_lib_with_privilege() -> None | bool:
+async def _can_use_icmp_lib_with_privilege() -> None | bool:
     """Verify we can create a raw socket."""
     try:
-        icmp_ping("127.0.0.1", count=0, timeout=0, privileged=True)
+        await async_ping("127.0.0.1", count=0, timeout=0, privileged=True)
     except SocketPermissionError:
         try:
-            icmp_ping("127.0.0.1", count=0, timeout=0, privileged=False)
+            await async_ping("127.0.0.1", count=0, timeout=0, privileged=False)
         except SocketPermissionError:
             _LOGGER.debug(
                 "Cannot use icmplib because privileges are insufficient to create the"

--- a/tests/components/ping/test_binary_sensor.py
+++ b/tests/components/ping/test_binary_sensor.py
@@ -14,7 +14,7 @@ from tests.common import get_fixture_path
 @pytest.fixture
 def mock_ping() -> None:
     """Mock icmplib.ping."""
-    with patch("homeassistant.components.ping.icmp_ping"):
+    with patch("homeassistant.components.ping.async_ping"):
         yield
 
 


### PR DESCRIPTION
## Proposed change
Update `_can_use_icmp_lib_with_privilege` function in `ping` to be async. I think the function dates back to the time when the package was not async.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
