### PR TITLE
Avoid UDP discovery when setting up tplink devices

### DIFF
--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -98,7 +98,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Save the device class name if it is not already saved
     # so that we can pass it to connect which avoids an update cycle
-    if not entry.data.get(CONF_DEVICE_TYPE) != device.device_type.value:
+    if device_type_str != device.device_type.value:
         hass.config_entries.async_update_entry(
             entry, data={**entry.data, CONF_DEVICE_TYPE: device.device_type.value}
         )

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -97,8 +97,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady from ex
 
     # Save the device class name if it is not already saved
-    # so that we can use connect_single next time instead of discover_single
-    # to avoid UDP discovery.
+    # so that we can pass it to connect which avoids an update cycle
     if not entry.data.get(CONF_DEVICE_TYPE) != device.device_type.value:
         hass.config_entries.async_update_entry(
             entry, data={**entry.data, CONF_DEVICE_TYPE: device.device_type.value}

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -5,7 +5,7 @@ import asyncio
 from datetime import timedelta
 from typing import Any
 
-from kasa import DeviceType, SmartDevice, SmartDeviceException
+from kasa import DeviceType, SmartDevice, SmartDeviceException, TPLinkKlap
 from kasa.discover import Discover
 
 from homeassistant import config_entries
@@ -60,7 +60,11 @@ async def async_discover_devices(hass: HomeAssistant) -> dict[str, SmartDevice]:
     discovered_devices: dict[str, SmartDevice] = {}
     for device_list in await asyncio.gather(*tasks):
         for device in device_list.values():
-            discovered_devices[dr.format_mac(device.mac)] = device
+            # We have no way to configure Klap devices yet
+            # so we do not want to discover them since the
+            # user will not be able to do anything with them
+            if not isinstance(device.protocol, TPLinkKlap):
+                discovered_devices[dr.format_mac(device.mac)] = device
     return discovered_devices
 
 

--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.typing import DiscoveryInfoType
 
 from . import async_discover_devices
-from .const import DOMAIN
+from .const import CONF_DEVICE_TYPE, DOMAIN
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -137,6 +137,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             title=f"{device.alias} {device.model}",
             data={
                 CONF_HOST: device.host,
+                CONF_DEVICE_TYPE: device.device_type.value,
             },
         )
 

--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -19,4 +19,6 @@ CONF_STRIP: Final = "strip"
 CONF_SWITCH: Final = "switch"
 CONF_SENSOR: Final = "sensor"
 
+CONF_DEVICE_TYPE: Final = "device_type"
+
 PLATFORMS: Final = [Platform.LIGHT, Platform.SENSOR, Platform.SWITCH]

--- a/tests/components/tplink/__init__.py
+++ b/tests/components/tplink/__init__.py
@@ -15,7 +15,7 @@ from kasa.exceptions import SmartDeviceException
 from kasa.protocol import TPLinkSmartHomeProtocol
 
 from homeassistant.components.tplink import CONF_HOST
-from homeassistant.components.tplink.const import DOMAIN
+from homeassistant.components.tplink.const import CONF_DEVICE_TYPE, DOMAIN
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -232,5 +232,7 @@ async def initialize_config_entry_for_device(
     with _patch_discovery(device=dev), _patch_single_discovery(device=dev):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
+
+    assert config_entry.data[CONF_DEVICE_TYPE] == _mocked_bulb().device_type.value
 
     return config_entry

--- a/tests/components/tplink/__init__.py
+++ b/tests/components/tplink/__init__.py
@@ -205,16 +205,14 @@ def _patch_discovery(device=None, no_device=False):
 
 @contextmanager
 def _patch_single_discovery(device=None, no_device=False):
-    async def _discover_single(*args, **kwargs):
+    async def _make_device(*args, **kwargs):
         if no_device:
             raise SmartDeviceException
         return device if device else _mocked_bulb()
 
     with patch(
-        "homeassistant.components.tplink.Discover.discover_single", new=_discover_single
-    ), patch(
-        "homeassistant.components.tplink.Discover.connect_single", new=_discover_single
-    ):
+        "homeassistant.components.tplink.Discover.discover_single", new=_make_device
+    ), patch("homeassistant.components.tplink.SmartDevice.connect", new=_make_device):
         yield
 
 

--- a/tests/components/tplink/__init__.py
+++ b/tests/components/tplink/__init__.py
@@ -11,11 +11,12 @@ from kasa import (
     SmartPlug,
     SmartStrip,
 )
