### PR TITLE
Use device area as context during intent recognition

### DIFF
--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -643,17 +643,20 @@ class DefaultAgent(AbstractConversationAgent):
         self, user_input: ConversationInput
     ) -> dict[str, Any] | None:
         """Return intent recognition context for user input."""
-        intent_context: dict[str, Any] | None = None
-        if user_input.device_id:
-            devices = dr.async_get(self.hass)
-            device = devices.async_get(user_input.device_id)
-            if (device is not None) and (device.area_id is not None):
-                areas = ar.async_get(self.hass)
-                device_area = areas.async_get_area(device.area_id)
-                if device_area is not None:
-                    intent_context = {"area": device_area.name}
+        if not user_input.device_id:
+            return None
 
-        return intent_context
+        devices = dr.async_get(self.hass)
+        device = devices.async_get(user_input.device_id)
+        if (device is None) or (device.area_id is None):
+            return None
+
+        areas = ar.async_get(self.hass)
+        device_area = areas.async_get_area(device.area_id)
+        if device_area is None:
+            return None
+
+        return {"area": device_area.name}
 
     def _get_error_text(
         self, response_type: ResponseType, lang_intents: LanguageIntents | None

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -188,11 +188,14 @@ class DefaultAgent(AbstractConversationAgent):
             return None
 
         slot_lists = self._make_slot_lists()
+        intent_context = self._make_intent_context(user_input)
+
         result = await self.hass.async_add_executor_job(
             self._recognize,
             user_input,
             lang_intents,
             slot_lists,
+            intent_context,
         )
 
         return result
@@ -221,15 +224,24 @@ class DefaultAgent(AbstractConversationAgent):
         # loaded in async_recognize.
         assert lang_intents is not None
 
+        # Include slot values from intent_context, such as the name of the
+        # device's area.
+        slots = {
+            entity_name: {"value": entity_value}
+            for entity_name, entity_value in result.context.items()
+        }
+
+        # Override context with result entities
+        slots.update(
+            {entity.name: {"value": entity.value} for entity in result.entities_list}
+        )
+
         try:
             intent_response = await intent.async_handle(
                 self.hass,
                 DOMAIN,
                 result.intent.name,
-                {
-                    entity.name: {"value": entity.value}
-                    for entity in result.entities_list
-                },
+                slots,
                 user_input.text,
                 user_input.context,
                 language,
@@ -277,12 +289,16 @@ class DefaultAgent(AbstractConversationAgent):
         user_input: ConversationInput,
         lang_intents: LanguageIntents,
         slot_lists: dict[str, SlotList],
+        intent_context: dict[str, Any] | None,
     ) -> RecognizeResult | None:
         """Search intents for a match to user input."""
         # Prioritize matches with entity names above area names
         maybe_result: RecognizeResult | None = None
         for result in recognize_all(
-            user_input.text, lang_intents.intents, slot_lists=slot_lists
+            user_input.text,
+            lang_intents.intents,
+            slot_lists=slot_lists,
+            intent_context=intent_context,
         ):
             if "name" in result.entities:
                 return result
@@ -622,6 +638,22 @@ class DefaultAgent(AbstractConversationAgent):
         }
 
         return self._slot_lists
