### PR TITLE
Add tests for Discovergy to reach full test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -218,9 +218,6 @@ omit =
     homeassistant/components/discogs/sensor.py
     homeassistant/components/discord/__init__.py
     homeassistant/components/discord/notify.py
-    homeassistant/components/discovergy/__init__.py
-    homeassistant/components/discovergy/sensor.py
-    homeassistant/components/discovergy/coordinator.py
     homeassistant/components/dlib_face_detect/image_processing.py
     homeassistant/components/dlib_face_identify/image_processing.py
     homeassistant/components/dlink/data.py

--- a/tests/components/discovergy/snapshots/test_sensor.ambr
+++ b/tests/components/discovergy/snapshots/test_sensor.ambr
@@ -1,0 +1,154 @@
+# serializer version: 1
+# name: test_sensor[electricity total consumption]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.electricity_teststrasse_1_total_consumption',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 4,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': 'Total consumption',
+    'platform': 'discovergy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'total_consumption',
+    'unique_id': 'abc123-energy',
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+  })
+# ---
+# name: test_sensor[electricity total consumption].1
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Electricity Teststraße 1 Total consumption',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.electricity_teststrasse_1_total_consumption',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '11934.8699715',
+  })
+# ---
+# name: test_sensor[electricity total power]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.electricity_teststrasse_1_total_power',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Total power',
+    'platform': 'discovergy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'total_power',
+    'unique_id': 'abc123-power',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_sensor[electricity total power].1
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Electricity Teststraße 1 Total power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.electricity_teststrasse_1_total_power',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '531.75',
+  })
+# ---
+# name: test_sensor[gas total consumption]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.gas_teststrasse_1_total_gas_consumption',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 4,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.GAS: 'gas'>,
+    'original_icon': None,
+    'original_name': 'Total gas consumption',
+    'platform': 'discovergy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'total_gas_consumption',
+    'unique_id': 'def456-volume',
+    'unit_of_measurement': <UnitOfVolume.CUBIC_METERS: 'm³'>,
+  })
+# ---
+# name: test_sensor[gas total consumption].1
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'gas',
+      'friendly_name': 'Gas Teststraße 1 Total gas consumption',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfVolume.CUBIC_METERS: 'm³'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.gas_teststrasse_1_total_gas_consumption',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '21064.8',
+  })
+# ---

