### PR TITLE
Bumb python-homewizard-energy to 4.1.0

### DIFF
--- a/homeassistant/components/homewizard/manifest.json
+++ b/homeassistant/components/homewizard/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "local_polling",
   "loggers": ["homewizard_energy"],
   "quality_scale": "platinum",
-  "requirements": ["python-homewizard-energy==4.0.0"],
+  "requirements": ["python-homewizard-energy==4.1.0"],
   "zeroconf": ["_hwenergy._tcp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2146,7 +2146,7 @@ python-gc100==1.0.3a0
 python-gitlab==1.6.0
 
 # homeassistant.components.homewizard
-python-homewizard-energy==4.0.0
+python-homewizard-energy==4.1.0
 
 # homeassistant.components.hp_ilo
 python-hpilo==4.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1603,7 +1603,7 @@ python-ecobee-api==0.2.17
 python-fullykiosk==0.0.12
 
 # homeassistant.components.homewizard
-python-homewizard-energy==4.0.0
+python-homewizard-energy==4.1.0
 
 # homeassistant.components.izone
 python-izone==1.2.9

--- a/tests/components/homewizard/snapshots/test_diagnostics.ambr
+++ b/tests/components/homewizard/snapshots/test_diagnostics.ambr
@@ -265,7 +265,9 @@
         'serial': '**REDACTED**',
       }),
       'state': None,
-      'system': None,
+      'system': dict({
+        'cloud_enabled': True,
+      }),
     }),
     'entry': dict({
       'ip_address': '**REDACTED**',

--- a/tests/components/homewizard/snapshots/test_diagnostics.ambr
+++ b/tests/components/homewizard/snapshots/test_diagnostics.ambr
@@ -334,7 +334,9 @@
         'serial': '**REDACTED**',
       }),
       'state': None,
-      'system': None,
+      'system': dict({
+        'cloud_enabled': True,
+      }),
     }),
     'entry': dict({
       'ip_address': '**REDACTED**',

--- a/tests/components/homewizard/snapshots/test_switch.ambr
+++ b/tests/components/homewizard/snapshots/test_switch.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_switch_entities[switch.device-state_set-power_on-HWE-SKT]
+# name: test_switch_entities[HWE-SKT-switch.device-state_set-power_on]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'outlet',
@@ -12,7 +12,7 @@
     'state': 'on',
   })
 # ---
-# name: test_switch_entities[switch.device-state_set-power_on-HWE-SKT].1
+# name: test_switch_entities[HWE-SKT-switch.device-state_set-power_on].1
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -43,7 +43,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_entities[switch.device-state_set-power_on-HWE-SKT].2
+# name: test_switch_entities[HWE-SKT-switch.device-state_set-power_on].2
   DeviceRegistryEntrySnapshot({
     'area_id': None,
     'config_entries': <ANY>,
@@ -75,7 +75,7 @@
     'via_device_id': None,
   })
 # ---
-# name: test_switch_entities[switch.device_cloud_connection-system_set-cloud_enabled-HWE-SKT]
+# name: test_switch_entities[HWE-SKT-switch.device_cloud_connection-system_set-cloud_enabled]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Cloud connection',
@@ -88,7 +88,7 @@
     'state': 'on',
   })
 # ---
-# name: test_switch_entities[switch.device_cloud_connection-system_set-cloud_enabled-HWE-SKT].1
+# name: test_switch_entities[HWE-SKT-switch.device_cloud_connection-system_set-cloud_enabled].1
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -119,7 +119,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_entities[switch.device_cloud_connection-system_set-cloud_enabled-HWE-SKT].2
+# name: test_switch_entities[HWE-SKT-switch.device_cloud_connection-system_set-cloud_enabled].2
   DeviceRegistryEntrySnapshot({
     'area_id': None,
     'config_entries': <ANY>,
@@ -151,7 +151,7 @@
     'via_device_id': None,
   })
 # ---
-# name: test_switch_entities[switch.device_switch_lock-state_set-switch_lock-HWE-SKT]
+# name: test_switch_entities[HWE-SKT-switch.device_switch_lock-state_set-switch_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Switch lock',
@@ -164,7 +164,7 @@
     'state': 'off',
   })
 # ---
