### PR TITLE
Add websocket command to capture audio from a device

### DIFF
--- a/homeassistant/components/assist_pipeline/__init__.py
+++ b/homeassistant/components/assist_pipeline/__init__.py
@@ -9,7 +9,13 @@ from homeassistant.components import stt
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_DEBUG_RECORDING_DIR, DATA_CONFIG, DATA_LAST_WAKE_UP, DOMAIN
+from .const import (
+    CONF_DEBUG_RECORDING_DIR,
+    DATA_CONFIG,
+    DATA_LAST_WAKE_UP,
+    DOMAIN,
+    EVENT_RECORDING,
+)
 from .error import PipelineNotFound
 from .pipeline import (
     AudioSettings,
@@ -40,6 +46,7 @@ __all__ = (
     "PipelineEventType",
     "PipelineNotFound",
     "WakeWordSettings",
+    "EVENT_RECORDING",
 )
 
 CONFIG_SCHEMA = vol.Schema(

--- a/homeassistant/components/assist_pipeline/const.py
+++ b/homeassistant/components/assist_pipeline/const.py
@@ -11,3 +11,5 @@ CONF_DEBUG_RECORDING_DIR = "debug_recording_dir"
 
 DATA_LAST_WAKE_UP = f"{DOMAIN}.last_wake_up"
 DEFAULT_WAKE_WORD_COOLDOWN = 2  # seconds
+
+EVENT_RECORDING = f"{DOMAIN}_recording"

--- a/homeassistant/components/assist_pipeline/logbook.py
+++ b/homeassistant/components/assist_pipeline/logbook.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from homeassistant.components.logbook import LOGBOOK_ENTRY_MESSAGE, LOGBOOK_ENTRY_NAME
-from homeassistant.const import ATTR_DEVICE_ID, ATTR_SECONDS
+from homeassistant.const import ATTR_DEVICE_ID
 from homeassistant.core import Event, HomeAssistant, callback
 import homeassistant.helpers.device_registry as dr
 
@@ -29,8 +29,7 @@ def async_describe_events(
         if device:
             device_name = device.name_by_user or device.name or "Unknown device"
 
-        timeout_seconds = event.data[ATTR_SECONDS]
-        message = f"{device_name} will record audio for {timeout_seconds} second(s)"
+        message = f"{device_name} started recording audio"
 
         return {
             LOGBOOK_ENTRY_NAME: device_name,

--- a/homeassistant/components/assist_pipeline/logbook.py
+++ b/homeassistant/components/assist_pipeline/logbook.py
@@ -25,12 +25,9 @@ def async_describe_events(
         device: dr.DeviceEntry | None = None
         device_name: str = "Unknown device"
 
-        try:
-            device = device_registry.devices[event.data[ATTR_DEVICE_ID]]
-            if device:
-                device_name = device.name_by_user or device.name or "Unknown device"
-        except (KeyError, AttributeError):
-            pass
+        device = device_registry.devices[event.data[ATTR_DEVICE_ID]]
+        if device:
+            device_name = device.name_by_user or device.name or "Unknown device"
 
         timeout_seconds = event.data[ATTR_SECONDS]
         message = f"{device_name} will record audio for {timeout_seconds} second(s)"

--- a/homeassistant/components/assist_pipeline/logbook.py
+++ b/homeassistant/components/assist_pipeline/logbook.py
@@ -1,0 +1,43 @@
+"""Describe assist_pipeline logbook events."""
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from homeassistant.components.logbook import LOGBOOK_ENTRY_MESSAGE, LOGBOOK_ENTRY_NAME
+from homeassistant.const import ATTR_DEVICE_ID, ATTR_SECONDS
+from homeassistant.core import Event, HomeAssistant, callback
+import homeassistant.helpers.device_registry as dr
+
+from .const import DOMAIN, EVENT_RECORDING
+
+
+@callback
+def async_describe_events(
+    hass: HomeAssistant,
+    async_describe_event: Callable[[str, str, Callable[[Event], dict[str, str]]], None],
+) -> None:
+    """Describe logbook events."""
+    device_registry = dr.async_get(hass)
+
+    @callback
+    def async_describe_logbook_event(event: Event) -> dict[str, str]:
+        """Describe logbook event."""
+        device: dr.DeviceEntry | None = None
+        device_name: str = "Unknown device"
+
+        try:
+            device = device_registry.devices[event.data[ATTR_DEVICE_ID]]
+            if device:
+                device_name = device.name_by_user or device.name or "Unknown device"
+        except (KeyError, AttributeError):
+            pass
+
+        timeout_seconds = event.data[ATTR_SECONDS]
+        message = f"{device_name} will record audio for {timeout_seconds} second(s)"
+
+        return {
+            LOGBOOK_ENTRY_NAME: device_name,
+            LOGBOOK_ENTRY_MESSAGE: message,
+        }
+
+    async_describe_event(DOMAIN, EVENT_RECORDING, async_describe_logbook_event)

--- a/homeassistant/components/assist_pipeline/websocket_api.py
+++ b/homeassistant/components/assist_pipeline/websocket_api.py
@@ -13,12 +13,17 @@ from typing import Any, Final
 import voluptuous as vol
 
 from homeassistant.components import conversation, stt, tts, websocket_api
-from homeassistant.const import MATCH_ALL
+from homeassistant.const import ATTR_DEVICE_ID, ATTR_SECONDS, MATCH_ALL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.util import language as language_util
 
-from .const import DEFAULT_PIPELINE_TIMEOUT, DEFAULT_WAKE_WORD_TIMEOUT, DOMAIN
+from .const import (
+    DEFAULT_PIPELINE_TIMEOUT,
+    DEFAULT_WAKE_WORD_TIMEOUT,
+    DOMAIN,
+    EVENT_RECORDING,
+)
 from .error import PipelineNotFound
 from .pipeline import (
     AudioSettings,
@@ -442,6 +447,15 @@ async def websocket_device_capture(
 
     # Audio will follow as events
     connection.send_result(msg["id"])
+
+    # Record to logbook
+    hass.bus.async_fire(
+        EVENT_RECORDING,
+        {
+            ATTR_DEVICE_ID: device_id,
+            ATTR_SECONDS: timeout_seconds,
+        },
+    )
 
     try:
         with contextlib.suppress(asyncio.TimeoutError):

--- a/tests/components/assist_pipeline/snapshots/test_websocket.ambr
+++ b/tests/components/assist_pipeline/snapshots/test_websocket.ambr
@@ -487,6 +487,119 @@
 # name: test_audio_pipeline_with_wake_word_timeout.3
   None
 # ---
+# name: test_device_capture
+  dict({
+    'language': 'en',
+    'pipeline': <ANY>,
+    'runner_data': dict({
+      'stt_binary_handler_id': 1,
+      'timeout': 300,
+    }),
+  })
+# ---
+# name: test_device_capture.1
+  dict({
+    'engine': 'test',
+    'metadata': dict({
+      'bit_rate': 16,
+      'channel': 1,
+      'codec': 'pcm',
+      'format': 'wav',
+      'language': 'en-US',
+      'sample_rate': 16000,
+    }),
+  })
+# ---
+# name: test_device_capture.2
+  None
+# ---
+# name: test_device_capture_override
+  dict({
+    'language': 'en',
+    'pipeline': <ANY>,
+    'runner_data': dict({
+      'stt_binary_handler_id': 1,
+      'timeout': 300,
+    }),
+  })
+# ---
+# name: test_device_capture_override.1
+  dict({
+    'engine': 'test',
+    'metadata': dict({
+      'bit_rate': 16,
+      'channel': 1,
+      'codec': 'pcm',
+      'format': 'wav',
+      'language': 'en-US',
+      'sample_rate': 16000,
+    }),
+  })
+# ---
+# name: test_device_capture_override.2
+  dict({
+    'audio': 'Y2h1bmsx',
+    'channels': 1,
+    'rate': 16000,
+    'type': 'audio',
+    'width': 2,
+  })
+# ---
+# name: test_device_capture_override.3
+  dict({
+    'stt_output': dict({
+      'text': 'test transcript',
+    }),
+  })
+# ---
+# name: test_device_capture_override.4
+  None
+# ---
+# name: test_device_capture_override.5
+  dict({
+    'overflow': False,
+    'type': 'end',
+  })
+# ---
+# name: test_device_capture_queue_full
+  dict({
+    'language': 'en',
+    'pipeline': <ANY>,
+    'runner_data': dict({
+      'stt_binary_handler_id': 1,
+      'timeout': 300,
+    }),
+  })
+# ---
+# name: test_device_capture_queue_full.1
+  dict({
+    'engine': 'test',
+    'metadata': dict({
+      'bit_rate': 16,
+      'channel': 1,
+      'codec': 'pcm',
+      'format': 'wav',
+      'language': 'en-US',
+      'sample_rate': 16000,
+    }),
+  })
+# ---
+# name: test_device_capture_queue_full.2
+  dict({
+    'stt_output': dict({
+      'text': 'test transcript',
+    }),
+  })
+# ---
+# name: test_device_capture_queue_full.3
+  None
+# ---
+# name: test_device_capture_queue_full.4
+  dict({
+    'overflow': True,
+    'type': 'end',
+  })
+# ---
 # name: test_intent_failed
   dict({
     'language': 'en',

--- a/tests/components/assist_pipeline/test_logbook.py
+++ b/tests/components/assist_pipeline/test_logbook.py
@@ -1,0 +1,43 @@
+"""The tests for assist_pipeline logbook."""
+from homeassistant.components import assist_pipeline, logbook
+from homeassistant.const import ATTR_DEVICE_ID, ATTR_SECONDS
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+from tests.components.logbook.common import MockRow, mock_humanify
+
+
+async def test_recording_event(
+    hass: HomeAssistant, init_components, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test recording event."""
+    hass.config.components.add("recorder")
+    assert await async_setup_component(hass, "logbook", {})
+
+    entry = MockConfigEntry()
+    entry.add_to_hass(hass)
+    satellite_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        connections=set(),
+        identifiers={("demo", "satellite-1234")},
+    )
+
+    device_registry.async_update_device(satellite_device.id, name="My Satellite")
+    event = mock_humanify(
+        hass,
+        [
+            MockRow(
+                assist_pipeline.EVENT_RECORDING,
+                {ATTR_DEVICE_ID: satellite_device.id, ATTR_SECONDS: 10},
+            ),
+        ],
+    )[0]
+
+    assert event[logbook.LOGBOOK_ENTRY_NAME] == "My Satellite"
+    assert event[logbook.LOGBOOK_ENTRY_DOMAIN] == assist_pipeline.DOMAIN
+    assert (
+        event[logbook.LOGBOOK_ENTRY_MESSAGE]
+        == "My Satellite will record audio for 10 second(s)"
+    )

--- a/tests/components/assist_pipeline/test_logbook.py
+++ b/tests/components/assist_pipeline/test_logbook.py
@@ -1,6 +1,6 @@
 """The tests for assist_pipeline logbook."""
 from homeassistant.components import assist_pipeline, logbook
-from homeassistant.const import ATTR_DEVICE_ID, ATTR_SECONDS
+from homeassistant.const import ATTR_DEVICE_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
@@ -30,7 +30,7 @@ async def test_recording_event(
         [
             MockRow(
                 assist_pipeline.EVENT_RECORDING,
-                {ATTR_DEVICE_ID: satellite_device.id, ATTR_SECONDS: 10},
+                {ATTR_DEVICE_ID: satellite_device.id},
             ),
         ],
     )[0]
@@ -38,6 +38,5 @@ async def test_recording_event(
     assert event[logbook.LOGBOOK_ENTRY_NAME] == "My Satellite"
     assert event[logbook.LOGBOOK_ENTRY_DOMAIN] == assist_pipeline.DOMAIN
     assert (
-        event[logbook.LOGBOOK_ENTRY_MESSAGE]
-        == "My Satellite will record audio for 10 second(s)"
+        event[logbook.LOGBOOK_ENTRY_MESSAGE] == "My Satellite started recording audio"
     )

--- a/tests/components/assist_pipeline/test_websocket.py
+++ b/tests/components/assist_pipeline/test_websocket.py
@@ -6,7 +6,11 @@ from unittest.mock import ANY, patch
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.assist_pipeline.const import DOMAIN
-from homeassistant.components.assist_pipeline.pipeline import Pipeline, PipelineData
+from homeassistant.components.assist_pipeline.pipeline import (
+    DeviceAudioQueue,
+    Pipeline,
+    PipelineData,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
@@ -2164,14 +2168,14 @@ async def test_device_capture(
     # run start
     msg = await client_pipeline.receive_json()
     assert msg["event"]["type"] == "run-start"
-    # msg["event"]["data"]["pipeline"] = ANY
-    # assert msg["event"]["data"] == snapshot
+    msg["event"]["data"]["pipeline"] = ANY
+    assert msg["event"]["data"] == snapshot
     handler_id = msg["event"]["data"]["runner_data"]["stt_binary_handler_id"]
 
     # stt
     msg = await client_pipeline.receive_json()
     assert msg["event"]["type"] == "stt-start"
-    # assert msg["event"]["data"] == snapshot
+    assert msg["event"]["data"] == snapshot
 
     for audio_chunk in audio_chunks:
         await client_pipeline.send_bytes(bytes([handler_id]) + audio_chunk)
@@ -2181,7 +2185,11 @@ async def test_device_capture(
 
     msg = await client_pipeline.receive_json()
     assert msg["event"]["type"] == "stt-end"
-    # assert msg["event"]["data"] == snapshot
+
+    # run end
+    msg = await client_pipeline.receive_json()
+    assert msg["event"]["type"] == "run-end"
+    assert msg["event"]["data"] == snapshot
 
     # Verify capture
     events = []
@@ -2196,7 +2204,7 @@ async def test_device_capture(
 
     assert len(events) == len(audio_chunks) + 1
 
-    # First 3 events should be audio chunks
+    # Verify audio chunks
     for i, audio_chunk in enumerate(audio_chunks):
         assert events[i]["type"] == "audio"
         assert events[i]["rate"] == 16000
@@ -2208,3 +2216,239 @@ async def test_device_capture(
 
     # Last event is the end
     assert events[-1]["type"] == "end"
+
+
+async def test_device_capture_override(
+    hass: HomeAssistant,
+    init_components,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test overriding an existing audio capture from a satellite device."""
+    entry = MockConfigEntry()
+    entry.add_to_hass(hass)
+    satellite_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        connections=set(),
+        identifiers={("demo", "satellite-1234")},
+    )
+
+    audio_chunks = [b"chunk1", b"chunk2", b"chunk3"]
+
+    # Start first capture
+    client_capture_1 = await hass_ws_client(hass)
+    await client_capture_1.send_json_auto_id(
+        {
+            "type": "assist_pipeline/device/capture",
+            "timeout": 30,
+            "device_id": satellite_device.id,
+        }
+    )
+
+    # result
+    msg = await client_capture_1.receive_json()
+    assert msg["success"]
+
+    # Run pipeline
+    client_pipeline = await hass_ws_client(hass)
+    await client_pipeline.send_json_auto_id(
+        {
+            "type": "assist_pipeline/run",
+            "start_stage": "stt",
+            "end_stage": "stt",
+            "input": {
+                "sample_rate": 16000,
+                "no_vad": True,
+                "no_chunking": True,
+            },
+            "device_id": satellite_device.id,
+        }
+    )
+
+    # result
+    msg = await client_pipeline.receive_json()
+    assert msg["success"]
+
+    # run start
+    msg = await client_pipeline.receive_json()
+    assert msg["event"]["type"] == "run-start"
+    msg["event"]["data"]["pipeline"] = ANY
+    assert msg["event"]["data"] == snapshot
+    handler_id = msg["event"]["data"]["runner_data"]["stt_binary_handler_id"]
+
+    # stt
+    msg = await client_pipeline.receive_json()
+    assert msg["event"]["type"] == "stt-start"
+    assert msg["event"]["data"] == snapshot
+
+    # Send first audio chunk
+    await client_pipeline.send_bytes(bytes([handler_id]) + audio_chunks[0])
+
+    # Verify first capture
+    msg = await client_capture_1.receive_json()
+    assert msg["type"] == "event"
+    assert msg["event"] == snapshot
+    assert msg["event"]["audio"] == base64.b64encode(audio_chunks[0]).decode("ascii")
+
+    # Start a new capture
+    client_capture_2 = await hass_ws_client(hass)
+    await client_capture_2.send_json_auto_id(
+        {
+            "type": "assist_pipeline/device/capture",
+            "timeout": 30,
+            "device_id": satellite_device.id,
+        }
+    )
+
+    # result (capture 2)
+    msg = await client_capture_2.receive_json()
+    assert msg["success"]
+
+    # Send remaining audio chunks
+    for audio_chunk in audio_chunks[1:]:
+        await client_pipeline.send_bytes(bytes([handler_id]) + audio_chunk)
+
+    # End of audio stream
+    await client_pipeline.send_bytes(bytes([handler_id]))
+
+    msg = await client_pipeline.receive_json()
+    assert msg["event"]["type"] == "stt-end"
+    assert msg["event"]["data"] == snapshot
+
+    # run end
+    msg = await client_pipeline.receive_json()
+    assert msg["event"]["type"] == "run-end"
+    assert msg["event"]["data"] == snapshot
+
+    # Verify that first capture ended with no more audio
+    msg = await client_capture_1.receive_json()
+    assert msg["type"] == "event"
+    assert msg["event"] == snapshot
+    assert msg["event"]["type"] == "end"
+
+    # Verify that the second capture got the remaining audio
+    events = []
+    async with asyncio.timeout(1):
+        while True:
+            msg = await client_capture_2.receive_json()
+            assert msg["type"] == "event"
+            event_data = msg["event"]
+            events.append(event_data)
+            if event_data["type"] == "end":
+                break
+
+    # -1 since first audio chunk went to the first capture
+    assert len(events) == len(audio_chunks)
+
+    # Verify all but first audio chunk
+    for i, audio_chunk in enumerate(audio_chunks[1:]):
+        assert events[i]["type"] == "audio"
+        assert events[i]["rate"] == 16000
+        assert events[i]["width"] == 2
+        assert events[i]["channels"] == 1
+
+        # Audio is base64 encoded
+        assert events[i]["audio"] == base64.b64encode(audio_chunk).decode("ascii")
+
+    # Last event is the end
+    assert events[-1]["type"] == "end"
+
+
+async def test_device_capture_queue_full(
+    hass: HomeAssistant,
+    init_components,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test audio capture from a satellite device when the recording queue fills up."""
+    entry = MockConfigEntry()
+    entry.add_to_hass(hass)
+    satellite_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        connections=set(),
+        identifiers={("demo", "satellite-1234")},
+    )
+
+    class FakeQueue(asyncio.Queue):
+        """Queue that reports full for anything but None."""
+
+        def put_nowait(self, item):
+            if item is not None:
+                raise asyncio.QueueFull()
+
+            super().put_nowait(item)
+
+    with patch(
+        "homeassistant.components.assist_pipeline.websocket_api.DeviceAudioQueue"
+    ) as mock:
+        mock.return_value = DeviceAudioQueue(queue=FakeQueue())
+
+        # Start capture
+        client_capture = await hass_ws_client(hass)
+        await client_capture.send_json_auto_id(
+            {
+                "type": "assist_pipeline/device/capture",
+                "timeout": 30,
+                "device_id": satellite_device.id,
+            }
+        )
+
+        # result
+        msg = await client_capture.receive_json()
+        assert msg["success"]
+
+    # Run pipeline
+    client_pipeline = await hass_ws_client(hass)
+    await client_pipeline.send_json_auto_id(
+        {
+            "type": "assist_pipeline/run",
+            "start_stage": "stt",
+            "end_stage": "stt",
+            "input": {
+                "sample_rate": 16000,
+                "no_vad": True,
+                "no_chunking": True,
+            },
+            "device_id": satellite_device.id,
+        }
+    )
+
+    # result
+    msg = await client_pipeline.receive_json()
+    assert msg["success"]
+
+    # run start
+    msg = await client_pipeline.receive_json()
+    assert msg["event"]["type"] == "run-start"
+    msg["event"]["data"]["pipeline"] = ANY
+    assert msg["event"]["data"] == snapshot
+    handler_id = msg["event"]["data"]["runner_data"]["stt_binary_handler_id"]
+
+    # stt
+    msg = await client_pipeline.receive_json()
+    assert msg["event"]["type"] == "stt-start"
+    assert msg["event"]["data"] == snapshot
+
+    # Single sample will "overflow" the queue
+    await client_pipeline.send_bytes(bytes([handler_id, 0, 0]))
+
+    # End of audio stream
+    await client_pipeline.send_bytes(bytes([handler_id]))
+
+    msg = await client_pipeline.receive_json()
+    assert msg["event"]["type"] == "stt-end"
+    assert msg["event"]["data"] == snapshot
+
+    msg = await client_pipeline.receive_json()
+    assert msg["event"]["type"] == "run-end"
+    assert msg["event"]["data"] == snapshot
+
+    # Queue should have been overflowed
+    async with asyncio.timeout(1):
+        msg = await client_capture.receive_json()
+        assert msg["type"] == "event"
+        assert msg["event"] == snapshot
+        assert msg["event"]["type"] == "end"
+        assert msg["event"]["overflow"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Intended for discussion; tests have not yet been written.

This PR adds a new websocket command: `assist_pipeline/device/capture` that causes all audio sent to HA from a specific `device_id` to be forwarded to the websocket client. Limitations are in place to prevent abuse of this command:
* Admin privileges are required
* A maximum of 30 seconds can be recorded at a time
* Only a single capture per device is allowed

With the `assist_pipeline/device/capture` command, the frontend device page for voice satellites could be extended to include a button to capture audio and play it back. This would make checking audio settings significantly easier than turning on the assist pipeline debug recording feature, which requires restarting HA and is not intended to be left on.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
