### PR TITLE
Fix switcher kis device's name logging

### DIFF
--- a/homeassistant/components/switcher_kis/switch.py
+++ b/homeassistant/components/switcher_kis/switch.py
@@ -105,7 +105,7 @@ class SwitcherBaseSwitchEntity(
 
     async def _async_call_api(self, api: str, *args: Any) -> None:
         """Call Switcher API."""
-        _LOGGER.debug("Calling api for %s, api: '%s', args: %s", self.name, api, args)
+        _LOGGER.debug("Calling api for %s, api: '%s', args: %s", self.coordinator.name, api, args)
         response: SwitcherBaseResponse = None
         error = None
 


### PR DESCRIPTION
Looking at debug logs, the original code outputs "None" for device's name:
Calling api for None, api: 'control_device', args: (<Command.ON: '1'>,)

Whereas line 122 outputs correct name:
Call api for Switcher Touch 8DF8 failed, api: 'control_device', args:

