### PR TITLE
Improve errors for component configuration with multiple errors

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -578,26 +578,44 @@ def find_annotation(
     return find_annotation_rec(config, list(path), None)
 
 
-def stringify_invalid(ex: vol.Invalid) -> str:
+def stringify_invalid(
+    ex: vol.Invalid, domain: str, config: dict, max_sub_error_length: int
+) -> str:
     """Stringify voluptuous.Invalid.
 
     This is an alternative to the custom __str__ implemented in
-    voluptuous.error.Invalid. The main modification is to format
-    the path delimited by -> instead of @data[].
+    voluptuous.error.Invalid. The modifications are:
+    - Format the path delimited by -> instead of @data[]
+    - Suffix with domain, file and line of the error
+    - Give a more user friendly output for unknown options
     """
+    message_prefix = f"Invalid config for [{domain}]"
+    if annotation := find_annotation(config, ex.path):
+        message_prefix += f" at {annotation[0]}, line {annotation[1]}"
     path = "->".join(str(m) for m in ex.path)
+    if ex.error_message == "extra keys not allowed":
+        return (
+            f"{message_prefix}: '{ex.path[-1]}' is an invalid option for [{domain}], "
+            f"check: {path}"
+        )
     # This function is an alternative to the stringification done by
     # vol.Invalid.__str__, so we need to call Exception.__str__ here
     # instead of str(ex)
     output = Exception.__str__(ex)
     if error_type := ex.error_type:
         output += " for " + error_type
-    return f"{output} '{path}'"
+    offending_item_summary = repr(_get_by_path(config, ex.path))
+    if len(offending_item_summary) > max_sub_error_length:
+        offending_item_summary = (
+            f"{offending_item_summary[: max_sub_error_length - 3]}..."
+        )
+    return f"{message_prefix}: {output} '{path}', got {offending_item_summary}."
 
 
 def humanize_error(
-    data: Any,
     validation_error: vol.Invalid,
+    domain: str,
+    config: dict,
     max_sub_error_length: int = MAX_VALIDATION_ERROR_ITEM_LENGTH,
 ) -> str:
     """Provide a more helpful + complete validation error message.
@@ -608,16 +626,11 @@ def humanize_error(
     if isinstance(validation_error, vol.MultipleInvalid):
         return "\n".join(
             sorted(
-                humanize_error(data, sub_error, max_sub_error_length)
+                humanize_error(sub_error, domain, config, max_sub_error_length)
                 for sub_error in validation_error.errors
             )
         )
-    offending_item_summary = repr(_get_by_path(data, validation_error.path))
-    if len(offending_item_summary) > max_sub_error_length:
-        offending_item_summary = (
-            f"{offending_item_summary[: max_sub_error_length - 3]}..."
-        )
-    return f"{stringify_invalid(validation_error)}, got {offending_item_summary}"
+    return stringify_invalid(validation_error, domain, config, max_sub_error_length)
 
 
 @callback
@@ -629,25 +642,12 @@ def _format_config_error(
     This method must be run in the event loop.
     """
     is_friendly = False
-    message = f"Invalid config for [{domain}]"
 
     if isinstance(ex, vol.Invalid):
-        if annotation := find_annotation(config, ex.path):
-            message += f" at {annotation[0]}, line {annotation[1]}: "
-        else:
-            message += ": "
-
-        if "extra keys not allowed" in ex.error_message:
-            path = "->".join(str(m) for m in ex.path)
-            message += (
-                f"'{ex.path[-1]}' is an invalid option for [{domain}], check: {path}"
-            )
-        else:
-            message += f"{humanize_error(config, ex)}."
+        message = humanize_error(ex, domain, config)
         is_friendly = True
     else:
-        message += ": "
-        message += str(ex) or repr(ex)
+        message = f"Invalid config for [{domain}]: {str(ex) or repr(ex)}"
 
     if domain != CONF_CORE and link:
         message += f" Please check the docs at {link}"

--- a/tests/snapshots/test_config.ambr
+++ b/tests/snapshots/test_config.ambr
@@ -105,14 +105,22 @@
 # ---
 # name: test_component_config_validation_error_with_docs[basic]
   list([
-    "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 6: required key not provided 'platform', got None. Please check the docs at https://www.home-assistant.io/integrations/iot_domain",
-    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 9: expected str for dictionary value 'option1', got 123. Please check the docs at https://www.home-assistant.io/integrations/non_adr_0007",
-    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 12: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option Please check the docs at https://www.home-assistant.io/integrations/non_adr_0007",
-    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 19: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option Please check the docs at https://www.home-assistant.io/integrations/non_adr_0007",
-    "Invalid config for [adr_0007_2] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 27: required key not provided 'adr_0007_2->host', got None. Please check the docs at https://www.home-assistant.io/integrations/adr_0007_2",
-    "Invalid config for [adr_0007_3] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 32: expected int for dictionary value 'adr_0007_3->port', got 'foo'. Please check the docs at https://www.home-assistant.io/integrations/adr_0007_3",
-    "Invalid config for [adr_0007_4] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 37: 'no_such_option' is an invalid option for [adr_0007_4], check: adr_0007_4->no_such_option Please check the docs at https://www.home-assistant.io/integrations/adr_0007_4",
-    "Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 44: 'no_such_option' is an invalid option for [adr_0007_5], check: adr_0007_5->no_such_option Please check the docs at https://www.home-assistant.io/integrations/adr_0007_5",
+    "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 6: required key not provided 'platform', got None. Please check the docs at https://www.home-assistant.io/integrations/iot_domain.",
+    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 9: expected str for dictionary value 'option1', got 123. Please check the docs at https://www.home-assistant.io/integrations/non_adr_0007.",
+    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 12: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option. Please check the docs at https://www.home-assistant.io/integrations/non_adr_0007",
+    '''
+      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 18: required key not provided 'option1', got None. Please check the docs at https://www.home-assistant.io/integrations/non_adr_0007.
+      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 19: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option. Please check the docs at https://www.home-assistant.io/integrations/non_adr_0007
+      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 20: expected str for dictionary value 'option2', got 123. Please check the docs at https://www.home-assistant.io/integrations/non_adr_0007.
+    ''',
+    "Invalid config for [adr_0007_2] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 27: required key not provided 'adr_0007_2->host', got None. Please check the docs at https://www.home-assistant.io/integrations/adr_0007_2.",
+    "Invalid config for [adr_0007_3] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 32: expected int for dictionary value 'adr_0007_3->port', got 'foo'. Please check the docs at https://www.home-assistant.io/integrations/adr_0007_3.",
+    "Invalid config for [adr_0007_4] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 37: 'no_such_option' is an invalid option for [adr_0007_4], check: adr_0007_4->no_such_option. Please check the docs at https://www.home-assistant.io/integrations/adr_0007_4",
+    '''
+      Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 43: required key not provided 'adr_0007_5->host', got None. Please check the docs at https://www.home-assistant.io/integrations/adr_0007_5.
+      Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 44: 'no_such_option' is an invalid option for [adr_0007_5], check: adr_0007_5->no_such_option. Please check the docs at https://www.home-assistant.io/integrations/adr_0007_5
+      Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 45: expected int for dictionary value 'adr_0007_5->port', got 'foo'. Please check the docs at https://www.home-assistant.io/integrations/adr_0007_5.
+    ''',
   ])
 # ---
 # name: test_package_merge_error[packages]

--- a/tests/snapshots/test_config.ambr
+++ b/tests/snapshots/test_config.ambr
@@ -4,11 +4,19 @@
     "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 6: required key not provided 'platform', got None.",
     "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 9: expected str for dictionary value 'option1', got 123.",
     "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 12: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
-    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 19: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
+    '''
+      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 18: required key not provided 'option1', got None.
+      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 19: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option
+      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 20: expected str for dictionary value 'option2', got 123.
+    ''',
     "Invalid config for [adr_0007_2] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 27: required key not provided 'adr_0007_2->host', got None.",
     "Invalid config for [adr_0007_3] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 32: expected int for dictionary value 'adr_0007_3->port', got 'foo'.",
     "Invalid config for [adr_0007_4] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 37: 'no_such_option' is an invalid option for [adr_0007_4], check: adr_0007_4->no_such_option",
-    "Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 44: 'no_such_option' is an invalid option for [adr_0007_5], check: adr_0007_5->no_such_option",
+    '''
+      Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 43: required key not provided 'adr_0007_5->host', got None.
+      Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 44: 'no_such_option' is an invalid option for [adr_0007_5], check: adr_0007_5->no_such_option
+      Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 45: expected int for dictionary value 'adr_0007_5->port', got 'foo'.
+    ''',
   ])
 # ---
 # name: test_component_config_validation_error[basic_include]
