### PR TITLE
New api endpoint for Trafikverket Weather

### DIFF
--- a/homeassistant/components/trafikverket_camera/manifest.json
+++ b/homeassistant/components/trafikverket_camera/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/trafikverket_camera",
   "iot_class": "cloud_polling",
   "loggers": ["pytrafikverket"],
-  "requirements": ["pytrafikverket==0.3.8"]
+  "requirements": ["pytrafikverket==0.3.9.1"]
 }

--- a/homeassistant/components/trafikverket_ferry/manifest.json
+++ b/homeassistant/components/trafikverket_ferry/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/trafikverket_ferry",
   "iot_class": "cloud_polling",
   "loggers": ["pytrafikverket"],
-  "requirements": ["pytrafikverket==0.3.8"]
+  "requirements": ["pytrafikverket==0.3.9.1"]
 }

--- a/homeassistant/components/trafikverket_train/config_flow.py
+++ b/homeassistant/components/trafikverket_train/config_flow.py
@@ -9,7 +9,6 @@ from typing import Any
 from pytrafikverket import TrafikverketTrain
 from pytrafikverket.exceptions import (
     InvalidAuthentication,
-    MultipleTrainAnnouncementFound,
     MultipleTrainStationsFound,
     NoTrainAnnouncementFound,
     NoTrainStationFound,
@@ -107,8 +106,6 @@ async def validate_input(
         errors["base"] = "more_stations"
     except NoTrainAnnouncementFound:
         errors["base"] = "no_trains"
-    except MultipleTrainAnnouncementFound:
-        errors["base"] = "multiple_trains"
     except UnknownError as error:
         _LOGGER.error("Unknown error occurred during validation %s", str(error))
         errors["base"] = "cannot_connect"

--- a/homeassistant/components/trafikverket_train/coordinator.py
+++ b/homeassistant/components/trafikverket_train/coordinator.py
@@ -8,7 +8,6 @@ import logging
 from pytrafikverket import TrafikverketTrain
 from pytrafikverket.exceptions import (
     InvalidAuthentication,
-    MultipleTrainAnnouncementFound,
     NoTrainAnnouncementFound,
     UnknownError,
 )
@@ -112,7 +111,6 @@ class TVDataUpdateCoordinator(DataUpdateCoordinator[TrainData]):
             raise ConfigEntryAuthFailed from error
         except (
             NoTrainAnnouncementFound,
-            MultipleTrainAnnouncementFound,
             UnknownError,
         ) as error:
             raise UpdateFailed(

--- a/homeassistant/components/trafikverket_train/manifest.json
+++ b/homeassistant/components/trafikverket_train/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/trafikverket_train",
   "iot_class": "cloud_polling",
   "loggers": ["pytrafikverket"],
-  "requirements": ["pytrafikverket==0.3.8"]
+  "requirements": ["pytrafikverket==0.3.9.1"]
 }

--- a/homeassistant/components/trafikverket_train/strings.json
+++ b/homeassistant/components/trafikverket_train/strings.json
@@ -10,7 +10,6 @@
       "invalid_station": "Could not find a station with the specified name",
       "more_stations": "Found multiple stations with the specified name",
       "no_trains": "No train found",
-      "multiple_trains": "Multiple trains found",
       "incorrect_api_key": "Invalid API key for selected account"
     },
     "step": {

--- a/homeassistant/components/trafikverket_weatherstation/manifest.json
+++ b/homeassistant/components/trafikverket_weatherstation/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/trafikverket_weatherstation",
   "iot_class": "cloud_polling",
   "loggers": ["pytrafikverket"],
-  "requirements": ["pytrafikverket==0.3.8"]
+  "requirements": ["pytrafikverket==0.3.9.1"]
 }

--- a/homeassistant/components/trafikverket_weatherstation/strings.json
+++ b/homeassistant/components/trafikverket_weatherstation/strings.json
@@ -35,55 +35,19 @@
       "precipitation": {
         "name": "Precipitation type",
         "state": {
-          "drizzle": "Drizzle",
-          "hail": "Hail",
-          "none": "None",
+          "no": "No",
           "rain": "Rain",
+          "freezing_rain": "Freezing rain",
           "snow": "Snow",
-          "rain_snow_mixed": "Rain and snow mixed",
-          "freezing_rain": "Freezing rain"
+          "sleet": "Sleet",
+          "yes": "Yes"
         }
       },
       "wind_direction": {
         "name": "Wind direction"
       },
-      "wind_direction_text": {
-        "name": "Wind direction text",
-        "state": {
-          "east": "East",
-          "north_east": "North east",
-          "east_south_east": "East-south east",
-          "north": "North",
-          "north_north_east": "North-north east",
-          "north_north_west": "North-north west",
-          "north_west": "North west",
-          "south": "South",
-          "south_east": "South east",
-          "south_south_west": "South-south west",
-          "south_west": "South west",
-          "west": "West"
-        }
-      },
       "wind_speed_max": {
         "name": "Wind speed max"
-      },
-      "precipitation_amountname": {
-        "name": "Precipitation name",
-        "state": {
-          "error": "Error",
-          "mild_rain": "Mild rain",
-          "moderate_rain": "Moderate rain",
-          "heavy_rain": "Heavy rain",
-          "mild_snow_rain": "Mild rain and snow mixed",
-          "moderate_snow_rain": "Moderate rain and snow mixed",
-          "heavy_snow_rain": "Heavy rain and snow mixed",
-          "mild_snow": "Mild snow",
-          "moderate_snow": "Moderate snow",
-          "heavy_snow": "Heavy snow",
-          "other": "Other",
-          "none": "None",
-          "unknown": "Unknown"
-        }
       },
       "measure_time": {
         "name": "Measure time"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2234,7 +2234,7 @@ pytradfri[async]==9.0.1
 # homeassistant.components.trafikverket_ferry
 # homeassistant.components.trafikverket_train
 # homeassistant.components.trafikverket_weatherstation
-pytrafikverket==0.3.8
+pytrafikverket==0.3.9.1
 
 # homeassistant.components.v2c
 pytrydan==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1664,7 +1664,7 @@ pytradfri[async]==9.0.1
 # homeassistant.components.trafikverket_ferry
 # homeassistant.components.trafikverket_train
 # homeassistant.components.trafikverket_weatherstation
-pytrafikverket==0.3.8
+pytrafikverket==0.3.9.1
 
 # homeassistant.components.v2c
 pytrydan==0.4.0

--- a/tests/components/trafikverket_train/test_config_flow.py
+++ b/tests/components/trafikverket_train/test_config_flow.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 import pytest
 from pytrafikverket.exceptions import (
     InvalidAuthentication,
-    MultipleTrainAnnouncementFound,
     MultipleTrainStationsFound,
     NoTrainAnnouncementFound,
     NoTrainStationFound,
@@ -176,10 +175,6 @@ async def test_flow_fails(
         (
             NoTrainAnnouncementFound,
             "no_trains",
-        ),
-        (
-            MultipleTrainAnnouncementFound,
-            "multiple_trains",
         ),
         (
             UnknownError,
@@ -370,10 +365,6 @@ async def test_reauth_flow_error(
         (
             NoTrainAnnouncementFound,
             "no_trains",
-        ),
-        (
-            MultipleTrainAnnouncementFound,
-            "multiple_trains",
         ),
         (
             UnknownError,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Trafikverket Weather has changed it's endpoint and is no longer providing the information for wind direction and precipitation in plain text so therefore these sensors has been removed

- Wind direction text
- Precipitation name

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump pytrafikverket to 0.3.9.1
https://github.com/gjohansson-ST/pytrafikverket/compare/0.3.8...0.3.9.1

Removal of two sensors no longer provided by the new endpoint.
New sensors etc. will be done in follow-up PR

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #101753
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29899

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
