### PR TITLE
Reduce nesting in discovergy setup

### DIFF
--- a/homeassistant/components/discovergy/sensor.py
+++ b/homeassistant/components/discovergy/sensor.py
@@ -30,12 +30,19 @@ from .const import DOMAIN, MANUFACTURER
 PARALLEL_UPDATES = 1
 
 
+def _get_and_scale(reading: Reading, key: str, scale: int) -> datetime | float | None:
+    """Get a value from a Reading and divide with scale it."""
+    if (value := reading.values.get(key)) is not None:
+        return value / scale
+    return None
+
+
 @dataclass(kw_only=True)
 class DiscovergySensorEntityDescription(SensorEntityDescription):
     """Class to describe a Discovergy sensor entity."""
 
     value_fn: Callable[[Reading, str, int], datetime | float | None] = field(
-        default=lambda reading, key, scale: float(reading.values[key] / scale)
+        default=_get_and_scale
     )
     alternative_keys: list[str] = field(default_factory=lambda: [])
     scale: int = field(default_factory=lambda: 1000)
@@ -165,33 +172,27 @@ async def async_setup_entry(
 
     entities: list[DiscovergySensor] = []
     for meter in meters:
-        sensors = None
-        if meter.measurement_type == "ELECTRICITY":
-            sensors = ELECTRICITY_SENSORS
-        elif meter.measurement_type == "GAS":
-            sensors = GAS_SENSORS
-
+        sensors: tuple[DiscovergySensorEntityDescription, ...] = ()
         coordinator: DiscovergyUpdateCoordinator = data.coordinators[meter.meter_id]
 
-        if sensors is not None:
-            for description in sensors:
-                # check if this meter has this data, then add this sensor
-                for key in {description.key, *description.alternative_keys}:
-                    if key in coordinator.data.values:
-                        entities.append(
-                            DiscovergySensor(key, description, meter, coordinator)
-                        )
+        # select sensor descriptions based on meter type and combine with additional sensors
+        if meter.measurement_type == "ELECTRICITY":
+            sensors = ELECTRICITY_SENSORS + ADDITIONAL_SENSORS
+        elif meter.measurement_type == "GAS":
+            sensors = GAS_SENSORS + ADDITIONAL_SENSORS
 
-        for description in ADDITIONAL_SENSORS:
-            entities.append(
-                DiscovergySensor(description.key, description, meter, coordinator)
-            )
+        entities.extend(
+            DiscovergySensor(value_key, description, meter, coordinator)
+            for description in sensors
+            for value_key in {description.key, *description.alternative_keys}
+            if description.value_fn(coordinator.data, value_key, description.scale)
+        )
 
     async_add_entities(entities, False)
 
 
 class DiscovergySensor(CoordinatorEntity[DiscovergyUpdateCoordinator], SensorEntity):
-    """Represents a discovergy smart meter sensor."""
+    """Represents a Discovergy smart meter sensor."""
 
     entity_description: DiscovergySensorEntityDescription
     data_key: str

--- a/homeassistant/components/discovergy/sensor.py
+++ b/homeassistant/components/discovergy/sensor.py
@@ -188,7 +188,7 @@ async def async_setup_entry(
             if description.value_fn(coordinator.data, value_key, description.scale)
         )
 
-    async_add_entities(entities, False)
+    async_add_entities(entities)
 
 
 class DiscovergySensor(CoordinatorEntity[DiscovergyUpdateCoordinator], SensorEntity):

--- a/tests/components/discovergy/snapshots/test_sensor.ambr
+++ b/tests/components/discovergy/snapshots/test_sensor.ambr
@@ -1,4 +1,38 @@
 # serializer version: 1
+# name: test_sensor[electricity last transmitted]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.electricity_teststrasse_1_last_transmitted',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Last transmitted',
+    'platform': 'discovergy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'last_transmitted',
+    'unique_id': 'abc123-last_transmitted',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[electricity last transmitted].1
+  None
+# ---
 # name: test_sensor[electricity total consumption]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -100,6 +134,40 @@
     'last_updated': <ANY>,
     'state': '531.75',
   })
+# ---
+# name: test_sensor[gas last transmitted]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.gas_teststrasse_1_last_transmitted',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Last transmitted',
+    'platform': 'discovergy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'last_transmitted',
+    'unique_id': 'def456-last_transmitted',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[gas last transmitted].1
+  None
 # ---
 # name: test_sensor[gas total consumption]
   EntityRegistryEntrySnapshot({

--- a/tests/components/discovergy/test_sensor.py
+++ b/tests/components/discovergy/test_sensor.py
@@ -16,12 +16,16 @@ from homeassistant.helpers import entity_registry as er
     [
         "sensor.electricity_teststrasse_1_total_consumption",
         "sensor.electricity_teststrasse_1_total_power",
+        "sensor.electricity_teststrasse_1_last_transmitted",
         "sensor.gas_teststrasse_1_total_gas_consumption",
+        "sensor.gas_teststrasse_1_last_transmitted",
     ],
     ids=[
         "electricity total consumption",
         "electricity total power",
+        "electricity last transmitted",
         "gas total consumption",
+        "gas last transmitted",
     ],
 )
 @pytest.mark.usefixtures("setup_integration")


### PR DESCRIPTION
## Proposed change
Reduce the for and if nesting in Discovergy config entry setup. Also add a test for the additional sensor.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
