### PR TITLE
Improve formatting of config validation errors

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -17,7 +17,7 @@ from urllib.parse import urlparse
 
 from awesomeversion import AwesomeVersion
 import voluptuous as vol
-from voluptuous.humanize import humanize_error
+from voluptuous.humanize import MAX_VALIDATION_ERROR_ITEM_LENGTH
 
 from . import auth
 from .auth import mfa_modules as auth_mfa_modules, providers as auth_providers
@@ -576,6 +576,44 @@ def find_annotation(
         return _get_annotation(item)
 
     return find_annotation_rec(config, list(path), None)
+
+
+def stringify_invalid(ex: vol.Invalid) -> str:
+    """Stringify voluptuous.Invalid.
+
+    Based on voluptuous.error.Invalid.__str__, the main modification
+    is to format the path delimited by -> instead of @data[].
+    """
+    path = "->".join(str(m) for m in ex.path)
+    output = Exception.__str__(ex)
+    if error_type := ex.error_type:
+        output += " for " + error_type
+    return f"{output} '{path}'"
+
+
+def humanize_error(
+    data: Any,
+    validation_error: vol.Invalid,
+    max_sub_error_length: int = MAX_VALIDATION_ERROR_ITEM_LENGTH,
+) -> str:
+    """Provide a more helpful + complete validation error message.
+
+    This is a aodified version of voluptuous.error.Invalid.__str__,
+    the modifications make some minor changes to the formatting.
+    """
+    if isinstance(validation_error, vol.MultipleInvalid):
+        return "\n".join(
+            sorted(
+                humanize_error(data, sub_error, max_sub_error_length)
+                for sub_error in validation_error.errors
+            )
+        )
+    offending_item_summary = repr(_get_by_path(data, validation_error.path))
+    if len(offending_item_summary) > max_sub_error_length:
+        offending_item_summary = (
+            offending_item_summary[: max_sub_error_length - 3] + "..."
+        )
+    return f"{stringify_invalid(validation_error)}, got {offending_item_summary}"
 
 
 @callback

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -585,6 +585,9 @@ def stringify_invalid(ex: vol.Invalid) -> str:
     is to format the path delimited by -> instead of @data[].
     """
     path = "->".join(str(m) for m in ex.path)
+    # This function is an alternative to the stringification done by
+    # vol.Invalid.__str__, so we need to call Exception.__str__ here
+    # instead of str(ex)
     output = Exception.__str__(ex)
     if error_type := ex.error_type:
         output += " for " + error_type
@@ -598,7 +601,7 @@ def humanize_error(
 ) -> str:
     """Provide a more helpful + complete validation error message.
 
-    This is a aodified version of voluptuous.error.Invalid.__str__,
+    This is a modified version of voluptuous.error.Invalid.__str__,
     the modifications make some minor changes to the formatting.
     """
     if isinstance(validation_error, vol.MultipleInvalid):
@@ -611,7 +614,7 @@ def humanize_error(
     offending_item_summary = repr(_get_by_path(data, validation_error.path))
     if len(offending_item_summary) > max_sub_error_length:
         offending_item_summary = (
-            offending_item_summary[: max_sub_error_length - 3] + "..."
+            f"{offending_item_summary[: max_sub_error_length - 3]}..."
         )
     return f"{stringify_invalid(validation_error)}, got {offending_item_summary}"
 

--- a/tests/components/template/test_alarm_control_panel.py
+++ b/tests/components/template/test_alarm_control_panel.py
@@ -204,7 +204,7 @@ async def test_optimistic_states(hass: HomeAssistant, start_ha) -> None:
             {
                 "alarm_control_panel": {"platform": "template"},
             },
-            "required key not provided @ data['panels']",
+            "required key not provided 'panels'",
         ),
         (
             {

--- a/tests/helpers/test_check_config.py
+++ b/tests/helpers/test_check_config.py
@@ -83,8 +83,7 @@ async def test_bad_core_config(hass: HomeAssistant) -> None:
             (
                 "Invalid config for [homeassistant] at "
                 f"{hass.config.path(YAML_CONFIG_FILE)}, line 2: "
-                "not a valid value for dictionary value @ data['unit_system']. Got "
-                "'bad'."
+                "not a valid value for dictionary value 'unit_system', got 'bad'."
             ),
             "homeassistant",
             {"unit_system": "bad"},

--- a/tests/snapshots/test_config.ambr
+++ b/tests/snapshots/test_config.ambr
@@ -1,54 +1,54 @@
 # serializer version: 1
 # name: test_component_config_validation_error[basic]
   list([
-    "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 6: required key not provided @ data['platform']. Got None.",
-    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 9: expected str for dictionary value @ data['option1']. Got 123.",
+    "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 6: required key not provided 'platform', got None.",
+    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 9: expected str for dictionary value 'option1', got 123.",
     "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 12: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
-    "Invalid config for [adr_0007_2] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 19: required key not provided @ data['adr_0007_2']['host']. Got None.",
-    "Invalid config for [adr_0007_3] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 24: expected int for dictionary value @ data['adr_0007_3']['port']. Got 'foo'.",
+    "Invalid config for [adr_0007_2] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 19: required key not provided 'adr_0007_2->host', got None.",
+    "Invalid config for [adr_0007_3] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 24: expected int for dictionary value 'adr_0007_3->port', got 'foo'.",
     "Invalid config for [adr_0007_4] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 29: 'no_such_option' is an invalid option for [adr_0007_4], check: adr_0007_4->no_such_option",
   ])
 # ---
 # name: test_component_config_validation_error[basic_include]
   list([
-    "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/iot_domain.yaml, line 5: required key not provided @ data['platform']. Got None.",
-    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/iot_domain.yaml, line 8: expected str for dictionary value @ data['option1']. Got 123.",
+    "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/iot_domain.yaml, line 5: required key not provided 'platform', got None.",
+    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/iot_domain.yaml, line 8: expected str for dictionary value 'option1', got 123.",
     "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/iot_domain.yaml, line 11: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
-    "Invalid config for [adr_0007_2] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/configuration.yaml, line 3: required key not provided @ data['adr_0007_2']['host']. Got None.",
-    "Invalid config for [adr_0007_3] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/adr_0007_3.yaml, line 3: expected int for dictionary value @ data['adr_0007_3']['port']. Got 'foo'.",
+    "Invalid config for [adr_0007_2] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/configuration.yaml, line 3: required key not provided 'adr_0007_2->host', got None.",
+    "Invalid config for [adr_0007_3] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/adr_0007_3.yaml, line 3: expected int for dictionary value 'adr_0007_3->port', got 'foo'.",
   ])
 # ---
 # name: test_component_config_validation_error[include_dir_list]
   list([
-    "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_list/iot_domain/iot_domain_2.yaml, line 2: required key not provided @ data['platform']. Got None.",
-    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_list/iot_domain/iot_domain_3.yaml, line 3: expected str for dictionary value @ data['option1']. Got 123.",
+    "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_list/iot_domain/iot_domain_2.yaml, line 2: required key not provided 'platform', got None.",
+    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_list/iot_domain/iot_domain_3.yaml, line 3: expected str for dictionary value 'option1', got 123.",
     "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_list/iot_domain/iot_domain_4.yaml, line 3: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
   ])
 # ---
 # name: test_component_config_validation_error[include_dir_merge_list]
   list([
-    "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_merge_list/iot_domain/iot_domain_1.yaml, line 5: required key not provided @ data['platform']. Got None.",
-    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_merge_list/iot_domain/iot_domain_2.yaml, line 3: expected str for dictionary value @ data['option1']. Got 123.",
+    "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_merge_list/iot_domain/iot_domain_1.yaml, line 5: required key not provided 'platform', got None.",
+    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_merge_list/iot_domain/iot_domain_2.yaml, line 3: expected str for dictionary value 'option1', got 123.",
     "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_merge_list/iot_domain/iot_domain_2.yaml, line 6: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
   ])
 # ---
 # name: test_component_config_validation_error[packages]
   list([
-    "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 11: required key not provided @ data['platform']. Got None.",
-    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 16: expected str for dictionary value @ data['option1']. Got 123.",
+    "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 11: required key not provided 'platform', got None.",
+    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 16: expected str for dictionary value 'option1', got 123.",
     "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 21: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
-    "Invalid config for [adr_0007_2] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 28: required key not provided @ data['adr_0007_2']['host']. Got None.",
-    "Invalid config for [adr_0007_3] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 33: expected int for dictionary value @ data['adr_0007_3']['port']. Got 'foo'.",
+    "Invalid config for [adr_0007_2] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 28: required key not provided 'adr_0007_2->host', got None.",
+    "Invalid config for [adr_0007_3] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 33: expected int for dictionary value 'adr_0007_3->port', got 'foo'.",
     "Invalid config for [adr_0007_4] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 38: 'no_such_option' is an invalid option for [adr_0007_4], check: adr_0007_4->no_such_option",
   ])
 # ---
 # name: test_component_config_validation_error[packages_include_dir_named]
   list([
-    "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/iot_domain.yaml, line 6: required key not provided @ data['platform']. Got None.",
-    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/iot_domain.yaml, line 9: expected str for dictionary value @ data['option1']. Got 123.",
-    "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/iot_domain.yaml, line 12: required key not provided @ data['platform']. Got None.",
-    "Invalid config for [adr_0007_2] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/adr_0007_2.yaml, line 2: required key not provided @ data['adr_0007_2']['host']. Got None.",
-    "Invalid config for [adr_0007_3] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/adr_0007_3.yaml, line 4: expected int for dictionary value @ data['adr_0007_3']['port']. Got 'foo'.",
+    "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/iot_domain.yaml, line 6: required key not provided 'platform', got None.",
+    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/iot_domain.yaml, line 9: expected str for dictionary value 'option1', got 123.",
+    "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/iot_domain.yaml, line 12: required key not provided 'platform', got None.",
+    "Invalid config for [adr_0007_2] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/adr_0007_2.yaml, line 2: required key not provided 'adr_0007_2->host', got None.",
+    "Invalid config for [adr_0007_3] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/adr_0007_3.yaml, line 4: expected int for dictionary value 'adr_0007_3->port', got 'foo'.",
     "Invalid config for [adr_0007_4] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/adr_0007_4.yaml, line 4: 'no_such_option' is an invalid option for [adr_0007_4], check: adr_0007_4->no_such_option",
   ])
 # ---


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve formatting of config validation errors:

With this PR:
```
Invalid config for [iot_domain.non_adr_0007] at configuration.yaml, line 7: expected str for dictionary value 'option1', got 123.
Invalid config for [iot_domain] at configuration.yaml, line 9: required key not provided 'platform', got None.
Invalid config for [adr_0007_2] at configuration.yaml, line 16: required key not provided 'adr_0007_2->host', got None.
Invalid config for [adr_0007_3] at configuration.yaml, line 21: expected int for dictionary value 'adr_0007_3->port', got 'foo'.
```

Without this PR:
```
Invalid config for [iot_domain.non_adr_0007] at configuration.yaml, line 7: expected str for dictionary value @ data['option1']. Got 123.",
Invalid config for [iot_domain] at configuration.yaml, line 9: required key not provided @ data['platform']. Got None.
Invalid config for [adr_0007_2] at configuration.yaml, line 16: required key not provided @ data['adr_0007_2']['host']. Got None.
Invalid config for [adr_0007_3] at configuration.yaml, line 21: expected int for dictionary value @ data['adr_0007_3']['port']. Got 'foo'.
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
