### PR TITLE
Remove support for deprecated light attributes from light scenes

### DIFF
--- a/homeassistant/components/light/reproduce_state.py
+++ b/homeassistant/components/light/reproduce_state.py
@@ -17,15 +17,10 @@ from homeassistant.core import Context, HomeAssistant, State
 
 from . import (
     ATTR_BRIGHTNESS,
-    ATTR_BRIGHTNESS_PCT,
     ATTR_COLOR_MODE,
-    ATTR_COLOR_NAME,
     ATTR_COLOR_TEMP,
     ATTR_EFFECT,
-    ATTR_FLASH,
     ATTR_HS_COLOR,
-    ATTR_KELVIN,
-    ATTR_PROFILE,
     ATTR_RGB_COLOR,
     ATTR_RGBW_COLOR,
     ATTR_RGBWW_COLOR,
@@ -40,13 +35,7 @@ _LOGGER = logging.getLogger(__name__)
 
 VALID_STATES = {STATE_ON, STATE_OFF}
 
-ATTR_GROUP = [
-    ATTR_BRIGHTNESS,
-    ATTR_BRIGHTNESS_PCT,
-    ATTR_EFFECT,
-    ATTR_FLASH,
-    ATTR_TRANSITION,
-]
+ATTR_GROUP = [ATTR_BRIGHTNESS, ATTR_EFFECT]
 
 COLOR_GROUP = [
     ATTR_HS_COLOR,
@@ -55,10 +44,6 @@ COLOR_GROUP = [
     ATTR_RGBW_COLOR,
     ATTR_RGBWW_COLOR,
     ATTR_XY_COLOR,
-    # The following color attributes are deprecated
-    ATTR_PROFILE,
-    ATTR_COLOR_NAME,
-    ATTR_KELVIN,
 ]
 
 
@@ -78,21 +63,6 @@ COLOR_MODE_TO_ATTRIBUTE = {
     ColorMode.WHITE: ColorModeAttr(ATTR_WHITE, ATTR_BRIGHTNESS),
     ColorMode.XY: ColorModeAttr(ATTR_XY_COLOR, ATTR_XY_COLOR),
 }
-
-DEPRECATED_GROUP = [
-    ATTR_BRIGHTNESS_PCT,
-    ATTR_COLOR_NAME,
-    ATTR_FLASH,
-    ATTR_KELVIN,
-    ATTR_PROFILE,
-    ATTR_TRANSITION,
-]
-
-DEPRECATION_WARNING = (
-    "The use of other attributes than device state attributes is deprecated and will be"
-    " removed in a future release. Invalid attributes are %s. Read the logs for further"
-    " details: https://www.home-assistant.io/integrations/scene/"
-)
 
 
 def _color_mode_same(cur_state: State, state: State) -> bool:
@@ -123,11 +93,6 @@ async def _async_reproduce_state(
             "Invalid state specified for %s: %s", state.entity_id, state.state
         )
         return
-
-    # Warn if deprecated attributes are used
-    deprecated_attrs = [attr for attr in state.attributes if attr in DEPRECATED_GROUP]
-    if deprecated_attrs:
-        _LOGGER.warning(DEPRECATION_WARNING, deprecated_attrs)
 
     # Return if we are already at the right state.
     if (

--- a/tests/components/light/test_reproduce_state.py
+++ b/tests/components/light/test_reproduce_state.py
@@ -2,35 +2,24 @@
 import pytest
 
 from homeassistant.components import light
-from homeassistant.components.light.reproduce_state import DEPRECATION_WARNING
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
 VALID_BRIGHTNESS = {"brightness": 180}
-VALID_FLASH = {"flash": "short"}
 VALID_EFFECT = {"effect": "random"}
-VALID_TRANSITION = {"transition": 15}
-VALID_COLOR_NAME = {"color_name": "red"}
 VALID_COLOR_TEMP = {"color_temp": 240}
 VALID_HS_COLOR = {"hs_color": (345, 75)}
-VALID_KELVIN = {"kelvin": 4000}
-VALID_PROFILE = {"profile": "relax"}
 VALID_RGB_COLOR = {"rgb_color": (255, 63, 111)}
 VALID_RGBW_COLOR = {"rgbw_color": (255, 63, 111, 10)}
 VALID_RGBWW_COLOR = {"rgbww_color": (255, 63, 111, 10, 20)}
 VALID_XY_COLOR = {"xy_color": (0.59, 0.274)}
 
 NONE_BRIGHTNESS = {"brightness": None}
-NONE_FLASH = {"flash": None}
 NONE_EFFECT = {"effect": None}
-NONE_TRANSITION = {"transition": None}
-NONE_COLOR_NAME = {"color_name": None}
 NONE_COLOR_TEMP = {"color_temp": None}
 NONE_HS_COLOR = {"hs_color": None}
-NONE_KELVIN = {"kelvin": None}
-NONE_PROFILE = {"profile": None}
 NONE_RGB_COLOR = {"rgb_color": None}
 NONE_RGBW_COLOR = {"rgbw_color": None}
 NONE_RGBWW_COLOR = {"rgbww_color": None}
@@ -43,14 +32,9 @@ async def test_reproducing_states(
     """Test reproducing Light states."""
     hass.states.async_set("light.entity_off", "off", {})
     hass.states.async_set("light.entity_bright", "on", VALID_BRIGHTNESS)
-    hass.states.async_set("light.entity_flash", "on", VALID_FLASH)
     hass.states.async_set("light.entity_effect", "on", VALID_EFFECT)
-    hass.states.async_set("light.entity_trans", "on", VALID_TRANSITION)
-    hass.states.async_set("light.entity_name", "on", VALID_COLOR_NAME)
     hass.states.async_set("light.entity_temp", "on", VALID_COLOR_TEMP)
     hass.states.async_set("light.entity_hs", "on", VALID_HS_COLOR)
-    hass.states.async_set("light.entity_kelvin", "on", VALID_KELVIN)
-    hass.states.async_set("light.entity_profile", "on", VALID_PROFILE)
     hass.states.async_set("light.entity_rgb", "on", VALID_RGB_COLOR)
     hass.states.async_set("light.entity_xy", "on", VALID_XY_COLOR)
 
@@ -63,14 +47,9 @@ async def test_reproducing_states(
         [
             State("light.entity_off", "off"),
             State("light.entity_bright", "on", VALID_BRIGHTNESS),
-            State("light.entity_flash", "on", VALID_FLASH),
             State("light.entity_effect", "on", VALID_EFFECT),
-            State("light.entity_trans", "on", VALID_TRANSITION),
-            State("light.entity_name", "on", VALID_COLOR_NAME),
             State("light.entity_temp", "on", VALID_COLOR_TEMP),
             State("light.entity_hs", "on", VALID_HS_COLOR),
-            State("light.entity_kelvin", "on", VALID_KELVIN),
-            State("light.entity_profile", "on", VALID_PROFILE),
             State("light.entity_rgb", "on", VALID_RGB_COLOR),
             State("light.entity_xy", "on", VALID_XY_COLOR),
         ],
@@ -92,20 +71,15 @@ async def test_reproducing_states(
         [
             State("light.entity_xy", "off"),
             State("light.entity_off", "on", VALID_BRIGHTNESS),
-            State("light.entity_bright", "on", VALID_FLASH),
-            State("light.entity_flash", "on", VALID_EFFECT),
-            State("light.entity_effect", "on", VALID_TRANSITION),
-            State("light.entity_trans", "on", VALID_COLOR_NAME),
-            State("light.entity_name", "on", VALID_COLOR_TEMP),
+            State("light.entity_bright", "on", VALID_EFFECT),
+            State("light.entity_effect", "on", VALID_COLOR_TEMP),
             State("light.entity_temp", "on", VALID_HS_COLOR),
-            State("light.entity_hs", "on", VALID_KELVIN),
-            State("light.entity_kelvin", "on", VALID_PROFILE),
-            State("light.entity_profile", "on", VALID_RGB_COLOR),
+            State("light.entity_hs", "on", VALID_RGB_COLOR),
             State("light.entity_rgb", "on", VALID_XY_COLOR),
         ],
     )
 
-    assert len(turn_on_calls) == 11
+    assert len(turn_on_calls) == 6
 
     expected_calls = []
 
@@ -113,41 +87,21 @@ async def test_reproducing_states(
     expected_off["entity_id"] = "light.entity_off"
     expected_calls.append(expected_off)
 
-    expected_bright = dict(VALID_FLASH)
+    expected_bright = dict(VALID_EFFECT)
     expected_bright["entity_id"] = "light.entity_bright"
     expected_calls.append(expected_bright)
 
-    expected_flash = dict(VALID_EFFECT)
-    expected_flash["entity_id"] = "light.entity_flash"
-    expected_calls.append(expected_flash)
-
-    expected_effect = dict(VALID_TRANSITION)
+    expected_effect = dict(VALID_COLOR_TEMP)
     expected_effect["entity_id"] = "light.entity_effect"
     expected_calls.append(expected_effect)
-
-    expected_trans = dict(VALID_COLOR_NAME)
-    expected_trans["entity_id"] = "light.entity_trans"
-    expected_calls.append(expected_trans)
-
-    expected_name = dict(VALID_COLOR_TEMP)
-    expected_name["entity_id"] = "light.entity_name"
-    expected_calls.append(expected_name)
 
     expected_temp = dict(VALID_HS_COLOR)
     expected_temp["entity_id"] = "light.entity_temp"
     expected_calls.append(expected_temp)
 
-    expected_hs = dict(VALID_KELVIN)
+    expected_hs = dict(VALID_RGB_COLOR)
     expected_hs["entity_id"] = "light.entity_hs"
     expected_calls.append(expected_hs)
-
-    expected_kelvin = dict(VALID_PROFILE)
-    expected_kelvin["entity_id"] = "light.entity_kelvin"
-    expected_calls.append(expected_kelvin)
-
-    expected_profile = dict(VALID_RGB_COLOR)
-    expected_profile["entity_id"] = "light.entity_profile"
-    expected_calls.append(expected_profile)
 
     expected_rgb = dict(VALID_XY_COLOR)
     expected_rgb["entity_id"] = "light.entity_rgb"
@@ -191,10 +145,8 @@ async def test_filter_color_modes(
     """Test filtering of parameters according to color mode."""
     hass.states.async_set("light.entity", "off", {})
     all_colors = {
-        **VALID_COLOR_NAME,
         **VALID_COLOR_TEMP,
         **VALID_HS_COLOR,
-        **VALID_KELVIN,
         **VALID_RGB_COLOR,
         **VALID_RGBW_COLOR,
         **VALID_RGBWW_COLOR,
@@ -240,31 +192,13 @@ async def test_filter_color_modes(
     assert len(turn_on_calls) == 1
 
 
-async def test_deprecation_warning(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Test deprecation warning."""
-    hass.states.async_set("light.entity_off", "off", {})
-    turn_on_calls = async_mock_service(hass, "light", "turn_on")
-    await async_reproduce_state(
-        hass, [State("light.entity_off", "on", {"brightness_pct": 80})]
-    )
-    assert len(turn_on_calls) == 1
-    assert DEPRECATION_WARNING % ["brightness_pct"] in caplog.text
-
-
 @pytest.mark.parametrize(
     "saved_state",
     (
         NONE_BRIGHTNESS,
-        NONE_FLASH,
         NONE_EFFECT,
-        NONE_TRANSITION,
-        NONE_COLOR_NAME,
         NONE_COLOR_TEMP,
         NONE_HS_COLOR,
-        NONE_KELVIN,
-        NONE_PROFILE,
         NONE_RGB_COLOR,
         NONE_RGBW_COLOR,
         NONE_RGBWW_COLOR,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Support for previously deprecated attributes `brightness_pct`, `color_name`, `flash`, `kelvin`, `profile`, and `transition` has been removed from light scenes. The attributes were deprecated in light scenes in November 2019 by PR https://github.com/home-assistant/core/pull/28557

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove support for deprecated light attributes from light scenes:
```
    ATTR_BRIGHTNESS_PCT,
    ATTR_COLOR_NAME,
    ATTR_FLASH,
    ATTR_KELVIN,
    ATTR_PROFILE,
    ATTR_TRANSITION,
```

These were deprecated in November 2019 by PR https://github.com/home-assistant/core/pull/28557

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