+from kasa.device_type import DeviceType
 from kasa.exceptions import SmartDeviceException
 from kasa.protocol import TPLinkSmartHomeProtocol
 
 from homeassistant.components.tplink import CONF_HOST
-from homeassistant.components.tplink.const import CONF_DEVICE_TYPE, DOMAIN
+from homeassistant.components.tplink.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -63,7 +64,7 @@ def _mocked_bulb() -> SmartBulb:
     bulb.set_hsv = AsyncMock()
     bulb.set_color_temp = AsyncMock()
     bulb.protocol = _mock_protocol()
-    bulb.device_type = MagicMock(value="Bulb")
+    bulb.device_type = DeviceType.Bulb
     return bulb
 
 
@@ -105,6 +106,7 @@ def _mocked_smart_light_strip() -> SmartLightStrip:
     strip.set_effect = AsyncMock()
     strip.set_custom_effect = AsyncMock()
     strip.protocol = _mock_protocol()
+    strip.device_type = DeviceType.Strip
     return strip
 
 
@@ -136,6 +138,7 @@ def _mocked_dimmer() -> SmartDimmer:
     dimmer.set_color_temp = AsyncMock()
     dimmer.set_led = AsyncMock()
     dimmer.protocol = _mock_protocol()
+    dimmer.device_type = DeviceType.Dimmer
     return dimmer
 
 
@@ -157,6 +160,7 @@ def _mocked_plug() -> SmartPlug:
     plug.turn_on = AsyncMock()
     plug.set_led = AsyncMock()
     plug.protocol = _mock_protocol()
+    plug.device_type = DeviceType.Plug
     return plug
 
 
@@ -178,6 +182,7 @@ def _mocked_strip() -> SmartStrip:
     strip.turn_on = AsyncMock()
     strip.set_led = AsyncMock()
     strip.protocol = _mock_protocol()
+    strip.device_type = DeviceType.Strip
     plug0 = _mocked_plug()
     plug0.alias = "Plug0"
     plug0.device_id = "bb:bb:cc:dd:ee:ff_PLUG0DEVICEID"
@@ -232,7 +237,5 @@ async def initialize_config_entry_for_device(
     with _patch_discovery(device=dev), _patch_single_discovery(device=dev):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
-
-    assert config_entry.data[CONF_DEVICE_TYPE] == _mocked_bulb().device_type.value
 
     return config_entry

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -1,6 +1,7 @@
 """Test the tplink config flow."""
 from unittest.mock import patch
 
+from kasa.device_type import DeviceType
 import pytest
 
 from homeassistant import config_entries
@@ -68,7 +69,10 @@ async def test_discovery(hass: HomeAssistant) -> None:
 
     assert result3["type"] == "create_entry"
     assert result3["title"] == DEFAULT_ENTRY_TITLE
-    assert result3["data"] == {CONF_HOST: IP_ADDRESS, CONF_DEVICE_TYPE: "Bulb"}
+    assert result3["data"] == {
+        CONF_HOST: IP_ADDRESS,
+        CONF_DEVICE_TYPE: DeviceType.Bulb.value,
+    }
     mock_setup.assert_called_once()
     mock_setup_entry.assert_called_once()
 
@@ -139,7 +143,10 @@ async def test_discovery_with_existing_device_present(hass: HomeAssistant) -> No
         )
         assert result3["type"] == "create_entry"
         assert result3["title"] == DEFAULT_ENTRY_TITLE
-        assert result3["data"] == {CONF_HOST: IP_ADDRESS, CONF_DEVICE_TYPE: "Bulb"}
+        assert result3["data"] == {
+            CONF_HOST: IP_ADDRESS,
+            CONF_DEVICE_TYPE: DeviceType.Bulb.value,
+        }
         await hass.async_block_till_done()
 
     mock_setup_entry.assert_called_once()
