### PR TITLE
Enable the use of non-encrypted token in Nuki

### DIFF
--- a/homeassistant/components/nuki/__init__.py
+++ b/homeassistant/components/nuki/__init__.py
@@ -39,7 +39,7 @@ from homeassistant.helpers.update_coordinator import (
     UpdateFailed,
 )
 
-from .const import DEFAULT_TIMEOUT, DOMAIN, ERROR_STATES
+from .const import CONF_ENCRYPT_TOKEN, DEFAULT_TIMEOUT, DOMAIN, ERROR_STATES
 from .helpers import NukiWebhookException, parse_id
 
 _NukiDeviceT = TypeVar("_NukiDeviceT", bound=NukiDevice)
@@ -188,7 +188,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry.data[CONF_HOST],
             entry.data[CONF_TOKEN],
             entry.data[CONF_PORT],
-            True,
+            entry.data[CONF_ENCRYPT_TOKEN],
             DEFAULT_TIMEOUT,
         )
 

--- a/homeassistant/components/nuki/__init__.py
+++ b/homeassistant/components/nuki/__init__.py
@@ -188,7 +188,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry.data[CONF_HOST],
             entry.data[CONF_TOKEN],
             entry.data[CONF_PORT],
-            entry.data[CONF_ENCRYPT_TOKEN],
+            entry.data.get(CONF_ENCRYPT_TOKEN, True),
             DEFAULT_TIMEOUT,
         )
 

--- a/homeassistant/components/nuki/config_flow.py
+++ b/homeassistant/components/nuki/config_flow.py
@@ -141,19 +141,9 @@ class NukiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         errors = {}
         if user_input is not None:
-            data_schema = vol.Schema(
+            data_schema = USER_SCHEMA.extend(
                 {
-                    vol.Required(CONF_HOST, default=user_input.get(CONF_HOST, "")): str,
-                    vol.Optional(
-                        CONF_PORT, default=user_input.get(CONF_PORT, DEFAULT_PORT)
-                    ): vol.Coerce(int),
-                    vol.Required(
-                        CONF_TOKEN, default=user_input.get(CONF_TOKEN, "")
-                    ): str,
-                    vol.Optional(
-                        CONF_ENCRYPT_TOKEN,
-                        default=user_input.get(CONF_ENCRYPT_TOKEN, True),
-                    ): bool,
+                    vol.Optional(CONF_ENCRYPT_TOKEN, default=True): bool,
                 }
             )
             try:
@@ -173,5 +163,7 @@ class NukiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(title=bridge_id, data=user_input)
 
         return self.async_show_form(
-            step_id="user", data_schema=data_schema, errors=errors
+            step_id="user",
+            data_schema=self.add_suggested_values_to_schema(data_schema, user_input),
+            errors=errors,
         )

--- a/homeassistant/components/nuki/config_flow.py
+++ b/homeassistant/components/nuki/config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.components import dhcp
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TOKEN
 from homeassistant.data_entry_flow import FlowResult
 
-from .const import DEFAULT_PORT, DEFAULT_TIMEOUT, DOMAIN
+from .const import CONF_ENCRYPT_TOKEN, DEFAULT_PORT, DEFAULT_TIMEOUT, DOMAIN
 from .helpers import CannotConnect, InvalidAuth, parse_id
 
 _LOGGER = logging.getLogger(__name__)
@@ -23,10 +23,16 @@ USER_SCHEMA = vol.Schema(
         vol.Required(CONF_HOST): str,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): vol.Coerce(int),
         vol.Required(CONF_TOKEN): str,
+        vol.Optional(CONF_ENCRYPT_TOKEN, default=True): bool,
     }
 )
 
-REAUTH_SCHEMA = vol.Schema({vol.Required(CONF_TOKEN): str})
+REAUTH_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_TOKEN): str,
+        vol.Optional(CONF_ENCRYPT_TOKEN, default=True): bool,
+    }
+)
 
 
 async def validate_input(hass, data):
@@ -41,7 +47,7 @@ async def validate_input(hass, data):
             data[CONF_HOST],
             data[CONF_TOKEN],
             data[CONF_PORT],
-            True,
+            data[CONF_ENCRYPT_TOKEN],
             DEFAULT_TIMEOUT,
         )
 
@@ -77,6 +83,7 @@ class NukiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required(CONF_HOST, default=discovery_info.ip): str,
                 vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
                 vol.Required(CONF_TOKEN): str,
+                vol.Required(CONF_ENCRYPT_TOKEN, default=True): bool,
             }
         )
 
@@ -100,6 +107,7 @@ class NukiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             CONF_HOST: self._data[CONF_HOST],
             CONF_PORT: self._data[CONF_PORT],
             CONF_TOKEN: user_input[CONF_TOKEN],
+            CONF_ENCRYPT_TOKEN: user_input[CONF_ENCRYPT_TOKEN],
         }
 
         try:

--- a/homeassistant/components/nuki/const.py
+++ b/homeassistant/components/nuki/const.py
@@ -12,3 +12,6 @@ DEFAULT_PORT = 8080
 DEFAULT_TIMEOUT = 20
 
 ERROR_STATES = (0, 254, 255)
+
+# Encrypt token, instead of using a plaintext token
+CONF_ENCRYPT_TOKEN = "encrypt_token"

--- a/homeassistant/components/nuki/strings.json
+++ b/homeassistant/components/nuki/strings.json
@@ -5,7 +5,8 @@
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]",
-          "token": "[%key:common::config_flow::data::access_token%]"
+          "token": "[%key:common::config_flow::data::access_token%]",
+          "encrypt_token": "Use a secure connection to the Bridge."
         }
       },
       "reauth_confirm": {

--- a/homeassistant/components/nuki/strings.json
+++ b/homeassistant/components/nuki/strings.json
@@ -6,14 +6,15 @@
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]",
           "token": "[%key:common::config_flow::data::access_token%]",
-          "encrypt_token": "Use a secure connection to the Bridge."
+          "encrypt_token": "Use an encrypted token for authentication."
         }
       },
       "reauth_confirm": {
         "title": "[%key:common::config_flow::title::reauth%]",
         "description": "The Nuki integration needs to re-authenticate with your bridge.",
         "data": {
-          "token": "[%key:common::config_flow::data::access_token%]"
+          "token": "[%key:common::config_flow::data::access_token%]",
+          "encrypt_token": "Use an encrypted token for authentication."
         }
       }
     },

--- a/homeassistant/components/nuki/strings.json
+++ b/homeassistant/components/nuki/strings.json
@@ -14,7 +14,7 @@
         "description": "The Nuki integration needs to re-authenticate with your bridge.",
         "data": {
           "token": "[%key:common::config_flow::data::access_token%]",
-          "encrypt_token": "Use an encrypted token for authentication."
+          "encrypt_token": "[%key:component::nuki::config::step::user::data::encrypt_token%]"
         }
       }
     },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As there are more and more reports of people, who cannot connect their Nuki to Home Assistant anymore due to the hw clock on the Bridge is out-of-sync from the Home Assistant clock.
Reason behind that is, that the encrypted tokens use the current timestamp to encrypt the token, making it unusable if the clocks are out-of-sync.
As there is no way to obtain a timestamp from the Nuki Bridge without the use of a plain text token I've configured an option to disable the token encryption, so that the callback can be configured without the use of a timestamp.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #101544 fixes #93230 
- This PR is related to issue: #96442 #93996
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29847

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