+
+    def _make_intent_context(
+        self, user_input: ConversationInput
+    ) -> dict[str, Any] | None:
+        """Return intent recognition context for user input."""
+        intent_context: dict[str, Any] | None = None
+        if user_input.device_id:
+            devices = dr.async_get(self.hass)
+            device = devices.async_get(user_input.device_id)
+            if (device is not None) and (device.area_id is not None):
+                areas = ar.async_get(self.hass)
+                device_area = areas.async_get_area(device.area_id)
+                if device_area is not None:
+                    intent_context = {"area": device_area.name}
+
+        return intent_context
 
     def _get_error_text(
         self, response_type: ResponseType, lang_intents: LanguageIntents | None

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -1,4 +1,5 @@
 """Test for the default agent."""
+from collections import defaultdict
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -293,3 +294,124 @@ async def test_nevermind_item(hass: HomeAssistant, init_components) -> None:
 
     assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
     assert not result.response.speech
+
+
+async def test_device_area_context(
+    hass: HomeAssistant,
+    init_components,
+    area_registry: ar.AreaRegistry,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that including a device_id will target a specific area."""
+    turn_on_calls = async_mock_service(hass, "light", "turn_on")
+    turn_off_calls = async_mock_service(hass, "light", "turn_off")
+
+    area_kitchen = area_registry.async_get_or_create("kitchen")
+    area_bedroom = area_registry.async_get_or_create("bedroom")
+
+    # Create 2 lights in each area
+    area_lights = defaultdict(list)
+    for area in (area_kitchen, area_bedroom):
+        for i in range(2):
+            light_entity = entity_registry.async_get_or_create(
+                "light", "demo", f"{area.name}-light-{i}"
+            )
+            entity_registry.async_update_entity(light_entity.entity_id, area_id=area.id)
+            hass.states.async_set(
+                light_entity.entity_id,
+                "off",
+                attributes={ATTR_FRIENDLY_NAME: f"{area.name} light {i}"},
+            )
+            area_lights[area.name].append(light_entity)
+
+    # Create voice satellites in each area
+    entry = MockConfigEntry()
+    entry.add_to_hass(hass)
+
+    kitchen_satellite = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        connections=set(),
+        identifiers={("demo", "id-satellite-kitchen")},
+    )
+    device_registry.async_update_device(kitchen_satellite.id, area_id=area_kitchen.id)
+
+    bedroom_satellite = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        connections=set(),
+        identifiers={("demo", "id-satellite-bedroom")},
+    )
+    device_registry.async_update_device(bedroom_satellite.id, area_id=area_bedroom.id)
+
+    # Turn on all lights in the area of a device
+    result = await conversation.async_converse(
+        hass,
+        "turn on all lights",
+        None,
+        Context(),
+        None,
+        device_id=kitchen_satellite.id,
+    )
+    await hass.async_block_till_done()
+    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+
+    # Verify only kitchen lights were targeted
+    assert {s.entity_id for s in result.response.matched_states} == {
+        e.entity_id for e in area_lights["kitchen"]
+    }
+    assert {c.data["entity_id"][0] for c in turn_on_calls} == {
+        e.entity_id for e in area_lights["kitchen"]
+    }
+    turn_on_calls.clear()
+
+    # Ensure we can still target other areas by name
+    result = await conversation.async_converse(
+        hass,
+        "turn on all lights in the bedroom",
+        None,
+        Context(),
+        None,
+        device_id=kitchen_satellite.id,
+    )
+    await hass.async_block_till_done()
+    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+
+    # Verify only bedroom lights were targeted
+    assert {s.entity_id for s in result.response.matched_states} == {
+        e.entity_id for e in area_lights["bedroom"]
+    }
+    assert {c.data["entity_id"][0] for c in turn_on_calls} == {
+        e.entity_id for e in area_lights["bedroom"]
+    }
+    turn_on_calls.clear()
+
+    # Turn off all lights in the area of the otherkj device
+    result = await conversation.async_converse(
+        hass,
+        "turn all lights off",
+        None,
+        Context(),
+        None,
+        device_id=bedroom_satellite.id,
+    )
+    await hass.async_block_till_done()
+    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+
+    # Verify only bedroom lights were targeted
+    assert {s.entity_id for s in result.response.matched_states} == {
+        e.entity_id for e in area_lights["bedroom"]
+    }
+    assert {c.data["entity_id"][0] for c in turn_off_calls} == {
+        e.entity_id for e in area_lights["bedroom"]
+    }
+    turn_off_calls.clear()
+
+    # Not providing a device id should not match
+    for command in ("on", "off"):
+        result = await conversation.async_converse(
+            hass, f"turn {command} all lights", None, Context(), None
+        )
+        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert (
+            result.response.error_code == intent.IntentResponseErrorCode.NO_INTENT_MATCH
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When an assist pipeline is run with a `device_id`, the area of that device (if set) will be used as context during intent recognition. Sentences like ["turn on all the lights in here" ](https://github.com/home-assistant/intents/blob/07ffc5ad7a99376f810a3ca39fb0141d72ec6a4c/sentences/en/light_HassTurnOn.yaml#L25) will automatically use this context and turn on lights in the area of the voice satellite.

Thanks to @tetele for the [initial implementation](https://github.com/home-assistant/core/pull/99363) of this feature!

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
