### PR TITLE
Add forced update from API when a change is made and webhook is not active

### DIFF
--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -301,6 +301,9 @@ class NetatmoThermostat(NetatmoBase, ClimateEntity):
             return HVACAction.HEATING
         return HVACAction.IDLE
 
+    async def _async_update_if_no_webhook(self):
+        await self.data_handler.async_update_if_no_webhook(self._signal_name)
+
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         if hvac_mode == HVACMode.OFF:
@@ -340,6 +343,7 @@ class NetatmoThermostat(NetatmoBase, ClimateEntity):
             _LOGGER.error("Preset mode '%s' not available", preset_mode)
 
         self.async_write_ha_state()
+        await self._async_update_if_no_webhook()
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature for 2 hours."""
@@ -347,6 +351,7 @@ class NetatmoThermostat(NetatmoBase, ClimateEntity):
             STATE_NETATMO_MANUAL, min(kwargs[ATTR_TEMPERATURE], DEFAULT_MAX_TEMP)
         )
         self.async_write_ha_state()
+        await self._async_update_if_no_webhook()
 
     async def async_turn_off(self) -> None:
         """Turn the entity off."""
@@ -358,11 +363,13 @@ class NetatmoThermostat(NetatmoBase, ClimateEntity):
         elif self._attr_hvac_mode != HVACMode.OFF:
             await self._room.async_therm_set(STATE_NETATMO_OFF)
         self.async_write_ha_state()
+        await self._async_update_if_no_webhook()
 
     async def async_turn_on(self) -> None:
         """Turn the entity on."""
         await self._room.async_therm_set(STATE_NETATMO_HOME)
         self.async_write_ha_state()
+        await self._async_update_if_no_webhook()
 
     @property
     def available(self) -> bool:
@@ -429,6 +436,7 @@ class NetatmoThermostat(NetatmoBase, ClimateEntity):
             kwargs.get(ATTR_SCHEDULE_NAME),
             schedule_id,
         )
+        await self._async_update_if_no_webhook()
 
     async def _async_service_set_preset_mode_with_end_datetime(
         self, **kwargs: Any
@@ -446,6 +454,7 @@ class NetatmoThermostat(NetatmoBase, ClimateEntity):
             preset_mode,
             end_timestamp,
         )
+        await self._async_update_if_no_webhook()
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -301,9 +301,6 @@ class NetatmoThermostat(NetatmoBase, ClimateEntity):
             return HVACAction.HEATING
         return HVACAction.IDLE
 
-    async def _async_update_if_no_webhook(self):
-        await self.data_handler.async_update_if_no_webhook(self._signal_name)
-
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         if hvac_mode == HVACMode.OFF:

--- a/homeassistant/components/netatmo/const.py
+++ b/homeassistant/components/netatmo/const.py
@@ -37,6 +37,8 @@ API_SCOPES_EXCLUDED_FROM_CLOUD = [
     "write_mhs1",
 ]
 
+ISSUE_ID_WEBHOOK_NOT_RECEIVING = "webhook_not_receiving"
+
 NETATMO_CREATE_BATTERY = "netatmo_create_battery"
 NETATMO_CREATE_CAMERA = "netatmo_create_camera"
 NETATMO_CREATE_CAMERA_LIGHT = "netatmo_create_camera_light"

--- a/homeassistant/components/netatmo/cover.py
+++ b/homeassistant/components/netatmo/cover.py
@@ -84,20 +84,24 @@ class NetatmoCover(NetatmoBase, CoverEntity):
         await self._cover.async_close()
         self._attr_is_closed = True
         self.async_write_ha_state()
+        await self._async_update_if_no_webhook()
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         await self._cover.async_open()
         self._attr_is_closed = False
         self.async_write_ha_state()
+        await self._async_update_if_no_webhook()
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         await self._cover.async_stop()
+        await self._async_update_if_no_webhook()
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover shutter to a specific position."""
         await self._cover.async_set_target_position(kwargs[ATTR_POSITION])
+        await self._async_update_if_no_webhook()
 
     @callback
     def async_update_callback(self) -> None:

--- a/homeassistant/components/netatmo/data_handler.py
+++ b/homeassistant/components/netatmo/data_handler.py
@@ -176,6 +176,7 @@ class NetatmoDataHandler:
                 DOMAIN,
                 ISSUE_ID_WEBHOOK_NOT_RECEIVING,
                 is_fixable=False,
+                is_persistent=True,
                 issue_domain=DOMAIN,
                 learn_more_url='https://www.home-assistant.io/integrations/netatmo/#webhook-events',
                 severity=IssueSeverity.WARNING,

--- a/homeassistant/components/netatmo/light.py
+++ b/homeassistant/components/netatmo/light.py
@@ -138,11 +138,13 @@ class NetatmoCameraLight(NetatmoBase, LightEntity):
         """Turn camera floodlight on."""
         _LOGGER.debug("Turn camera '%s' on", self.name)
         await self._camera.async_floodlight_on()