@@ -16,11 +24,19 @@
     "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/iot_domain.yaml, line 5: required key not provided 'platform', got None.",
     "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/iot_domain.yaml, line 8: expected str for dictionary value 'option1', got 123.",
     "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/iot_domain.yaml, line 11: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
-    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/iot_domain.yaml, line 18: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
+    '''
+      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/iot_domain.yaml, line 17: required key not provided 'option1', got None.
+      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/iot_domain.yaml, line 18: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option
+      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/iot_domain.yaml, line 19: expected str for dictionary value 'option2', got 123.
+    ''',
     "Invalid config for [adr_0007_2] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/configuration.yaml, line 3: required key not provided 'adr_0007_2->host', got None.",
     "Invalid config for [adr_0007_3] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/adr_0007_3.yaml, line 3: expected int for dictionary value 'adr_0007_3->port', got 'foo'.",
     "Invalid config for [adr_0007_4] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/adr_0007_4.yaml, line 3: 'no_such_option' is an invalid option for [adr_0007_4], check: adr_0007_4->no_such_option",
-    "Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/adr_0007_5.yaml, line 5: 'no_such_option' is an invalid option for [adr_0007_5], check: adr_0007_5->no_such_option",
+    '''
+      Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/configuration.yaml, line 6: required key not provided 'adr_0007_5->host', got None.
+      Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/adr_0007_5.yaml, line 5: 'no_such_option' is an invalid option for [adr_0007_5], check: adr_0007_5->no_such_option
+      Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/adr_0007_5.yaml, line 6: expected int for dictionary value 'adr_0007_5->port', got 'foo'.
+    ''',
   ])
 # ---
 # name: test_component_config_validation_error[include_dir_list]
