### PR TITLE
Use entity description for Reolink cameras

### DIFF
--- a/homeassistant/components/reolink/camera.py
+++ b/homeassistant/components/reolink/camera.py
@@ -1,11 +1,17 @@
 """Component providing support for Reolink IP cameras."""
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
 import logging
 
-from reolink_aio.api import DUAL_LENS_MODELS
+from reolink_aio.api import DUAL_LENS_MODELS, Host
 
-from homeassistant.components.camera import Camera, CameraEntityFeature
+from homeassistant.components.camera import (
+    Camera,
+    CameraEntityDescription,
+    CameraEntityFeature,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -17,6 +23,70 @@ from .entity import ReolinkChannelCoordinatorEntity
 _LOGGER = logging.getLogger(__name__)
 
 
+@dataclass(kw_only=True)
+class ReolinkCameraEntityDescription(
+    CameraEntityDescription,
+):
+    """A class that describes camera entities for a camera channel."""
+
+    stream: str
+    supported: Callable[[Host, int], bool] = lambda api, ch: True
+
+
+CAMERA_ENTITIES = (
+    ReolinkCameraEntityDescription(
+        key="sub",
+        stream="sub",
+        translation_key="sub",
+    ),
+    ReolinkCameraEntityDescription(
+        key="main",
+        stream="main",
+        translation_key="main",
+        entity_registry_enabled_default=False,
+    ),
+    ReolinkCameraEntityDescription(
+        key="snapshots_sub",
+        stream="snapshots_sub",
+        translation_key="snapshots_sub",
+        entity_registry_enabled_default=False,
+    ),
+    ReolinkCameraEntityDescription(
+        key="snapshots",
+        stream="snapshots_main",
+        translation_key="snapshots_main",
+        entity_registry_enabled_default=False,
+    ),
+    ReolinkCameraEntityDescription(
+        key="ext",
+        stream="ext",
+        translation_key="ext",
+        supported=lambda api, ch: api.protocol in ["rtmp", "flv"],
+        entity_registry_enabled_default=False,
+    ),
+    ReolinkCameraEntityDescription(
+        key="autotrack_sub",
+        stream="autotrack_sub",
+        translation_key="autotrack_sub",
+        supported=lambda api, ch: api.supported(ch, "autotrack_stream"),
+    ),
+    ReolinkCameraEntityDescription(
+        key="autotrack_snapshots_sub",
+        stream="autotrack_snapshots_sub",
+        translation_key="autotrack_snapshots_sub",
+        supported=lambda api, ch: api.supported(ch, "autotrack_stream"),
+        entity_registry_enabled_default=False,
+    ),
+    ReolinkCameraEntityDescription(
+        key="autotrack_snapshots_main",
+        stream="autotrack_snapshots_main",
+        translation_key="autotrack_snapshots_main",
+        supported=lambda api, ch: api.supported(ch, "autotrack_stream"),
+        entity_registry_enabled_default=False,
+    ),
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -24,62 +94,59 @@ async def async_setup_entry(
 ) -> None:
     """Set up a Reolink IP Camera."""
     reolink_data: ReolinkData = hass.data[DOMAIN][config_entry.entry_id]
-    host = reolink_data.host
 
-    cameras = []
-    for channel in host.api.stream_channels:
-        streams = ["sub", "main", "snapshots_sub", "snapshots_main"]
-        if host.api.protocol in ["rtmp", "flv"]:
-            streams.append("ext")
-
-        if host.api.supported(channel, "autotrack_stream"):
-            streams.extend(
-                ["autotrack_sub", "autotrack_snapshots_sub", "autotrack_snapshots_main"]
+    entities: list[ReolinkCamera] = [
+        ReolinkCamera(reolink_data, channel, entity_description)
+        for entity_description in CAMERA_ENTITIES
+        for channel in reolink_data.host.api.stream_channels
+        if entity_description.supported(reolink_data.host.api, channel)
+        and (
+            "snapshots" in entity_description.stream
+            or await reolink_data.host.api.get_stream_source(
+                channel, entity_description.stream
             )
-
-        for stream in streams:
-            stream_url = await host.api.get_stream_source(channel, stream)
-            if stream_url is None and "snapshots" not in stream:
-                continue
-            cameras.append(ReolinkCamera(reolink_data, channel, stream))
-
-    async_add_entities(cameras)
+            is not None
+        )
+    ]
+    async_add_entities(entities)
 
 
 class ReolinkCamera(ReolinkChannelCoordinatorEntity, Camera):
     """An implementation of a Reolink IP camera."""
 
     _attr_supported_features: CameraEntityFeature = CameraEntityFeature.STREAM
+    entity_description: ReolinkCameraEntityDescription
 
     def __init__(
         self,
         reolink_data: ReolinkData,
         channel: int,
-        stream: str,
+        entity_description: ReolinkCameraEntityDescription,
     ) -> None:
         """Initialize Reolink camera stream."""
+        self.entity_description = entity_description
         ReolinkChannelCoordinatorEntity.__init__(self, reolink_data, channel)
         Camera.__init__(self)
 
-        self._stream = stream
-
-        stream_name = self._stream.replace("_", " ")
         if self._host.api.model in DUAL_LENS_MODELS:
-            self._attr_name = f"{stream_name} lens {self._channel}"
-        else:
-            self._attr_name = stream_name
-        stream_id = self._stream
-        if stream_id == "snapshots_main":
-            stream_id = "snapshots"
-        self._attr_unique_id = f"{self._host.unique_id}_{self._channel}_{stream_id}"
-        self._attr_entity_registry_enabled_default = stream in ["sub", "autotrack_sub"]
+            self._attr_translation_key = (
+                f"{entity_description.translation_key}_lens_{self._channel}"
+            )
+
+        self._attr_unique_id = (
+            f"{self._host.unique_id}_{channel}_{entity_description.key}"
+        )
 
     async def stream_source(self) -> str | None:
         """Return the source of the stream."""
-        return await self._host.api.get_stream_source(self._channel, self._stream)
+        return await self._host.api.get_stream_source(
+            self._channel, self.entity_description.stream
+        )
 
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
         """Return a still image response from the camera."""
-        return await self._host.api.get_snapshot(self._channel, self._stream)
+        return await self._host.api.get_snapshot(
+            self._channel, self.entity_description.stream
+        )

--- a/homeassistant/components/reolink/camera.py
+++ b/homeassistant/components/reolink/camera.py
@@ -95,19 +95,19 @@ async def async_setup_entry(
     """Set up a Reolink IP Camera."""
     reolink_data: ReolinkData = hass.data[DOMAIN][config_entry.entry_id]
 
-    entities: list[ReolinkCamera] = [
-        ReolinkCamera(reolink_data, channel, entity_description)
-        for entity_description in CAMERA_ENTITIES
-        for channel in reolink_data.host.api.stream_channels
-        if entity_description.supported(reolink_data.host.api, channel)
-        and (
-            "snapshots" in entity_description.stream
-            or await reolink_data.host.api.get_stream_source(
+    entities: list[ReolinkCamera] = []
+    for entity_description in CAMERA_ENTITIES:
+        for channel in reolink_data.host.api.stream_channels:
+            if not entity_description.supported(reolink_data.host.api, channel):
+                continue
+            stream_url = await reolink_data.host.api.get_stream_source(
                 channel, entity_description.stream
             )
-            is not None
-        )
-    ]
+            if stream_url is None and "snapshots" not in entity_description.stream:
+                continue
+
+            entities.append(ReolinkCamera(reolink_data, channel, entity_description))
+
     async_add_entities(entities)
 
 

--- a/homeassistant/components/reolink/strings.json
+++ b/homeassistant/components/reolink/strings.json
@@ -147,6 +147,62 @@
         "name": "Guard set current position"
       }
     },
+    "camera": {
+      "sub": {
+        "name": "Fluent"
+      },
+      "main": {
+        "name": "Clear"
+      },
+      "snapshots_sub": {
+        "name": "Snapshots fluent"
+      },
+      "snapshots_main": {
+        "name": "Snapshots clear"
+      },
+      "ext": {
+        "name": "Balanced"
+      },
+      "sub_lens_0": {
+        "name": "Fluent lens 0"
+      },
+      "main_lens_0": {
+        "name": "Clear lens 0"
+      },
+      "snapshots_sub_lens_0": {
+        "name": "Snapshots fluent lens 0"
+      },
+      "snapshots_main_lens_0": {
+        "name": "Snapshots clear lens 0"
+      },
+      "ext_lens_0": {
+        "name": "Balanced lens 0"
+      },
+      "sub_lens_1": {
+        "name": "Fluent lens 1"
+      },
+      "main_lens_1": {
+        "name": "Clear lens 1"
+      },
+      "snapshots_sub_lens_1": {
+        "name": "Snapshots fluent lens 1"
+      },
+      "snapshots_main_lens_1": {
+        "name": "Snapshots clear lens 1"
+      },
+      "ext_lens_1": {
+        "name": "Balanced lens 1"
+      },
+      "autotrack_sub": {
+        "name": "Autotrack fluent"
+      },
+      "autotrack_snapshots_sub": {
+        "name": "Autotrack snapshots fluent"
+      },
+      "autotrack_snapshots_main": {
+        "name": "Autotrack snapshots clear"
+      }
+    },
     "light": {
       "floodlight": {
         "name": "Floodlight"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use entity description for Reolink cameras to have them setup in the same way as all other platforms.
This is needed for a followup PR https://github.com/home-assistant/core/pull/104142 that will implement a common base ReolinkEntityDescription.

The names of the cameras are now translated and have changed, unique ID is the same:
sub -> Fluent (low resolution)
main -> Clear (high resolution)
ext -> Balanced (mid resolution)
The API always reffers to sub/main/ext streams, but the Reolink phone app/desktop client uses Fluent/Clear/Balanced to indicate the diffrent stream resolutions, so users will most likely be more familiar with Fluent/Clear/Balanced.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29886

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
