### PR TITLE
Use AsyncMock and fixtures in co2signal tests

### DIFF
--- a/homeassistant/components/co2signal/config_flow.py
+++ b/homeassistant/components/co2signal/config_flow.py
@@ -120,18 +120,18 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         session = async_get_clientsession(self.hass)
-        async with ElectricityMaps(token=data[CONF_API_KEY], session=session) as em:
-            try:
-                await fetch_latest_carbon_intensity(self.hass, em, data)
-            except InvalidToken:
-                errors["base"] = "invalid_auth"
-            except ElectricityMapsError:
-                errors["base"] = "unknown"
-            else:
-                return self.async_create_entry(
-                    title=get_extra_name(data) or "CO2 Signal",
-                    data=data,
-                )
+        em = ElectricityMaps(token=data[CONF_API_KEY], session=session)
+        try:
+            await fetch_latest_carbon_intensity(self.hass, em, data)
+        except InvalidToken:
+            errors["base"] = "invalid_auth"
+        except ElectricityMapsError:
+            errors["base"] = "unknown"
+        else:
+            return self.async_create_entry(
+                title=get_extra_name(data) or "CO2 Signal",
+                data=data,
+            )
 
         return self.async_show_form(
             step_id=step_id,

--- a/homeassistant/components/co2signal/coordinator.py
+++ b/homeassistant/components/co2signal/coordinator.py
@@ -39,12 +39,11 @@ class CO2SignalCoordinator(DataUpdateCoordinator[CarbonIntensityResponse]):
     async def _async_update_data(self) -> CarbonIntensityResponse:
         """Fetch the latest data from the source."""
 
-        async with self.client as em:
-            try:
-                return await fetch_latest_carbon_intensity(
-                    self.hass, em, self.config_entry.data
-                )
-            except InvalidToken as err:
-                raise ConfigEntryError from err
-            except ElectricityMapsError as err:
-                raise UpdateFailed(str(err)) from err
+        try:
+            return await fetch_latest_carbon_intensity(
+                self.hass, self.client, self.config_entry.data
+            )
+        except InvalidToken as err:
+            raise ConfigEntryError from err
+        except ElectricityMapsError as err:
+            raise UpdateFailed(str(err)) from err

--- a/tests/components/co2signal/__init__.py
+++ b/tests/components/co2signal/__init__.py
@@ -1,11 +1,18 @@
 """Tests for the CO2 Signal integration."""
+from aioelectricitymaps.models import (
+    CarbonIntensityData,
+    CarbonIntensityResponse,
+    CarbonIntensityUnit,
+)
 
-VALID_PAYLOAD = {
-    "status": "ok",
-    "countryCode": "FR",
-    "data": {
-        "carbonIntensity": 45.98623190095805,
-        "fossilFuelPercentage": 5.461182741937103,
-    },
-    "units": {"carbonIntensity": "gCO2eq/kWh"},
-}
+VALID_RESPONSE = CarbonIntensityResponse(
+    status="ok",
+    country_code="FR",
+    data=CarbonIntensityData(
+        carbon_intensity=45.98623190095805,
+        fossil_fuel_percentage=5.461182741937103,
+    ),
+    units=CarbonIntensityUnit(
+        carbon_intensity="gCO2eq/kWh",
+    ),
+)

--- a/tests/components/co2signal/conftest.py
+++ b/tests/components/co2signal/conftest.py
@@ -1,0 +1,59 @@
+"""Fixtures for Electricity maps integration tests."""
+from unittest.mock import AsyncMock, patch
+
+from aioelectricitymaps import ElectricityMaps
+import pytest
+
+from homeassistant.components.co2signal import DOMAIN
+from homeassistant.const import CONF_API_KEY
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+from tests.components.co2signal import VALID_RESPONSE
+
+
+@pytest.fixture(name="electricity_maps")
+def mock_electricity_maps() -> None:
+    """Mock the ElectricityMaps client."""
+    mock = AsyncMock(
+        __aenter__=AsyncMock(
+            return_value=AsyncMock(
+                spec=ElectricityMaps,
+                latest_carbon_intensity_by_coordinates=AsyncMock(
+                    return_value=VALID_RESPONSE
+                ),
+                latest_carbon_intensity_by_country_code=AsyncMock(
+                    return_value=VALID_RESPONSE
+                ),
+            )
+        ),
+        __aexit__=AsyncMock(return_value=None),
+    )
+
+    with patch(
+        "homeassistant.components.co2signal.ElectricityMaps",
+        return_value=mock,
+    ):
+        yield mock
+
+
+@pytest.fixture(name="config_entry")
+async def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Return a MockConfigEntry for testing."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_API_KEY: "api_key", "location": ""},
+        entry_id="904a74160aa6f335526706bee85dfb83",
+    )
+
+
+@pytest.fixture(name="setup_integration")
+async def mock_setup_integration(
+    hass: HomeAssistant, config_entry: MockConfigEntry, electricity_maps: AsyncMock
+) -> None:
+    """Fixture for setting up the component."""
+    config_entry.add_to_hass(hass)
+
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()

