### PR TITLE
Update pytest-socket setup so allow_hosts works without enable_socket

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -423,6 +423,8 @@ norecursedirs = [
 log_format = "%(asctime)s.%(msecs)03d %(levelname)-8s %(threadName)s %(name)s:%(filename)s:%(lineno)s %(message)s"
 log_date_format = "%Y-%m-%d %H:%M:%S"
 asyncio_mode = "auto"
+# Options for pytest-socket allow_unix_socket is set to True because it's needed by asyncio.
+addopts = "--disable-socket --allow-unix-socket --allow-hosts=127.0.0.1"
 filterwarnings = [
     "error::sqlalchemy.exc.SAWarning",
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,6 @@ from aiohttp.web import Application
 import freezegun
 import multidict
 import pytest
-import pytest_socket
 import requests_mock
 from syrupy.assertion import SnapshotAssertion
 
@@ -126,21 +125,11 @@ def pytest_configure(config: pytest.Config) -> None:
 
 
 def pytest_runtest_setup() -> None:
-    """Prepare pytest_socket and freezegun.
-
-    pytest_socket:
-    Throw if tests attempt to open sockets.
-
-    allow_unix_socket is set to True because it's needed by asyncio.
-    Important: socket_allow_hosts must be called before disable_socket, otherwise all
-    destinations will be allowed.
+    """Prepare freezegun.
 
     freezegun:
     Modified to include https://github.com/spulec/freezegun/pull/424
     """
-    pytest_socket.socket_allow_hosts(["127.0.0.1"])
-    pytest_socket.disable_socket(allow_unix_socket=True)
-
     freezegun.api.datetime_to_fakedatetime = ha_datetime_to_fakedatetime  # type: ignore[attr-defined]
     freezegun.api.FakeDatetime = HAFakeDatetime  # type: ignore[attr-defined]
 

--- a/tests/test_test_fixtures.py
+++ b/tests/test_test_fixtures.py
@@ -8,16 +8,35 @@ from homeassistant.core import HomeAssistant, async_get_hass
 
 
 def test_sockets_disabled() -> None:
-    """Test we can't open sockets."""
-    with pytest.raises(pytest_socket.SocketBlockedError):
-        socket.socket()
-
-
-def test_sockets_enabled(socket_enabled) -> None:
-    """Test we can't connect to an address different from 127.0.0.1."""
+    """Test we can't open sockets not in allowed_hosts."""
     mysocket = socket.socket()
     with pytest.raises(pytest_socket.SocketConnectBlockedError):
         mysocket.connect(("127.0.0.2", 1234))
+
+
+def test_sockets_enabled(socket_enabled) -> None:
+    """Test we can open sockets to any address."""
+    mysocket = socket.socket()
+    with pytest.raises(ConnectionRefusedError):
+        mysocket.connect(("127.0.0.2", 1234))
+
+
+def test_sockets_allowed_hosts_config() -> None:
+    """Test we can try to connect to 127.0.0.1."""
+    mysocket = socket.socket()
+    with pytest.raises(ConnectionRefusedError):
+        mysocket.connect(("127.0.0.1", 1234))
+
+
+@pytest.mark.allow_hosts(["127.0.0.2"])
+def test_sockets_allowed_hosts_mark() -> None:
+    """Test we can try to connect to an address specified in the mark."""
+    mysocket = socket.socket()
+    with pytest.raises(ConnectionRefusedError):
+        mysocket.connect(("127.0.0.2", 1234))
+    # And that the mark has overridden the config
+    with pytest.raises(pytest_socket.SocketConnectBlockedError):
+        mysocket.connect(("127.0.0.1", 1234))
 
 
 async def test_hass_cv(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

EDIT: After creating this draft PR and seeing the CI tests failing I realised a lot of tests are accessing 127.0.0.1 and not reporting errors.  This PR then causes them to timeout and fail when they don't immediately get a socket exception.  I managed to work around the vscode-pytest issue by using a different test adapter so closing this PR.

I'm currently unable to use the vscode-pytest plug-in to debug tests as it communicates with it's test runner via a socket to localhost, and the way pytest-socket has been configured in HA prevents the connection.  

This PR proposes to remove the setup of pytest-socket in [core/tests/conftest.py:pytest_runtest_setup()]( https://github.com/home-assistant/core/blob/dev/tests/conftest.py#L141) and set it up via pytest.ini instead.  The result is that the behaviour becomes the behaviour of [pytest_socket:pytest_runtest_setup()]( https://github.com/miketheman/pytest-socket/blob/main/pytest_socket.py#L118) which is that --allow-hosts takes precedence over --disable-socket rather than the other way round.

The original PR that enabled pytest-socket is https://github.com/home-assistant/core/pull/55516 and included logic that was not yet in the released version so that may have influenced the decision of how to configure it.

I've searched around and no-one else seems to be complaining about this issue on HA so apologies if I've missed something obvious.  There is an open issue on [vscode-python](https://github.com/microsoft/vscode-python/issues/22383) where it's suggested to use allow_hosts to solve it.  Whilst I appreciate this could be viewed as an issue in the vscode-python extension it does seem like the preferred behaviour in HA is to allow 127.0.0.1 anyway as the enable_socket fixture is added to quite a few tests.

N.B. The error I get from the extension is below.  In a previous version of the extension it would just hang indefinitely due to a bug in it's error handling:
`vscode_pytest.VSCodePytestError: Error attempting to connect to extension communication socket[vscode-pytest]: A test tried to use socket.socket.`

 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