+        await self._async_update_if_no_webhook()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn camera floodlight into auto mode."""
         _LOGGER.debug("Turn camera '%s' to auto mode", self.name)
         await self._camera.async_floodlight_auto()
+        await self._async_update_if_no_webhook()
 
     @callback
     def async_update_callback(self) -> None:
@@ -201,12 +203,14 @@ class NetatmoLight(NetatmoBase, LightEntity):
 
         self._attr_is_on = True
         self.async_write_ha_state()
+        await self._async_update_if_no_webhook()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn light off."""
         await self._dimmer.async_off()
         self._attr_is_on = False
         self.async_write_ha_state()
+        await self._async_update_if_no_webhook()
 
     @callback
     def async_update_callback(self) -> None:

--- a/homeassistant/components/netatmo/netatmo_entity_base.py
+++ b/homeassistant/components/netatmo/netatmo_entity_base.py
@@ -27,6 +27,7 @@ class NetatmoBase(Entity):
         """Set up Netatmo entity base."""
         self.data_handler = data_handler
         self._publishers: list[dict[str, Any]] = []
+        self._signal_name: str | None = None
 
         self._device_name: str = ""
         self._id: str = ""
@@ -35,6 +36,9 @@ class NetatmoBase(Entity):
         self._attr_name = None
         self._attr_unique_id = None
         self._attr_extra_state_attributes = {}
+
+    async def _async_update_if_no_webhook(self):
+        await self.data_handler.async_update_if_no_webhook(self._signal_name)
 
     async def async_added_to_hass(self) -> None:
         """Entity created."""

--- a/homeassistant/components/netatmo/select.py
+++ b/homeassistant/components/netatmo/select.py
@@ -120,6 +120,7 @@ class NetatmoScheduleSelect(NetatmoBase, SelectEntity):
                 sid,
             )
             await self._home.async_switch_schedule(schedule_id=sid)
+            await self._async_update_if_no_webhook()
             break
 
     @callback

--- a/homeassistant/components/netatmo/strings.json
+++ b/homeassistant/components/netatmo/strings.json
@@ -138,7 +138,7 @@
   "issues": {
     "webhook_not_receiving": {
       "title": "Webhook is not active",
-      "description": "The webhook is not registered or does not appear to be receiving events. The status of your devices and entities may not update when changed outside of Home Assistant."
+      "description": "The webhook is not registered or does not appear to be receiving events. The status of your devices and entities may not update when changed outside of Home Assistant and device triggers may not function correctly."
     }
   }
 }

--- a/homeassistant/components/netatmo/strings.json
+++ b/homeassistant/components/netatmo/strings.json
@@ -137,8 +137,8 @@
   },
   "issues": {
     "webhook_not_receiving": {
-      "title": "Webhook is not active",
-      "description": "The webhook is not registered or does not appear to be receiving events. The status of your devices and entities may not update when changed outside of Home Assistant and device triggers may not function correctly."
+      "title": "Netatmo webhook is not active",
+      "description": "The webhook for the Netatmo integration is not registered or does not appear to be receiving events. The status of your devices and entities may not update when changed outside of Home Assistant and device triggers may not function correctly."
     }
   }
 }

--- a/homeassistant/components/netatmo/strings.json
+++ b/homeassistant/components/netatmo/strings.json
@@ -134,5 +134,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "webhook_not_receiving": {
+      "title": "Webhook is not active",
+      "description": "The webhook is not registered or does not appear to be receiving events. The status of your devices and entities may not update when changed outside of Home Assistant."
+    }
   }
 }

--- a/homeassistant/components/netatmo/switch.py
+++ b/homeassistant/components/netatmo/switch.py
@@ -79,9 +79,11 @@ class NetatmoSwitch(NetatmoBase, SwitchEntity):
         await self._switch.async_on()
         self._attr_is_on = True
         self.async_write_ha_state()
+        await self._async_update_if_no_webhook()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the zone off."""
         await self._switch.async_off()
         self._attr_is_on = False
         self.async_write_ha_state()
+        await self._async_update_if_no_webhook()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

> NOTE
>
> Keeping this as draft for now as I am just looking for feedback on the idea.
>
> This is an attempt to make the integration more functional when the webhook is not configured, and make it easier to diagnose when entities are not updating.
>
> Apologies if this is the wrong way to look for feedback on things like this.

Implement forced update from the API when a change is made within Home Assistant, **ONLY** if a webhook registered event has **NOT** been received (i.e. the webhook is either not registered or not receiving events). This would make HA more responsive when the webhook is not registered/functional.

There are a number of issues with this approach such as when updates are made to the state outside of HA, and I believe device triggers would not function dueas they are built onto the events. Due to this, I have also added an HA issue which should appear when these API updates are being made instead of using webhook events. If "ignore" is clicked, this should reappear on next startup if the webhook is still not active. If any event other than webhook unregistered is received, the issue will be deleted.

I have only been able to test this with climate devices, but changes in HA are much more responsive.

Should help a lot with issues such as #81752 but won't resolve it fully.

![image](https://github.com/home-assistant/core/assets/50599779/9769a472-c91c-4081-898f-c5d8e1b63936)

![image](https://github.com/home-assistant/core/assets/50599779/33966428-b3eb-40d8-a24b-6dfcd22e4010)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #81752
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