--- a/tests/components/discovergy/test_init.py
+++ b/tests/components/discovergy/test_init.py
@@ -1,0 +1,62 @@
+"""Test Discovergy component setup."""
+from unittest.mock import AsyncMock
+
+from pydiscovergy.error import DiscovergyClientError, HTTPError, InvalidLogin
+import pytest
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("discovergy")
+async def test_config_setup(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test for setup success."""
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+
+@pytest.mark.parametrize(
+    ("error", "expected_state"),
+    [
+        (InvalidLogin, ConfigEntryState.SETUP_ERROR),
+        (HTTPError, ConfigEntryState.SETUP_RETRY),
+        (DiscovergyClientError, ConfigEntryState.SETUP_RETRY),
+        (Exception, ConfigEntryState.SETUP_RETRY),
+    ],
+)
+async def test_config_not_ready(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    discovergy: AsyncMock,
+    error: Exception,
+    expected_state: ConfigEntryState,
+) -> None:
+    """Test for setup failure."""
+    config_entry.add_to_hass(hass)
+
+    discovergy.meters.side_effect = error
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    assert config_entry.state is expected_state
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_reload_config_entry(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test config entry reload."""
+    new_data = {"email": "abc@example.com", "password": "password"}
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    assert hass.config_entries.async_update_entry(config_entry, data=new_data)
+
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry.data == new_data

--- a/tests/components/discovergy/test_sensor.py
+++ b/tests/components/discovergy/test_sensor.py
@@ -2,62 +2,21 @@
 from datetime import timedelta
 from unittest.mock import AsyncMock
 
+from freezegun.api import FrozenDateTimeFactory
 from pydiscovergy.error import DiscovergyClientError, HTTPError, InvalidLogin
 import pytest
+from syrupy import SnapshotAssertion
 
-from homeassistant.components.sensor import (
-    ATTR_STATE_CLASS,
-    SensorDeviceClass,
-    SensorStateClass,
-)
-from homeassistant.const import (
-    ATTR_DEVICE_CLASS,
-    ATTR_UNIT_OF_MEASUREMENT,
-    UnitOfEnergy,
-    UnitOfPower,
-    UnitOfVolume,
-)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-import homeassistant.util.dt as dt_util
-
-from tests.common import async_fire_time_changed
 
 
 @pytest.mark.parametrize(
-    (
-        "state_name",
-        "expected_unique_id",
-        "expected_state",
-        "expected_unit",
-        "expected_device_class",
-        "expected_state_class",
-    ),
+    "state_name",
     [
-        (
-            "sensor.electricity_teststrasse_1_total_consumption",
-            "abc123-energy",
-            "11934.8699715",
-            UnitOfEnergy.KILO_WATT_HOUR,
-            SensorDeviceClass.ENERGY,
-            SensorStateClass.TOTAL_INCREASING,
-        ),
-        (
-            "sensor.electricity_teststrasse_1_total_power",
-            "abc123-power",
-            "531.75",
-            UnitOfPower.WATT,
-            SensorDeviceClass.POWER,
-            SensorStateClass.MEASUREMENT,
-        ),
-        (
-            "sensor.gas_teststrasse_1_total_gas_consumption",
-            "def456-volume",
-            "21064.8",
-            UnitOfVolume.CUBIC_METERS,
-            SensorDeviceClass.GAS,
-            SensorStateClass.TOTAL_INCREASING,
-        ),
+        "sensor.electricity_teststrasse_1_total_consumption",
+        "sensor.electricity_teststrasse_1_total_power",
+        "sensor.gas_teststrasse_1_total_gas_consumption",
     ],
     ids=[
         "electricity total consumption",
@@ -70,23 +29,15 @@ async def test_sensor(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     state_name: str,
-    expected_unique_id: str,
-    expected_state: str,
-    expected_unit: str,
-    expected_device_class: SensorDeviceClass,
-    expected_state_class: SensorStateClass,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test sensor setup and update."""
 
     entry = entity_registry.async_get(state_name)
-    assert entry
-    assert entry.unique_id == expected_unique_id
+    assert entry == snapshot
 
     state = hass.states.get(state_name)
-    assert state.state == expected_state
-    assert state.attributes.get(ATTR_DEVICE_CLASS) == expected_device_class
-    assert state.attributes.get(ATTR_STATE_CLASS) == expected_state_class
-    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == expected_unit
+    assert state == snapshot
 
 
 @pytest.mark.parametrize(
@@ -101,13 +52,18 @@ async def test_sensor(
 @pytest.mark.usefixtures("setup_integration")
 async def test_sensor_update_fail(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     discovergy: AsyncMock,
     error: Exception,
 ) -> None:
     """Test sensor errors."""
+    state = hass.states.get("sensor.electricity_teststrasse_1_total_consumption")
+    assert state
+    assert state.state == "11934.8699715"
+
     discovergy.meter_last_reading.side_effect = error
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=300))
+    freezer.tick(timedelta(minutes=1))
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.electricity_teststrasse_1_total_consumption")

--- a/tests/components/discovergy/test_sensor.py
+++ b/tests/components/discovergy/test_sensor.py
@@ -1,0 +1,115 @@
+"""Tests Discovergy sensor component."""
+from datetime import timedelta
+from unittest.mock import AsyncMock
+
+from pydiscovergy.error import DiscovergyClientError, HTTPError, InvalidLogin
+import pytest
+
+from homeassistant.components.sensor import (
+    ATTR_STATE_CLASS,
+    SensorDeviceClass,
+    SensorStateClass,
+)
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_UNIT_OF_MEASUREMENT,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfVolume,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+import homeassistant.util.dt as dt_util
+
+from tests.common import async_fire_time_changed
+
+
+@pytest.mark.parametrize(
+    (
+        "state_name",
+        "expected_unique_id",
+        "expected_state",
+        "expected_unit",
+        "expected_device_class",
+        "expected_state_class",
+    ),
+    [
+        (
+            "sensor.electricity_teststrasse_1_total_consumption",
+            "abc123-energy",
+            "11934.8699715",
+            UnitOfEnergy.KILO_WATT_HOUR,
+            SensorDeviceClass.ENERGY,
+            SensorStateClass.TOTAL_INCREASING,
+        ),
+        (
+            "sensor.electricity_teststrasse_1_total_power",
+            "abc123-power",
+            "531.75",
+            UnitOfPower.WATT,
+            SensorDeviceClass.POWER,
+            SensorStateClass.MEASUREMENT,
+        ),
+        (
+            "sensor.gas_teststrasse_1_total_gas_consumption",
+            "def456-volume",
+            "21064.8",
+            UnitOfVolume.CUBIC_METERS,
+            SensorDeviceClass.GAS,
+            SensorStateClass.TOTAL_INCREASING,
+        ),
+    ],
+    ids=[
+        "electricity total consumption",
+        "electricity total power",
+        "gas total consumption",
+    ],
+)
+@pytest.mark.usefixtures("setup_integration")
+async def test_sensor(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    state_name: str,
+    expected_unique_id: str,
+    expected_state: str,
+    expected_unit: str,
+    expected_device_class: SensorDeviceClass,
+    expected_state_class: SensorStateClass,
+) -> None:
+    """Test sensor setup and update."""
+
+    entry = entity_registry.async_get(state_name)
+    assert entry
+    assert entry.unique_id == expected_unique_id
+
+    state = hass.states.get(state_name)
+    assert state.state == expected_state
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == expected_device_class
+    assert state.attributes.get(ATTR_STATE_CLASS) == expected_state_class
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == expected_unit
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        InvalidLogin,
+        HTTPError,
+        DiscovergyClientError,
+        Exception,
+    ],
+)
+@pytest.mark.usefixtures("setup_integration")
+async def test_sensor_update_fail(
+    hass: HomeAssistant,
+    discovergy: AsyncMock,
+    error: Exception,
+) -> None:
+    """Test sensor errors."""
+    discovergy.meter_last_reading.side_effect = error
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=300))
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.electricity_teststrasse_1_total_consumption")
+    assert state
+    assert state.state == "unavailable"


### PR DESCRIPTION
## Proposed change
SSIA, add tests for the init and sensors of Discovergy.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
