### PR TITLE
Update m* tests to use entity & device registry fixtures

### DIFF
--- a/tests/components/matter/test_binary_sensor.py
+++ b/tests/components/matter/test_binary_sensor.py
@@ -90,6 +90,7 @@ async def test_occupancy_sensor(
 @pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_battery_sensor(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     matter_client: MagicMock,
     door_lock: MatterNode,
 ) -> None:
@@ -108,7 +109,6 @@ async def test_battery_sensor(
     assert state
     assert state.state == "on"
 
-    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get(entity_id)
 
     assert entry

--- a/tests/components/matter/test_diagnostics.py
+++ b/tests/components/matter/test_diagnostics.py
@@ -81,6 +81,7 @@ async def test_config_entry_diagnostics(
 async def test_device_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
+    device_registry: dr.DeviceRegistry,
     matter_client: MagicMock,
     config_entry_diagnostics: dict[str, Any],
     device_diagnostics: dict[str, Any],
@@ -102,8 +103,9 @@ async def test_device_diagnostics(
     )
     matter_client.get_diagnostics.return_value = server_diagnostics
     config_entry = hass.config_entries.async_entries(DOMAIN)[0]
-    dev_reg = dr.async_get(hass)
-    device = dr.async_entries_for_config_entry(dev_reg, config_entry.entry_id)[0]
+    device = dr.async_entries_for_config_entry(device_registry, config_entry.entry_id)[
+        0
+    ]
     assert device
 
     diagnostics = await get_diagnostics_for_device(

--- a/tests/components/matter/test_helpers.py
+++ b/tests/components/matter/test_helpers.py
@@ -37,10 +37,10 @@ async def test_get_device_id(
 @pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_get_node_from_device_entry(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     matter_client: MagicMock,
 ) -> None:
     """Test get_node_from_device_entry."""
-    device_registry = dr.async_get(hass)
     other_domain = "other_domain"
     other_config_entry = MockConfigEntry(domain=other_domain)
     other_config_entry.add_to_hass(hass)

--- a/tests/components/matter/test_init.py
+++ b/tests/components/matter/test_init.py
@@ -612,6 +612,8 @@ async def test_remove_entry(
 @pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_remove_config_entry_device(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     matter_client: MagicMock,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
@@ -621,11 +623,9 @@ async def test_remove_config_entry_device(
     await hass.async_block_till_done()
 
     config_entry = hass.config_entries.async_entries(DOMAIN)[0]
-    device_registry = dr.async_get(hass)
     device_entry = dr.async_entries_for_config_entry(
         device_registry, config_entry.entry_id
     )[0]
-    entity_registry = er.async_get(hass)
     entity_id = "light.m5stamp_lighting_app"
 
     assert device_entry
@@ -654,6 +654,7 @@ async def test_remove_config_entry_device(
 @pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_remove_config_entry_device_no_node(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     matter_client: MagicMock,
     integration: MockConfigEntry,
     hass_ws_client: WebSocketGenerator,
@@ -661,7 +662,6 @@ async def test_remove_config_entry_device_no_node(
     """Test that a device can be removed ok without an existing node."""
     assert await async_setup_component(hass, "config", {})
     config_entry = integration
-    device_registry = dr.async_get(hass)
     device_entry = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={

--- a/tests/components/matter/test_sensor.py
+++ b/tests/components/matter/test_sensor.py
@@ -187,6 +187,7 @@ async def test_temperature_sensor(
 @pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_battery_sensor(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     matter_client: MagicMock,
     eve_contact_sensor_node: MatterNode,
 ) -> None:
@@ -203,7 +204,6 @@ async def test_battery_sensor(
     assert state
     assert state.state == "50"
 
-    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get(entity_id)
 
     assert entry

--- a/tests/components/maxcube/test_maxcube_binary_sensor.py
+++ b/tests/components/maxcube/test_maxcube_binary_sensor.py
@@ -23,10 +23,12 @@ BATTERY_ENTITY_ID = f"{ENTITY_ID}_battery"
 
 
 async def test_window_shuttler(
-    hass: HomeAssistant, cube: MaxCube, windowshutter: MaxWindowShutter
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    cube: MaxCube,
+    windowshutter: MaxWindowShutter,
 ) -> None:
     """Test a successful setup with a shuttler device."""
-    entity_registry = er.async_get(hass)
     assert entity_registry.async_is_registered(ENTITY_ID)
     entity = entity_registry.async_get(ENTITY_ID)
     assert entity.unique_id == "AABBCCDD03"
@@ -47,10 +49,12 @@ async def test_window_shuttler(
 
 
 async def test_window_shuttler_battery(
-    hass: HomeAssistant, cube: MaxCube, windowshutter: MaxWindowShutter
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    cube: MaxCube,
+    windowshutter: MaxWindowShutter,
 ) -> None:
     """Test battery binary_state with a shuttler device."""
-    entity_registry = er.async_get(hass)
     assert entity_registry.async_is_registered(BATTERY_ENTITY_ID)
     entity = entity_registry.async_get(BATTERY_ENTITY_ID)
     assert entity.unique_id == "AABBCCDD03_battery"

--- a/tests/components/maxcube/test_maxcube_climate.py
+++ b/tests/components/maxcube/test_maxcube_climate.py
@@ -60,9 +60,10 @@ WALL_ENTITY_ID = "climate.testroom_testwallthermostat"
 VALVE_POSITION = "valve_position"
 
 
-async def test_setup_thermostat(hass: HomeAssistant, cube: MaxCube) -> None:
+async def test_setup_thermostat(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, cube: MaxCube
+) -> None:
     """Test a successful setup of a thermostat device."""
-    entity_registry = er.async_get(hass)
     assert entity_registry.async_is_registered(ENTITY_ID)
     entity = entity_registry.async_get(ENTITY_ID)
     assert entity.unique_id == "AABBCCDD01"
@@ -96,9 +97,10 @@ async def test_setup_thermostat(hass: HomeAssistant, cube: MaxCube) -> None:
     assert state.attributes.get(VALVE_POSITION) == 25
 
 
-async def test_setup_wallthermostat(hass: HomeAssistant, cube: MaxCube) -> None:
+async def test_setup_wallthermostat(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, cube: MaxCube
+) -> None:
     """Test a successful setup of a wall thermostat device."""
-    entity_registry = er.async_get(hass)
     assert entity_registry.async_is_registered(WALL_ENTITY_ID)
     entity = entity_registry.async_get(WALL_ENTITY_ID)
     assert entity.unique_id == "AABBCCDD02"

--- a/tests/components/met/test_init.py
+++ b/tests/components/met/test_init.py
@@ -52,13 +52,15 @@ async def test_fail_default_home_entry(
 
 
 async def test_removing_incorrect_devices(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_weather
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+    mock_weather,
 ) -> None:
     """Test we remove incorrect devices."""
     entry = await init_integration(hass)
 
-    device_reg = dr.async_get(hass)
-    device_reg.async_get_or_create(
+    device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         name="Forecast_legacy",
         entry_type=dr.DeviceEntryType.SERVICE,
@@ -71,6 +73,6 @@ async def test_removing_incorrect_devices(
     assert await hass.config_entries.async_reload(entry.entry_id)
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
-    assert not device_reg.async_get_device(identifiers={(DOMAIN,)})
-    assert device_reg.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+    assert not device_registry.async_get_device(identifiers={(DOMAIN,)})
+    assert device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
     assert "Removing improper device Forecast_legacy" in caplog.text

--- a/tests/components/met/test_weather.py
+++ b/tests/components/met/test_weather.py
@@ -6,21 +6,23 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 
-async def test_new_config_entry(hass: HomeAssistant, mock_weather) -> None:
+async def test_new_config_entry(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_weather
+) -> None:
     """Test the expected entities are created."""
-    registry = er.async_get(hass)
     await hass.config_entries.flow.async_init("met", context={"source": "onboarding"})
     await hass.async_block_till_done()
     assert len(hass.states.async_entity_ids("weather")) == 1
 
     entry = hass.config_entries.async_entries()[0]
-    assert len(er.async_entries_for_config_entry(registry, entry.entry_id)) == 1
+    assert len(er.async_entries_for_config_entry(entity_registry, entry.entry_id)) == 1
 
 
-async def test_legacy_config_entry(hass: HomeAssistant, mock_weather) -> None:
+async def test_legacy_config_entry(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_weather
+) -> None:
     """Test the expected entities are created."""
-    registry = er.async_get(hass)
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         WEATHER_DOMAIN,
         DOMAIN,
         "home-hourly",
@@ -30,7 +32,7 @@ async def test_legacy_config_entry(hass: HomeAssistant, mock_weather) -> None:
     assert len(hass.states.async_entity_ids("weather")) == 2
 
     entry = hass.config_entries.async_entries()[0]
-    assert len(er.async_entries_for_config_entry(registry, entry.entry_id)) == 2
+    assert len(er.async_entries_for_config_entry(entity_registry, entry.entry_id)) == 2
 
 
 async def test_tracking_home(hass: HomeAssistant, mock_weather) -> None:

--- a/tests/components/met_eireann/test_weather.py
+++ b/tests/components/met_eireann/test_weather.py
@@ -32,20 +32,22 @@ async def setup_config_entry(hass: HomeAssistant) -> ConfigEntry:
     return mock_data
 
 
-async def test_new_config_entry(hass: HomeAssistant, mock_weather) -> None:
+async def test_new_config_entry(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_weather
+) -> None:
     """Test the expected entities are created."""
-    registry = er.async_get(hass)
     await setup_config_entry(hass)
     assert len(hass.states.async_entity_ids("weather")) == 1
 
     entry = hass.config_entries.async_entries()[0]
-    assert len(er.async_entries_for_config_entry(registry, entry.entry_id)) == 1
+    assert len(er.async_entries_for_config_entry(entity_registry, entry.entry_id)) == 1
 
 
-async def test_legacy_config_entry(hass: HomeAssistant, mock_weather) -> None:
+async def test_legacy_config_entry(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_weather
+) -> None:
     """Test the expected entities are created."""
-    registry = er.async_get(hass)
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         WEATHER_DOMAIN,
         DOMAIN,
         "10-20-hourly",
@@ -54,7 +56,7 @@ async def test_legacy_config_entry(hass: HomeAssistant, mock_weather) -> None:
     assert len(hass.states.async_entity_ids("weather")) == 2
 
     entry = hass.config_entries.async_entries()[0]
-    assert len(er.async_entries_for_config_entry(registry, entry.entry_id)) == 2
+    assert len(er.async_entries_for_config_entry(entity_registry, entry.entry_id)) == 2
 
 
 async def test_weather(hass: HomeAssistant, mock_weather) -> None:

--- a/tests/components/metoffice/test_init.py
+++ b/tests/components/metoffice/test_init.py
@@ -89,6 +89,7 @@ from tests.common import MockConfigEntry
 )
 async def test_migrate_unique_id(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     old_unique_id: str,
     new_unique_id: str,
     migration_needed: bool,
@@ -102,9 +103,7 @@ async def test_migrate_unique_id(
     )
     entry.add_to_hass(hass)
 
-    ent_reg = er.async_get(hass)
-
-    entity: er.RegistryEntry = ent_reg.async_get_or_create(
+    entity: er.RegistryEntry = entity_registry.async_get_or_create(
         suggested_object_id="my_sensor",
         disabled_by=None,
         domain=SENSOR_DOMAIN,
@@ -118,9 +117,12 @@ async def test_migrate_unique_id(
     await hass.async_block_till_done()
 
     if migration_needed:
-        assert ent_reg.async_get_entity_id(SENSOR_DOMAIN, DOMAIN, old_unique_id) is None
+        assert (
+            entity_registry.async_get_entity_id(SENSOR_DOMAIN, DOMAIN, old_unique_id)
+            is None
+        )
 
     assert (
-        ent_reg.async_get_entity_id(SENSOR_DOMAIN, DOMAIN, new_unique_id)
+        entity_registry.async_get_entity_id(SENSOR_DOMAIN, DOMAIN, new_unique_id)
         == "sensor.my_sensor"
     )

--- a/tests/components/metoffice/test_weather.py
+++ b/tests/components/metoffice/test_weather.py
@@ -100,13 +100,15 @@ async def test_site_cannot_connect(
 
 @pytest.mark.freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.UTC))
 async def test_site_cannot_update(
-    hass: HomeAssistant, requests_mock: requests_mock.Mocker, wavertree_data
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    requests_mock: requests_mock.Mocker,
+    wavertree_data,
 ) -> None:
     """Test we handle cannot connect error."""
-    registry = er.async_get(hass)
 
     # Pre-create the hourly entity
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         WEATHER_DOMAIN,
         DOMAIN,
         "53.38374_-2.90929",
@@ -143,13 +145,15 @@ async def test_site_cannot_update(
 
 @pytest.mark.freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.UTC))
 async def test_one_weather_site_running(
-    hass: HomeAssistant, requests_mock: requests_mock.Mocker, wavertree_data
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    requests_mock: requests_mock.Mocker,
+    wavertree_data,
 ) -> None:
     """Test the Met Office weather platform."""
-    registry = er.async_get(hass)
 
     # Pre-create the hourly entity
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         WEATHER_DOMAIN,
         DOMAIN,
         "53.38374_-2.90929",
@@ -219,19 +223,21 @@ async def test_one_weather_site_running(
 
 @pytest.mark.freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.UTC))
 async def test_two_weather_sites_running(
-    hass: HomeAssistant, requests_mock: requests_mock.Mocker, wavertree_data
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    requests_mock: requests_mock.Mocker,
+    wavertree_data,
 ) -> None:
     """Test we handle two different weather sites both running."""
-    registry = er.async_get(hass)
 
     # Pre-create the hourly entities
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         WEATHER_DOMAIN,
         DOMAIN,
         "53.38374_-2.90929",
         suggested_object_id="met_office_wavertree_3_hourly",
     )
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         WEATHER_DOMAIN,
         DOMAIN,
         "52.75556_0.44231",
@@ -369,9 +375,10 @@ async def test_two_weather_sites_running(
 
 
 @pytest.mark.freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.UTC))
-async def test_new_config_entry(hass: HomeAssistant, no_sensor, wavertree_data) -> None:
+async def test_new_config_entry(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, no_sensor, wavertree_data
+) -> None:
     """Test the expected entities are created."""
-    registry = er.async_get(hass)
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -383,17 +390,16 @@ async def test_new_config_entry(hass: HomeAssistant, no_sensor, wavertree_data) 
 
     assert len(hass.states.async_entity_ids(WEATHER_DOMAIN)) == 1
     entry = hass.config_entries.async_entries()[0]
-    assert len(er.async_entries_for_config_entry(registry, entry.entry_id)) == 1
+    assert len(er.async_entries_for_config_entry(entity_registry, entry.entry_id)) == 1
 
 
 @pytest.mark.freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.UTC))
 async def test_legacy_config_entry(
-    hass: HomeAssistant, no_sensor, wavertree_data
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, no_sensor, wavertree_data
 ) -> None:
     """Test the expected entities are created."""
-    registry = er.async_get(hass)
     # Pre-create the hourly entity
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         WEATHER_DOMAIN,
         DOMAIN,
         "53.38374_-2.90929",
@@ -411,7 +417,7 @@ async def test_legacy_config_entry(
 
     assert len(hass.states.async_entity_ids("weather")) == 2
     entry = hass.config_entries.async_entries()[0]
-    assert len(er.async_entries_for_config_entry(registry, entry.entry_id)) == 2
+    assert len(er.async_entries_for_config_entry(entity_registry, entry.entry_id)) == 2
 
 
 @pytest.mark.freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.UTC))
@@ -510,6 +516,7 @@ async def test_forecast_service(
 async def test_forecast_subscription(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
+    entity_registry: er.EntityRegistry,
     freezer: FrozenDateTimeFactory,
     snapshot: SnapshotAssertion,
     no_sensor,
@@ -519,9 +526,8 @@ async def test_forecast_subscription(
     """Test multiple forecast."""
     client = await hass_ws_client(hass)
 
-    registry = er.async_get(hass)
     # Pre-create the hourly entity
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         WEATHER_DOMAIN,
         DOMAIN,
         "53.38374_-2.90929",

--- a/tests/components/mikrotik/test_device_tracker.py
+++ b/tests/components/mikrotik/test_device_tracker.py
@@ -208,29 +208,30 @@ async def test_hub_wifiwave2(hass: HomeAssistant, mock_device_registry_devices) 
     assert device_4.attributes["host_name"] == "Device_4"
 
 
-async def test_restoring_devices(hass: HomeAssistant) -> None:
+async def test_restoring_devices(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test restoring existing device_tracker entities if not detected on startup."""
     config_entry = MockConfigEntry(
         domain=mikrotik.DOMAIN, data=MOCK_DATA, options=MOCK_OPTIONS
     )
     config_entry.add_to_hass(hass)
 
-    registry = er.async_get(hass)
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         device_tracker.DOMAIN,
         mikrotik.DOMAIN,
         "00:00:00:00:00:01",
         suggested_object_id="device_1",
         config_entry=config_entry,
     )
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         device_tracker.DOMAIN,
         mikrotik.DOMAIN,
         "00:00:00:00:00:02",
         suggested_object_id="device_2",
         config_entry=config_entry,
     )
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         device_tracker.DOMAIN,
         mikrotik.DOMAIN,
         "00:00:00:00:00:03",

--- a/tests/components/min_max/test_init.py
+++ b/tests/components/min_max/test_init.py
@@ -11,6 +11,7 @@ from tests.common import MockConfigEntry
 @pytest.mark.parametrize("platform", ("sensor",))
 async def test_setup_and_remove_config_entry(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     platform: str,
 ) -> None:
     """Test setting up and removing a config entry."""
@@ -19,7 +20,6 @@ async def test_setup_and_remove_config_entry(
 
     input_sensors = ["sensor.input_one", "sensor.input_two"]
 
-    registry = er.async_get(hass)
     min_max_entity_id = f"{platform}.my_min_max"
 
     # Setup the config entry
@@ -39,7 +39,7 @@ async def test_setup_and_remove_config_entry(
     await hass.async_block_till_done()
 
     # Check the entity is registered in the entity registry
-    assert registry.async_get(min_max_entity_id) is not None
+    assert entity_registry.async_get(min_max_entity_id) is not None
 
     # Check the platform is setup correctly
     state = hass.states.get(min_max_entity_id)
@@ -51,4 +51,4 @@ async def test_setup_and_remove_config_entry(
 
     # Check the state and entity registry entry are removed
     assert hass.states.get(min_max_entity_id) is None
-    assert registry.async_get(min_max_entity_id) is None
+    assert entity_registry.async_get(min_max_entity_id) is None

--- a/tests/components/min_max/test_sensor.py
+++ b/tests/components/min_max/test_sensor.py
@@ -60,7 +60,9 @@ async def test_default_name_sensor(hass: HomeAssistant) -> None:
     assert entity_ids[2] == state.attributes.get("min_entity_id")
 
 
-async def test_min_sensor(hass: HomeAssistant) -> None:
+async def test_min_sensor(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test the min sensor."""
     config = {
         "sensor": {
@@ -87,8 +89,7 @@ async def test_min_sensor(hass: HomeAssistant) -> None:
     assert entity_ids[2] == state.attributes.get("min_entity_id")
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entity_reg = er.async_get(hass)
-    entity = entity_reg.async_get("sensor.test_min")
+    entity = entity_registry.async_get("sensor.test_min")
     assert entity.unique_id == "very_unique_id"
 
 
@@ -470,7 +471,9 @@ async def test_sensor_incorrect_state(
     assert "Unable to store state. Only numerical states are supported" in caplog.text
 
 
-async def test_sum_sensor(hass: HomeAssistant) -> None:
+async def test_sum_sensor(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test the sum sensor."""
     config = {
         "sensor": {
@@ -496,8 +499,7 @@ async def test_sum_sensor(hass: HomeAssistant) -> None:
     assert str(float(SUM_VALUE)) == state.state
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entity_reg = er.async_get(hass)
-    entity = entity_reg.async_get("sensor.test_sum")
+    entity = entity_registry.async_get("sensor.test_sum")
     assert entity.unique_id == "very_unique_id_sum_sensor"
 
 

--- a/tests/components/minecraft_server/test_init.py
+++ b/tests/components/minecraft_server/test_init.py
@@ -178,7 +178,10 @@ async def test_setup_entry_not_ready(
 
 
 async def test_entry_migration(
-    hass: HomeAssistant, v1_mock_config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    v1_mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test entry migration from version 1 to 3, where host and port is required for the connection to the server."""
     v1_mock_config_entry.add_to_hass(hass)
@@ -218,12 +221,10 @@ async def test_entry_migration(
     assert migrated_config_entry.state == ConfigEntryState.LOADED
 
     # Test migrated device entry.
-    device_registry = dr.async_get(hass)
     device_entry = device_registry.async_get(device_entry_id)
     assert device_entry.identifiers == {(DOMAIN, migrated_config_entry.entry_id)}
 
     # Test migrated sensor entity entries.
-    entity_registry = er.async_get(hass)
     for mapping in sensor_entity_id_key_mapping_list:
         entity_entry = entity_registry.async_get(mapping["entity_id"])
         assert (

--- a/tests/components/mobile_app/test_binary_sensor.py
+++ b/tests/components/mobile_app/test_binary_sensor.py
@@ -9,7 +9,10 @@ from homeassistant.helpers import device_registry as dr
 
 
 async def test_sensor(
-    hass: HomeAssistant, create_registrations, webhook_client
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    create_registrations,
+    webhook_client,
 ) -> None:
     """Test that sensors can be registered and updated."""
     webhook_id = create_registrations[1]["webhook_id"]
@@ -77,8 +80,7 @@ async def test_sensor(
     assert updated_entity.state == "off"
     assert "foo" not in updated_entity.attributes
 
-    dev_reg = dr.async_get(hass)
-    assert len(dev_reg.devices) == len(create_registrations)
+    assert len(device_registry.devices) == len(create_registrations)
 
     # Reload to verify state is restored
     config_entry = hass.config_entries.async_entries("mobile_app")[1]

--- a/tests/components/mobile_app/test_init.py
+++ b/tests/components/mobile_app/test_init.py
@@ -28,14 +28,16 @@ async def test_unload_unloads(
     assert len(calls) == 1
 
 
-async def test_remove_entry(hass: HomeAssistant, create_registrations) -> None:
+async def test_remove_entry(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    create_registrations,
+) -> None:
     """Test we clean up when we remove entry."""
     for config_entry in hass.config_entries.async_entries("mobile_app"):
         await hass.config_entries.async_remove(config_entry.entry_id)
         assert config_entry.data["webhook_id"] in hass.data[DOMAIN][DATA_DELETED_IDS]
 
-    dev_reg = dr.async_get(hass)
-    assert len(dev_reg.devices) == 0
-
-    ent_reg = er.async_get(hass)
-    assert len(ent_reg.entities) == 0
+    assert len(device_registry.devices) == 0
+    assert len(entity_registry.entities) == 0

--- a/tests/components/mobile_app/test_sensor.py
+++ b/tests/components/mobile_app/test_sensor.py
@@ -25,6 +25,8 @@ from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
 )
 async def test_sensor(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     create_registrations,
     webhook_client,
     unit_system,
@@ -77,9 +79,7 @@ async def test_sensor(
     assert entity.state == state1
 
     assert (
-        er.async_get(hass)
-        .async_get("sensor.test_1_battery_temperature")
-        .entity_category
+        entity_registry.async_get("sensor.test_1_battery_temperature").entity_category
         == "diagnostic"
     )
 
@@ -109,8 +109,7 @@ async def test_sensor(
     assert updated_entity.state == state2
     assert "foo" not in updated_entity.attributes
 
-    dev_reg = dr.async_get(hass)
-    assert len(dev_reg.devices) == len(create_registrations)
+    assert len(device_registry.devices) == len(create_registrations)
 
     # Reload to verify state is restored
     config_entry = hass.config_entries.async_entries("mobile_app")[1]
@@ -503,7 +502,10 @@ async def test_sensor_datetime(
 
 
 async def test_default_disabling_entity(
-    hass: HomeAssistant, create_registrations, webhook_client
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    create_registrations,
+    webhook_client,
 ) -> None:
     """Test that sensors can be disabled by default upon registration."""
     webhook_id = create_registrations[1]["webhook_id"]
@@ -532,13 +534,16 @@ async def test_default_disabling_entity(
     assert entity is None
 
     assert (
-        er.async_get(hass).async_get("sensor.test_1_battery_state").disabled_by
+        entity_registry.async_get("sensor.test_1_battery_state").disabled_by
         == er.RegistryEntryDisabler.INTEGRATION
     )
 
 
 async def test_updating_disabled_sensor(
-    hass: HomeAssistant, create_registrations, webhook_client
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    create_registrations,
+    webhook_client,
 ) -> None:
     """Test that sensors return error if disabled in instance."""
     webhook_id = create_registrations[1]["webhook_id"]
@@ -580,7 +585,7 @@ async def test_updating_disabled_sensor(
     assert json["battery_state"]["success"] is True
     assert "is_disabled" not in json["battery_state"]
 
-    er.async_get(hass).async_update_entity(
+    entity_registry.async_update_entity(
         "sensor.test_1_battery_state", disabled_by=er.RegistryEntryDisabler.USER
     )
 

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -854,12 +854,13 @@ async def test_webhook_camera_stream_stream_available_but_errors(
 
 
 async def test_webhook_handle_scan_tag(
-    hass: HomeAssistant, create_registrations, webhook_client
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    create_registrations,
+    webhook_client,
 ) -> None:
     """Test that we can scan tags."""
-    device = dr.async_get(hass).async_get_device(
-        identifiers={(DOMAIN, "mock-device-id")}
-    )
+    device = device_registry.async_get_device(identifiers={(DOMAIN, "mock-device-id")})
     assert device is not None
 
     events = async_capture_events(hass, EVENT_TAG_SCANNED)
@@ -920,7 +921,10 @@ async def test_register_sensor_limits_state_class(
 
 
 async def test_reregister_sensor(
-    hass: HomeAssistant, create_registrations, webhook_client
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    create_registrations,
+    webhook_client,
 ) -> None:
     """Test that we can add more info in re-registration."""
     webhook_id = create_registrations[1]["webhook_id"]
@@ -941,8 +945,7 @@ async def test_reregister_sensor(
 
     assert reg_resp.status == HTTPStatus.CREATED
 
-    ent_reg = er.async_get(hass)
-    entry = ent_reg.async_get("sensor.test_1_battery_state")
+    entry = entity_registry.async_get("sensor.test_1_battery_state")
     assert entry.original_name == "Test 1 Battery State"
     assert entry.device_class is None
     assert entry.unit_of_measurement is None
@@ -970,7 +973,7 @@ async def test_reregister_sensor(
     )
 
     assert reg_resp.status == HTTPStatus.CREATED
-    entry = ent_reg.async_get("sensor.test_1_battery_state")
+    entry = entity_registry.async_get("sensor.test_1_battery_state")
     assert entry.original_name == "Test 1 New Name"
     assert entry.device_class == "battery"
     assert entry.unit_of_measurement == "%"
@@ -992,7 +995,7 @@ async def test_reregister_sensor(
     )
 
     assert reg_resp.status == HTTPStatus.CREATED
-    entry = ent_reg.async_get("sensor.test_1_battery_state")
+    entry = entity_registry.async_get("sensor.test_1_battery_state")
     assert entry.disabled_by is None
 
     reg_resp = await webhook_client.post(
@@ -1014,7 +1017,7 @@ async def test_reregister_sensor(
     )
 
     assert reg_resp.status == HTTPStatus.CREATED
-    entry = ent_reg.async_get("sensor.test_1_battery_state")
+    entry = entity_registry.async_get("sensor.test_1_battery_state")
     assert entry.original_name == "Test 1 New Name 2"
     assert entry.device_class is None
     assert entry.unit_of_measurement is None
@@ -1067,6 +1070,7 @@ async def test_webhook_handle_conversation_process(
 
 async def test_sending_sensor_state(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     create_registrations,
     webhook_client,
     caplog: pytest.LogCaptureFixture,
@@ -1105,8 +1109,7 @@ async def test_sending_sensor_state(
 
     assert reg_resp.status == HTTPStatus.CREATED
 
-    ent_reg = er.async_get(hass)
-    entry = ent_reg.async_get("sensor.test_1_battery_state")
+    entry = entity_registry.async_get("sensor.test_1_battery_state")
     assert entry.original_name == "Test 1 Battery State"
     assert entry.device_class is None
     assert entry.unit_of_measurement is None

--- a/tests/components/modbus/test_binary_sensor.py
+++ b/tests/components/modbus/test_binary_sensor.py
@@ -445,11 +445,14 @@ async def test_config_virtual_binary_sensor(hass: HomeAssistant, mock_modbus) ->
     ],
 )
 async def test_virtual_binary_sensor(
-    hass: HomeAssistant, expected, slaves, mock_do_cycle
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    expected,
+    slaves,
+    mock_do_cycle,
 ) -> None:
     """Run test for given config."""
     assert hass.states.get(ENTITY_ID).state == expected
-    entity_registry = er.async_get(hass)
 
     for i, slave in enumerate(slaves):
         entity_id = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}_{i+1}".replace(" ", "_")

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -869,9 +869,10 @@ async def test_all_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> None:
         ),
     ],
 )
-async def test_virtual_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> None:
+async def test_virtual_sensor(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_do_cycle, expected
+) -> None:
     """Run test for sensor."""
-    entity_registry = er.async_get(hass)
     for i in range(0, len(expected)):
         entity_id = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
         unique_id = f"{SLAVE_UNIQUE_ID}"

--- a/tests/components/modern_forms/test_binary_sensor.py
+++ b/tests/components/modern_forms/test_binary_sensor.py
@@ -11,20 +11,20 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 async def test_binary_sensors(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test the creation and values of the Modern Forms sensors."""
 
-    registry = er.async_get(hass)
-
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         BINARY_SENSOR_DOMAIN,
         DOMAIN,
         "AA:BB:CC:DD:EE:FF_light_sleep_timer_active",
         suggested_object_id="modernformsfan_light_sleep_timer_active",
         disabled_by=None,
     )
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         BINARY_SENSOR_DOMAIN,
         DOMAIN,
         "AA:BB:CC:DD:EE:FF_fan_sleep_timer_active",

--- a/tests/components/modern_forms/test_fan.py
+++ b/tests/components/modern_forms/test_fan.py
@@ -35,12 +35,12 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 async def test_fan_state(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test the creation and values of the Modern Forms fans."""
     await init_integration(hass, aioclient_mock)
-
-    entity_registry = er.async_get(hass)
 
     state = hass.states.get("fan.modernformsfan_fan")
     assert state

--- a/tests/components/modern_forms/test_init.py
+++ b/tests/components/modern_forms/test_init.py
@@ -38,13 +38,14 @@ async def test_unload_config_entry(
 
 
 async def test_fan_only_device(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test we set unique ID if not set yet."""
     await init_integration(
         hass, aioclient_mock, mock_type=modern_forms_no_light_call_mock
     )
-    entity_registry = er.async_get(hass)
 
     fan_entry = entity_registry.async_get("fan.modernformsfan_fan")
     assert fan_entry

--- a/tests/components/modern_forms/test_light.py
+++ b/tests/components/modern_forms/test_light.py
@@ -28,12 +28,12 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 async def test_light_state(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test the creation and values of the Modern Forms lights."""
     await init_integration(hass, aioclient_mock)
-
-    entity_registry = er.async_get(hass)
 
     state = hass.states.get("light.modernformsfan_light")
     assert state

--- a/tests/components/modern_forms/test_sensor.py
+++ b/tests/components/modern_forms/test_sensor.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_ICON
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
 
 from . import init_integration, modern_forms_timers_set_mock
 
@@ -18,7 +17,6 @@ async def test_sensors(
 
     # await init_integration(hass, aioclient_mock)
     await init_integration(hass, aioclient_mock)
-    er.async_get(hass)
 
     # Light timer remaining time
     state = hass.states.get("sensor.modernformsfan_light_sleep_time")
@@ -42,7 +40,6 @@ async def test_active_sensors(
 
     # await init_integration(hass, aioclient_mock)
     await init_integration(hass, aioclient_mock, mock_type=modern_forms_timers_set_mock)
-    er.async_get(hass)
 
     # Light timer remaining time
     state = hass.states.get("sensor.modernformsfan_light_sleep_time")

--- a/tests/components/modern_forms/test_switch.py
+++ b/tests/components/modern_forms/test_switch.py
@@ -22,12 +22,12 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 async def test_switch_state(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test the creation and values of the Modern Forms switches."""
     await init_integration(hass, aioclient_mock)
-
-    entity_registry = er.async_get(hass)
 
     state = hass.states.get("switch.modernformsfan_away_mode")
     assert state

--- a/tests/components/monoprice/test_media_player.py
+++ b/tests/components/monoprice/test_media_player.py
@@ -489,45 +489,45 @@ async def test_volume_up_down(hass: HomeAssistant) -> None:
     assert monoprice.zones[11].volume == 37
 
 
-async def test_first_run_with_available_zones(hass: HomeAssistant) -> None:
+async def test_first_run_with_available_zones(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test first run with all zones available."""
     monoprice = MockMonoprice()
     await _setup_monoprice(hass, monoprice)
 
-    registry = er.async_get(hass)
-
-    entry = registry.async_get(ZONE_7_ID)
+    entry = entity_registry.async_get(ZONE_7_ID)
     assert not entry.disabled
 
 
-async def test_first_run_with_failing_zones(hass: HomeAssistant) -> None:
+async def test_first_run_with_failing_zones(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test first run with failed zones."""
     monoprice = MockMonoprice()
 
     with patch.object(MockMonoprice, "zone_status", side_effect=SerialException):
         await _setup_monoprice(hass, monoprice)
 
-    registry = er.async_get(hass)
-
-    entry = registry.async_get(ZONE_1_ID)
+    entry = entity_registry.async_get(ZONE_1_ID)
     assert not entry.disabled
 
-    entry = registry.async_get(ZONE_7_ID)
+    entry = entity_registry.async_get(ZONE_7_ID)
     assert entry.disabled
     assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
-async def test_not_first_run_with_failing_zone(hass: HomeAssistant) -> None:
+async def test_not_first_run_with_failing_zone(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test first run with failed zones."""
     monoprice = MockMonoprice()
 
     with patch.object(MockMonoprice, "zone_status", side_effect=SerialException):
         await _setup_monoprice_not_first_run(hass, monoprice)
 
-    registry = er.async_get(hass)
-
-    entry = registry.async_get(ZONE_1_ID)
+    entry = entity_registry.async_get(ZONE_1_ID)
     assert not entry.disabled
 
-    entry = registry.async_get(ZONE_7_ID)
+    entry = entity_registry.async_get(ZONE_7_ID)
     assert not entry.disabled

--- a/tests/components/moon/test_sensor.py
+++ b/tests/components/moon/test_sensor.py
@@ -39,6 +39,8 @@ from tests.common import MockConfigEntry
 )
 async def test_moon_day(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
     moon_value: float,
     native_value: str,
@@ -70,13 +72,11 @@ async def test_moon_day(
         STATE_WANING_CRESCENT,
     ]
 
-    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get("sensor.moon_phase")
     assert entry
     assert entry.unique_id == mock_config_entry.entry_id
     assert entry.translation_key == "phase"
 
-    device_registry = dr.async_get(hass)
     assert entry.device_id
     device_entry = device_registry.async_get(entry.device_id)
     assert device_entry

--- a/tests/components/motioneye/test_camera.py
+++ b/tests/components/motioneye/test_camera.py
@@ -135,10 +135,12 @@ async def test_setup_camera_new_data_same(hass: HomeAssistant) -> None:
     assert hass.states.get(TEST_CAMERA_ENTITY_ID)
 
 
-async def test_setup_camera_new_data_camera_removed(hass: HomeAssistant) -> None:
+async def test_setup_camera_new_data_camera_removed(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test a data refresh with a removed camera."""
-    device_registry = dr.async_get(hass)
-    entity_registry = er.async_get(hass)
 
     client = create_mock_motioneye_client()
     config_entry = await setup_mock_motioneye_config_entry(hass, client=client)
@@ -315,12 +317,15 @@ async def test_state_attributes(hass: HomeAssistant) -> None:
     assert not entity_state.attributes.get("motion_detection")
 
 
-async def test_device_info(hass: HomeAssistant) -> None:
+async def test_device_info(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Verify device information includes expected details."""
     entry = await setup_mock_motioneye_config_entry(hass)
 
     device_identifier = get_motioneye_device_identifier(entry.entry_id, TEST_CAMERA_ID)
-    device_registry = dr.async_get(hass)
 
     device = device_registry.async_get_device(identifiers={device_identifier})
     assert device
@@ -330,7 +335,6 @@ async def test_device_info(hass: HomeAssistant) -> None:
     assert device.model == MOTIONEYE_MANUFACTURER
     assert device.name == TEST_CAMERA_NAME
 
-    entity_registry = er.async_get(hass)
     entities_from_device = [
         entry.entity_id
         for entry in er.async_entries_for_device(entity_registry, device.id)

--- a/tests/components/motioneye/test_media_source.py
+++ b/tests/components/motioneye/test_media_source.py
@@ -78,13 +78,14 @@ async def setup_media_source(hass) -> None:
     assert await async_setup_component(hass, "media_source", {})
 
 
-async def test_async_browse_media_success(hass: HomeAssistant) -> None:
+async def test_async_browse_media_success(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test successful browse media."""
 
     client = create_mock_motioneye_client()
     config = await setup_mock_motioneye_config_entry(hass, client=client)
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_or_create(
         config_entry_id=config.entry_id,
         identifiers={TEST_CAMERA_DEVICE_IDENTIFIER},
@@ -295,13 +296,14 @@ async def test_async_browse_media_success(hass: HomeAssistant) -> None:
     }
 
 
-async def test_async_browse_media_images_success(hass: HomeAssistant) -> None:
+async def test_async_browse_media_images_success(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test successful browse media of images."""
 
     client = create_mock_motioneye_client()
     config = await setup_mock_motioneye_config_entry(hass, client=client)
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_or_create(
         config_entry_id=config.entry_id,
         identifiers={TEST_CAMERA_DEVICE_IDENTIFIER},
@@ -346,14 +348,15 @@ async def test_async_browse_media_images_success(hass: HomeAssistant) -> None:
     }
 
 
-async def test_async_resolve_media_success(hass: HomeAssistant) -> None:
+async def test_async_resolve_media_success(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test successful resolve media."""
 
     client = create_mock_motioneye_client()
 
     config = await setup_mock_motioneye_config_entry(hass, client=client)
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_or_create(
         config_entry_id=config.entry_id,
         identifiers={TEST_CAMERA_DEVICE_IDENTIFIER},
@@ -380,14 +383,15 @@ async def test_async_resolve_media_success(hass: HomeAssistant) -> None:
     assert client.get_image_url.call_args == call(TEST_CAMERA_ID, "/foo.jpg")
 
 
-async def test_async_resolve_media_failure(hass: HomeAssistant) -> None:
+async def test_async_resolve_media_failure(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test failed resolve media calls."""
 
     client = create_mock_motioneye_client()
 
     config = await setup_mock_motioneye_config_entry(hass, client=client)
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_or_create(
         config_entry_id=config.entry_id,
         identifiers={TEST_CAMERA_DEVICE_IDENTIFIER},

--- a/tests/components/motioneye/test_sensor.py
+++ b/tests/components/motioneye/test_sensor.py
@@ -73,7 +73,11 @@ async def test_sensor_actions(
     assert entity_state.attributes.get(KEY_ACTIONS) is None
 
 
-async def test_sensor_device_info(hass: HomeAssistant) -> None:
+async def test_sensor_device_info(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Verify device information includes expected details."""
 
     # Enable the action sensor (it is disabled by default).
@@ -91,11 +95,9 @@ async def test_sensor_device_info(hass: HomeAssistant) -> None:
         config_entry.entry_id, TEST_CAMERA_ID
     )
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(identifiers={device_identifer})
     assert device
 
-    entity_registry = er.async_get(hass)
     entities_from_device = [
         entry.entity_id
         for entry in er.async_entries_for_device(entity_registry, device.id)
@@ -104,12 +106,13 @@ async def test_sensor_device_info(hass: HomeAssistant) -> None:
 
 
 async def test_sensor_actions_can_be_enabled(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Verify the action sensor can be enabled."""
     client = create_mock_motioneye_client()
     await setup_mock_motioneye_config_entry(hass, client=client)
-    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get(TEST_SENSOR_ACTION_ENTITY_ID)
     assert entry

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -152,7 +152,9 @@ async def test_switch_has_correct_entities(hass: HomeAssistant) -> None:
 
 
 async def test_disabled_switches_can_be_enabled(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Verify disabled switches can be enabled."""
     client = create_mock_motioneye_client()
@@ -165,7 +167,6 @@ async def test_disabled_switches_can_be_enabled(
 
     for switch_key in disabled_switch_keys:
         entity_id = f"{TEST_SWITCH_ENTITY_ID_BASE}_{switch_key}"
-        entity_registry = er.async_get(hass)
         entry = entity_registry.async_get(entity_id)
         assert entry
         assert entry.disabled
@@ -191,19 +192,21 @@ async def test_disabled_switches_can_be_enabled(
         assert entity_state
 
 
-async def test_switch_device_info(hass: HomeAssistant) -> None:
+async def test_switch_device_info(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Verify device information includes expected details."""
     config_entry = await setup_mock_motioneye_config_entry(hass)
 
     device_identifer = get_motioneye_device_identifier(
         config_entry.entry_id, TEST_CAMERA_ID
     )
-    device_registry = dr.async_get(hass)
 
     device = device_registry.async_get_device(identifiers={device_identifer})
     assert device
 
-    entity_registry = er.async_get(hass)
     entities_from_device = [
         entry.entity_id
         for entry in er.async_entries_for_device(entity_registry, device.id)

--- a/tests/components/motioneye/test_web_hooks.py
+++ b/tests/components/motioneye/test_web_hooks.py
@@ -63,12 +63,13 @@ WEB_HOOK_FILE_STORED_QUERY_STRING = (
 )
 
 
-async def test_setup_camera_without_webhook(hass: HomeAssistant) -> None:
+async def test_setup_camera_without_webhook(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test a camera with no webhook."""
     client = create_mock_motioneye_client()
     config_entry = await setup_mock_motioneye_config_entry(hass, client=client)
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(
         identifiers={TEST_CAMERA_DEVICE_IDENTIFIER}
     )
@@ -95,6 +96,7 @@ async def test_setup_camera_without_webhook(hass: HomeAssistant) -> None:
 
 async def test_setup_camera_with_wrong_webhook(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test camera with wrong web hook."""
     wrong_url = "http://wrong-url"
@@ -123,7 +125,6 @@ async def test_setup_camera_with_wrong_webhook(
         )
         await hass.async_block_till_done()
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(
         identifiers={TEST_CAMERA_DEVICE_IDENTIFIER}
     )
@@ -151,6 +152,7 @@ async def test_setup_camera_with_wrong_webhook(
 
 async def test_setup_camera_with_old_webhook(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Verify that webhooks are overwritten if they are from this integration.
 
@@ -176,7 +178,6 @@ async def test_setup_camera_with_old_webhook(
     )
     assert client.async_set_camera.called
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(
         identifiers={TEST_CAMERA_DEVICE_IDENTIFIER}
     )
@@ -204,6 +205,7 @@ async def test_setup_camera_with_old_webhook(
 
 async def test_setup_camera_with_correct_webhook(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Verify that webhooks are not overwritten if they are already correct."""
 
@@ -212,7 +214,6 @@ async def test_setup_camera_with_correct_webhook(
         hass, data={CONF_URL: TEST_URL, CONF_WEBHOOK_ID: "webhook_secret_id"}
     )
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={TEST_CAMERA_DEVICE_IDENTIFIER},
@@ -278,12 +279,13 @@ async def test_setup_camera_with_no_home_assistant_urls(
 
 
 async def test_good_query(
-    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    hass_client_no_auth: ClientSessionGenerator,
 ) -> None:
     """Test good callbacks."""
     await async_setup_component(hass, "http", {"http": {}})
 
-    device_registry = dr.async_get(hass)
     client = create_mock_motioneye_client()
     config_entry = await setup_mock_motioneye_config_entry(hass, client=client)
 
@@ -377,12 +379,13 @@ async def test_bad_query_cannot_decode(
 
 
 async def test_event_media_data(
-    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    hass_client_no_auth: ClientSessionGenerator,
 ) -> None:
     """Test an event with a file path generates media data."""
     await async_setup_component(hass, "http", {"http": {}})
 
-    device_registry = dr.async_get(hass)
     client = create_mock_motioneye_client()
     config_entry = await setup_mock_motioneye_config_entry(hass, client=client)
 

--- a/tests/components/mqtt/test_device_trigger.py
+++ b/tests/components/mqtt/test_device_trigger.py
@@ -973,11 +973,12 @@ async def test_attach_remove_late2(
 
 
 async def test_entity_device_info_with_connection(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test MQTT device registry integration."""
     await mqtt_mock_entry()
-    registry = dr.async_get(hass)
 
     data = json.dumps(
         {
@@ -998,7 +999,7 @@ async def test_entity_device_info_with_connection(
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device(
+    device = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, "02:5b:26:a8:dc:12")}
     )
     assert device is not None
@@ -1011,11 +1012,12 @@ async def test_entity_device_info_with_connection(
 
 
 async def test_entity_device_info_with_identifier(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test MQTT device registry integration."""
     await mqtt_mock_entry()
-    registry = dr.async_get(hass)
 
     data = json.dumps(
         {
@@ -1036,7 +1038,7 @@ async def test_entity_device_info_with_identifier(
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
+    device = device_registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
     assert device.identifiers == {("mqtt", "helloworld")}
     assert device.manufacturer == "Whatever"
@@ -1047,11 +1049,12 @@ async def test_entity_device_info_with_identifier(
 
 
 async def test_entity_device_info_update(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test device registry update."""
     await mqtt_mock_entry()
-    registry = dr.async_get(hass)
 
     config = {
         "automation_type": "trigger",
@@ -1072,7 +1075,7 @@ async def test_entity_device_info_update(
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
+    device = device_registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
     assert device.name == "Beer"
 
@@ -1081,7 +1084,7 @@ async def test_entity_device_info_update(
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
+    device = device_registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
     assert device.name == "Milk"
 
@@ -1390,14 +1393,15 @@ async def test_cleanup_device_with_entity2(
 
 
 async def test_trigger_debug_info(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test debug_info.
 
     This is a test helper for MQTT debug_info.
     """
     await mqtt_mock_entry()
-    registry = dr.async_get(hass)
 
     config1 = {
         "platform": "mqtt",
@@ -1429,7 +1433,7 @@ async def test_trigger_debug_info(
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla2/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device(
+    device = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, "02:5b:26:a8:dc:12")}
     )
     assert device is not None

--- a/tests/components/mqtt/test_event.py
+++ b/tests/components/mqtt/test_event.py
@@ -500,14 +500,15 @@ async def test_entity_id_update_discovery_update(
 
 
 async def test_entity_device_info_with_hub(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test MQTT event device registry integration."""
     await mqtt_mock_entry()
     other_config_entry = MockConfigEntry()
     other_config_entry.add_to_hass(hass)
-    registry = dr.async_get(hass)
-    hub = registry.async_get_or_create(
+    hub = device_registry.async_get_or_create(
         config_entry_id=other_config_entry.entry_id,
         connections=set(),
         identifiers={("mqtt", "hub-id")},
@@ -527,7 +528,7 @@ async def test_entity_device_info_with_hub(
     async_fire_mqtt_message(hass, "homeassistant/event/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
+    device = device_registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
     assert device.via_device_id == hub.id
 

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -3050,7 +3050,9 @@ async def test_mqtt_ws_get_device_debug_info_binary(
 
 
 async def test_debug_info_multiple_devices(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test we get correct debug_info when multiple devices are present."""
     await mqtt_mock_entry()
@@ -3097,8 +3099,6 @@ async def test_debug_info_multiple_devices(
         },
     ]
 
-    registry = dr.async_get(hass)
-
     for dev in devices:
         data = json.dumps(dev["config"])
         domain = dev["domain"]
@@ -3109,7 +3109,7 @@ async def test_debug_info_multiple_devices(
     for dev in devices:
         domain = dev["domain"]
         id = dev["config"]["device"]["identifiers"][0]
-        device = registry.async_get_device(identifiers={("mqtt", id)})
+        device = device_registry.async_get_device(identifiers={("mqtt", id)})
         assert device is not None
 
         debug_info_data = debug_info.info_for_device(hass, device.id)
@@ -3132,7 +3132,9 @@ async def test_debug_info_multiple_devices(
 
 
 async def test_debug_info_multiple_entities_triggers(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test we get correct debug_info for a device with multiple entities and triggers."""
     await mqtt_mock_entry()
@@ -3179,8 +3181,6 @@ async def test_debug_info_multiple_entities_triggers(
         },
     ]
 
-    registry = dr.async_get(hass)
-
     for c in config:
         data = json.dumps(c["config"])
         domain = c["domain"]
@@ -3190,7 +3190,7 @@ async def test_debug_info_multiple_entities_triggers(
         await hass.async_block_till_done()
 
     device_id = config[0]["config"]["device"]["identifiers"][0]
-    device = registry.async_get_device(identifiers={("mqtt", device_id)})
+    device = device_registry.async_get_device(identifiers={("mqtt", device_id)})
     assert device is not None
     debug_info_data = debug_info.info_for_device(hass, device.id)
     assert len(debug_info_data["entities"]) == 2
@@ -3253,7 +3253,9 @@ async def test_debug_info_non_mqtt(
 
 
 async def test_debug_info_wildcard(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test debug info."""
     await mqtt_mock_entry()
@@ -3264,13 +3266,11 @@ async def test_debug_info_wildcard(
         "unique_id": "veryunique",
     }
 
-    registry = dr.async_get(hass)
-
     data = json.dumps(config)
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
+    device = device_registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
 
     debug_info_data = debug_info.info_for_device(hass, device.id)
@@ -3301,7 +3301,9 @@ async def test_debug_info_wildcard(
 
 
 async def test_debug_info_filter_same(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test debug info removes messages with same timestamp."""
     await mqtt_mock_entry()
@@ -3312,13 +3314,11 @@ async def test_debug_info_filter_same(
         "unique_id": "veryunique",
     }
 
-    registry = dr.async_get(hass)
-
     data = json.dumps(config)
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
+    device = device_registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
 
     debug_info_data = debug_info.info_for_device(hass, device.id)
@@ -3361,7 +3361,9 @@ async def test_debug_info_filter_same(
 
 
 async def test_debug_info_same_topic(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test debug info."""
     await mqtt_mock_entry()
@@ -3373,13 +3375,11 @@ async def test_debug_info_same_topic(
         "unique_id": "veryunique",
     }
 
-    registry = dr.async_get(hass)
-
     data = json.dumps(config)
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
+    device = device_registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
 
     debug_info_data = debug_info.info_for_device(hass, device.id)
@@ -3415,7 +3415,9 @@ async def test_debug_info_same_topic(
 
 
 async def test_debug_info_qos_retain(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test debug info."""
     await mqtt_mock_entry()
@@ -3426,13 +3428,11 @@ async def test_debug_info_qos_retain(
         "unique_id": "veryunique",
     }
 
-    registry = dr.async_get(hass)
-
     data = json.dumps(config)
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
+    device = device_registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
 
     debug_info_data = debug_info.info_for_device(hass, device.id)

--- a/tests/components/mqtt/test_mixins.py
+++ b/tests/components/mqtt/test_mixins.py
@@ -312,6 +312,7 @@ async def test_availability_with_shared_state_topic(
 @patch("homeassistant.components.mqtt.client.DISCOVERY_COOLDOWN", 0.0)
 async def test_default_entity_and_device_name(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mqtt_client_mock: MqttMockPahoClient,
     mqtt_config_entry_data,
     caplog: pytest.LogCaptureFixture,
@@ -336,9 +337,7 @@ async def test_default_entity_and_device_name(
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     await hass.async_block_till_done()
 
-    registry = dr.async_get(hass)
-
-    device = registry.async_get_device({("mqtt", "helloworld")})
+    device = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device is not None
     assert device.name == device_name
 

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -1134,14 +1134,15 @@ async def test_entity_id_update_discovery_update(
 
 
 async def test_entity_device_info_with_hub(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test MQTT sensor device registry integration."""
     await mqtt_mock_entry()
     other_config_entry = MockConfigEntry()
     other_config_entry.add_to_hass(hass)
-    registry = dr.async_get(hass)
-    hub = registry.async_get_or_create(
+    hub = device_registry.async_get_or_create(
         config_entry_id=other_config_entry.entry_id,
         connections=set(),
         identifiers={("mqtt", "hub-id")},
@@ -1160,7 +1161,7 @@ async def test_entity_device_info_with_hub(
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
+    device = device_registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
     assert device.via_device_id == hub.id
 

--- a/tests/components/mqtt/test_tag.py
+++ b/tests/components/mqtt/test_tag.py
@@ -444,11 +444,12 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
 
 
 async def test_entity_device_info_with_connection(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test MQTT device registry integration."""
     await mqtt_mock_entry()
-    registry = dr.async_get(hass)
 
     data = json.dumps(
         {
@@ -466,7 +467,7 @@ async def test_entity_device_info_with_connection(
     async_fire_mqtt_message(hass, "homeassistant/tag/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device(
+    device = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, "02:5b:26:a8:dc:12")}
     )
     assert device is not None
@@ -479,11 +480,12 @@ async def test_entity_device_info_with_connection(
 
 
 async def test_entity_device_info_with_identifier(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test MQTT device registry integration."""
     await mqtt_mock_entry()
-    registry = dr.async_get(hass)
 
     data = json.dumps(
         {
@@ -501,7 +503,7 @@ async def test_entity_device_info_with_identifier(
     async_fire_mqtt_message(hass, "homeassistant/tag/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
+    device = device_registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
     assert device.identifiers == {("mqtt", "helloworld")}
     assert device.manufacturer == "Whatever"
@@ -512,11 +514,12 @@ async def test_entity_device_info_with_identifier(
 
 
 async def test_entity_device_info_update(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test device registry update."""
     await mqtt_mock_entry()
-    registry = dr.async_get(hass)
 
     config = {
         "topic": "test-topic",
@@ -534,7 +537,7 @@ async def test_entity_device_info_update(
     async_fire_mqtt_message(hass, "homeassistant/tag/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
+    device = device_registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
     assert device.name == "Beer"
 
@@ -543,7 +546,7 @@ async def test_entity_device_info_update(
     async_fire_mqtt_message(hass, "homeassistant/tag/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
+    device = device_registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
     assert device.name == "Milk"
 

--- a/tests/components/mqtt_room/test_sensor.py
+++ b/tests/components/mqtt_room/test_sensor.py
@@ -118,7 +118,7 @@ async def test_room_update(hass: HomeAssistant, mqtt_mock: MqttMockHAClient) -> 
 
 
 async def test_unique_id_is_set(
-    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test the updating between rooms."""
     unique_name = "my_unique_name_0123456789"
@@ -141,6 +141,5 @@ async def test_unique_id_is_set(
     state = hass.states.get(SENSOR_STATE)
     assert state.state is not None
 
-    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get(SENSOR_STATE)
     assert entry.unique_id == unique_name

--- a/tests/components/mysensors/test_init.py
+++ b/tests/components/mysensors/test_init.py
@@ -15,6 +15,8 @@ from tests.typing import WebSocketGenerator
 
 async def test_remove_config_entry_device(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     gps_sensor: Sensor,
     integration: MockConfigEntry,
     gateway: BaseSyncGateway,
@@ -27,11 +29,9 @@ async def test_remove_config_entry_device(
     assert await async_setup_component(hass, "config", {})
     await hass.async_block_till_done()
 
-    device_registry = dr.async_get(hass)
     device_entry = device_registry.async_get_device(
         identifiers={(DOMAIN, f"{config_entry.entry_id}-{node_id}")}
     )
-    entity_registry = er.async_get(hass)
     state = hass.states.get(entity_id)
 
     assert gateway.sensors

--- a/tests/components/nam/test_button.py
+++ b/tests/components/nam/test_button.py
@@ -10,10 +10,8 @@ from homeassistant.util import dt as dt_util
 from . import init_integration
 
 
-async def test_button(hass: HomeAssistant) -> None:
+async def test_button(hass: HomeAssistant, entity_registry: er.EntityRegistry) -> None:
     """Test states of the button."""
-    registry = er.async_get(hass)
-
     await init_integration(hass)
 
     state = hass.states.get("button.nettigo_air_monitor_restart")
@@ -21,7 +19,7 @@ async def test_button(hass: HomeAssistant) -> None:
     assert state.state == STATE_UNKNOWN
     assert state.attributes.get(ATTR_DEVICE_CLASS) == ButtonDeviceClass.RESTART
 
-    entry = registry.async_get("button.nettigo_air_monitor_restart")
+    entry = entity_registry.async_get("button.nettigo_air_monitor_restart")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-restart"
 

--- a/tests/components/nam/test_init.py
+++ b/tests/components/nam/test_init.py
@@ -93,11 +93,11 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
     assert not hass.data.get(DOMAIN)
 
 
-async def test_remove_air_quality_entities(hass: HomeAssistant) -> None:
+async def test_remove_air_quality_entities(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test remove air_quality entities from registry."""
-    registry = er.async_get(hass)
-
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         AIR_QUALITY_PLATFORM,
         DOMAIN,
         "aa:bb:cc:dd:ee:ff-sds011",
@@ -105,7 +105,7 @@ async def test_remove_air_quality_entities(hass: HomeAssistant) -> None:
         disabled_by=None,
     )
 
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         AIR_QUALITY_PLATFORM,
         DOMAIN,
         "aa:bb:cc:dd:ee:ff-sps30",
@@ -115,8 +115,8 @@ async def test_remove_air_quality_entities(hass: HomeAssistant) -> None:
 
     await init_integration(hass)
 
-    entry = registry.async_get("air_quality.nettigo_air_monitor_sds011")
+    entry = entity_registry.async_get("air_quality.nettigo_air_monitor_sds011")
     assert entry is None
 
-    entry = registry.async_get("air_quality.nettigo_air_monitor_sps30")
+    entry = entity_registry.async_get("air_quality.nettigo_air_monitor_sps30")
     assert entry is None

--- a/tests/components/nam/test_sensor.py
+++ b/tests/components/nam/test_sensor.py
@@ -35,11 +35,9 @@ from . import INCOMPLETE_NAM_DATA, init_integration, nam_data
 from tests.common import async_fire_time_changed
 
 
-async def test_sensor(hass: HomeAssistant) -> None:
+async def test_sensor(hass: HomeAssistant, entity_registry: er.EntityRegistry) -> None:
     """Test states of the air_quality."""
-    registry = er.async_get(hass)
-
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         SENSOR_DOMAIN,
         DOMAIN,
         "aa:bb:cc:dd:ee:ff-signal",
@@ -47,7 +45,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         disabled_by=None,
     )
 
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         SENSOR_DOMAIN,
         DOMAIN,
         "aa:bb:cc:dd:ee:ff-uptime",
@@ -67,7 +65,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_bme280_humidity")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_bme280_humidity")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-bme280_humidity"
 
@@ -78,7 +76,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfTemperature.CELSIUS
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_bme280_temperature")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_bme280_temperature")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-bme280_temperature"
 
@@ -89,7 +87,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPressure.HPA
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_bme280_pressure")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_bme280_pressure")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-bme280_pressure"
 
@@ -100,7 +98,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfTemperature.CELSIUS
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_bmp180_temperature")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_bmp180_temperature")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-bmp180_temperature"
 
@@ -111,7 +109,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPressure.HPA
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_bmp180_pressure")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_bmp180_pressure")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-bmp180_pressure"
 
@@ -122,7 +120,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfTemperature.CELSIUS
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_bmp280_temperature")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_bmp280_temperature")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-bmp280_temperature"
 
@@ -133,7 +131,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPressure.HPA
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_bmp280_pressure")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_bmp280_pressure")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-bmp280_pressure"
 
@@ -144,7 +142,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_sht3x_humidity")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_sht3x_humidity")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-sht3x_humidity"
 
@@ -155,7 +153,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfTemperature.CELSIUS
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_sht3x_temperature")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_sht3x_temperature")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-sht3x_temperature"
 
@@ -166,7 +164,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_dht22_humidity")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_dht22_humidity")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-dht22_humidity"
 
@@ -177,7 +175,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfTemperature.CELSIUS
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_dht22_temperature")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_dht22_temperature")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-dht22_temperature"
 
@@ -188,7 +186,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_heca_humidity")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_heca_humidity")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-heca_humidity"
 
@@ -199,7 +197,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfTemperature.CELSIUS
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_heca_temperature")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_heca_temperature")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-heca_temperature"
 
@@ -213,7 +211,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == SIGNAL_STRENGTH_DECIBELS_MILLIWATT
     )
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_signal_strength")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_signal_strength")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-signal"
 
@@ -226,7 +224,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TIMESTAMP
     assert state.attributes.get(ATTR_STATE_CLASS) is None
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_uptime")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_uptime")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-uptime"
 
@@ -245,7 +243,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     ]
     assert state.attributes.get(ATTR_ICON) == "mdi:air-filter"
 
-    entry = registry.async_get(
+    entry = entity_registry.async_get(
         "sensor.nettigo_air_monitor_pmsx003_common_air_quality_index_level"
     )
     assert entry
@@ -259,7 +257,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state.state == "19"
     assert state.attributes.get(ATTR_ICON) == "mdi:air-filter"
 
-    entry = registry.async_get(
+    entry = entity_registry.async_get(
         "sensor.nettigo_air_monitor_pmsx003_common_air_quality_index"
     )
     assert entry
@@ -275,7 +273,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_pmsx003_pm10")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_pmsx003_pm10")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-pms_p1"
 
@@ -289,7 +287,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_pmsx003_pm2_5")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_pmsx003_pm2_5")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-pms_p2"
 
@@ -303,7 +301,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_pmsx003_pm1")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_pmsx003_pm1")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-pms_p0"
 
@@ -317,7 +315,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_sds011_pm10")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_sds011_pm10")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-sds011_p1"
 
@@ -328,7 +326,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state.state == "19"
     assert state.attributes.get(ATTR_ICON) == "mdi:air-filter"
 
-    entry = registry.async_get(
+    entry = entity_registry.async_get(
         "sensor.nettigo_air_monitor_sds011_common_air_quality_index"
     )
     assert entry
@@ -349,7 +347,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     ]
     assert state.attributes.get(ATTR_ICON) == "mdi:air-filter"
 
-    entry = registry.async_get(
+    entry = entity_registry.async_get(
         "sensor.nettigo_air_monitor_sds011_common_air_quality_index_level"
     )
     assert entry
@@ -366,7 +364,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_sds011_pm2_5")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_sds011_pm2_5")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-sds011_p2"
 
@@ -375,7 +373,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state.state == "54"
     assert state.attributes.get(ATTR_ICON) == "mdi:air-filter"
 
-    entry = registry.async_get(
+    entry = entity_registry.async_get(
         "sensor.nettigo_air_monitor_sps30_common_air_quality_index"
     )
     assert entry
@@ -396,7 +394,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     ]
     assert state.attributes.get(ATTR_ICON) == "mdi:air-filter"
 
-    entry = registry.async_get(
+    entry = entity_registry.async_get(
         "sensor.nettigo_air_monitor_sps30_common_air_quality_index_level"
     )
     assert entry
@@ -413,7 +411,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_sps30_pm1")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_sps30_pm1")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-sps30_p0"
 
@@ -427,7 +425,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_sps30_pm10")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_sps30_pm10")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-sps30_p1"
 
@@ -441,7 +439,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_sps30_pm2_5")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_sps30_pm2_5")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-sps30_p2"
 
@@ -455,7 +453,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     )
     assert state.attributes.get(ATTR_ICON) == "mdi:molecule"
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_sps30_pm4")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_sps30_pm4")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-sps30_p4"
 
@@ -468,24 +466,27 @@ async def test_sensor(hass: HomeAssistant) -> None:
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_PARTS_PER_MILLION
     )
-    entry = registry.async_get("sensor.nettigo_air_monitor_mh_z14a_carbon_dioxide")
+    entry = entity_registry.async_get(
+        "sensor.nettigo_air_monitor_mh_z14a_carbon_dioxide"
+    )
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-mhz14a_carbon_dioxide"
 
 
-async def test_sensor_disabled(hass: HomeAssistant) -> None:
+async def test_sensor_disabled(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test sensor disabled by default."""
     await init_integration(hass)
-    registry = er.async_get(hass)
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_signal_strength")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_signal_strength")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-signal"
     assert entry.disabled
     assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
     # Test enabling entity
-    updated_entry = registry.async_update_entity(
+    updated_entry = entity_registry.async_update_entity(
         entry.entity_id, **{"disabled_by": None}
     )
 
@@ -574,11 +575,11 @@ async def test_manual_update_entity(hass: HomeAssistant) -> None:
     assert mock_get_data.call_count == 1
 
 
-async def test_unique_id_migration(hass: HomeAssistant) -> None:
+async def test_unique_id_migration(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test states of the unique_id migration."""
-    registry = er.async_get(hass)
-
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         SENSOR_DOMAIN,
         DOMAIN,
         "aa:bb:cc:dd:ee:ff-temperature",
@@ -586,7 +587,7 @@ async def test_unique_id_migration(hass: HomeAssistant) -> None:
         disabled_by=None,
     )
 
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         SENSOR_DOMAIN,
         DOMAIN,
         "aa:bb:cc:dd:ee:ff-humidity",
@@ -596,10 +597,10 @@ async def test_unique_id_migration(hass: HomeAssistant) -> None:
 
     await init_integration(hass)
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_dht22_temperature")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_dht22_temperature")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-dht22_temperature"
 
-    entry = registry.async_get("sensor.nettigo_air_monitor_dht22_humidity")
+    entry = entity_registry.async_get("sensor.nettigo_air_monitor_dht22_humidity")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-dht22_humidity"


### PR DESCRIPTION
## Proposed change
Update the component tests starting with `m` to use the entity & device registry fixtures

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