@@ -28,7 +44,11 @@
     "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_list/iot_domain/iot_domain_2.yaml, line 2: required key not provided 'platform', got None.",
     "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_list/iot_domain/iot_domain_3.yaml, line 3: expected str for dictionary value 'option1', got 123.",
     "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_list/iot_domain/iot_domain_4.yaml, line 3: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
-    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_list/iot_domain/iot_domain_5.yaml, line 6: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
+    '''
+      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_list/iot_domain/iot_domain_5.yaml, line 5: required key not provided 'option1', got None.
+      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_list/iot_domain/iot_domain_5.yaml, line 6: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option
+      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_list/iot_domain/iot_domain_5.yaml, line 7: expected str for dictionary value 'option2', got 123.
+    ''',
   ])
 # ---
 # name: test_component_config_validation_error[include_dir_merge_list]
@@ -36,7 +56,11 @@
     "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_merge_list/iot_domain/iot_domain_1.yaml, line 5: required key not provided 'platform', got None.",
     "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_merge_list/iot_domain/iot_domain_2.yaml, line 3: expected str for dictionary value 'option1', got 123.",
     "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_merge_list/iot_domain/iot_domain_2.yaml, line 6: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
-    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_merge_list/iot_domain/iot_domain_2.yaml, line 13: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
+    '''
+      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_merge_list/iot_domain/iot_domain_2.yaml, line 12: required key not provided 'option1', got None.
+      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_merge_list/iot_domain/iot_domain_2.yaml, line 13: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option
+      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_merge_list/iot_domain/iot_domain_2.yaml, line 14: expected str for dictionary value 'option2', got 123.
+    ''',
   ])
 # ---
 # name: test_component_config_validation_error[packages]
