### PR TITLE
Use relative paths in configuration validation error messages

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -249,7 +249,7 @@ async def async_check_config_schema(
                     integration = await async_get_integration(hass, DOMAIN)
                     # pylint: disable-next=protected-access
                     message = conf_util.format_schema_error(
-                        ex, domain, config, integration.documentation
+                        hass, ex, domain, config, integration.documentation
                     )
                     raise ServiceValidationError(
                         message,

--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -93,7 +93,11 @@ async def async_check_ha_config_file(  # noqa: C901
     async_clear_install_history(hass)
 
     def _pack_error(
-        package: str, component: str, config: ConfigType, message: str
+        hass: HomeAssistant,
+        package: str,
+        component: str,
+        config: ConfigType,
+        message: str,
     ) -> None:
         """Handle errors from packages."""
         message = f"Package {package} setup failed. {message}"
@@ -109,7 +113,7 @@ async def async_check_ha_config_file(  # noqa: C901
     ) -> None:
         """Handle errors from components."""
         if isinstance(ex, vol.Invalid):
-            message = format_schema_error(ex, domain, component_config)
+            message = format_schema_error(hass, ex, domain, component_config)
         else:
             message = format_homeassistant_error(ex, domain, component_config)
         if domain in frontend_dependencies:
@@ -158,7 +162,9 @@ async def async_check_ha_config_file(  # noqa: C901
         result[CONF_CORE] = core_config
     except vol.Invalid as err:
         result.add_error(
-            format_schema_error(err, CONF_CORE, core_config), CONF_CORE, core_config
+            format_schema_error(hass, err, CONF_CORE, core_config),
+            CONF_CORE,
+            core_config,
         )
         core_config = {}
 

--- a/tests/helpers/test_check_config.py
+++ b/tests/helpers/test_check_config.py
@@ -82,9 +82,8 @@ async def test_bad_core_config(hass: HomeAssistant) -> None:
 
         error = CheckConfigError(
             (
-                "Invalid config for [homeassistant] at "
-                f"{hass.config.path(YAML_CONFIG_FILE)}, line 2: "
-                "not a valid value for dictionary value 'unit_system', got 'bad'."
+                f"Invalid config for [homeassistant] at {YAML_CONFIG_FILE}, line 2:"
+                " not a valid value for dictionary value 'unit_system', got 'bad'."
             ),
             "homeassistant",
             {"unit_system": "bad"},

--- a/tests/snapshots/test_config.ambr
+++ b/tests/snapshots/test_config.ambr
@@ -3,47 +3,47 @@
   list([
     dict({
       'has_exc_info': False,
-      'message': "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 6: required key 'platform' not provided.",
+      'message': "Invalid config for [iot_domain] at configuration.yaml, line 6: required key 'platform' not provided.",
     }),
     dict({
       'has_exc_info': False,
-      'message': "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 9: expected str for dictionary value 'option1', got 123.",
+      'message': "Invalid config for [iot_domain.non_adr_0007] at configuration.yaml, line 9: expected str for dictionary value 'option1', got 123.",
     }),
     dict({
       'has_exc_info': False,
-      'message': "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 12: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
-    }),
-    dict({
-      'has_exc_info': False,
-      'message': '''
-        Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 18: required key 'option1' not provided.
-        Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 19: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option
-        Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 20: expected str for dictionary value 'option2', got 123.
-      ''',
-    }),
-    dict({
-      'has_exc_info': False,
-      'message': "Invalid config for [adr_0007_2] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 27: required key 'host' not provided.",
-    }),
-    dict({
-      'has_exc_info': False,
-      'message': "Invalid config for [adr_0007_3] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 32: expected int for dictionary value 'adr_0007_3->port', got 'foo'.",
-    }),
-    dict({
-      'has_exc_info': False,
-      'message': "Invalid config for [adr_0007_4] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 37: 'no_such_option' is an invalid option for [adr_0007_4], check: adr_0007_4->no_such_option",
+      'message': "Invalid config for [iot_domain.non_adr_0007] at configuration.yaml, line 12: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
     }),
     dict({
       'has_exc_info': False,
       'message': '''
-        Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 43: required key 'host' not provided.
-        Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 44: 'no_such_option' is an invalid option for [adr_0007_5], check: adr_0007_5->no_such_option
-        Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 45: expected int for dictionary value 'adr_0007_5->port', got 'foo'.
+        Invalid config for [iot_domain.non_adr_0007] at configuration.yaml, line 18: required key 'option1' not provided.
+        Invalid config for [iot_domain.non_adr_0007] at configuration.yaml, line 19: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option
+        Invalid config for [iot_domain.non_adr_0007] at configuration.yaml, line 20: expected str for dictionary value 'option2', got 123.
       ''',
     }),
     dict({
       'has_exc_info': False,
-      'message': "Invalid config for [custom_validator_ok_2] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 52: required key 'host' not provided.",
+      'message': "Invalid config for [adr_0007_2] at configuration.yaml, line 27: required key 'host' not provided.",
+    }),
+    dict({
+      'has_exc_info': False,
+      'message': "Invalid config for [adr_0007_3] at configuration.yaml, line 32: expected int for dictionary value 'adr_0007_3->port', got 'foo'.",
+    }),
+    dict({
+      'has_exc_info': False,
+      'message': "Invalid config for [adr_0007_4] at configuration.yaml, line 37: 'no_such_option' is an invalid option for [adr_0007_4], check: adr_0007_4->no_such_option",
+    }),
+    dict({
+      'has_exc_info': False,
+      'message': '''
+        Invalid config for [adr_0007_5] at configuration.yaml, line 43: required key 'host' not provided.
+        Invalid config for [adr_0007_5] at configuration.yaml, line 44: 'no_such_option' is an invalid option for [adr_0007_5], check: adr_0007_5->no_such_option
+        Invalid config for [adr_0007_5] at configuration.yaml, line 45: expected int for dictionary value 'adr_0007_5->port', got 'foo'.
+      ''',
+    }),
+    dict({
+      'has_exc_info': False,
+      'message': "Invalid config for [custom_validator_ok_2] at configuration.yaml, line 52: required key 'host' not provided.",
     }),
     dict({
       'has_exc_info': True,
@@ -59,47 +59,47 @@
   list([
     dict({
       'has_exc_info': False,
-      'message': "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/iot_domain.yaml, line 5: required key 'platform' not provided.",
+      'message': "Invalid config for [iot_domain] at integrations/iot_domain.yaml, line 5: required key 'platform' not provided.",
     }),
     dict({
       'has_exc_info': False,
-      'message': "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/iot_domain.yaml, line 8: expected str for dictionary value 'option1', got 123.",
+      'message': "Invalid config for [iot_domain.non_adr_0007] at integrations/iot_domain.yaml, line 8: expected str for dictionary value 'option1', got 123.",
     }),
     dict({
       'has_exc_info': False,
-      'message': "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/iot_domain.yaml, line 11: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
-    }),
-    dict({
-      'has_exc_info': False,
-      'message': '''
-        Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/iot_domain.yaml, line 17: required key 'option1' not provided.
-        Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/iot_domain.yaml, line 18: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option
-        Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/iot_domain.yaml, line 19: expected str for dictionary value 'option2', got 123.
-      ''',
-    }),
-    dict({
-      'has_exc_info': False,
-      'message': "Invalid config for [adr_0007_2] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/configuration.yaml, line 3: required key 'host' not provided.",
-    }),
-    dict({
-      'has_exc_info': False,
-      'message': "Invalid config for [adr_0007_3] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/adr_0007_3.yaml, line 3: expected int for dictionary value 'adr_0007_3->port', got 'foo'.",
-    }),
-    dict({
-      'has_exc_info': False,
-      'message': "Invalid config for [adr_0007_4] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/adr_0007_4.yaml, line 3: 'no_such_option' is an invalid option for [adr_0007_4], check: adr_0007_4->no_such_option",
+      'message': "Invalid config for [iot_domain.non_adr_0007] at integrations/iot_domain.yaml, line 11: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
     }),
     dict({
       'has_exc_info': False,
       'message': '''
-        Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/configuration.yaml, line 6: required key 'host' not provided.
-        Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/adr_0007_5.yaml, line 5: 'no_such_option' is an invalid option for [adr_0007_5], check: adr_0007_5->no_such_option
-        Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/integrations/adr_0007_5.yaml, line 6: expected int for dictionary value 'adr_0007_5->port', got 'foo'.
+        Invalid config for [iot_domain.non_adr_0007] at integrations/iot_domain.yaml, line 17: required key 'option1' not provided.
+        Invalid config for [iot_domain.non_adr_0007] at integrations/iot_domain.yaml, line 18: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option
+        Invalid config for [iot_domain.non_adr_0007] at integrations/iot_domain.yaml, line 19: expected str for dictionary value 'option2', got 123.
       ''',
     }),
     dict({
       'has_exc_info': False,
-      'message': "Invalid config for [custom_validator_ok_2] at <BASE_PATH>/fixtures/core/config/component_validation/basic_include/configuration.yaml, line 8: required key 'host' not provided.",
+      'message': "Invalid config for [adr_0007_2] at configuration.yaml, line 3: required key 'host' not provided.",
+    }),
+    dict({
+      'has_exc_info': False,
+      'message': "Invalid config for [adr_0007_3] at integrations/adr_0007_3.yaml, line 3: expected int for dictionary value 'adr_0007_3->port', got 'foo'.",
+    }),
+    dict({
+      'has_exc_info': False,
+      'message': "Invalid config for [adr_0007_4] at integrations/adr_0007_4.yaml, line 3: 'no_such_option' is an invalid option for [adr_0007_4], check: adr_0007_4->no_such_option",
+    }),
+    dict({
+      'has_exc_info': False,
+      'message': '''
+        Invalid config for [adr_0007_5] at configuration.yaml, line 6: required key 'host' not provided.
+        Invalid config for [adr_0007_5] at integrations/adr_0007_5.yaml, line 5: 'no_such_option' is an invalid option for [adr_0007_5], check: adr_0007_5->no_such_option
+        Invalid config for [adr_0007_5] at integrations/adr_0007_5.yaml, line 6: expected int for dictionary value 'adr_0007_5->port', got 'foo'.
+      ''',
+    }),
+    dict({
+      'has_exc_info': False,
+      'message': "Invalid config for [custom_validator_ok_2] at configuration.yaml, line 8: required key 'host' not provided.",
     }),
     dict({
       'has_exc_info': True,
@@ -115,22 +115,22 @@
   list([
     dict({
       'has_exc_info': False,
-      'message': "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_list/iot_domain/iot_domain_2.yaml, line 2: required key 'platform' not provided.",
+      'message': "Invalid config for [iot_domain] at iot_domain/iot_domain_2.yaml, line 2: required key 'platform' not provided.",
     }),
     dict({
       'has_exc_info': False,
-      'message': "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_list/iot_domain/iot_domain_3.yaml, line 3: expected str for dictionary value 'option1', got 123.",
+      'message': "Invalid config for [iot_domain.non_adr_0007] at iot_domain/iot_domain_3.yaml, line 3: expected str for dictionary value 'option1', got 123.",
     }),
     dict({
       'has_exc_info': False,
-      'message': "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_list/iot_domain/iot_domain_4.yaml, line 3: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
+      'message': "Invalid config for [iot_domain.non_adr_0007] at iot_domain/iot_domain_4.yaml, line 3: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
     }),
     dict({
       'has_exc_info': False,
       'message': '''
-        Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_list/iot_domain/iot_domain_5.yaml, line 5: required key 'option1' not provided.
-        Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_list/iot_domain/iot_domain_5.yaml, line 6: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option
-        Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_list/iot_domain/iot_domain_5.yaml, line 7: expected str for dictionary value 'option2', got 123.
+        Invalid config for [iot_domain.non_adr_0007] at iot_domain/iot_domain_5.yaml, line 5: required key 'option1' not provided.
+        Invalid config for [iot_domain.non_adr_0007] at iot_domain/iot_domain_5.yaml, line 6: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option
+        Invalid config for [iot_domain.non_adr_0007] at iot_domain/iot_domain_5.yaml, line 7: expected str for dictionary value 'option2', got 123.
       ''',
     }),
     dict({
@@ -147,22 +147,22 @@
   list([
     dict({
       'has_exc_info': False,
-      'message': "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_merge_list/iot_domain/iot_domain_1.yaml, line 5: required key 'platform' not provided.",
+      'message': "Invalid config for [iot_domain] at iot_domain/iot_domain_1.yaml, line 5: required key 'platform' not provided.",
     }),
     dict({
       'has_exc_info': False,
-      'message': "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_merge_list/iot_domain/iot_domain_2.yaml, line 3: expected str for dictionary value 'option1', got 123.",
+      'message': "Invalid config for [iot_domain.non_adr_0007] at iot_domain/iot_domain_2.yaml, line 3: expected str for dictionary value 'option1', got 123.",
     }),
     dict({
       'has_exc_info': False,
-      'message': "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_merge_list/iot_domain/iot_domain_2.yaml, line 6: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
+      'message': "Invalid config for [iot_domain.non_adr_0007] at iot_domain/iot_domain_2.yaml, line 6: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
     }),
     dict({
       'has_exc_info': False,
       'message': '''
-        Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_merge_list/iot_domain/iot_domain_2.yaml, line 12: required key 'option1' not provided.
-        Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_merge_list/iot_domain/iot_domain_2.yaml, line 13: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option
-        Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/include_dir_merge_list/iot_domain/iot_domain_2.yaml, line 14: expected str for dictionary value 'option2', got 123.
+        Invalid config for [iot_domain.non_adr_0007] at iot_domain/iot_domain_2.yaml, line 12: required key 'option1' not provided.
+        Invalid config for [iot_domain.non_adr_0007] at iot_domain/iot_domain_2.yaml, line 13: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option
+        Invalid config for [iot_domain.non_adr_0007] at iot_domain/iot_domain_2.yaml, line 14: expected str for dictionary value 'option2', got 123.
       ''',
     }),
     dict({
@@ -179,47 +179,47 @@
   list([
     dict({
       'has_exc_info': False,
-      'message': "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 11: required key 'platform' not provided.",
+      'message': "Invalid config for [iot_domain] at configuration.yaml, line 11: required key 'platform' not provided.",
     }),
     dict({
       'has_exc_info': False,
-      'message': "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 16: expected str for dictionary value 'option1', got 123.",
+      'message': "Invalid config for [iot_domain.non_adr_0007] at configuration.yaml, line 16: expected str for dictionary value 'option1', got 123.",
     }),
     dict({
       'has_exc_info': False,
-      'message': "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 21: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
-    }),
-    dict({
-      'has_exc_info': False,
-      'message': '''
-        Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 29: required key 'option1' not provided.
-        Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 30: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option
-        Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 31: expected str for dictionary value 'option2', got 123.
-      ''',
-    }),
-    dict({
-      'has_exc_info': False,
-      'message': "Invalid config for [adr_0007_2] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 38: required key 'host' not provided.",
-    }),
-    dict({
-      'has_exc_info': False,
-      'message': "Invalid config for [adr_0007_3] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 43: expected int for dictionary value 'adr_0007_3->port', got 'foo'.",
-    }),
-    dict({
-      'has_exc_info': False,
-      'message': "Invalid config for [adr_0007_4] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 48: 'no_such_option' is an invalid option for [adr_0007_4], check: adr_0007_4->no_such_option",
+      'message': "Invalid config for [iot_domain.non_adr_0007] at configuration.yaml, line 21: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
     }),
     dict({
       'has_exc_info': False,
       'message': '''
-        Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 54: required key 'host' not provided.
-        Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 55: 'no_such_option' is an invalid option for [adr_0007_5], check: adr_0007_5->no_such_option
-        Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 56: expected int for dictionary value 'adr_0007_5->port', got 'foo'.
+        Invalid config for [iot_domain.non_adr_0007] at configuration.yaml, line 29: required key 'option1' not provided.
+        Invalid config for [iot_domain.non_adr_0007] at configuration.yaml, line 30: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option
+        Invalid config for [iot_domain.non_adr_0007] at configuration.yaml, line 31: expected str for dictionary value 'option2', got 123.
       ''',
     }),
     dict({
       'has_exc_info': False,
-      'message': "Invalid config for [custom_validator_ok_2] at <BASE_PATH>/fixtures/core/config/component_validation/packages/configuration.yaml, line 64: required key 'host' not provided.",
+      'message': "Invalid config for [adr_0007_2] at configuration.yaml, line 38: required key 'host' not provided.",
+    }),
+    dict({
+      'has_exc_info': False,
+      'message': "Invalid config for [adr_0007_3] at configuration.yaml, line 43: expected int for dictionary value 'adr_0007_3->port', got 'foo'.",
+    }),
+    dict({
+      'has_exc_info': False,
+      'message': "Invalid config for [adr_0007_4] at configuration.yaml, line 48: 'no_such_option' is an invalid option for [adr_0007_4], check: adr_0007_4->no_such_option",
+    }),
+    dict({
+      'has_exc_info': False,
+      'message': '''
+        Invalid config for [adr_0007_5] at configuration.yaml, line 54: required key 'host' not provided.
+        Invalid config for [adr_0007_5] at configuration.yaml, line 55: 'no_such_option' is an invalid option for [adr_0007_5], check: adr_0007_5->no_such_option
+        Invalid config for [adr_0007_5] at configuration.yaml, line 56: expected int for dictionary value 'adr_0007_5->port', got 'foo'.
+      ''',
+    }),
+    dict({
+      'has_exc_info': False,
+      'message': "Invalid config for [custom_validator_ok_2] at configuration.yaml, line 64: required key 'host' not provided.",
     }),
     dict({
       'has_exc_info': True,
@@ -235,47 +235,47 @@
   list([
     dict({
       'has_exc_info': False,
-      'message': "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/iot_domain.yaml, line 6: required key 'platform' not provided.",
+      'message': "Invalid config for [iot_domain] at integrations/iot_domain.yaml, line 6: required key 'platform' not provided.",
     }),
     dict({
       'has_exc_info': False,
-      'message': "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/iot_domain.yaml, line 9: expected str for dictionary value 'option1', got 123.",
+      'message': "Invalid config for [iot_domain.non_adr_0007] at integrations/iot_domain.yaml, line 9: expected str for dictionary value 'option1', got 123.",
     }),
     dict({
       'has_exc_info': False,
-      'message': "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/iot_domain.yaml, line 12: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
-    }),
-    dict({
-      'has_exc_info': False,
-      'message': '''
-        Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/iot_domain.yaml, line 18: required key 'option1' not provided.
-        Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/iot_domain.yaml, line 19: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option
-        Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/iot_domain.yaml, line 20: expected str for dictionary value 'option2', got 123.
-      ''',
-    }),
-    dict({
-      'has_exc_info': False,
-      'message': "Invalid config for [adr_0007_2] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/adr_0007_2.yaml, line 2: required key 'host' not provided.",
-    }),
-    dict({
-      'has_exc_info': False,
-      'message': "Invalid config for [adr_0007_3] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/adr_0007_3.yaml, line 4: expected int for dictionary value 'adr_0007_3->port', got 'foo'.",
-    }),
-    dict({
-      'has_exc_info': False,
-      'message': "Invalid config for [adr_0007_4] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/adr_0007_4.yaml, line 4: 'no_such_option' is an invalid option for [adr_0007_4], check: adr_0007_4->no_such_option",
+      'message': "Invalid config for [iot_domain.non_adr_0007] at integrations/iot_domain.yaml, line 12: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option",
     }),
     dict({
       'has_exc_info': False,
       'message': '''
-        Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/adr_0007_5.yaml, line 5: required key 'host' not provided.
-        Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/adr_0007_5.yaml, line 6: 'no_such_option' is an invalid option for [adr_0007_5], check: adr_0007_5->no_such_option
-        Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/adr_0007_5.yaml, line 7: expected int for dictionary value 'adr_0007_5->port', got 'foo'.
+        Invalid config for [iot_domain.non_adr_0007] at integrations/iot_domain.yaml, line 18: required key 'option1' not provided.
+        Invalid config for [iot_domain.non_adr_0007] at integrations/iot_domain.yaml, line 19: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option
+        Invalid config for [iot_domain.non_adr_0007] at integrations/iot_domain.yaml, line 20: expected str for dictionary value 'option2', got 123.
       ''',
     }),
     dict({
       'has_exc_info': False,
-      'message': "Invalid config for [custom_validator_ok_2] at <BASE_PATH>/fixtures/core/config/component_validation/packages_include_dir_named/integrations/custom_validator_ok_2.yaml, line 2: required key 'host' not provided.",
+      'message': "Invalid config for [adr_0007_2] at integrations/adr_0007_2.yaml, line 2: required key 'host' not provided.",
+    }),
+    dict({
+      'has_exc_info': False,
+      'message': "Invalid config for [adr_0007_3] at integrations/adr_0007_3.yaml, line 4: expected int for dictionary value 'adr_0007_3->port', got 'foo'.",
+    }),
+    dict({
+      'has_exc_info': False,
+      'message': "Invalid config for [adr_0007_4] at integrations/adr_0007_4.yaml, line 4: 'no_such_option' is an invalid option for [adr_0007_4], check: adr_0007_4->no_such_option",
+    }),
+    dict({
+      'has_exc_info': False,
+      'message': '''
+        Invalid config for [adr_0007_5] at integrations/adr_0007_5.yaml, line 5: required key 'host' not provided.
+        Invalid config for [adr_0007_5] at integrations/adr_0007_5.yaml, line 6: 'no_such_option' is an invalid option for [adr_0007_5], check: adr_0007_5->no_such_option
+        Invalid config for [adr_0007_5] at integrations/adr_0007_5.yaml, line 7: expected int for dictionary value 'adr_0007_5->port', got 'foo'.
+      ''',
+    }),
+    dict({
+      'has_exc_info': False,
+      'message': "Invalid config for [custom_validator_ok_2] at integrations/custom_validator_ok_2.yaml, line 2: required key 'host' not provided.",
     }),
     dict({
       'has_exc_info': True,
@@ -289,61 +289,61 @@
 # ---
 # name: test_component_config_validation_error_with_docs[basic]
   list([
-    "Invalid config for [iot_domain] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 6: required key 'platform' not provided. Please check the docs at https://www.home-assistant.io/integrations/iot_domain.",
-    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 9: expected str for dictionary value 'option1', got 123. Please check the docs at https://www.home-assistant.io/integrations/non_adr_0007.",
-    "Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 12: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option. Please check the docs at https://www.home-assistant.io/integrations/non_adr_0007",
+    "Invalid config for [iot_domain] at configuration.yaml, line 6: required key 'platform' not provided. Please check the docs at https://www.home-assistant.io/integrations/iot_domain.",
+    "Invalid config for [iot_domain.non_adr_0007] at configuration.yaml, line 9: expected str for dictionary value 'option1', got 123. Please check the docs at https://www.home-assistant.io/integrations/non_adr_0007.",
+    "Invalid config for [iot_domain.non_adr_0007] at configuration.yaml, line 12: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option. Please check the docs at https://www.home-assistant.io/integrations/non_adr_0007",
     '''
-      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 18: required key 'option1' not provided. Please check the docs at https://www.home-assistant.io/integrations/non_adr_0007.
-      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 19: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option. Please check the docs at https://www.home-assistant.io/integrations/non_adr_0007
-      Invalid config for [iot_domain.non_adr_0007] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 20: expected str for dictionary value 'option2', got 123. Please check the docs at https://www.home-assistant.io/integrations/non_adr_0007.
+      Invalid config for [iot_domain.non_adr_0007] at configuration.yaml, line 18: required key 'option1' not provided. Please check the docs at https://www.home-assistant.io/integrations/non_adr_0007.
+      Invalid config for [iot_domain.non_adr_0007] at configuration.yaml, line 19: 'no_such_option' is an invalid option for [iot_domain.non_adr_0007], check: no_such_option. Please check the docs at https://www.home-assistant.io/integrations/non_adr_0007
+      Invalid config for [iot_domain.non_adr_0007] at configuration.yaml, line 20: expected str for dictionary value 'option2', got 123. Please check the docs at https://www.home-assistant.io/integrations/non_adr_0007.
     ''',
-    "Invalid config for [adr_0007_2] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 27: required key 'host' not provided. Please check the docs at https://www.home-assistant.io/integrations/adr_0007_2.",
-    "Invalid config for [adr_0007_3] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 32: expected int for dictionary value 'adr_0007_3->port', got 'foo'. Please check the docs at https://www.home-assistant.io/integrations/adr_0007_3.",
-    "Invalid config for [adr_0007_4] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 37: 'no_such_option' is an invalid option for [adr_0007_4], check: adr_0007_4->no_such_option. Please check the docs at https://www.home-assistant.io/integrations/adr_0007_4",
+    "Invalid config for [adr_0007_2] at configuration.yaml, line 27: required key 'host' not provided. Please check the docs at https://www.home-assistant.io/integrations/adr_0007_2.",
+    "Invalid config for [adr_0007_3] at configuration.yaml, line 32: expected int for dictionary value 'adr_0007_3->port', got 'foo'. Please check the docs at https://www.home-assistant.io/integrations/adr_0007_3.",
+    "Invalid config for [adr_0007_4] at configuration.yaml, line 37: 'no_such_option' is an invalid option for [adr_0007_4], check: adr_0007_4->no_such_option. Please check the docs at https://www.home-assistant.io/integrations/adr_0007_4",
     '''
-      Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 43: required key 'host' not provided. Please check the docs at https://www.home-assistant.io/integrations/adr_0007_5.
-      Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 44: 'no_such_option' is an invalid option for [adr_0007_5], check: adr_0007_5->no_such_option. Please check the docs at https://www.home-assistant.io/integrations/adr_0007_5
-      Invalid config for [adr_0007_5] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 45: expected int for dictionary value 'adr_0007_5->port', got 'foo'. Please check the docs at https://www.home-assistant.io/integrations/adr_0007_5.
+      Invalid config for [adr_0007_5] at configuration.yaml, line 43: required key 'host' not provided. Please check the docs at https://www.home-assistant.io/integrations/adr_0007_5.
+      Invalid config for [adr_0007_5] at configuration.yaml, line 44: 'no_such_option' is an invalid option for [adr_0007_5], check: adr_0007_5->no_such_option. Please check the docs at https://www.home-assistant.io/integrations/adr_0007_5
+      Invalid config for [adr_0007_5] at configuration.yaml, line 45: expected int for dictionary value 'adr_0007_5->port', got 'foo'. Please check the docs at https://www.home-assistant.io/integrations/adr_0007_5.
     ''',
-    "Invalid config for [custom_validator_ok_2] at <BASE_PATH>/fixtures/core/config/component_validation/basic/configuration.yaml, line 52: required key 'host' not provided. Please check the docs at https://www.home-assistant.io/integrations/custom_validator_ok_2.",
+    "Invalid config for [custom_validator_ok_2] at configuration.yaml, line 52: required key 'host' not provided. Please check the docs at https://www.home-assistant.io/integrations/custom_validator_ok_2.",
     'Invalid config for [custom_validator_bad_1]: broken Please check the docs at https://www.home-assistant.io/integrations/custom_validator_bad_1.',
     'Unknown error calling custom_validator_bad_2 config validator',
   ])
 # ---
 # name: test_package_merge_error[packages]
   list([
-    'Package pack_1 setup failed. Integration adr_0007_1 cannot be merged. Dict expected in main config. (See <BASE_PATH>/fixtures/core/config/package_errors/packages/configuration.yaml:9).',
-    'Package pack_2 setup failed. Integration adr_0007_2 cannot be merged. Expected a dict. (See <BASE_PATH>/fixtures/core/config/package_errors/packages/configuration.yaml:13).',
-    "Package pack_4 setup failed. Integration adr_0007_3 has duplicate key 'host'. (See <BASE_PATH>/fixtures/core/config/package_errors/packages/configuration.yaml:20).",
-    "Package pack_5 setup failed. Integration 'unknown_integration' not found. (See <BASE_PATH>/fixtures/core/config/package_errors/packages/configuration.yaml:23).",
+    'Package pack_1 setup failed. Integration adr_0007_1 cannot be merged. Dict expected in main config. (See configuration.yaml:9).',
+    'Package pack_2 setup failed. Integration adr_0007_2 cannot be merged. Expected a dict. (See configuration.yaml:13).',
+    "Package pack_4 setup failed. Integration adr_0007_3 has duplicate key 'host'. (See configuration.yaml:20).",
+    "Package pack_5 setup failed. Integration 'unknown_integration' not found. (See configuration.yaml:23).",
   ])
 # ---
 # name: test_package_merge_error[packages_include_dir_named]
   list([
-    'Package adr_0007_1 setup failed. Integration adr_0007_1 cannot be merged. Dict expected in main config. (See <BASE_PATH>/fixtures/core/config/package_errors/packages_include_dir_named/integrations/adr_0007_1.yaml:2).',
-    'Package adr_0007_2 setup failed. Integration adr_0007_2 cannot be merged. Expected a dict. (See <BASE_PATH>/fixtures/core/config/package_errors/packages_include_dir_named/integrations/adr_0007_2.yaml:2).',
-    "Package adr_0007_3_2 setup failed. Integration adr_0007_3 has duplicate key 'host'. (See <BASE_PATH>/fixtures/core/config/package_errors/packages_include_dir_named/integrations/adr_0007_3_2.yaml:1).",
-    "Package unknown_integration setup failed. Integration 'unknown_integration' not found. (See <BASE_PATH>/fixtures/core/config/package_errors/packages_include_dir_named/integrations/unknown_integration.yaml:2).",
+    'Package adr_0007_1 setup failed. Integration adr_0007_1 cannot be merged. Dict expected in main config. (See integrations/adr_0007_1.yaml:2).',
+    'Package adr_0007_2 setup failed. Integration adr_0007_2 cannot be merged. Expected a dict. (See integrations/adr_0007_2.yaml:2).',
+    "Package adr_0007_3_2 setup failed. Integration adr_0007_3 has duplicate key 'host'. (See integrations/adr_0007_3_2.yaml:1).",
+    "Package unknown_integration setup failed. Integration 'unknown_integration' not found. (See integrations/unknown_integration.yaml:2).",
   ])
 # ---
 # name: test_package_merge_exception[packages-error0]
   list([
-    "Package pack_1 setup failed. Integration test_domain caused error: No such file or directory: b'liblibc.a' (See <BASE_PATH>/fixtures/core/config/package_exceptions/packages/configuration.yaml:4).",
+    "Package pack_1 setup failed. Integration test_domain caused error: No such file or directory: b'liblibc.a' (See configuration.yaml:4).",
   ])
 # ---
 # name: test_package_merge_exception[packages-error1]
   list([
-    "Package pack_1 setup failed. Integration test_domain caused error: ModuleNotFoundError: No module named 'not_installed_something' (See <BASE_PATH>/fixtures/core/config/package_exceptions/packages/configuration.yaml:4).",
+    "Package pack_1 setup failed. Integration test_domain caused error: ModuleNotFoundError: No module named 'not_installed_something' (See configuration.yaml:4).",
   ])
 # ---
 # name: test_package_merge_exception[packages_include_dir_named-error0]
   list([
-    "Package unknown_integration setup failed. Integration test_domain caused error: No such file or directory: b'liblibc.a' (See <BASE_PATH>/fixtures/core/config/package_exceptions/packages_include_dir_named/integrations/unknown_integration.yaml:1).",
+    "Package unknown_integration setup failed. Integration test_domain caused error: No such file or directory: b'liblibc.a' (See integrations/unknown_integration.yaml:1).",
   ])
 # ---
 # name: test_package_merge_exception[packages_include_dir_named-error1]
   list([
-    "Package unknown_integration setup failed. Integration test_domain caused error: ModuleNotFoundError: No module named 'not_installed_something' (See <BASE_PATH>/fixtures/core/config/package_exceptions/packages_include_dir_named/integrations/unknown_integration.yaml:1).",
+    "Package unknown_integration setup failed. Integration test_domain caused error: ModuleNotFoundError: No module named 'not_installed_something' (See integrations/unknown_integration.yaml:1).",
   ])
 # ---
 # name: test_yaml_error[basic]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1730,7 +1730,7 @@ async def test_component_config_validation_error(
 
     error_records = [
         {
-            "message": record.message.replace(base_path, "<BASE_PATH>"),
+            "message": record.message,
             "has_exc_info": bool(record.exc_info),
         }
         for record in caplog.get_records("call")
@@ -1783,7 +1783,7 @@ async def test_component_config_validation_error_with_docs(
         )
 
     error_records = [
-        record.message.replace(base_path, "<BASE_PATH>")
+        record.message
         for record in caplog.get_records("call")
         if record.levelno == logging.ERROR
     ]
@@ -1811,7 +1811,7 @@ async def test_package_merge_error(
     await config_util.async_hass_config_yaml(hass)
 
     error_records = [
-        record.message.replace(base_path, "<BASE_PATH>")
+        record.message
         for record in caplog.get_records("call")
         if record.levelno == logging.ERROR
     ]
@@ -1851,7 +1851,7 @@ async def test_package_merge_exception(
         await config_util.async_hass_config_yaml(hass)
 
     error_records = [
-        record.message.replace(base_path, "<BASE_PATH>")
+        record.message
         for record in caplog.get_records("call")
         if record.levelno == logging.ERROR
     ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use relative paths in configuration validation error messages to improve the readability of error messages

Example with this PR:
```
Invalid config for [iot_domain] at configuration.yaml, line 6: required key 'platform' not provided.
```

Example without this PR:
```
Invalid config for [iot_domain] at /home/erik/development/home-assistant_fork/fixtures/core/config/component_validation/basic/configuration.yaml, line 6: required key 'platform' not provided.
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