@@ -204,7 +211,10 @@ async def test_manual(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
     assert result4["type"] == "create_entry"
     assert result4["title"] == DEFAULT_ENTRY_TITLE
-    assert result4["data"] == {CONF_HOST: IP_ADDRESS, CONF_DEVICE_TYPE: "Bulb"}
+    assert result4["data"] == {
+        CONF_HOST: IP_ADDRESS,
+        CONF_DEVICE_TYPE: DeviceType.Bulb.value,
+    }
 
     # Duplicate
     result = await hass.config_entries.flow.async_init(
@@ -238,7 +248,10 @@ async def test_manual_no_capabilities(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
-    assert result["data"] == {CONF_HOST: IP_ADDRESS, CONF_DEVICE_TYPE: "Bulb"}
+    assert result["data"] == {
+        CONF_HOST: IP_ADDRESS,
+        CONF_DEVICE_TYPE: DeviceType.Bulb.value,
+    }
 
 
 async def test_discovered_by_discovery_and_dhcp(hass: HomeAssistant) -> None:
@@ -327,7 +340,10 @@ async def test_discovered_by_dhcp_or_discovery(
         await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
-    assert result2["data"] == {CONF_HOST: IP_ADDRESS, CONF_DEVICE_TYPE: "Bulb"}
+    assert result2["data"] == {
+        CONF_HOST: IP_ADDRESS,
+        CONF_DEVICE_TYPE: DeviceType.Bulb.value,
+    }
     assert mock_async_setup.called
     assert mock_async_setup_entry.called
 

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -6,6 +6,7 @@ import pytest
 from homeassistant import config_entries
 from homeassistant.components import dhcp
 from homeassistant.components.tplink import DOMAIN
+from homeassistant.components.tplink.const import CONF_DEVICE_TYPE
 from homeassistant.const import CONF_DEVICE, CONF_HOST, CONF_MAC, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -67,7 +68,7 @@ async def test_discovery(hass: HomeAssistant) -> None:
 
     assert result3["type"] == "create_entry"
     assert result3["title"] == DEFAULT_ENTRY_TITLE
-    assert result3["data"] == {CONF_HOST: IP_ADDRESS}
+    assert result3["data"] == {CONF_HOST: IP_ADDRESS, CONF_DEVICE_TYPE: "Bulb"}
     mock_setup.assert_called_once()
     mock_setup_entry.assert_called_once()
 
@@ -138,9 +139,7 @@ async def test_discovery_with_existing_device_present(hass: HomeAssistant) -> No
         )
         assert result3["type"] == "create_entry"
         assert result3["title"] == DEFAULT_ENTRY_TITLE
-        assert result3["data"] == {
-            CONF_HOST: IP_ADDRESS,
-        }
+        assert result3["data"] == {CONF_HOST: IP_ADDRESS, CONF_DEVICE_TYPE: "Bulb"}
         await hass.async_block_till_done()
 
     mock_setup_entry.assert_called_once()
@@ -205,9 +204,7 @@ async def test_manual(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
     assert result4["type"] == "create_entry"
     assert result4["title"] == DEFAULT_ENTRY_TITLE
-    assert result4["data"] == {
-        CONF_HOST: IP_ADDRESS,
-    }
+    assert result4["data"] == {CONF_HOST: IP_ADDRESS, CONF_DEVICE_TYPE: "Bulb"}
 
     # Duplicate
     result = await hass.config_entries.flow.async_init(
@@ -241,9 +238,7 @@ async def test_manual_no_capabilities(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
-    assert result["data"] == {
-        CONF_HOST: IP_ADDRESS,
-    }
+    assert result["data"] == {CONF_HOST: IP_ADDRESS, CONF_DEVICE_TYPE: "Bulb"}
 
 
 async def test_discovered_by_discovery_and_dhcp(hass: HomeAssistant) -> None:
@@ -332,9 +327,7 @@ async def test_discovered_by_dhcp_or_discovery(
         await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
-    assert result2["data"] == {
-        CONF_HOST: IP_ADDRESS,
-    }
+    assert result2["data"] == {CONF_HOST: IP_ADDRESS, CONF_DEVICE_TYPE: "Bulb"}
     assert mock_async_setup.called
     assert mock_async_setup_entry.called
 

--- a/tests/components/tplink/test_diagnostics.py
+++ b/tests/components/tplink/test_diagnostics.py
@@ -4,6 +4,7 @@ import json
 from kasa import SmartDevice
 import pytest
 
+from homeassistant.components.tplink.const import CONF_DEVICE_TYPE
 from homeassistant.core import HomeAssistant
 
 from . import _mocked_bulb, _mocked_plug, initialize_config_entry_for_device
@@ -44,6 +45,8 @@ async def test_diagnostics(
     mocked_dev.internal_state = diagnostics_data["device_last_response"]
 
     config_entry = await initialize_config_entry_for_device(hass, mocked_dev)
+
+    assert config_entry.data[CONF_DEVICE_TYPE] == mocked_dev.device_type.value
     result = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
 
     assert isinstance(result, dict)


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
By saving and passing the device type to `connect`, we can avoid an update cycle, and UDP discovery which should improve reliability for networks where UDP is a problem or the device times out getting connected. 

needs https://github.com/python-kasa/python-kasa/pull/538

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #103977
- This PR is related to issue: #93312 #100618 #93879 #99449 #94020
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
