### PR TITLE
Bump ring_doorbell to 0.8.2 with listen extra

### DIFF
--- a/homeassistant/components/ring/manifest.json
+++ b/homeassistant/components/ring/manifest.json
@@ -13,5 +13,5 @@
   "documentation": "https://www.home-assistant.io/integrations/ring",
   "iot_class": "cloud_polling",
   "loggers": ["ring_doorbell"],
-  "requirements": ["ring-doorbell==0.8.0"]
+  "requirements": ["ring-doorbell[listen]==0.8.2"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2351,7 +2351,7 @@ rfk101py==0.0.1
 rflink==0.0.65
 
 # homeassistant.components.ring
-ring-doorbell==0.8.0
+ring-doorbell[listen]==0.8.2
 
 # homeassistant.components.fleetgo
 ritassist==0.9.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1757,7 +1757,7 @@ reolink-aio==0.8.1
 rflink==0.0.65
 
 # homeassistant.components.ring
-ring-doorbell==0.8.0
+ring-doorbell[listen]==0.8.2
 
 # homeassistant.components.roku
 rokuecp==0.18.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This library bump to 0.8.2 will fix reported issues with unsupported device types which are now supported.

The [listen] extra is a pre-requisite to fix issues with users not receiving some or all of their motion or doorbell alerts: https://github.com/home-assistant/core/issues/88705, https://github.com/home-assistant/core/issues/81124 and https://github.com/home-assistant/core/issues/66960.  A subsequent PR will contain the ring integration changes to activate new logic in the ring_doorbell library.  By itself the [listen] extra will have no effect.

The [listen] extra installs a new package _firebase-messaging_ which depends on 4 packages that are already HA depencies: _cryptography_, _requests_, _protobuf_ and _http-ece_ (_http-ece_ via the _pywebpush_ dependency in html5 integration).

The only other changes between 0.8.0 and 0.8.2 of the ring_doorbell library are to wrap a couple more exceptions coming from the ring_doorbell library in the custom RingError exception.  The ring integration already catches and handles this custom exception.

https://github.com/tchellomello/python-ring-doorbell/releases/tag/0.8.1
https://github.com/tchellomello/python-ring-doorbell/releases/tag/0.8.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- The primary cause of the alert issues being reported is that the active ring alerts data received from the polling ring api call does not return all active alerts (likely since the start of 2022 when users first started reporting the issue).  
- The call to this api endpoint is also prone to errors due to the frequency with which it is called (currently every 5 seconds).  Possibly this is due to ring imposing rate limiting.   It can also exhaust the connection pool under certain error conditions.

The solution is to switch from polling the api to connecting via firebase cloud messaging to receive realtime push notifications.  This is how the official ring apps receive their alerts, and also how other 3rd party ring libraries such as ring-mqqt receive their alerts.

Installing the extra [listen] will install the package _firebase-messaging_ which is used for connecting to the firebase cloud messaging platform and receiving push notifications.  A subsequent PR will then start the ring_doorbell listener in the ring integration and configure the ring binary sensor platform to receive the notifications.

- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/104402
- This PR is related to issue:  https://github.com/home-assistant/core/issues/88705, https://github.com/home-assistant/core/issues/81124 and https://github.com/home-assistant/core/issues/66960
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