-# name: test_switch_entities[switch.device_switch_lock-state_set-switch_lock-HWE-SKT].1
+# name: test_switch_entities[HWE-SKT-switch.device_switch_lock-state_set-switch_lock].1
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -195,7 +195,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_entities[switch.device_switch_lock-state_set-switch_lock-HWE-SKT].2
+# name: test_switch_entities[HWE-SKT-switch.device_switch_lock-state_set-switch_lock].2
   DeviceRegistryEntrySnapshot({
     'area_id': None,
     'config_entries': <ANY>,
@@ -224,6 +224,158 @@
     'serial_number': None,
     'suggested_area': None,
     'sw_version': '3.03',
+    'via_device_id': None,
+  })
+# ---
+# name: test_switch_entities[SDM230-switch.device_cloud_connection-system_set-cloud_enabled]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Device Cloud connection',
+      'icon': 'mdi:cloud',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.device_cloud_connection',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_entities[SDM230-switch.device_cloud_connection-system_set-cloud_enabled].1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.device_cloud_connection',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:cloud',
+    'original_name': 'Cloud connection',
+    'platform': 'homewizard',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'cloud_connection',
+    'unique_id': 'aabbccddeeff_cloud_connection',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities[SDM230-switch.device_cloud_connection-system_set-cloud_enabled].2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        '3c:39:e7:aa:bb:cc',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'homewizard',
+        '3c39e7aabbcc',
+      ),
+    }),
+    'is_new': False,
+    'manufacturer': 'HomeWizard',
+    'model': 'SDM230-wifi',
+    'name': 'Device',
+    'name_by_user': None,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': '3.06',
+    'via_device_id': None,
+  })
+# ---
+# name: test_switch_entities[SDM630-switch.device_cloud_connection-system_set-cloud_enabled]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Device Cloud connection',
+      'icon': 'mdi:cloud',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.device_cloud_connection',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_entities[SDM630-switch.device_cloud_connection-system_set-cloud_enabled].1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.device_cloud_connection',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:cloud',
+    'original_name': 'Cloud connection',
+    'platform': 'homewizard',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'cloud_connection',
+    'unique_id': 'aabbccddeeff_cloud_connection',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities[SDM630-switch.device_cloud_connection-system_set-cloud_enabled].2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        '3c:39:e7:aa:bb:cc',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'homewizard',
+        '3c39e7aabbcc',
+      ),
+    }),
+    'is_new': False,
+    'manufacturer': 'HomeWizard',
+    'model': 'SDM630-wifi',
+    'name': 'Device',
+    'name_by_user': None,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': '3.06',
     'via_device_id': None,
   })
 # ---

--- a/tests/components/homewizard/test_switch.py
+++ b/tests/components/homewizard/test_switch.py
@@ -49,7 +49,6 @@ pytestmark = [
             [
                 "switch.device",
                 "switch.device_switch_lock",
-                "switch.device_cloud_connection",
             ],
         ),
     ],
@@ -63,13 +62,14 @@ async def test_entities_not_created_for_device(
         assert not hass.states.get(entity_id)
 
 
-@pytest.mark.parametrize("device_fixture", ["HWE-SKT"])
 @pytest.mark.parametrize(
-    ("entity_id", "method", "parameter"),
+    ("device_fixture", "entity_id", "method", "parameter"),
     [
-        ("switch.device", "state_set", "power_on"),
-        ("switch.device_switch_lock", "state_set", "switch_lock"),
-        ("switch.device_cloud_connection", "system_set", "cloud_enabled"),
+        ("HWE-SKT", "switch.device", "state_set", "power_on"),
+        ("HWE-SKT", "switch.device_switch_lock", "state_set", "switch_lock"),
+        ("HWE-SKT", "switch.device_cloud_connection", "system_set", "cloud_enabled"),
+        ("SDM230", "switch.device_cloud_connection", "system_set", "cloud_enabled"),
+        ("SDM630", "switch.device_cloud_connection", "system_set", "cloud_enabled"),
     ],
 )
 async def test_switch_entities(

--- a/tests/components/homewizard/test_switch.py
+++ b/tests/components/homewizard/test_switch.py
@@ -42,7 +42,6 @@ pytestmark = [
             [
                 "switch.device",
                 "switch.device_switch_lock",
-                "switch.device_cloud_connection",
             ],
         ),
         (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bumb python-homewizard-energy to 4.1.0 to fix missing 'Enable cloud' switch. This was caused by a mismatch in the device name. (`SDM230-WIFI != SDM230-wifi`).

https://github.com/homewizard/python-homewizard-energy/releases/tag/v4.1.0
https://github.com/DCSBL/python-homewizard-energy/compare/v4.0.0...v4.1.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
