### PR TITLE
Don't check SSL certificate retrieving webos image

### DIFF
--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -8,7 +8,6 @@ from datetime import timedelta
 from functools import wraps
 from http import HTTPStatus
 import logging
-import ssl
 from typing import Any, Concatenate, ParamSpec, TypeVar, cast
 
 from aiowebostv import WebOsClient, WebOsTvPairError
@@ -473,14 +472,11 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
         SSLContext to bypass validation errors if url starts with https.
         """
         content = None
-        ssl_context = None
-        if url.startswith("https"):
-            ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)
 
         websession = async_get_clientsession(self.hass)
         with suppress(asyncio.TimeoutError):
             async with asyncio.timeout(10):
-                response = await websession.get(url, ssl=ssl_context)
+                response = await websession.get(url, ssl=False)
                 if response.status == HTTPStatus.OK:
                     content = await response.read()
 


### PR DESCRIPTION
I didn't test this in HA, but I did test this in a Python REPL, manually querying my TV. The old method for ignoring SSL certificate validation doesn't work at all. This method does and is supported by the aiohttp documentation.

https://docs.aiohttp.org/en/stable/client_reference.html

Fixes #102109

## Proposed change
Fix #102109, restoring intended behavior. The webserver on LG TVs uses an invalid self-signed certificate.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #102109

## Checklist
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.