### PR TITLE
Reverse component path

### DIFF
--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -280,7 +280,7 @@ class DeviceTrackerPlatform:
     ) -> None:
         """Set up a legacy platform."""
         assert self.type == PLATFORM_TYPE_LEGACY
-        full_name = f"{DOMAIN}.{self.name}"
+        full_name = f"{self.name}.{DOMAIN}"
         LOGGER.info("Setting up %s", full_name)
         with async_start_setup(hass, [full_name]):
             try:

--- a/homeassistant/components/ios/notify.py
+++ b/homeassistant/components/ios/notify.py
@@ -52,7 +52,7 @@ def get_service(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> iOSNotificationService | None:
     """Get the iOS notification service."""
-    if "notify.ios" not in hass.config.components:
+    if "ios.notify" not in hass.config.components:
         # Need this to enable requirements checking in the app.
         hass.config.components.add("ios.notify")
 

--- a/homeassistant/components/ios/notify.py
+++ b/homeassistant/components/ios/notify.py
@@ -54,7 +54,7 @@ def get_service(
     """Get the iOS notification service."""
     if "notify.ios" not in hass.config.components:
         # Need this to enable requirements checking in the app.
-        hass.config.components.add("notify.ios")
+        hass.config.components.add("ios.notify")
 
     if not ios.devices_with_push(hass):
         return None

--- a/homeassistant/components/notify/legacy.py
+++ b/homeassistant/components/notify/legacy.py
@@ -125,7 +125,7 @@ def async_setup_legacy(
             hass.data[NOTIFY_SERVICES].setdefault(integration_name, []).append(
                 notify_service
             )
-            hass.config.components.add(f"{DOMAIN}.{integration_name}")
+            hass.config.components.add(f"{integration_name}.{DOMAIN}")
 
     async def async_platform_discovered(
         platform: str, info: DiscoveryInfoType | None

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -545,7 +545,7 @@ class SpeechManager:
         self.providers[engine] = provider
 
         self.hass.config.components.add(
-            PLATFORM_FORMAT.format(domain=engine, platform=DOMAIN)
+            PLATFORM_FORMAT.format(domain=DOMAIN, platform=engine)
         )
 
     @callback

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -16,7 +16,7 @@ REQUIRED_NEXT_PYTHON_VER: Final[tuple[int, int, int]] = (3, 11, 0)
 REQUIRED_NEXT_PYTHON_HA_RELEASE: Final = ""
 
 # Format for platform files
-PLATFORM_FORMAT: Final = "{domain}.{platform}"
+PLATFORM_FORMAT: Final = "{platform}.{domain}"
 
 
 class Platform(StrEnum):

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -16,7 +16,7 @@ REQUIRED_NEXT_PYTHON_VER: Final[tuple[int, int, int]] = (3, 11, 0)
 REQUIRED_NEXT_PYTHON_HA_RELEASE: Final = ""
 
 # Format for platform files
-PLATFORM_FORMAT: Final = "{platform}.{domain}"
+PLATFORM_FORMAT: Final = "{domain}.{platform}"
 
 
 class Platform(StrEnum):

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -304,7 +304,7 @@ class EntityPlatform:
         current_platform.set(self)
         logger = self.logger
         hass = self.hass
-        full_name = f"{self.domain}.{self.platform_name}"
+        full_name = f"{self.platform_name}.{self.domain}"
         object_id_language = (
             hass.config.language
             if hass.config.language in languages.NATIVE_ENTITY_IDS

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -48,7 +48,7 @@ def component_translation_path(
     If component is just a single file, will return None.
     """
     parts = component.split(".")
-    domain = parts[-1]
+    domain = parts[0]
     is_platform = len(parts) == 2
 
     # If it's a component that is just one file, we don't support translations
@@ -57,7 +57,7 @@ def component_translation_path(
         return None
 
     if is_platform:
-        filename = f"{parts[0]}.{language}.json"
+        filename = f"{parts[1]}.{language}.json"
     else:
         filename = f"{language}.json"
 
@@ -96,7 +96,7 @@ def _merge_resources(
     # Build response
     resources: dict[str, dict[str, Any]] = {}
     for component in components:
-        domain = component.partition(".")[0]
+        domain = component.rpartition(".")[-1]
 
         domain_resources = resources.setdefault(domain, {})
 
@@ -154,7 +154,7 @@ async def _async_get_component_strings(
     # Determine paths of missing components/platforms
     files_to_load = {}
     for loaded in components:
-        domain = loaded.rpartition(".")[-1]
+        domain = loaded.partition(".")[0]
         integration = integrations[domain]
 
         path = component_translation_path(loaded, language, integration)
@@ -225,7 +225,7 @@ class _TranslationCache:
         languages = [LOCALE_EN] if language == LOCALE_EN else [LOCALE_EN, language]
 
         integrations: dict[str, Integration] = {}
-        domains = list({loaded.rpartition(".")[-1] for loaded in components})
+        domains = list({loaded.partition(".")[0] for loaded in components})
         ints_or_excs = await async_get_integrations(self.hass, domains)
         for domain, int_or_exc in ints_or_excs.items():
             if isinstance(int_or_exc, Exception):

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -492,7 +492,7 @@ def async_get_loaded_integrations(hass: core.HomeAssistant) -> set[str]:
         if "." not in component:
             integrations.add(component)
             continue
-        domain, _, platform = component.partition(".")
+        platform, _, domain = component.partition(".")
         if domain in BASE_PLATFORMS:
             integrations.add(platform)
     return integrations
@@ -517,7 +517,7 @@ def async_start_setup(
     time_taken = dt_util.utcnow() - started
     for unique, domain in unique_components.items():
         del setup_started[unique]
-        integration = domain.rpartition(".")[-1]
+        integration = domain.partition(".")[0]
         if integration in setup_time:
             setup_time[integration] += time_taken
         else:

--- a/tests/components/device_tracker/test_config_entry.py
+++ b/tests/components/device_tracker/test_config_entry.py
@@ -259,7 +259,7 @@ async def test_connected_device_registered(
 
     assert await entity_platform.async_setup_entry(config_entry)
     await hass.async_block_till_done()
-    full_name = f"{entity_platform.domain}.{config_entry.domain}"
+    full_name = f"{config_entry.domain}.{entity_platform.domain}"
     assert full_name in hass.config.components
     assert len(hass.states.async_entity_ids()) == 0  # should be disabled
     assert len(entity_registry.entities) == 3

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -123,7 +123,7 @@ async def test_reading_yaml_config(
     assert device.config_picture == config.config_picture
     assert device.consider_home == config.consider_home
     assert device.icon == config.icon
-    assert f"{device_tracker.DOMAIN}.test" in hass.config.components
+    assert f"test.{device_tracker.DOMAIN}" in hass.config.components
 
 
 @patch("homeassistant.components.device_tracker.const.LOGGER.warning")
@@ -603,7 +603,7 @@ async def test_bad_platform(hass: HomeAssistant) -> None:
     with assert_setup_component(0, device_tracker.DOMAIN):
         assert await async_setup_component(hass, device_tracker.DOMAIN, config)
 
-    assert f"{device_tracker.DOMAIN}.bad_platform" not in hass.config.components
+    assert f"bad_platform.{device_tracker.DOMAIN}" not in hass.config.components
 
 
 async def test_adding_unknown_device_to_config(

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -150,7 +150,7 @@ async def test_restore_state(
 async def test_setup_component(hass: HomeAssistant, setup: str) -> None:
     """Set up a TTS platform with defaults."""
     assert hass.services.has_service(tts.DOMAIN, "clear_cache")
-    assert f"{tts.DOMAIN}.test" in hass.config.components
+    assert f"test.{tts.DOMAIN}" in hass.config.components
 
 
 @pytest.mark.parametrize("init_tts_cache_dir_side_effect", [OSError(2, "No access")])

--- a/tests/components/weather/test_init.py
+++ b/tests/components/weather/test_init.py
@@ -1250,7 +1250,7 @@ async def test_issue_forecast_deprecated_no_logging(
 
     assert weather_entity.state == ATTR_CONDITION_SUNNY
 
-    assert "Setting up weather.test" in caplog.text
+    assert "Setting up test.weather" in caplog.text
     assert (
         "custom_components.test_weather.weather::weather.test is using a forecast attribute on an instance of WeatherEntity"
         not in caplog.text

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -215,7 +215,7 @@ async def test_platform_not_ready(hass: HomeAssistant) -> None:
         await component.async_setup({DOMAIN: {"platform": "mod1"}})
         await hass.async_block_till_done()
         assert len(platform1_setup.mock_calls) == 1
-        assert "test_domain.mod1" not in hass.config.components
+        assert "mod1.test_domain" not in hass.config.components
 
         # Should not trigger attempt 2
         async_fire_time_changed(hass, utcnow + timedelta(seconds=29))
@@ -226,7 +226,7 @@ async def test_platform_not_ready(hass: HomeAssistant) -> None:
         async_fire_time_changed(hass, utcnow + timedelta(seconds=30))
         await hass.async_block_till_done()
         assert len(platform1_setup.mock_calls) == 2
-        assert "test_domain.mod1" not in hass.config.components
+        assert "mod1.test_domain" not in hass.config.components
 
         # This should not trigger attempt 3
         async_fire_time_changed(hass, utcnow + timedelta(seconds=59))
@@ -237,7 +237,7 @@ async def test_platform_not_ready(hass: HomeAssistant) -> None:
         async_fire_time_changed(hass, utcnow + timedelta(seconds=60))
         await hass.async_block_till_done()
         assert len(platform1_setup.mock_calls) == 3
-        assert "test_domain.mod1" in hass.config.components
+        assert "mod1.test_domain" in hass.config.components
 
 
 async def test_extract_from_service_fails_if_no_entity_id(hass: HomeAssistant) -> None:
@@ -317,7 +317,7 @@ async def test_setup_dependencies_platform(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert "test_component" in hass.config.components
     assert "test_component2" in hass.config.components
-    assert "test_domain.test_component" in hass.config.components
+    assert "test_component.test_domain" in hass.config.components
 
 
 async def test_setup_entry(hass: HomeAssistant) -> None:
@@ -680,7 +680,7 @@ async def test_platforms_shutdown_on_stop(hass: HomeAssistant) -> None:
     await component.async_setup({DOMAIN: {"platform": "mod1"}})
     await hass.async_block_till_done()
     assert len(platform1_setup.mock_calls) == 1
-    assert "test_domain.mod1" not in hass.config.components
+    assert "mod1.test_domain" not in hass.config.components
 
     with patch.object(
         component._platforms[DOMAIN], "async_shutdown"

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -268,7 +268,7 @@ async def test_platform_error_slow_setup(
         await component.async_setup({DOMAIN: {"platform": "test_platform"}})
         await hass.async_block_till_done()
         assert len(called) == 1
-        assert "test_domain.test_platform" not in hass.config.components
+        assert "test_platform.test_domain" not in hass.config.components
         assert "test_platform is taking longer than 0 seconds" in caplog.text
 
     # Cleanup lingering (setup_platform) task after test is done
@@ -833,7 +833,7 @@ async def test_setup_entry(
 
     assert await entity_platform.async_setup_entry(config_entry)
     await hass.async_block_till_done()
-    full_name = f"{entity_platform.domain}.{config_entry.domain}"
+    full_name = f"{config_entry.domain}.{entity_platform.domain}"
     assert full_name in hass.config.components
     assert len(hass.states.async_entity_ids()) == 1
     assert len(entity_registry.entities) == 1
@@ -856,7 +856,7 @@ async def test_setup_entry_platform_not_ready(
     with patch.object(entity_platform, "async_call_later") as mock_call_later:
         assert not await ent_platform.async_setup_entry(config_entry)
 
-    full_name = f"{ent_platform.domain}.{config_entry.domain}"
+    full_name = f"{config_entry.domain}.{ent_platform.domain}"
     assert full_name not in hass.config.components
     assert len(async_setup_entry.mock_calls) == 1
     assert "Platform test not ready yet" in caplog.text
@@ -877,7 +877,7 @@ async def test_setup_entry_platform_not_ready_with_message(
     with patch.object(entity_platform, "async_call_later") as mock_call_later:
         assert not await ent_platform.async_setup_entry(config_entry)
 
-    full_name = f"{ent_platform.domain}.{config_entry.domain}"
+    full_name = f"{config_entry.domain}.{ent_platform.domain}"
     assert full_name not in hass.config.components
     assert len(async_setup_entry.mock_calls) == 1
 
@@ -904,7 +904,7 @@ async def test_setup_entry_platform_not_ready_from_exception(
     with patch.object(entity_platform, "async_call_later") as mock_call_later:
         assert not await ent_platform.async_setup_entry(config_entry)
 
-    full_name = f"{ent_platform.domain}.{config_entry.domain}"
+    full_name = f"{config_entry.domain}.{ent_platform.domain}"
     assert full_name not in hass.config.components
     assert len(async_setup_entry.mock_calls) == 1
 
@@ -1669,7 +1669,7 @@ async def test_setup_entry_with_entities_that_block_forever(
     ):
         assert await platform.async_setup_entry(config_entry)
         await hass.async_block_till_done()
-    full_name = f"{platform.domain}.{config_entry.domain}"
+    full_name = f"{config_entry.domain}.{platform.domain}"
     assert full_name in hass.config.components
     assert len(hass.states.async_entity_ids()) == 0
     assert len(entity_registry.entities) == 1

--- a/tests/helpers/test_reload.py
+++ b/tests/helpers/test_reload.py
@@ -51,7 +51,7 @@ async def test_reload_platform(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert component_setup.called
 
-    assert f"{DOMAIN}.{PLATFORM}" in hass.config.components
+    assert f"{PLATFORM}.{DOMAIN}" in hass.config.components
     assert len(setup_called) == 1
 
     platform = async_get_platform_without_config_entry(hass, PLATFORM, DOMAIN)
@@ -91,7 +91,7 @@ async def test_setup_reload_service(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert component_setup.called
 
-    assert f"{DOMAIN}.{PLATFORM}" in hass.config.components
+    assert f"{PLATFORM}.{DOMAIN}" in hass.config.components
     assert len(setup_called) == 1
 
     await async_setup_reload_service(hass, PLATFORM, [DOMAIN])
@@ -132,7 +132,7 @@ async def test_setup_reload_service_when_async_process_component_config_fails(
     await hass.async_block_till_done()
     assert component_setup.called
 
-    assert f"{DOMAIN}.{PLATFORM}" in hass.config.components
+    assert f"{PLATFORM}.{DOMAIN}" in hass.config.components
     assert len(setup_called) == 1
 
     await async_setup_reload_service(hass, PLATFORM, [DOMAIN])
@@ -182,7 +182,7 @@ async def test_setup_reload_service_with_platform_that_provides_async_reset_plat
     await hass.async_block_till_done()
     assert component_setup.called
 
-    assert f"{DOMAIN}.{PLATFORM}" in hass.config.components
+    assert f"{PLATFORM}.{DOMAIN}" in hass.config.components
     assert len(setup_called) == 1
 
     await async_setup_reload_service(hass, PLATFORM, [DOMAIN])

--- a/tests/helpers/test_restore_state.py
+++ b/tests/helpers/test_restore_state.py
@@ -508,7 +508,7 @@ async def test_restore_entity_end_to_end(
     await hass.async_block_till_done()
     assert component_setup.called
 
-    assert f"{DOMAIN}.{PLATFORM}" in hass.config.components
+    assert f"{PLATFORM}.{DOMAIN}" in hass.config.components
     assert len(setup_called) == 1
 
     platform = async_get_platform_without_config_entry(hass, PLATFORM, DOMAIN)

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -255,7 +255,7 @@ async def test_translation_merging(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we merge translations of two integrations."""
-    hass.config.components.add("sensor.moon")
+    hass.config.components.add("moon.sensor")
     hass.config.components.add("sensor")
 
     orig_load_translations = translation.load_translations_files
@@ -263,7 +263,7 @@ async def test_translation_merging(
     def mock_load_translations_files(files):
         """Mock loading."""
         result = orig_load_translations(files)
-        result["sensor.moon"] = {
+        result["moon.sensor"] = {
             "state": {"moon__phase": {"first_quarter": "First Quarter"}}
         }
         return result
@@ -276,7 +276,7 @@ async def test_translation_merging(
 
     assert "component.sensor.state.moon__phase.first_quarter" in translations
 
-    hass.config.components.add("sensor.season")
+    hass.config.components.add("season.sensor")
 
     # Patch in some bad translation data
     def mock_load_bad_translations_files(files):
@@ -323,7 +323,7 @@ async def test_translation_merging_loaded_apart(
 
     assert "component.sensor.state.moon__phase.first_quarter" not in translations
 
-    hass.config.components.add("sensor.moon")
+    hass.config.components.add("moon.sensor")
 
     with patch(
         "homeassistant.helpers.translation.load_translations_files",

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -56,14 +56,14 @@ async def test_component_translation_path(
     )
 
     assert path.normpath(
-        translation.component_translation_path("switch.test", "en", int_test)
+        translation.component_translation_path("test.switch", "en", int_test)
     ) == path.normpath(
         hass.config.path("custom_components", "test", "translations", "switch.en.json")
     )
 
     assert path.normpath(
         translation.component_translation_path(
-            "switch.test_embedded", "en", int_test_embedded
+            "test_embedded.switch", "en", int_test_embedded
         )
     ) == path.normpath(
         hass.config.path(
@@ -282,7 +282,7 @@ async def test_translation_merging(
     def mock_load_bad_translations_files(files):
         """Mock loading."""
         result = orig_load_translations(files)
-        result["sensor.season"] = {"state": "bad data"}
+        result["season.sensor"] = {"state": "bad data"}
         return result
 
     with patch(
@@ -308,7 +308,7 @@ async def test_translation_merging_loaded_apart(
     def mock_load_translations_files(files):
         """Mock loading."""
         result = orig_load_translations(files)
-        result["sensor.moon"] = {
+        result["moon.sensor"] = {
             "state": {"moon__phase": {"first_quarter": "First Quarter"}}
         }
         return result

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -663,7 +663,7 @@ async def test_async_get_loaded_integrations(hass: HomeAssistant) -> None:
     hass.config.components.add("notbase.switch")
     hass.config.components.add("myintegration")
     hass.config.components.add("device_tracker")
-    hass.config.components.add("device_tracker.other")
+    hass.config.components.add("other.device_tracker")
     hass.config.components.add("myintegration.light")
     assert setup.async_get_loaded_integrations(hass) == {
         "other",

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -720,9 +720,9 @@ async def test_async_start_setup(hass: HomeAssistant) -> None:
 
 async def test_async_start_setup_platforms(hass: HomeAssistant) -> None:
     """Test setup started context manager keeps track of setup times for platforms."""
-    with setup.async_start_setup(hass, ["sensor.august"]):
+    with setup.async_start_setup(hass, ["august.sensor"]):
         assert isinstance(
-            hass.data[setup.DATA_SETUP_STARTED]["sensor.august"], datetime.datetime
+            hass.data[setup.DATA_SETUP_STARTED]["august.sensor"], datetime.datetime
         )
 
     assert "august" not in hass.data[setup.DATA_SETUP_STARTED]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reverse the keys in `hass.config.components` from `light.hue` to the modern `hue.light` in some remaining cases.

Most cases already use `hue.light`, but some legacy code still used the old path.

### Rationale
This is better aligned with how platforms are actually located after https://github.com/home-assistant/architecture/issues/124 / https://github.com/home-assistant/core/pull/19948

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