--- a/tests/components/co2signal/conftest.py
+++ b/tests/components/co2signal/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Electricity maps integration tests."""
+from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 from aioelectricitymaps import ElectricityMaps
@@ -14,7 +15,7 @@ from tests.components.co2signal import VALID_RESPONSE
 
 
 @pytest.fixture(name="electricity_maps")
-def mock_electricity_maps() -> None:
+def mock_electricity_maps() -> Generator[AsyncMock, None, None]:
     """Mock the ElectricityMaps client."""
     mock = AsyncMock(
         __aenter__=AsyncMock(

--- a/tests/components/co2signal/test_config_flow.py
+++ b/tests/components/co2signal/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the CO2 Signal config flow."""
+from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 from aioelectricitymaps.exceptions import (
@@ -15,7 +16,9 @@ from homeassistant.data_entry_flow import FlowResultType
 
 
 @pytest.fixture(name="em_config_flow")
-def mock_em_config_flow(electricity_maps: AsyncMock) -> None:
+def mock_em_config_flow(
+    electricity_maps: AsyncMock,
+) -> Generator[AsyncMock, None, None]:
     """Patch the electricity maps client in the config flow."""
     with patch(
         "homeassistant.components.co2signal.config_flow.ElectricityMaps",

--- a/tests/components/co2signal/test_config_flow.py
+++ b/tests/components/co2signal/test_config_flow.py
@@ -1,5 +1,5 @@
 """Test the CO2 Signal config flow."""
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from aioelectricitymaps.exceptions import (
     ElectricityMapsDecodeError,
@@ -13,9 +13,18 @@ from homeassistant.components.co2signal import DOMAIN, config_flow
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from . import VALID_PAYLOAD
+
+@pytest.fixture(name="em_config_flow")
+def mock_em_config_flow(electricity_maps: AsyncMock) -> None:
+    """Patch the electricity maps client in the config flow."""
+    with patch(
+        "homeassistant.components.co2signal.config_flow.ElectricityMaps",
+        return_value=electricity_maps,
+    ):
+        yield electricity_maps
 
 
+@pytest.mark.usefixtures("em_config_flow")
 async def test_form_home(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
@@ -26,9 +35,6 @@ async def test_form_home(hass: HomeAssistant) -> None:
     assert result["errors"] is None
 
     with patch(
-        "homeassistant.components.co2signal.config_flow.ElectricityMaps._get",
-        return_value=VALID_PAYLOAD,
-    ), patch(
         "homeassistant.components.co2signal.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -49,6 +55,7 @@ async def test_form_home(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+@pytest.mark.usefixtures("em_config_flow")
 async def test_form_coordinates(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
@@ -68,9 +75,6 @@ async def test_form_coordinates(hass: HomeAssistant) -> None:
     assert result2["type"] == FlowResultType.FORM
 
     with patch(
-        "homeassistant.components.co2signal.config_flow.ElectricityMaps._get",
-        return_value=VALID_PAYLOAD,
-    ), patch(
         "homeassistant.components.co2signal.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -93,6 +97,7 @@ async def test_form_coordinates(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+@pytest.mark.usefixtures("em_config_flow")
 async def test_form_country(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
@@ -112,9 +117,6 @@ async def test_form_country(hass: HomeAssistant) -> None:
     assert result2["type"] == FlowResultType.FORM
 
     with patch(
-        "homeassistant.components.co2signal.config_flow.ElectricityMaps._get",
-        return_value=VALID_PAYLOAD,
-    ), patch(
         "homeassistant.components.co2signal.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -151,39 +153,43 @@ async def test_form_country(hass: HomeAssistant) -> None:
         "json decode error",
     ],
 )
-async def test_form_error_handling(hass: HomeAssistant, side_effect, err_code) -> None:
+async def test_form_error_handling(
+    hass: HomeAssistant, em_config_flow: AsyncMock, side_effect, err_code
+) -> None:
     """Test we handle expected errors."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch(
-        "homeassistant.components.co2signal.config_flow.ElectricityMaps._get",
-        side_effect=side_effect,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "location": config_flow.TYPE_USE_HOME,
-                "api_key": "api_key",
-            },
-        )
+    # keep a copy of the old return value before setting the side effect
+    old_return_value = em_config_flow.__aenter__.return_value
+    em_config_flow.__aenter__.return_value = AsyncMock(
+        latest_carbon_intensity_by_coordinates=AsyncMock(side_effect=side_effect),
+        latest_carbon_intensity_by_country_code=AsyncMock(side_effec=side_effect),
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "location": config_flow.TYPE_USE_HOME,
+            "api_key": "api_key",
+        },
+    )
 
     assert result["type"] == FlowResultType.FORM
     assert result["errors"] == {"base": err_code}
 
-    with patch(
-        "homeassistant.components.co2signal.config_flow.ElectricityMaps._get",
-        return_value=VALID_PAYLOAD,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "location": config_flow.TYPE_USE_HOME,
-                "api_key": "api_key",
-            },
-        )
-        await hass.async_block_till_done()
+    # reset mock and test if now succeeds
+    em_config_flow.__aenter__.return_value = old_return_value
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "location": config_flow.TYPE_USE_HOME,
+            "api_key": "api_key",
+        },
+    )
+    await hass.async_block_till_done()
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "CO2 Signal"

--- a/tests/components/co2signal/test_diagnostics.py
+++ b/tests/components/co2signal/test_diagnostics.py
@@ -1,38 +1,23 @@
 """Test the CO2Signal diagnostics."""
-from unittest.mock import patch
 
+import pytest
 from syrupy import SnapshotAssertion
 
-from homeassistant.components.co2signal import DOMAIN
-from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
-
-from . import VALID_PAYLOAD
 
 from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 
 
+@pytest.mark.usefixtures("setup_integration")
 async def test_entry_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
+    config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test config entry diagnostics."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_API_KEY: "api_key", "location": ""},
-        entry_id="904a74160aa6f335526706bee85dfb83",
-    )
-    config_entry.add_to_hass(hass)
-    with patch(
-        "homeassistant.components.co2signal.coordinator.ElectricityMaps._get",
-        return_value=VALID_PAYLOAD,
-    ):
-        assert await async_setup_component(hass, DOMAIN, {})
-
     result = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
 
     assert result == snapshot


### PR DESCRIPTION
## Proposed change
Make use of `AsyncMock` and more fixtures in `co2signal` tests, so that new sensor tests can be easily added without repeating code.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
