### PR TITLE
Context slot decisions moved into hassil

### DIFF
--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -224,17 +224,10 @@ class DefaultAgent(AbstractConversationAgent):
         # loaded in async_recognize.
         assert lang_intents is not None
 
-        # Include slot values from intent_context, such as the name of the
-        # device's area.
+        # Slot values to pass to the intent
         slots = {
-            entity_name: {"value": entity_value}
-            for entity_name, entity_value in result.context.items()
+            entity.name: {"value": entity.value} for entity in result.entities_list
         }
-
-        # Override context with result entities
-        slots.update(
-            {entity.name: {"value": entity.value} for entity in result.entities_list}
-        )
 
         try:
             intent_response = await intent.async_handle(

--- a/homeassistant/components/conversation/manifest.json
+++ b/homeassistant/components/conversation/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["hassil==1.5.0", "home-assistant-intents==2023.11.13"]
+  "requirements": ["hassil==1.5.1", "home-assistant-intents==2023.11.17"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -25,10 +25,10 @@ fnv-hash-fast==0.5.0
 ha-av==10.1.1
 ha-ffmpeg==3.1.0
 hass-nabucasa==0.74.0
-hassil==1.5.0
+hassil==1.5.1
 home-assistant-bluetooth==1.10.4
 home-assistant-frontend==20231030.2
-home-assistant-intents==2023.11.13
+home-assistant-intents==2023.11.17
 httpx==0.25.0
 ifaddr==0.2.0
 janus==1.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -985,7 +985,7 @@ hass-nabucasa==0.74.0
 hass-splunk==0.1.1
 
 # homeassistant.components.conversation
-hassil==1.5.0
+hassil==1.5.1
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.4
@@ -1018,7 +1018,7 @@ holidays==0.36
 home-assistant-frontend==20231030.2
 
 # homeassistant.components.conversation
-home-assistant-intents==2023.11.13
+home-assistant-intents==2023.11.17
 
 # homeassistant.components.home_connect
 homeconnect==0.7.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -778,7 +778,7 @@ habitipy==0.2.0
 hass-nabucasa==0.74.0
 
 # homeassistant.components.conversation
-hassil==1.5.0
+hassil==1.5.1
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.4
@@ -802,7 +802,7 @@ holidays==0.36
 home-assistant-frontend==20231030.2
 
 # homeassistant.components.conversation
-home-assistant-intents==2023.11.13
+home-assistant-intents==2023.11.17
 
 # homeassistant.components.home_connect
 homeconnect==0.7.2

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -343,10 +343,10 @@ async def test_device_area_context(
     )
     device_registry.async_update_device(bedroom_satellite.id, area_id=area_bedroom.id)
 
-    # Turn on all lights in the area of a device
+    # Turn on lights in the area of a device
     result = await conversation.async_converse(
         hass,
-        "turn on all lights",
+        "turn on the lights",
         None,
         Context(),
         None,
@@ -367,7 +367,7 @@ async def test_device_area_context(
     # Ensure we can still target other areas by name
     result = await conversation.async_converse(
         hass,
-        "turn on all lights in the bedroom",
+        "turn on lights in the bedroom",
         None,
         Context(),
         None,
@@ -388,7 +388,7 @@ async def test_device_area_context(
     # Turn off all lights in the area of the otherkj device
     result = await conversation.async_converse(
         hass,
-        "turn all lights off",
+        "turn lights off",
         None,
         Context(),
         None,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Context values, such as a device's area, affect hassil's intent matching. Sometimes, but not always, a value from context should be "promoted" to an intent slot and used during HA's intent handling. The decision for when to do this has been moved into hassil itself where more information is available.

This changes requires:

- Bump hassil to 1.5.1: https://github.com/home-assistant/hassil/compare/v1.5.0...v1.5.1
- Bump homeassistant-intents to 2023.11.17: https://github.com/home-assistant/intents/compare/2023.11.13...2023.11.17

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
