### PR TITLE
Add camera in use and pending reboot binary sensors to System Bridge

### DIFF
--- a/homeassistant/components/system_bridge/binary_sensor.py
+++ b/homeassistant/components/system_bridge/binary_sensor.py
@@ -108,8 +108,6 @@ class SystemBridgeBinarySensor(SystemBridgeEntity, BinarySensorEntity):
             description.key,
         )
         self.entity_description = description
-        if description.name != UNDEFINED:
-            self._attr_has_entity_name = False
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/system_bridge/binary_sensor.py
+++ b/homeassistant/components/system_bridge/binary_sensor.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import SystemBridgeDataUpdateCoordinator
+from .coordinator import SystemBridgeCoordinatorData, SystemBridgeDataUpdateCoordinator
 from .entity import SystemBridgeEntity
 
 
@@ -27,9 +27,29 @@ class SystemBridgeBinarySensorEntityDescription(BinarySensorEntityDescription):
     value: Callable = round
 
 
+def camera_in_use(data: SystemBridgeCoordinatorData) -> bool | None:
+    """Return if the camera is in use."""
+    if data.system.camera_usage is not None:
+        return len(data.system.camera_usage) > 0
+    return None
+
+
 BASE_BINARY_SENSOR_TYPES: tuple[SystemBridgeBinarySensorEntityDescription, ...] = (
     SystemBridgeBinarySensorEntityDescription(
+        key="camera_in_use",
+        translation_key="camera_in_use",
+        device_class=BinarySensorDeviceClass.OCCUPANCY,
+        value=camera_in_use,
+    ),
+    SystemBridgeBinarySensorEntityDescription(
+        key="pending_restart",
+        translation_key="pending_restart",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        value=lambda data: data.system.pending_reboot,
+    ),
+    SystemBridgeBinarySensorEntityDescription(
         key="version_available",
+        translation_key="version_available",
         device_class=BinarySensorDeviceClass.UPDATE,
         value=lambda data: data.system.version_newer_available,
     ),

--- a/homeassistant/components/system_bridge/binary_sensor.py
+++ b/homeassistant/components/system_bridge/binary_sensor.py
@@ -24,11 +24,11 @@ from .entity import SystemBridgeEntity
 class SystemBridgeBinarySensorEntityDescription(BinarySensorEntityDescription):
     """Class describing System Bridge binary sensor entities."""
 
-    value: Callable = round
+    value_fn: Callable = round
 
 
 def camera_in_use(data: SystemBridgeCoordinatorData) -> bool | None:
-    """Return if the camera is in use."""
+    """Return if any camera is in use."""
     if data.system.camera_usage is not None:
         return len(data.system.camera_usage) > 0
     return None

--- a/homeassistant/components/system_bridge/binary_sensor.py
+++ b/homeassistant/components/system_bridge/binary_sensor.py
@@ -38,13 +38,11 @@ BASE_BINARY_SENSOR_TYPES: tuple[SystemBridgeBinarySensorEntityDescription, ...] 
     SystemBridgeBinarySensorEntityDescription(
         key="camera_in_use",
         translation_key="camera_in_use",
-        device_class=BinarySensorDeviceClass.OCCUPANCY,
         value=camera_in_use,
     ),
     SystemBridgeBinarySensorEntityDescription(
         key="pending_restart",
         translation_key="pending_restart",
-        device_class=BinarySensorDeviceClass.PROBLEM,
         value=lambda data: data.system.pending_reboot,
     ),
     SystemBridgeBinarySensorEntityDescription(

--- a/homeassistant/components/system_bridge/binary_sensor.py
+++ b/homeassistant/components/system_bridge/binary_sensor.py
@@ -46,7 +46,7 @@ BASE_BINARY_SENSOR_TYPES: tuple[SystemBridgeBinarySensorEntityDescription, ...] 
         key="pending_restart",
         translation_key="pending_restart",
         icon="mdi:restart",
-        value=lambda data: data.system.pending_reboot,
+        value=lambda data: data.system.pending_restart,
     ),
     SystemBridgeBinarySensorEntityDescription(
         key="version_available",

--- a/homeassistant/components/system_bridge/binary_sensor.py
+++ b/homeassistant/components/system_bridge/binary_sensor.py
@@ -39,11 +39,13 @@ BASE_BINARY_SENSOR_TYPES: tuple[SystemBridgeBinarySensorEntityDescription, ...] 
     SystemBridgeBinarySensorEntityDescription(
         key="camera_in_use",
         translation_key="camera_in_use",
+        icon="mdi:webcam",
         value=camera_in_use,
     ),
     SystemBridgeBinarySensorEntityDescription(
         key="pending_restart",
         translation_key="pending_restart",
+        icon="mdi:restart",
         value=lambda data: data.system.pending_reboot,
     ),
     SystemBridgeBinarySensorEntityDescription(

--- a/homeassistant/components/system_bridge/binary_sensor.py
+++ b/homeassistant/components/system_bridge/binary_sensor.py
@@ -43,10 +43,10 @@ BASE_BINARY_SENSOR_TYPES: tuple[SystemBridgeBinarySensorEntityDescription, ...] 
         value=camera_in_use,
     ),
     SystemBridgeBinarySensorEntityDescription(
-        key="pending_restart",
-        translation_key="pending_restart",
+        key="pending_reboot",
+        translation_key="pending_reboot",
         icon="mdi:restart",
-        value=lambda data: data.system.pending_restart,
+        value=lambda data: data.system.pending_reboot,
     ),
     SystemBridgeBinarySensorEntityDescription(
         key="version_available",

--- a/homeassistant/components/system_bridge/binary_sensor.py
+++ b/homeassistant/components/system_bridge/binary_sensor.py
@@ -14,7 +14,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import UNDEFINED
 
 from .const import DOMAIN
 from .coordinator import SystemBridgeCoordinatorData, SystemBridgeDataUpdateCoordinator
@@ -50,7 +49,6 @@ BASE_BINARY_SENSOR_TYPES: tuple[SystemBridgeBinarySensorEntityDescription, ...] 
     ),
     SystemBridgeBinarySensorEntityDescription(
         key="version_available",
-        translation_key="version_available",
         device_class=BinarySensorDeviceClass.UPDATE,
         value=lambda data: data.system.version_newer_available,
     ),
@@ -59,7 +57,6 @@ BASE_BINARY_SENSOR_TYPES: tuple[SystemBridgeBinarySensorEntityDescription, ...] 
 BATTERY_BINARY_SENSOR_TYPES: tuple[SystemBridgeBinarySensorEntityDescription, ...] = (
     SystemBridgeBinarySensorEntityDescription(
         key="battery_is_charging",
-        translation_key="battery_is_charging",
         device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
         value=lambda data: data.battery.is_charging,
     ),

--- a/homeassistant/components/system_bridge/binary_sensor.py
+++ b/homeassistant/components/system_bridge/binary_sensor.py
@@ -14,6 +14,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import UNDEFINED
 
 from .const import DOMAIN
 from .coordinator import SystemBridgeCoordinatorData, SystemBridgeDataUpdateCoordinator
@@ -89,6 +90,7 @@ async def async_setup_entry(
 class SystemBridgeBinarySensor(SystemBridgeEntity, BinarySensorEntity):
     """Define a System Bridge binary sensor."""
 
+    _attr_has_entity_name = True
     entity_description: SystemBridgeBinarySensorEntityDescription
 
     def __init__(
@@ -104,6 +106,8 @@ class SystemBridgeBinarySensor(SystemBridgeEntity, BinarySensorEntity):
             description.key,
         )
         self.entity_description = description
+        if description.name != UNDEFINED:
+            self._attr_has_entity_name = False
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/system_bridge/binary_sensor.py
+++ b/homeassistant/components/system_bridge/binary_sensor.py
@@ -16,7 +16,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import SystemBridgeCoordinatorData, SystemBridgeDataUpdateCoordinator
+from .coordinator import SystemBridgeDataUpdateCoordinator
+from .data import SystemBridgeData
 from .entity import SystemBridgeEntity
 
 
@@ -27,7 +28,7 @@ class SystemBridgeBinarySensorEntityDescription(BinarySensorEntityDescription):
     value_fn: Callable = round
 
 
-def camera_in_use(data: SystemBridgeCoordinatorData) -> bool | None:
+def camera_in_use(data: SystemBridgeData) -> bool | None:
     """Return if any camera is in use."""
     if data.system.camera_usage is not None:
         return len(data.system.camera_usage) > 0
@@ -39,18 +40,18 @@ BASE_BINARY_SENSOR_TYPES: tuple[SystemBridgeBinarySensorEntityDescription, ...] 
         key="camera_in_use",
         translation_key="camera_in_use",
         icon="mdi:webcam",
-        value=camera_in_use,
+        value_fn=camera_in_use,
     ),
     SystemBridgeBinarySensorEntityDescription(
         key="pending_reboot",
         translation_key="pending_reboot",
         icon="mdi:restart",
-        value=lambda data: data.system.pending_reboot,
+        value_fn=lambda data: data.system.pending_reboot,
     ),
     SystemBridgeBinarySensorEntityDescription(
         key="version_available",
         device_class=BinarySensorDeviceClass.UPDATE,
-        value=lambda data: data.system.version_newer_available,
+        value_fn=lambda data: data.system.version_newer_available,
     ),
 )
 
@@ -58,7 +59,7 @@ BATTERY_BINARY_SENSOR_TYPES: tuple[SystemBridgeBinarySensorEntityDescription, ..
     SystemBridgeBinarySensorEntityDescription(
         key="battery_is_charging",
         device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
-        value=lambda data: data.battery.is_charging,
+        value_fn=lambda data: data.battery.is_charging,
     ),
 )
 
@@ -109,4 +110,4 @@ class SystemBridgeBinarySensor(SystemBridgeEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return the boolean state of the binary sensor."""
-        return self.entity_description.value(self.coordinator.data)
+        return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/system_bridge/binary_sensor.py
+++ b/homeassistant/components/system_bridge/binary_sensor.py
@@ -57,6 +57,7 @@ BASE_BINARY_SENSOR_TYPES: tuple[SystemBridgeBinarySensorEntityDescription, ...] 
 BATTERY_BINARY_SENSOR_TYPES: tuple[SystemBridgeBinarySensorEntityDescription, ...] = (
     SystemBridgeBinarySensorEntityDescription(
         key="battery_is_charging",
+        translation_key="battery_is_charging",
         device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
         value=lambda data: data.battery.is_charging,
     ),
@@ -90,7 +91,6 @@ async def async_setup_entry(
 class SystemBridgeBinarySensor(SystemBridgeEntity, BinarySensorEntity):
     """Define a System Bridge binary sensor."""
 
-    _attr_has_entity_name = True
     entity_description: SystemBridgeBinarySensorEntityDescription
 
     def __init__(

--- a/homeassistant/components/system_bridge/strings.json
+++ b/homeassistant/components/system_bridge/strings.json
@@ -31,17 +31,11 @@
   },
   "entity": {
     "binary_sensor": {
-      "battery_is_charging": {
-        "name": "Battery charging"
-      },
       "camera_in_use": {
         "name": "Camera in use"
       },
       "pending_reboot": {
         "name": "Pending reboot"
-      },
-      "version_available": {
-        "name": "New version available"
       }
     },
     "media_player": {

--- a/homeassistant/components/system_bridge/strings.json
+++ b/homeassistant/components/system_bridge/strings.json
@@ -39,6 +39,9 @@
       "boot_time": {
         "name": "Boot time"
       },
+      "camera_in_use": {
+        "name": "Camera in use"
+      },
       "cpu_power_package": {
         "name": "CPU package power"
       },
@@ -66,6 +69,9 @@
       "os": {
         "name": "Operating system"
       },
+      "pending_restart": {
+        "name": "Pending restart"
+      },
       "processes": {
         "name": "Processes"
       },
@@ -74,6 +80,9 @@
       },
       "version": {
         "name": "Version"
+      },
+      "version_available": {
+        "name": "New version available"
       },
       "version_latest": {
         "name": "Latest version"

--- a/homeassistant/components/system_bridge/strings.json
+++ b/homeassistant/components/system_bridge/strings.json
@@ -30,6 +30,20 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "battery_is_charging": {
+        "name": "Battery is charging"
+      },
+      "camera_in_use": {
+        "name": "Camera in use"
+      },
+      "pending_restart": {
+        "name": "Pending restart"
+      },
+      "version_available": {
+        "name": "New version available"
+      }
+    },
     "media_player": {
       "media": {
         "name": "Media"
@@ -38,9 +52,6 @@
     "sensor": {
       "boot_time": {
         "name": "Boot time"
-      },
-      "camera_in_use": {
-        "name": "Camera in use"
       },
       "cpu_power_package": {
         "name": "CPU package power"
@@ -69,9 +80,6 @@
       "os": {
         "name": "Operating system"
       },
-      "pending_restart": {
-        "name": "Pending restart"
-      },
       "processes": {
         "name": "Processes"
       },
@@ -80,9 +88,6 @@
       },
       "version": {
         "name": "Version"
-      },
-      "version_available": {
-        "name": "New version available"
       },
       "version_latest": {
         "name": "Latest version"

--- a/homeassistant/components/system_bridge/strings.json
+++ b/homeassistant/components/system_bridge/strings.json
@@ -32,7 +32,7 @@
   "entity": {
     "binary_sensor": {
       "battery_is_charging": {
-        "name": "Battery is charging"
+        "name": "Battery charging"
       },
       "camera_in_use": {
         "name": "Camera in use"

--- a/homeassistant/components/system_bridge/strings.json
+++ b/homeassistant/components/system_bridge/strings.json
@@ -37,8 +37,8 @@
       "camera_in_use": {
         "name": "Camera in use"
       },
-      "pending_restart": {
-        "name": "Pending restart"
+      "pending_reboot": {
+        "name": "Pending reboot"
       },
       "version_available": {
         "name": "New version available"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds two new binary sensors to System Bridge.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] New feature (which adds functionality to an existing integration)

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29876

Closes timmo001/system-bridge#2844
Closes timmo001/system-bridge#2851

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
