### PR TITLE
Add entity tests for ping

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -947,9 +947,6 @@ omit =
     homeassistant/components/pilight/light.py
     homeassistant/components/pilight/switch.py
     homeassistant/components/ping/__init__.py
-    homeassistant/components/ping/binary_sensor.py
-    homeassistant/components/ping/coordinator.py
-    homeassistant/components/ping/device_tracker.py
     homeassistant/components/ping/helpers.py
     homeassistant/components/pioneer/media_player.py
     homeassistant/components/plaato/__init__.py

--- a/tests/components/ping/conftest.py
+++ b/tests/components/ping/conftest.py
@@ -8,7 +8,6 @@ from homeassistant.components.ping import DOMAIN
 from homeassistant.components.ping.const import CONF_PING_COUNT
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
@@ -51,5 +50,5 @@ async def mock_setup_integration(
     """Fixture for setting up the component."""
     config_entry.add_to_hass(hass)
 
-    assert await async_setup_component(hass, DOMAIN, {})
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/ping/conftest.py
+++ b/tests/components/ping/conftest.py
@@ -1,7 +1,16 @@
 """Test configuration for ping."""
 from unittest.mock import patch
 
+from icmplib import Host
 import pytest
+
+from homeassistant.components.ping import DOMAIN
+from homeassistant.components.ping.const import CONF_PING_COUNT
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture
@@ -12,3 +21,35 @@ def patch_setup(*args, **kwargs):
         return_value=True,
     ), patch("homeassistant.components.ping.async_setup", return_value=True):
         yield
