### PR TITLE
Improve formatting of package errors

### DIFF
--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -96,7 +96,7 @@ async def async_check_ha_config_file(  # noqa: C901
         package: str, component: str, config: ConfigType, message: str
     ) -> None:
         """Handle errors from packages."""
-        message = f"Package {package} setup failed. Component {component} {message}"
+        message = f"Package {package} setup failed. {message}"
         domain = f"homeassistant.packages.{package}.{component}"
         pack_config = core_config[CONF_PACKAGES].get(package, config)
         result.add_warning(message, domain, pack_config)

--- a/tests/fixtures/core/config/package_exceptions/packages/configuration.yaml
+++ b/tests/fixtures/core/config/package_exceptions/packages/configuration.yaml
@@ -1,0 +1,4 @@
+homeassistant:
+  packages:
+    pack_1:
+      test_domain:

--- a/tests/fixtures/core/config/package_exceptions/packages_include_dir_named/configuration.yaml
+++ b/tests/fixtures/core/config/package_exceptions/packages_include_dir_named/configuration.yaml
@@ -1,0 +1,3 @@
+homeassistant:
+  # Load packages
+  packages: !include_dir_named integrations

--- a/tests/fixtures/core/config/package_exceptions/packages_include_dir_named/integrations/unknown_integration.yaml
+++ b/tests/fixtures/core/config/package_exceptions/packages_include_dir_named/integrations/unknown_integration.yaml
@@ -1,0 +1,1 @@
+test_domain:

--- a/tests/helpers/test_check_config.py
+++ b/tests/helpers/test_check_config.py
@@ -380,7 +380,7 @@ async def test_package_invalid(hass: HomeAssistant) -> None:
 
         warning = CheckConfigError(
             (
-                "Package p1 setup failed. Component group cannot be merged. Expected a "
+                "Package p1 setup failed. Integration group cannot be merged. Expected a "
                 "dict."
             ),
             "homeassistant.packages.p1.group",

--- a/tests/snapshots/test_config.ambr
+++ b/tests/snapshots/test_config.ambr
@@ -314,16 +314,36 @@
   list([
     'Package pack_1 setup failed. Integration adr_0007_1 cannot be merged. Dict expected in main config. (See <BASE_PATH>/fixtures/core/config/package_errors/packages/configuration.yaml:9).',
     'Package pack_2 setup failed. Integration adr_0007_2 cannot be merged. Expected a dict. (See <BASE_PATH>/fixtures/core/config/package_errors/packages/configuration.yaml:13).',
-    "Package pack_4 setup failed. Integration adr_0007_3 has duplicate key 'host' (See <BASE_PATH>/fixtures/core/config/package_errors/packages/configuration.yaml:20).",
-    "Package pack_5 setup failed. Integration unknown_integration Integration 'unknown_integration' not found. (See <BASE_PATH>/fixtures/core/config/package_errors/packages/configuration.yaml:23).",
+    "Package pack_4 setup failed. Integration adr_0007_3 has duplicate key 'host'. (See <BASE_PATH>/fixtures/core/config/package_errors/packages/configuration.yaml:20).",
+    "Package pack_5 setup failed. Integration 'unknown_integration' not found. (See <BASE_PATH>/fixtures/core/config/package_errors/packages/configuration.yaml:23).",
   ])
 # ---
 # name: test_package_merge_error[packages_include_dir_named]
   list([
     'Package adr_0007_1 setup failed. Integration adr_0007_1 cannot be merged. Dict expected in main config. (See <BASE_PATH>/fixtures/core/config/package_errors/packages_include_dir_named/integrations/adr_0007_1.yaml:2).',
     'Package adr_0007_2 setup failed. Integration adr_0007_2 cannot be merged. Expected a dict. (See <BASE_PATH>/fixtures/core/config/package_errors/packages_include_dir_named/integrations/adr_0007_2.yaml:2).',
-    "Package adr_0007_3_2 setup failed. Integration adr_0007_3 has duplicate key 'host' (See <BASE_PATH>/fixtures/core/config/package_errors/packages_include_dir_named/integrations/adr_0007_3_2.yaml:1).",
-    "Package unknown_integration setup failed. Integration unknown_integration Integration 'unknown_integration' not found. (See <BASE_PATH>/fixtures/core/config/package_errors/packages_include_dir_named/integrations/unknown_integration.yaml:2).",
+    "Package adr_0007_3_2 setup failed. Integration adr_0007_3 has duplicate key 'host'. (See <BASE_PATH>/fixtures/core/config/package_errors/packages_include_dir_named/integrations/adr_0007_3_2.yaml:1).",
+    "Package unknown_integration setup failed. Integration 'unknown_integration' not found. (See <BASE_PATH>/fixtures/core/config/package_errors/packages_include_dir_named/integrations/unknown_integration.yaml:2).",
+  ])
+# ---
+# name: test_package_merge_exception[packages-error0]
+  list([
+    "Package pack_1 setup failed. Integration test_domain caused error: No such file or directory: b'liblibc.a' (See <BASE_PATH>/fixtures/core/config/package_exceptions/packages/configuration.yaml:4).",
+  ])
+# ---
+# name: test_package_merge_exception[packages-error1]
+  list([
+    "Package pack_1 setup failed. Integration test_domain caused error: ModuleNotFoundError: No module named 'not_installed_something' (See <BASE_PATH>/fixtures/core/config/package_exceptions/packages/configuration.yaml:4).",
+  ])
+# ---
+# name: test_package_merge_exception[packages_include_dir_named-error0]
+  list([
+    "Package unknown_integration setup failed. Integration test_domain caused error: No such file or directory: b'liblibc.a' (See <BASE_PATH>/fixtures/core/config/package_exceptions/packages_include_dir_named/integrations/unknown_integration.yaml:1).",
+  ])
+# ---
+# name: test_package_merge_exception[packages_include_dir_named-error1]
+  list([
+    "Package unknown_integration setup failed. Integration test_domain caused error: ModuleNotFoundError: No module named 'not_installed_something' (See <BASE_PATH>/fixtures/core/config/package_exceptions/packages_include_dir_named/integrations/unknown_integration.yaml:1).",
   ])
 # ---
 # name: test_yaml_error[basic]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve formatting of package errors

In particular, the error message when a package refers to a non-existing integration is improved:
```
Package pack_5 setup failed. Integration 'unknown_integration' not found. (See configuration.yaml:23).
```

Compared to before:
```
Package pack_5 setup failed. Integration unknown_integration Integration 'unknown_integration' not found. (See configuration.yaml:23).
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