@@ -44,11 +68,19 @@
     "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 11: required key not provided 'platform', got None.",
     "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 16: expected str for dictionary value 'option1', got 123.",
     "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 21: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
-    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 30: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
+    '''
+      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 29: required key not provided 'option1', got None.
+      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 30: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option
+      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 31: expected str for dictionary value 'option2', got 123.
+    ''',
     "Invalid config for [adr_0007_2] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 38: required key not provided 'adr_0007_2->host', got None.",
     "Invalid config for [adr_0007_3] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 43: expected int for dictionary value 'adr_0007_3->port', got 'foo'.",
     "Invalid config for [adr_0007_4] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 48: 'no_such_option' is an invalid option for [adr_0007_4], check: adr_0007_4->no_such_option",
-    "Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 55: 'no_such_option' is an invalid option for [adr_0007_5], check: adr_0007_5->no_such_option",
+    '''
+      Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 54: required key not provided 'adr_0007_5->host', got None.
+      Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 55: 'no_such_option' is an invalid option for [adr_0007_5], check: adr_0007_5->no_such_option
+      Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 56: expected int for dictionary value 'adr_0007_5->port', got 'foo'.
+    ''',
   ])
 # ---
 # name: test_component_config_validation_error[packages_include_dir_named]
@@ -56,11 +88,19 @@
     "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/iot_domain.yaml, line 6: required key not provided 'platform', got None.",
     "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/iot_domain.yaml, line 9: expected str for dictionary value 'option1', got 123.",
     "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/iot_domain.yaml, line 12: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
-    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/iot_domain.yaml, line 19: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
+    '''
+      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/iot_domain.yaml, line 18: required key not provided 'option1', got None.
+      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/iot_domain.yaml, line 19: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option
+      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/iot_domain.yaml, line 20: expected str for dictionary value 'option2', got 123.
+    ''',
     "Invalid config for [adr_0007_2] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/adr_0007_2.yaml, line 2: required key not provided 'adr_0007_2->host', got None.",
     "Invalid config for [adr_0007_3] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/adr_0007_3.yaml, line 4: expected int for dictionary value 'adr_0007_3->port', got 'foo'.",
     "Invalid config for [adr_0007_4] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/adr_0007_4.yaml, line 4: 'no_such_option' is an invalid option for [adr_0007_4], check: adr_0007_4->no_such_option",
-    "Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/adr_0007_5.yaml, line 6: 'no_such_option' is an invalid option for [adr_0007_5], check: adr_0007_5->no_such_option",
+    '''
+      Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/adr_0007_5.yaml, line 5: required key not provided 'adr_0007_5->host', got None.
+      Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/adr_0007_5.yaml, line 6: 'no_such_option' is an invalid option for [adr_0007_5], check: adr_0007_5->no_such_option
+      Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/adr_0007_5.yaml, line 7: expected int for dictionary value 'adr_0007_5->port', got 'foo'.
+    ''',
   ])
 # ---
 # name: test_component_config_validation_error_with_docs[basic]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve formatting of errors for component configuration with multiple errors:
- Prefix each error with integration domain, file and line of the error, this was previously only done for the first error
- Suffix each error with documentation link, this was previously only done for the last error
- Always display all errors, this did not work before if the first error was because of an unknown key
- Always do custom formatting when there are unknown keys, this previously only worked for the first error

Example with this PR when the first error is an unknown key:
```
Invalid config for [iot_domain.non_adr_0007] at configuration.yaml, line 18: required key not provided 'option1', got None.
Invalid config for [iot_domain.non_adr_0007] at configuration.yaml, line 19: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option
Invalid config for [iot_domain.non_adr_0007] at configuration.yaml, line 20: expected str for dictionary value 'option2', got 123.
```

The same three errors formatted without this PR just shows the first error:
```
Invalid config for [iot_domain.non_adr_0007] at configuration.yaml, line 19: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option"
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
