### PR TITLE
Update k-l* tests to use entity & device registry fixtures

### DIFF
--- a/tests/components/kaleidescape/test_init.py
+++ b/tests/components/kaleidescape/test_init.py
@@ -47,11 +47,11 @@ async def test_config_entry_not_ready(
 
 async def test_device(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_device: AsyncMock,
     mock_integration: MockConfigEntry,
 ) -> None:
     """Test device."""
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(
         identifiers={("kaleidescape", MOCK_SERIAL)}
     )

--- a/tests/components/kaleidescape/test_media_player.py
+++ b/tests/components/kaleidescape/test_media_player.py
@@ -170,11 +170,11 @@ async def test_services(
 
 async def test_device(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_device: MagicMock,
     mock_integration: MockConfigEntry,
 ) -> None:
     """Test device attributes."""
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(
         identifiers={("kaleidescape", MOCK_SERIAL)}
     )

--- a/tests/components/kaleidescape/test_sensor.py
+++ b/tests/components/kaleidescape/test_sensor.py
@@ -18,12 +18,13 @@ FRIENDLY_NAME = f"Kaleidescape Device {MOCK_SERIAL}"
 
 async def test_sensors(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     mock_device: MagicMock,
     mock_integration: MockConfigEntry,
 ) -> None:
     """Test sensors."""
     entity = hass.states.get(f"{ENTITY_ID}_media_location")
-    entry = er.async_get(hass).async_get(f"{ENTITY_ID}_media_location")
+    entry = entity_registry.async_get(f"{ENTITY_ID}_media_location")
     assert entity
     assert entity.state == "none"
     assert (
@@ -33,7 +34,7 @@ async def test_sensors(
     assert entry.unique_id == f"{MOCK_SERIAL}-media_location"
 
     entity = hass.states.get(f"{ENTITY_ID}_play_status")
-    entry = er.async_get(hass).async_get(f"{ENTITY_ID}_play_status")
+    entry = entity_registry.async_get(f"{ENTITY_ID}_play_status")
     assert entity
     assert entity.state == "none"
     assert entity.attributes.get(ATTR_FRIENDLY_NAME) == f"{FRIENDLY_NAME} Play status"

--- a/tests/components/knx/test_binary_sensor.py
+++ b/tests/components/knx/test_binary_sensor.py
@@ -24,7 +24,7 @@ from tests.common import (
 
 
 async def test_binary_sensor_entity_category(
-    hass: HomeAssistant, knx: KNXTestKit
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, knx: KNXTestKit
 ) -> None:
     """Test KNX binary sensor entity category."""
     await knx.setup_integration(
@@ -42,8 +42,7 @@ async def test_binary_sensor_entity_category(
     await knx.assert_read("1/1/1")
     await knx.receive_response("1/1/1", True)
 
-    registry = er.async_get(hass)
-    entity = registry.async_get("binary_sensor.test_normal")
+    entity = entity_registry.async_get("binary_sensor.test_normal")
     assert entity.entity_category is EntityCategory.DIAGNOSTIC
 
 

--- a/tests/components/kraken/test_sensor.py
+++ b/tests/components/kraken/test_sensor.py
@@ -134,7 +134,9 @@ async def test_sensor(
 
 
 async def test_sensors_available_after_restart(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test that all sensors are added again after a restart."""
     with patch(
@@ -153,7 +155,6 @@ async def test_sensors_available_after_restart(
         )
         entry.add_to_hass(hass)
 
-        device_registry = dr.async_get(hass)
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
             identifiers={(DOMAIN, "XBT_USD")},

--- a/tests/components/lametric/test_helpers.py
+++ b/tests/components/lametric/test_helpers.py
@@ -12,12 +12,11 @@ from tests.common import MockConfigEntry
 
 async def test_get_coordinator_by_device_id(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     init_integration: MockConfigEntry,
     mock_lametric: MagicMock,
 ) -> None:
     """Test get LaMetric coordinator by device ID ."""
-    entity_registry = er.async_get(hass)
-
     with pytest.raises(ValueError, match="Unknown LaMetric device ID: bla"):
         async_get_coordinator_by_device_id(hass, "bla")
 

--- a/tests/components/lametric/test_services.py
+++ b/tests/components/lametric/test_services.py
@@ -34,10 +34,10 @@ pytestmark = pytest.mark.usefixtures("init_integration")
 
 async def test_service_chart(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     mock_lametric: MagicMock,
 ) -> None:
     """Test the LaMetric chart service."""
-    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get("button.frenck_s_lametric_next_app")
     assert entry
@@ -121,10 +121,10 @@ async def test_service_chart(
 
 async def test_service_message(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     mock_lametric: MagicMock,
 ) -> None:
     """Test the LaMetric message service."""
-    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get("button.frenck_s_lametric_next_app")
     assert entry

--- a/tests/components/landisgyr_heat_meter/test_init.py
+++ b/tests/components/landisgyr_heat_meter/test_init.py
@@ -39,7 +39,9 @@ async def test_unload_entry(_, hass: HomeAssistant) -> None:
 
 
 @patch(API_HEAT_METER_SERVICE)
-async def test_migrate_entry(_, hass: HomeAssistant) -> None:
+async def test_migrate_entry(
+    _, hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test successful migration of entry data from version 1 to 2."""
 
     mock_entry_data = {
@@ -59,8 +61,7 @@ async def test_migrate_entry(_, hass: HomeAssistant) -> None:
     mock_entry.add_to_hass(hass)
 
     # Create entity entry to migrate to new unique ID
-    registry = er.async_get(hass)
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         SENSOR_DOMAIN,
         LANDISGYR_HEAT_METER_DOMAIN,
         "landisgyr_heat_meter_987654321_measuring_range_m3ph",
@@ -74,5 +75,5 @@ async def test_migrate_entry(_, hass: HomeAssistant) -> None:
 
     # Check if entity unique id is migrated successfully
     assert mock_entry.version == 2
-    entity = registry.async_get("sensor.heat_meter_measuring_range")
+    entity = entity_registry.async_get("sensor.heat_meter_measuring_range")
     assert entity.unique_id == "12345_measuring_range_m3ph"

--- a/tests/components/lcn/test_binary_sensor.py
+++ b/tests/components/lcn/test_binary_sensor.py
@@ -37,9 +37,10 @@ async def test_entity_state(hass: HomeAssistant, lcn_connection) -> None:
     assert state
 
 
-async def test_entity_attributes(hass: HomeAssistant, entry, lcn_connection) -> None:
+async def test_entity_attributes(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, entry, lcn_connection
+) -> None:
     """Test the attributes of an entity."""
-    entity_registry = er.async_get(hass)
 
     entity_setpoint1 = entity_registry.async_get(BINARY_SENSOR_LOCKREGULATOR1)
     assert entity_setpoint1

--- a/tests/components/lcn/test_cover.py
+++ b/tests/components/lcn/test_cover.py
@@ -38,9 +38,10 @@ async def test_setup_lcn_cover(hass: HomeAssistant, entry, lcn_connection) -> No
         assert state.state == STATE_OPEN
 
 
-async def test_entity_attributes(hass: HomeAssistant, entry, lcn_connection) -> None:
+async def test_entity_attributes(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, entry, lcn_connection
+) -> None:
     """Test the attributes of an entity."""
-    entity_registry = er.async_get(hass)
 
     entity_outputs = entity_registry.async_get(COVER_OUTPUTS)
 

--- a/tests/components/lcn/test_device_trigger.py
+++ b/tests/components/lcn/test_device_trigger.py
@@ -49,12 +49,11 @@ async def test_get_triggers_module_device(
 
 
 async def test_get_triggers_non_module_device(
-    hass: HomeAssistant, entry, lcn_connection
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry, entry, lcn_connection
 ) -> None:
     """Test we get the expected triggers from a LCN non-module device."""
     not_included_types = ("transmitter", "transponder", "fingerprint", "send_keys")
 
-    device_registry = dr.async_get(hass)
     host_device = device_registry.async_get_device(
         identifiers={(DOMAIN, entry.entry_id)}
     )

--- a/tests/components/lcn/test_init.py
+++ b/tests/components/lcn/test_init.py
@@ -48,20 +48,23 @@ async def test_async_setup_multiple_entries(hass: HomeAssistant, entry, entry2) 
     assert not hass.data.get(DOMAIN)
 
 
-async def test_async_setup_entry_update(hass: HomeAssistant, entry) -> None:
+async def test_async_setup_entry_update(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    entry,
+) -> None:
     """Test a successful setup entry if entry with same id already exists."""
     # setup first entry
     entry.source = config_entries.SOURCE_IMPORT
     entry.add_to_hass(hass)
 
     # create dummy entity for LCN platform as an orphan
-    entity_registry = er.async_get(hass)
     dummy_entity = entity_registry.async_get_or_create(
         "switch", DOMAIN, "dummy", config_entry=entry
     )
 
     # create dummy device for LCN platform as an orphan
-    device_registry = dr.async_get(hass)
     dummy_device = device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, entry.entry_id, 0, 7, False)},

--- a/tests/components/lcn/test_light.py
+++ b/tests/components/lcn/test_light.py
@@ -58,10 +58,10 @@ async def test_entity_state(hass: HomeAssistant, lcn_connection) -> None:
     assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == [ColorMode.ONOFF]
 
 
-async def test_entity_attributes(hass: HomeAssistant, entry, lcn_connection) -> None:
+async def test_entity_attributes(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, entry, lcn_connection
+) -> None:
     """Test the attributes of an entity."""
-    entity_registry = er.async_get(hass)
-
     entity_output = entity_registry.async_get(LIGHT_OUTPUT1)
 
     assert entity_output

--- a/tests/components/lcn/test_sensor.py
+++ b/tests/components/lcn/test_sensor.py
@@ -49,9 +49,10 @@ async def test_entity_state(hass: HomeAssistant, lcn_connection) -> None:
     assert state
 
 
-async def test_entity_attributes(hass: HomeAssistant, entry, lcn_connection) -> None:
+async def test_entity_attributes(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, entry, lcn_connection
+) -> None:
     """Test the attributes of an entity."""
-    entity_registry = er.async_get(hass)
 
     entity_var1 = entity_registry.async_get(SENSOR_VAR1)
     assert entity_var1

--- a/tests/components/lcn/test_switch.py
+++ b/tests/components/lcn/test_switch.py
@@ -39,9 +39,10 @@ async def test_setup_lcn_switch(hass: HomeAssistant, lcn_connection) -> None:
         assert state.state == STATE_OFF
 
 
-async def test_entity_attributes(hass: HomeAssistant, entry, lcn_connection) -> None:
+async def test_entity_attributes(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, entry, lcn_connection
+) -> None:
     """Test the attributes of an entity."""
-    entity_registry = er.async_get(hass)
 
     entity_output = entity_registry.async_get(SWITCH_OUTPUT1)
 

--- a/tests/components/lidarr/test_init.py
+++ b/tests/components/lidarr/test_init.py
@@ -45,12 +45,14 @@ async def test_async_setup_entry_auth_failed(
 
 
 async def test_device_info(
-    hass: HomeAssistant, setup_integration: ComponentSetup, connection
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    setup_integration: ComponentSetup,
+    connection,
 ) -> None:
     """Test device info."""
     await setup_integration()
     entry = hass.config_entries.async_entries(DOMAIN)[0]
-    device_registry = dr.async_get(hass)
     await hass.async_block_till_done()
     device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
 

--- a/tests/components/lifx/test_binary_sensor.py
+++ b/tests/components/lifx/test_binary_sensor.py
@@ -31,7 +31,9 @@ from . import (
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_hev_cycle_state(hass: HomeAssistant) -> None:
+async def test_hev_cycle_state(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test HEV cycle state binary sensor."""
     config_entry = MockConfigEntry(
         domain=lifx.DOMAIN,
@@ -48,7 +50,6 @@ async def test_hev_cycle_state(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     entity_id = "binary_sensor.my_bulb_clean_cycle"
-    entity_registry = er.async_get(hass)
 
     state = hass.states.get(entity_id)
     assert state

--- a/tests/components/lifx/test_button.py
+++ b/tests/components/lifx/test_button.py
@@ -31,7 +31,9 @@ def mock_lifx_coordinator_sleep():
         yield
 
 
-async def test_button_restart(hass: HomeAssistant) -> None:
+async def test_button_restart(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test that a bulb can be restarted."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -50,7 +52,6 @@ async def test_button_restart(hass: HomeAssistant) -> None:
     unique_id = f"{SERIAL}_restart"
     entity_id = "button.my_bulb_restart"
 
-    entity_registry = er.async_get(hass)
     entity = entity_registry.async_get(entity_id)
     assert entity
     assert not entity.disabled
@@ -63,7 +64,9 @@ async def test_button_restart(hass: HomeAssistant) -> None:
     bulb.set_reboot.assert_called_once()
 
 
-async def test_button_identify(hass: HomeAssistant) -> None:
+async def test_button_identify(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test that a bulb can be identified."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -82,7 +85,6 @@ async def test_button_identify(hass: HomeAssistant) -> None:
     unique_id = f"{SERIAL}_identify"
     entity_id = "button.my_bulb_identify"
 
-    entity_registry = er.async_get(hass)
     entity = entity_registry.async_get(entity_id)
     assert entity
     assert not entity.disabled

--- a/tests/components/lifx/test_config_flow.py
+++ b/tests/components/lifx/test_config_flow.py
@@ -536,7 +536,11 @@ async def test_refuse_relays(hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_suggested_area(hass: HomeAssistant) -> None:
+async def test_suggested_area(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test suggested area is populated from lifx group label."""
 
     class MockLifxCommandGetGroup:
@@ -567,10 +571,8 @@ async def test_suggested_area(hass: HomeAssistant) -> None:
         await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
         await hass.async_block_till_done()
 
-    entity_registry = er.async_get(hass)
     entity_id = "light.my_bulb"
     entity = entity_registry.async_get(entity_id)
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entity.device_id)
     assert device.suggested_area == "My LIFX Group"

--- a/tests/components/lifx/test_light.py
+++ b/tests/components/lifx/test_light.py
@@ -81,7 +81,11 @@ def patch_lifx_state_settle_delay():
         yield
 
 
-async def test_light_unique_id(hass: HomeAssistant) -> None:
+async def test_light_unique_id(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test a light unique id."""
     already_migrated_config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "1.2.3.4"}, unique_id=SERIAL
@@ -95,17 +99,19 @@ async def test_light_unique_id(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     entity_id = "light.my_bulb"
-    entity_registry = er.async_get(hass)
     assert entity_registry.async_get(entity_id).unique_id == SERIAL
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, SERIAL)}
     )
     assert device.identifiers == {(DOMAIN, SERIAL)}
 
 
-async def test_light_unique_id_new_firmware(hass: HomeAssistant) -> None:
+async def test_light_unique_id_new_firmware(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test a light unique id with newer firmware."""
     already_migrated_config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "1.2.3.4"}, unique_id=SERIAL
@@ -119,9 +125,7 @@ async def test_light_unique_id_new_firmware(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     entity_id = "light.my_bulb"
-    entity_registry = er.async_get(hass)
     assert entity_registry.async_get(entity_id).unique_id == SERIAL
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, MAC_ADDRESS)},
     )
@@ -1115,7 +1119,9 @@ async def test_white_bulb(hass: HomeAssistant) -> None:
     bulb.set_color.reset_mock()
 
 
-async def test_config_zoned_light_strip_fails(hass: HomeAssistant) -> None:
+async def test_config_zoned_light_strip_fails(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test we handle failure to update zones."""
     already_migrated_config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: IP_ADDRESS}, unique_id=SERIAL
@@ -1144,7 +1150,6 @@ async def test_config_zoned_light_strip_fails(hass: HomeAssistant) -> None:
     with _patch_discovery(device=light_strip), _patch_device(device=light_strip):
         await async_setup_component(hass, lifx.DOMAIN, {lifx.DOMAIN: {}})
         await hass.async_block_till_done()
-        entity_registry = er.async_get(hass)
         assert entity_registry.async_get(entity_id).unique_id == SERIAL
         assert hass.states.get(entity_id).state == STATE_OFF
 
@@ -1153,7 +1158,9 @@ async def test_config_zoned_light_strip_fails(hass: HomeAssistant) -> None:
         assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
 
-async def test_legacy_zoned_light_strip(hass: HomeAssistant) -> None:
+async def test_legacy_zoned_light_strip(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test we handle failure to update zones."""
     already_migrated_config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: IP_ADDRESS}, unique_id=SERIAL
@@ -1183,7 +1190,6 @@ async def test_legacy_zoned_light_strip(hass: HomeAssistant) -> None:
     with _patch_discovery(device=light_strip), _patch_device(device=light_strip):
         await async_setup_component(hass, lifx.DOMAIN, {lifx.DOMAIN: {}})
         await hass.async_block_till_done()
-        entity_registry = er.async_get(hass)
         assert entity_registry.async_get(entity_id).unique_id == SERIAL
         assert hass.states.get(entity_id).state == STATE_OFF
         # 1 to get the number of zones
@@ -1197,7 +1203,9 @@ async def test_legacy_zoned_light_strip(hass: HomeAssistant) -> None:
         assert get_color_zones_mock.call_count == 5
 
 
-async def test_white_light_fails(hass: HomeAssistant) -> None:
+async def test_white_light_fails(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test we handle failure to power on off."""
     already_migrated_config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: IP_ADDRESS}, unique_id=SERIAL
@@ -1211,7 +1219,6 @@ async def test_white_light_fails(hass: HomeAssistant) -> None:
     with _patch_discovery(device=bulb), _patch_device(device=bulb):
         await async_setup_component(hass, lifx.DOMAIN, {lifx.DOMAIN: {}})
         await hass.async_block_till_done()
-        entity_registry = er.async_get(hass)
         assert entity_registry.async_get(entity_id).unique_id == SERIAL
         assert hass.states.get(entity_id).state == STATE_OFF
         with pytest.raises(HomeAssistantError):

--- a/tests/components/lifx/test_select.py
+++ b/tests/components/lifx/test_select.py
@@ -25,7 +25,9 @@ from . import (
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_theme_select(hass: HomeAssistant) -> None:
+async def test_theme_select(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test selecting a theme."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -46,7 +48,6 @@ async def test_theme_select(hass: HomeAssistant) -> None:
 
     entity_id = "select.my_bulb_theme"
 
-    entity_registry = er.async_get(hass)
     entity = entity_registry.async_get(entity_id)
     assert entity
     assert not entity.disabled
@@ -62,7 +63,9 @@ async def test_theme_select(hass: HomeAssistant) -> None:
     bulb.set_extended_color_zones.reset_mock()
 
 
-async def test_infrared_brightness(hass: HomeAssistant) -> None:
+async def test_infrared_brightness(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test getting and setting infrared brightness."""
 
     config_entry = MockConfigEntry(
@@ -82,7 +85,6 @@ async def test_infrared_brightness(hass: HomeAssistant) -> None:
     unique_id = f"{SERIAL}_infrared_brightness"
     entity_id = "select.my_bulb_infrared_brightness"
 
-    entity_registry = er.async_get(hass)
     entity = entity_registry.async_get(entity_id)
     assert entity
     assert not entity.disabled

--- a/tests/components/lifx/test_sensor.py
+++ b/tests/components/lifx/test_sensor.py
@@ -31,7 +31,9 @@ from . import (
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_rssi_sensor(hass: HomeAssistant) -> None:
+async def test_rssi_sensor(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test LIFX RSSI sensor entity."""
 
     config_entry = MockConfigEntry(
@@ -49,7 +51,6 @@ async def test_rssi_sensor(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     entity_id = "sensor.my_bulb_rssi"
-    entity_registry = er.async_get(hass)
 
     entry = entity_registry.entities.get(entity_id)
     assert entry
@@ -82,7 +83,9 @@ async def test_rssi_sensor(hass: HomeAssistant) -> None:
     assert rssi.attributes["state_class"] == SensorStateClass.MEASUREMENT
 
 
-async def test_rssi_sensor_old_firmware(hass: HomeAssistant) -> None:
+async def test_rssi_sensor_old_firmware(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test LIFX RSSI sensor entity."""
 
     config_entry = MockConfigEntry(
@@ -100,7 +103,6 @@ async def test_rssi_sensor_old_firmware(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     entity_id = "sensor.my_bulb_rssi"
-    entity_registry = er.async_get(hass)
 
     entry = entity_registry.entities.get(entity_id)
     assert entry

--- a/tests/components/litejet/test_scene.py
+++ b/tests/components/litejet/test_scene.py
@@ -17,16 +17,16 @@ ENTITY_OTHER_SCENE = "scene.litejet_mock_scene_2"
 ENTITY_OTHER_SCENE_NUMBER = 2
 
 
-async def test_disabled_by_default(hass: HomeAssistant, mock_litejet) -> None:
+async def test_disabled_by_default(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_litejet
+) -> None:
     """Test the scene is disabled by default."""
     await async_init_integration(hass)
-
-    registry = er.async_get(hass)
 
     state = hass.states.get(ENTITY_SCENE)
     assert state is None
 
-    entry = registry.async_get(ENTITY_SCENE)
+    entry = entity_registry.async_get(ENTITY_SCENE)
     assert entry
     assert entry.disabled
     assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION

--- a/tests/components/litterrobot/test_button.py
+++ b/tests/components/litterrobot/test_button.py
@@ -13,10 +13,11 @@ from .conftest import setup_integration
 BUTTON_ENTITY = "button.test_reset_waste_drawer"
 
 
-async def test_button(hass: HomeAssistant, mock_account: MagicMock) -> None:
+async def test_button(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_account: MagicMock
+) -> None:
     """Test the creation and values of the Litter-Robot button."""
     await setup_integration(hass, mock_account, BUTTON_DOMAIN)
-    entity_registry = er.async_get(hass)
 
     state = hass.states.get(BUTTON_ENTITY)
     assert state

--- a/tests/components/litterrobot/test_init.py
+++ b/tests/components/litterrobot/test_init.py
@@ -14,7 +14,6 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.setup import async_setup_component
 
 from .common import CONFIG, VACUUM_ENTITY_ID, remove_device
@@ -73,17 +72,19 @@ async def test_entry_not_setup(
 
 
 async def test_device_remove_devices(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, mock_account: MagicMock
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    mock_account: MagicMock,
 ) -> None:
     """Test we can only remove a device that no longer exists."""
     assert await async_setup_component(hass, "config", {})
     config_entry = await setup_integration(hass, mock_account, VACUUM_DOMAIN)
 
-    registry: EntityRegistry = er.async_get(hass)
-    entity = registry.entities[VACUUM_ENTITY_ID]
+    entity = entity_registry.entities[VACUUM_ENTITY_ID]
     assert entity.unique_id == "LR3C012345-litter_box"
 
-    device_registry = dr.async_get(hass)
     device_entry = device_registry.async_get(entity.device_id)
     assert (
         await remove_device(

--- a/tests/components/litterrobot/test_vacuum.py
+++ b/tests/components/litterrobot/test_vacuum.py
@@ -32,21 +32,22 @@ COMPONENT_SERVICE_DOMAIN = {
 }
 
 
-async def test_vacuum(hass: HomeAssistant, mock_account: MagicMock) -> None:
+async def test_vacuum(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_account: MagicMock
+) -> None:
     """Tests the vacuum entity was set up."""
-    ent_reg = er.async_get(hass)
 
-    ent_reg.async_get_or_create(
+    entity_registry.async_get_or_create(
         PLATFORM_DOMAIN,
         DOMAIN,
         VACUUM_UNIQUE_ID,
         suggested_object_id=VACUUM_ENTITY_ID.replace(PLATFORM_DOMAIN, ""),
     )
-    ent_reg_entry = ent_reg.async_get(VACUUM_ENTITY_ID)
+    ent_reg_entry = entity_registry.async_get(VACUUM_ENTITY_ID)
     assert ent_reg_entry.unique_id == VACUUM_UNIQUE_ID
 
     await setup_integration(hass, mock_account, PLATFORM_DOMAIN)
-    assert len(ent_reg.entities) == 1
+    assert len(entity_registry.entities) == 1
     assert hass.services.has_service(DOMAIN, SERVICE_SET_SLEEP_MODE)
 
     vacuum = hass.states.get(VACUUM_ENTITY_ID)
@@ -54,7 +55,7 @@ async def test_vacuum(hass: HomeAssistant, mock_account: MagicMock) -> None:
     assert vacuum.state == STATE_DOCKED
     assert vacuum.attributes["is_sleeping"] is False
 
-    ent_reg_entry = ent_reg.async_get(VACUUM_ENTITY_ID)
+    ent_reg_entry = entity_registry.async_get(VACUUM_ENTITY_ID)
     assert ent_reg_entry.unique_id == VACUUM_UNIQUE_ID
 
 
@@ -70,15 +71,16 @@ async def test_vacuum_status_when_sleeping(
 
 
 async def test_no_robots(
-    hass: HomeAssistant, mock_account_with_no_robots: MagicMock
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_account_with_no_robots: MagicMock,
 ) -> None:
     """Tests the vacuum entity was set up."""
     entry = await setup_integration(hass, mock_account_with_no_robots, PLATFORM_DOMAIN)
 
     assert not hass.services.has_service(DOMAIN, SERVICE_SET_SLEEP_MODE)
 
-    ent_reg = er.async_get(hass)
-    assert len(ent_reg.entities) == 0
+    assert len(entity_registry.entities) == 0
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/lock/test_init.py
+++ b/tests/components/lock/test_init.py
@@ -103,10 +103,10 @@ async def test_lock_states(hass: HomeAssistant) -> None:
 
 async def test_set_default_code_option(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     enable_custom_integrations: None,
 ) -> None:
     """Test default code stored in the registry."""
-    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get_or_create("lock", "test", "very_unique")
     await hass.async_block_till_done()
@@ -134,10 +134,10 @@ async def test_set_default_code_option(
 
 async def test_default_code_option_update(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     enable_custom_integrations: None,
 ) -> None:
     """Test default code stored in the registry is updated."""
-    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get_or_create("lock", "test", "very_unique")
     await hass.async_block_till_done()

--- a/tests/components/luftdaten/test_sensor.py
+++ b/tests/components/luftdaten/test_sensor.py
@@ -23,11 +23,11 @@ from tests.common import MockConfigEntry
 
 async def test_luftdaten_sensors(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     init_integration: MockConfigEntry,
 ) -> None:
     """Test the Luftdaten sensors."""
-    entity_registry = er.async_get(hass)
-    device_registry = dr.async_get(hass)
 
     entry = entity_registry.async_get("sensor.sensor_12345_temperature")
     assert entry

--- a/tests/components/lutron_caseta/test_button.py
+++ b/tests/components/lutron_caseta/test_button.py
@@ -8,7 +8,9 @@ from homeassistant.helpers import entity_registry as er
 from . import MockBridge, async_setup_integration
 
 
-async def test_button_unique_id(hass: HomeAssistant) -> None:
+async def test_button_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test a button unique id."""
     await async_setup_integration(hass, MockBridge)
 
@@ -16,8 +18,6 @@ async def test_button_unique_id(hass: HomeAssistant) -> None:
         "button.hallway_main_stairs_position_1_keypad_kitchen_pendants"
     )
     caseta_button_entity_id = "button.dining_room_pico_stop"
-
-    entity_registry = er.async_get(hass)
 
     # Assert that Caseta buttons will have the bridge serial hash and the zone id as the uniqueID
     assert entity_registry.async_get(ra3_button_entity_id).unique_id == "000004d2_1372"

--- a/tests/components/lutron_caseta/test_cover.py
+++ b/tests/components/lutron_caseta/test_cover.py
@@ -7,13 +7,13 @@ from homeassistant.helpers import entity_registry as er
 from . import MockBridge, async_setup_integration
 
 
-async def test_cover_unique_id(hass: HomeAssistant) -> None:
+async def test_cover_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test a light unique id."""
     await async_setup_integration(hass, MockBridge)
 
     cover_entity_id = "cover.basement_bedroom_left_shade"
-
-    entity_registry = er.async_get(hass)
 
     # Assert that Caseta covers will have the bridge serial hash and the zone id as the uniqueID
     assert entity_registry.async_get(cover_entity_id).unique_id == "000004d2_802"

--- a/tests/components/lutron_caseta/test_fan.py
+++ b/tests/components/lutron_caseta/test_fan.py
@@ -7,13 +7,13 @@ from homeassistant.helpers import entity_registry as er
 from . import MockBridge, async_setup_integration
 
 
-async def test_fan_unique_id(hass: HomeAssistant) -> None:
+async def test_fan_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test a light unique id."""
     await async_setup_integration(hass, MockBridge)
 
     fan_entity_id = "fan.master_bedroom_ceiling_fan"
-
-    entity_registry = er.async_get(hass)
 
     # Assert that Caseta covers will have the bridge serial hash and the zone id as the uniqueID
     assert entity_registry.async_get(fan_entity_id).unique_id == "000004d2_804"

--- a/tests/components/lutron_caseta/test_light.py
+++ b/tests/components/lutron_caseta/test_light.py
@@ -8,14 +8,14 @@ from homeassistant.helpers import entity_registry as er
 from . import MockBridge, async_setup_integration
 
 
-async def test_light_unique_id(hass: HomeAssistant) -> None:
+async def test_light_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test a light unique id."""
     await async_setup_integration(hass, MockBridge)
 
     ra3_entity_id = "light.basement_bedroom_main_lights"
     caseta_entity_id = "light.kitchen_main_lights"
-
-    entity_registry = er.async_get(hass)
 
     # Assert that RA3 lights will have the bridge serial hash and the zone id as the uniqueID
     assert entity_registry.async_get(ra3_entity_id).unique_id == "000004d2_801"

--- a/tests/components/lutron_caseta/test_logbook.py
+++ b/tests/components/lutron_caseta/test_logbook.py
@@ -82,7 +82,7 @@ async def test_humanify_lutron_caseta_button_event(hass: HomeAssistant) -> None:
 
 
 async def test_humanify_lutron_caseta_button_event_integration_not_loaded(
-    hass: HomeAssistant,
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:
     """Test humanifying lutron_caseta_button_events when the integration fails to load."""
     hass.config.components.add("recorder")
@@ -109,7 +109,6 @@ async def test_humanify_lutron_caseta_button_event_integration_not_loaded(
         await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    device_registry = dr.async_get(hass)
     for device in device_registry.devices.values():
         if device.config_entries == {config_entry.entry_id}:
             dr_device_id = device.id
@@ -140,14 +139,15 @@ async def test_humanify_lutron_caseta_button_event_integration_not_loaded(
     assert event1["message"] == "press stop"
 
 
-async def test_humanify_lutron_caseta_button_event_ra3(hass: HomeAssistant) -> None:
+async def test_humanify_lutron_caseta_button_event_ra3(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test humanifying lutron_caseta_button_events from an RA3 hub."""
     hass.config.components.add("recorder")
     assert await async_setup_component(hass, "logbook", {})
     await async_setup_integration(hass, MockBridge)
 
-    registry = dr.async_get(hass)
-    keypad = registry.async_get_device(
+    keypad = device_registry.async_get_device(
         identifiers={(DOMAIN, 66286451)}, connections=set()
     )
     assert keypad
@@ -176,14 +176,15 @@ async def test_humanify_lutron_caseta_button_event_ra3(hass: HomeAssistant) -> N
     assert event1["message"] == "press Kitchen Pendants"
 
 
-async def test_humanify_lutron_caseta_button_unknown_type(hass: HomeAssistant) -> None:
+async def test_humanify_lutron_caseta_button_unknown_type(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test humanifying lutron_caseta_button_events with an unknown type."""
     hass.config.components.add("recorder")
     assert await async_setup_component(hass, "logbook", {})
     await async_setup_integration(hass, MockBridge)
 
-    registry = dr.async_get(hass)
-    keypad = registry.async_get_device(
+    keypad = device_registry.async_get_device(
         identifiers={(DOMAIN, 66286451)}, connections=set()
     )
     assert keypad

--- a/tests/components/lutron_caseta/test_switch.py
+++ b/tests/components/lutron_caseta/test_switch.py
@@ -6,13 +6,13 @@ from homeassistant.helpers import entity_registry as er
 from . import MockBridge, async_setup_integration
 
 
-async def test_switch_unique_id(hass: HomeAssistant) -> None:
+async def test_switch_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test a light unique id."""
     await async_setup_integration(hass, MockBridge)
 
     switch_entity_id = "switch.basement_bathroom_exhaust_fan"
-
-    entity_registry = er.async_get(hass)
 
     # Assert that Caseta covers will have the bridge serial hash and the zone id as the uniqueID
     assert entity_registry.async_get(switch_entity_id).unique_id == "000004d2_803"


### PR DESCRIPTION
## Proposed change
Update the component tests starting with `k` or `l` to use the entity & device registry fixtures

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