+
+
+@pytest.fixture(autouse=True)
+async def patch_ping():
+    """Patch icmplib async_ping."""
+    mock = Host("10.10.10.10", 5, [10, 1, 2])
+
+    with patch(
+        "homeassistant.components.ping.helpers.async_ping", return_value=mock
+    ), patch("homeassistant.components.ping.async_ping", return_value=mock):
+        yield mock
+
+
+@pytest.fixture(name="config_entry")
+async def mock_config_entry(hass: HomeAssistant, request) -> MockConfigEntry:
+    """Return a MockConfigEntry for testing."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="10.10.10.10",
+        options={CONF_HOST: "10.10.10.10", CONF_PING_COUNT: 10.0},
+    )
+
+
+@pytest.fixture(name="setup_integration")
+async def mock_setup_integration(
+    hass: HomeAssistant, config_entry: MockConfigEntry, patch_ping
+) -> None:
+    """Fixture for setting up the component."""
+    config_entry.add_to_hass(hass)
+
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()

--- a/tests/components/ping/conftest.py
+++ b/tests/components/ping/conftest.py
@@ -35,7 +35,7 @@ async def patch_ping():
 
 
 @pytest.fixture(name="config_entry")
-async def mock_config_entry(hass: HomeAssistant, request) -> MockConfigEntry:
+async def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
     """Return a MockConfigEntry for testing."""
     return MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/ping/fixtures/configuration.yaml
+++ b/tests/components/ping/fixtures/configuration.yaml
@@ -1,5 +1,0 @@
-binary_sensor:
-  - platform: ping
-    name: test2
-    host: 127.0.0.1
-    count: 1

--- a/tests/components/ping/snapshots/test_binary_sensor.ambr
+++ b/tests/components/ping/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,121 @@
+# serializer version: 1
+# name: test_sensor
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.10_10_10_10',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': '10.10.10.10',
+    'platform': 'ping',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor.1
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': '10.10.10.10',
+      'round_trip_time_avg': 4.333,
+      'round_trip_time_max': 10,
+      'round_trip_time_mdev': '',
+      'round_trip_time_min': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.10_10_10_10',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_sensor.2
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': '10.10.10.10',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.10_10_10_10',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup_and_update
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.10_10_10_10',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': '10.10.10.10',
+    'platform': 'ping',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_and_update.1
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': '10.10.10.10',
+      'round_trip_time_avg': 4.333,
+      'round_trip_time_max': 10,
+      'round_trip_time_mdev': '',
+      'round_trip_time_min': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.10_10_10_10',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_setup_and_update.2
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': '10.10.10.10',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.10_10_10_10',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/ping/test_binary_sensor.py
+++ b/tests/components/ping/test_binary_sensor.py
@@ -1,0 +1,89 @@
+"""Test the binary sensor platform of ping."""
+from datetime import timedelta
+from unittest.mock import patch
+
+from freezegun.api import FrozenDateTimeFactory
+from icmplib import Host
+import pytest
+from syrupy import SnapshotAssertion
+from syrupy.filters import props
+
+from homeassistant.components.ping.const import CONF_IMPORTED_BY, DOMAIN
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_setup_and_update(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    freezer: FrozenDateTimeFactory,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test sensor setup and update."""
+
+    # check if binary sensor is there
+    entry = entity_registry.async_get("binary_sensor.10_10_10_10")
+    assert entry == snapshot(exclude=props("unique_id"))
+
+    state = hass.states.get("binary_sensor.10_10_10_10")
+    assert state == snapshot
+
+    # check if the sensor turns off.
+    with patch(
+        "homeassistant.components.ping.helpers.async_ping",
+        return_value=Host(address="10.10.10.10", packets_sent=10, rtts=[]),
+    ):
+        freezer.tick(timedelta(minutes=6))
+        await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.10_10_10_10")
+    assert state == snapshot
+
+
+async def test_disabled_after_import(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+):
+    """Test if binary sensor is disabled after import."""
+    config_entry.data = {CONF_IMPORTED_BY: "device_tracker"}
+    config_entry.add_to_hass(hass)
+
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    # check if entity is disabled after import by device tracker
+    entry = entity_registry.async_get("binary_sensor.10_10_10_10")
+    assert entry
+    assert entry.disabled
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
+
+async def test_import_issue_creation(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+):
+    """Test if import issue is raised."""
+
+    await async_setup_component(
+        hass,
+        "binary_sensor",
+        {
+            "binary_sensor": {
+                "platform": "ping",
+                "name": "test",
+                "host": "127.0.0.1",
+                "count": 1,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    issue = issue_registry.async_get_issue(
+        HOMEASSISTANT_DOMAIN, f"deprecated_yaml_{DOMAIN}"
+    )
+    assert issue

--- a/tests/components/ping/test_device_tracker.py
+++ b/tests/components/ping/test_device_tracker.py
@@ -1,0 +1,62 @@
+"""Test the binary sensor platform of ping."""
+
+import pytest
+
+from homeassistant.components.ping.const import DOMAIN
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_setup_and_update(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test sensor setup and update."""
+
+    entry = entity_registry.async_get("device_tracker.10_10_10_10")
+    assert entry
+    assert entry.disabled
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
+    # check device tracker state is not there
+    state = hass.states.get("device_tracker.10_10_10_10")
+    assert state is None
+
+    # enable the entity
+    updated_entry = entity_registry.async_update_entity(
+        entity_id="device_tracker.10_10_10_10", disabled_by=None
+    )
+    assert updated_entry != entry
+    assert updated_entry.disabled is False
+
+    # reload config entry to enable entity
+    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # check device tracker is now "home"
+    state = hass.states.get("device_tracker.10_10_10_10")
+    assert state.state == "home"
+
+
+async def test_import_issue_creation(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+):
+    """Test if import issue is raised."""
+
+    await async_setup_component(
+        hass,
+        "device_tracker",
+        {"device_tracker": {"platform": "ping", "hosts": {"test": "10.10.10.10"}}},
+    )
+    await hass.async_block_till_done()
+
+    issue = issue_registry.async_get_issue(
+        HOMEASSISTANT_DOMAIN, f"deprecated_yaml_{DOMAIN}"
+    )
+    assert issue


### PR DESCRIPTION
## Proposed change
Add entity platform tests (device tracker and binary sensor).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
