### PR TITLE
Fix emulated_hue with None values

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -676,19 +676,20 @@ def get_entity_state_dict(config: Config, entity: State) -> dict[str, Any]:
 @lru_cache(maxsize=512)
 def _build_entity_state_dict(entity: State) -> dict[str, Any]:
     """Build a state dict for an entity."""
+    is_on = entity.state != STATE_OFF
     data: dict[str, Any] = {
-        STATE_ON: entity.state != STATE_OFF,
+        STATE_ON: is_on,
         STATE_BRIGHTNESS: None,
         STATE_HUE: None,
         STATE_SATURATION: None,
         STATE_COLOR_TEMP: None,
     }
-    if data[STATE_ON]:
+    attributes = entity.attributes
+    if is_on:
         data[STATE_BRIGHTNESS] = hass_to_hue_brightness(
-            entity.attributes.get(ATTR_BRIGHTNESS, 0)
+            attributes.get(ATTR_BRIGHTNESS) or 0
         )
-        hue_sat = entity.attributes.get(ATTR_HS_COLOR)
-        if hue_sat is not None:
+        if (hue_sat := attributes.get(ATTR_HS_COLOR)) is not None:
             hue = hue_sat[0]
             sat = hue_sat[1]
             # Convert hass hs values back to hue hs values
@@ -697,7 +698,7 @@ def _build_entity_state_dict(entity: State) -> dict[str, Any]:
         else:
             data[STATE_HUE] = HUE_API_STATE_HUE_MIN
             data[STATE_SATURATION] = HUE_API_STATE_SAT_MIN
-        data[STATE_COLOR_TEMP] = entity.attributes.get(ATTR_COLOR_TEMP, 0)
+        data[STATE_COLOR_TEMP] = attributes.get(ATTR_COLOR_TEMP) or 0
 
     else:
         data[STATE_BRIGHTNESS] = 0
@@ -706,25 +707,23 @@ def _build_entity_state_dict(entity: State) -> dict[str, Any]:
         data[STATE_COLOR_TEMP] = 0
 
     if entity.domain == climate.DOMAIN:
-        temperature = entity.attributes.get(ATTR_TEMPERATURE, 0)
+        temperature = attributes.get(ATTR_TEMPERATURE, 0)
         # Convert 0-100 to 0-254
         data[STATE_BRIGHTNESS] = round(temperature * HUE_API_STATE_BRI_MAX / 100)
     elif entity.domain == humidifier.DOMAIN:
-        humidity = entity.attributes.get(ATTR_HUMIDITY, 0)
+        humidity = attributes.get(ATTR_HUMIDITY, 0)
         # Convert 0-100 to 0-254
         data[STATE_BRIGHTNESS] = round(humidity * HUE_API_STATE_BRI_MAX / 100)
     elif entity.domain == media_player.DOMAIN:
-        level = entity.attributes.get(
-            ATTR_MEDIA_VOLUME_LEVEL, 1.0 if data[STATE_ON] else 0.0
-        )
+        level = attributes.get(ATTR_MEDIA_VOLUME_LEVEL, 1.0 if is_on else 0.0)
         # Convert 0.0-1.0 to 0-254
         data[STATE_BRIGHTNESS] = round(min(1.0, level) * HUE_API_STATE_BRI_MAX)
     elif entity.domain == fan.DOMAIN:
-        percentage = entity.attributes.get(ATTR_PERCENTAGE) or 0
+        percentage = attributes.get(ATTR_PERCENTAGE) or 0
         # Convert 0-100 to 0-254
         data[STATE_BRIGHTNESS] = round(percentage * HUE_API_STATE_BRI_MAX / 100)
     elif entity.domain == cover.DOMAIN:
-        level = entity.attributes.get(ATTR_CURRENT_POSITION, 0)
+        level = attributes.get(ATTR_CURRENT_POSITION, 0)
         data[STATE_BRIGHTNESS] = round(level / 100 * HUE_API_STATE_BRI_MAX)
     _clamp_values(data)
     return data

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -1694,3 +1694,34 @@ async def test_specificly_exposed_entities(
     result_json = await async_get_lights(client)
 
     assert "1" in result_json
+
+
+async def test_get_light_state_when_none(hass_hue: HomeAssistant, hue_client) -> None:
+    """Test the getting of light state when brightness is None."""
+    hass_hue.states.async_set(
+        "light.ceiling_lights",
+        STATE_ON,
+        {
+            light.ATTR_BRIGHTNESS: None,
+            light.ATTR_RGB_COLOR: None,
+            light.ATTR_HS_COLOR: None,
+            light.ATTR_COLOR_TEMP: None,
+            light.ATTR_XY_COLOR: None,
+            light.ATTR_SUPPORTED_COLOR_MODES: [
+                light.COLOR_MODE_COLOR_TEMP,
+                light.COLOR_MODE_HS,
+                light.COLOR_MODE_XY,
+            ],
+            light.ATTR_COLOR_MODE: light.COLOR_MODE_XY,
+        },
+    )
+
+    light_json = await perform_get_light_state(
+        hue_client, "light.ceiling_lights", HTTPStatus.OK
+    )
+    state = light_json["state"]
+    assert state[HUE_API_STATE_ON] is True
+    assert state[HUE_API_STATE_BRI] == 1
+    assert state[HUE_API_STATE_HUE] == 0
+    assert state[HUE_API_STATE_SAT] == 0
+    assert state[HUE_API_STATE_CT] == 153

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -1725,3 +1725,31 @@ async def test_get_light_state_when_none(hass_hue: HomeAssistant, hue_client) ->
     assert state[HUE_API_STATE_HUE] == 0
     assert state[HUE_API_STATE_SAT] == 0
     assert state[HUE_API_STATE_CT] == 153
+
+    hass_hue.states.async_set(
+        "light.ceiling_lights",
+        STATE_OFF,
+        {
+            light.ATTR_BRIGHTNESS: None,
+            light.ATTR_RGB_COLOR: None,
+            light.ATTR_HS_COLOR: None,
+            light.ATTR_COLOR_TEMP: None,
+            light.ATTR_XY_COLOR: None,
+            light.ATTR_SUPPORTED_COLOR_MODES: [
+                light.COLOR_MODE_COLOR_TEMP,
+                light.COLOR_MODE_HS,
+                light.COLOR_MODE_XY,
+            ],
+            light.ATTR_COLOR_MODE: light.COLOR_MODE_XY,
+        },
+    )
+
+    light_json = await perform_get_light_state(
+        hue_client, "light.ceiling_lights", HTTPStatus.OK
+    )
+    state = light_json["state"]
+    assert state[HUE_API_STATE_ON] is False
+    assert state[HUE_API_STATE_BRI] == 1
+    assert state[HUE_API_STATE_HUE] == 0
+    assert state[HUE_API_STATE_SAT] == 0
+    assert state[HUE_API_STATE_CT] == 153


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
regressed from #101946

fixes #104013
likely fixes #103538 (but nobody in that issue provided logs)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
