### PR TITLE
Add support for multiple models to STT entity

### DIFF
--- a/homeassistant/components/stt/models.py
+++ b/homeassistant/components/stt/models.py
@@ -35,3 +35,12 @@ class SpeechResult:
 
     text: str | None
     result: SpeechResultState
+
+
+@dataclass(frozen=True)
+class SpeechModel:
+    """Speech-to-text model."""
+
+    model_id: str
+    name: str
+    supported_languages: list[str]

--- a/homeassistant/components/wyoming/stt.py
+++ b/homeassistant/components/wyoming/stt.py
@@ -44,9 +44,17 @@ class WyomingSttProvider(stt.SpeechToTextEntity):
         self.service = service
         asr_service = service.info.asr[0]
 
+        self._supported_models: list[stt.SpeechModel] = []
         model_languages: set[str] = set()
         for asr_model in asr_service.models:
             if asr_model.installed:
+                self._supported_models.append(
+                    stt.SpeechModel(
+                        model_id=asr_model.name,
+                        name=asr_model.description or asr_model.name,
+                        supported_languages=asr_model.languages,
+                    )
+                )
                 model_languages.update(asr_model.languages)
 
         self._supported_languages = list(model_languages)
@@ -82,6 +90,11 @@ class WyomingSttProvider(stt.SpeechToTextEntity):
     def supported_channels(self) -> list[stt.AudioChannels]:
         """Return a list of supported channels."""
         return [stt.AudioChannels.CHANNEL_MONO]
+
+    @property
+    def supported_models(self) -> list[stt.SpeechModel]:
+        """Return a list of supported models."""
+        return self._supported_models
 
     async def async_process_audio_stream(
         self, metadata: stt.SpeechMetadata, stream: AsyncIterable[bytes]

--- a/tests/components/wyoming/__init__.py
+++ b/tests/components/wyoming/__init__.py
@@ -23,12 +23,19 @@ STT_INFO = Info(
             attribution=TEST_ATTR,
             models=[
                 AsrModel(
-                    name="Test Model",
+                    name="test_model",
                     description="Test Model",
                     installed=True,
                     attribution=TEST_ATTR,
                     languages=["en-US"],
-                )
+                ),
+                AsrModel(
+                    name="test_model_2",
+                    description="Test Model 2",
+                    installed=True,
+                    attribution=TEST_ATTR,
+                    languages=["en-US", "fr-FR"],
+                ),
             ],
         )
     ]

--- a/tests/components/wyoming/test_stt.py
+++ b/tests/components/wyoming/test_stt.py
@@ -19,12 +19,16 @@ async def test_support(hass: HomeAssistant, init_wyoming_stt) -> None:
     entity = stt.async_get_speech_to_text_entity(hass, "stt.test_asr")
     assert entity is not None
 
-    assert entity.supported_languages == ["en-US"]
+    assert set(entity.supported_languages) == {"en-US", "fr-FR"}
     assert entity.supported_formats == [stt.AudioFormats.WAV]
     assert entity.supported_codecs == [stt.AudioCodecs.PCM]
     assert entity.supported_bit_rates == [stt.AudioBitRates.BITRATE_16]
     assert entity.supported_sample_rates == [stt.AudioSampleRates.SAMPLERATE_16000]
     assert entity.supported_channels == [stt.AudioChannels.CHANNEL_MONO]
+    assert entity.supported_models == [
+        stt.SpeechModel("test_model", "Test Model", ["en-US"]),
+        stt.SpeechModel("test_model_2", "Test Model 2", ["en-US", "fr-FR"]),
+    ]
 
 
 async def test_streaming_audio(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Speech-to-text entities have a `supported_languages` property, but no way of communicating if they provide more than one model for a given language. Many speech-to-text engines, such as Whisper, offer models for the same language with different sizes and performance characteristics. The [official Whisper add-on](https://github.com/home-assistant/addons/tree/master/whisper) must be restarted in order to change model size.

This PR extends the speech-to-text entity with a `supported_models` property that lists each model the engine offers along with its supported languages. This list is empty by default for backwards compatibility, indicating the engine only provides one model per language. The `stt/engine/list` websocket command now includes a `supported_models` field in its response so that the frontend can use this information in a future PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
