### PR TITLE
Refactor config.async_log_exception

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -292,7 +292,7 @@ async def async_from_config_dict(
     try:
         await conf_util.async_process_ha_core_config(hass, core_config)
     except vol.Invalid as config_err:
-        conf_util.async_log_exception(config_err, "homeassistant", core_config, hass)
+        conf_util.async_log_schema_error(config_err, "homeassistant", core_config, hass)
         return None
     except HomeAssistantError:
         _LOGGER.error(

--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 from homeassistant import util
 from homeassistant.backports.functools import cached_property
 from homeassistant.components import zone
-from homeassistant.config import async_log_exception, load_yaml_config_file
+from homeassistant.config import async_log_schema_error, load_yaml_config_file
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_GPS_ACCURACY,
@@ -1006,7 +1006,7 @@ async def async_load_config(
             device = dev_schema(device)
             device["dev_id"] = cv.slugify(dev_id)
         except vol.Invalid as exp:
-            async_log_exception(exp, dev_id, devices, hass)
+            async_log_schema_error(exp, dev_id, devices, hass)
         else:
             result.append(Device(hass, **device))
     return result

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -248,7 +248,7 @@ async def async_check_config_schema(
                 except vol.Invalid as ex:
                     integration = await async_get_integration(hass, DOMAIN)
                     # pylint: disable-next=protected-access
-                    message = conf_util._format_schema_error(
+                    message = conf_util.format_schema_error(
                         ex, domain, config, integration.documentation
                     )
                     raise ServiceValidationError(

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -248,7 +248,7 @@ async def async_check_config_schema(
                 except vol.Invalid as ex:
                     integration = await async_get_integration(hass, DOMAIN)
                     # pylint: disable-next=protected-access
-                    message, _ = conf_util._format_config_error(
+                    message = conf_util._format_schema_error(
                         ex, domain, config, integration.documentation
                     )
                     raise ServiceValidationError(

--- a/homeassistant/components/template/config.py
+++ b/homeassistant/components/template/config.py
@@ -10,7 +10,7 @@ from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
 from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.weather import DOMAIN as WEATHER_DOMAIN
-from homeassistant.config import async_log_exception, config_without_domain
+from homeassistant.config import async_log_schema_error, config_without_domain
 from homeassistant.const import CONF_BINARY_SENSORS, CONF_SENSORS, CONF_UNIQUE_ID
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.trigger import async_validate_trigger_config
@@ -80,7 +80,7 @@ async def async_validate_config(hass, config):
                     hass, cfg[CONF_TRIGGER]
                 )
         except vol.Invalid as err:
-            async_log_exception(err, DOMAIN, cfg, hass)
+            async_log_schema_error(err, DOMAIN, cfg, hass)
             continue
 
         legacy_warn_printed = False

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -500,7 +500,7 @@ def async_log_schema_error(
     """Log a schema validation error."""
     if hass is not None:
         async_notify_setup_error(hass, domain, link)
-    message = _format_schema_error(ex, domain, config, link)
+    message = format_schema_error(ex, domain, config, link)
     _LOGGER.error(message)
 
 
@@ -519,7 +519,7 @@ def async_log_config_validator_error(
 
     if hass is not None:
         async_notify_setup_error(hass, domain, link)
-    message = _format_homeassistant_error(ex, domain, config, link)
+    message = format_homeassistant_error(ex, domain, config, link)
     _LOGGER.error(message, exc_info=ex)
 
 
@@ -671,7 +671,7 @@ def humanize_error(
 
 
 @callback
-def _format_homeassistant_error(
+def format_homeassistant_error(
     ex: HomeAssistantError, domain: str, config: dict, link: str | None = None
 ) -> str:
     """Format HomeAssistantError thrown by a custom config validator."""
@@ -684,7 +684,7 @@ def _format_homeassistant_error(
 
 
 @callback
-def _format_schema_error(
+def format_schema_error(
     ex: vol.Invalid, domain: str, config: dict, link: str | None = None
 ) -> str:
     """Format configuration validation error."""

--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -15,10 +15,10 @@ from homeassistant.config import (  # type: ignore[attr-defined]
     CONF_PACKAGES,
     CORE_CONFIG_SCHEMA,
     YAML_CONFIG_FILE,
-    _format_homeassistant_error,
-    _format_schema_error,
     config_per_platform,
     extract_domain_configs,
+    format_homeassistant_error,
+    format_schema_error,
     load_yaml_config_file,
     merge_packages_config,
 )
@@ -106,9 +106,9 @@ async def async_check_ha_config_file(  # noqa: C901
     ) -> None:
         """Handle errors from components."""
         if isinstance(ex, vol.Invalid):
-            message = _format_schema_error(ex, domain, component_config)
+            message = format_schema_error(ex, domain, component_config)
         else:
-            message = _format_homeassistant_error(ex, domain, component_config)
+            message = format_homeassistant_error(ex, domain, component_config)
         if domain in frontend_dependencies:
             result.add_error(message, domain, component_config)
         else:
@@ -155,7 +155,7 @@ async def async_check_ha_config_file(  # noqa: C901
         result[CONF_CORE] = core_config
     except vol.Invalid as err:
         result.add_error(
-            _format_schema_error(err, CONF_CORE, core_config), CONF_CORE, core_config
+            format_schema_error(err, CONF_CORE, core_config), CONF_CORE, core_config
         )
         core_config = {}
 

--- a/tests/snapshots/test_config.ambr
+++ b/tests/snapshots/test_config.ambr
@@ -305,6 +305,9 @@
       Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 44: 'no_such_option' is an invalid option for [adr_0007_5], check: adr_0007_5->no_such_option. Please check the docs at https://www.home-assistant.io/integrations/adr_0007_5
       Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 45: expected int for dictionary value 'adr_0007_5->port', got 'foo'. Please check the docs at https://www.home-assistant.io/integrations/adr_0007_5.
     ''',
+    "Invalid config for [custom_validator_ok_2] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 52: required key 'host' not provided. Please check the docs at https://www.home-assistant.io/integrations/custom_validator_ok_2.",
+    'Invalid config for [custom_validator_bad_1]: broken Please check the docs at https://www.home-assistant.io/integrations/custom_validator_bad_1.',
+    'Unknown error calling custom_validator_bad_2 config validator',
   ])
 # ---
 # name: test_package_merge_error[packages]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -295,6 +295,75 @@ async def mock_custom_validator_integrations(hass: HomeAssistant) -> list[Integr
         )
 
 
+@pytest.fixture
+async def mock_custom_validator_integrations_with_docs(
+    hass: HomeAssistant,
+) -> list[Integration]:
+    """Mock integrations with custom validator."""
+    integrations = []
+
+    for domain in ("custom_validator_ok_1", "custom_validator_ok_2"):
+
+        def gen_async_validate_config(domain):
+            schema = vol.Schema(
+                {
+                    domain: vol.Schema(
+                        {
+                            vol.Required("host"): str,
+                            vol.Optional("port", default=8080): int,
+                        }
+                    )
+                },
+                extra=vol.ALLOW_EXTRA,
+            )
+
+            async def async_validate_config(
+                hass: HomeAssistant, config: ConfigType
+            ) -> ConfigType:
+                """Validate config."""
+                return schema(config)
+
+            return async_validate_config
+
+        integrations.append(
+            mock_integration(
+                hass,
+                MockModule(
+                    domain,
+                    partial_manifest={
+                        "documentation": f"https://www.home-assistant.io/integrations/{domain}"
+                    },
+                ),
+            )
+        )
+        mock_platform(
+            hass,
+            f"{domain}.config",
+            Mock(async_validate_config=gen_async_validate_config(domain)),
+        )
+
+    for domain, exception in [
+        ("custom_validator_bad_1", HomeAssistantError("broken")),
+        ("custom_validator_bad_2", ValueError("broken")),
+    ]:
+        integrations.append(
+            mock_integration(
+                hass,
+                MockModule(
+                    domain,
+                    partial_manifest={
+                        "documentation": f"https://www.home-assistant.io/integrations/{domain}"
+                    },
+                ),
+            )
+        )
+        mock_platform(
+            hass,
+            f"{domain}.config",
+            Mock(async_validate_config=AsyncMock(side_effect=exception)),
+        )
+
+
 async def test_create_default_config(hass: HomeAssistant) -> None:
     """Test creation of default config."""
     assert not os.path.isfile(YAML_PATH)
@@ -1683,6 +1752,7 @@ async def test_component_config_validation_error_with_docs(
     mock_iot_domain_integration_with_docs: Integration,
     mock_non_adr_0007_integration_with_docs: None,
     mock_adr_0007_integrations_with_docs: list[Integration],
+    mock_custom_validator_integrations_with_docs: list[Integration],
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test schema error in component."""
@@ -1700,6 +1770,10 @@ async def test_component_config_validation_error_with_docs(
         "adr_0007_3",
         "adr_0007_4",
         "adr_0007_5",
+        "custom_validator_ok_1",
+        "custom_validator_ok_2",
+        "custom_validator_bad_1",
+        "custom_validator_bad_2",
     ]:
         integration = await async_get_integration(hass, domain)
         await config_util.async_process_component_config(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor config.async_log_exception:
- The function was mainly to format `vol.Invalid` raised when validating configuration schemas, rename it to `async_log_schema_error` and make it only support logging instances of `vol.Invalid`
- Move the functionality logging other exceptions, which is called when a custom validator raises, to a new function `async_log_config_validator_error`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
