### PR TITLE
Support new deCONZ Particulate Matter endpoint

### DIFF
--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_push",
   "loggers": ["pydeconz"],
   "quality_scale": "platinum",
-  "requirements": ["pydeconz==113"],
+  "requirements": ["pydeconz==114"],
   "ssdp": [
     {
       "manufacturer": "Royal Philips Electronics",

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -17,6 +17,7 @@ from pydeconz.models.sensor.generic_status import GenericStatus
 from pydeconz.models.sensor.humidity import Humidity
 from pydeconz.models.sensor.light_level import LightLevel
 from pydeconz.models.sensor.moisture import Moisture
+from pydeconz.models.sensor.particulate_matter import ParticulateMatter
 from pydeconz.models.sensor.power import Power
 from pydeconz.models.sensor.pressure import Pressure
 from pydeconz.models.sensor.switch import Switch
@@ -83,6 +84,7 @@ T = TypeVar(
     Humidity,
     LightLevel,
     Moisture,
+    ParticulateMatter,
     Power,
     Pressure,
     Temperature,
@@ -212,6 +214,17 @@ ENTITY_DESCRIPTIONS: tuple[DeconzSensorDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=PERCENTAGE,
         suggested_display_precision=1,
+    ),
+    DeconzSensorDescription[ParticulateMatter](
+        key="particulate_matter_pm2_5",
+        supported_fn=lambda device: device.measured_value is not None,
+        update_key="measured_value",
+        value_fn=lambda device: device.measured_value,
+        instance_check=ParticulateMatter,
+        name_suffix="PM25",
+        device_class=SensorDeviceClass.PM25,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     ),
     DeconzSensorDescription[Power](
         key="power",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1674,7 +1674,7 @@ pydaikin==2.11.1
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==113
+pydeconz==114
 
 # homeassistant.components.delijn
 pydelijn==1.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1263,7 +1263,7 @@ pycsspeechtts==1.0.8
 pydaikin==2.11.1
 
 # homeassistant.components.deconz
-pydeconz==113
+pydeconz==114
 
 # homeassistant.components.dexcom
 pydexcom==0.2.3

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -530,6 +530,55 @@ TEST_DATA = [
             "next_state": "1.3",
         },
     ),
+    (  # Particulate matter -> pm2_5
+        {
+            "capabilities": {
+                "measured_value": {
+                    "max": 999,
+                    "min": 0,
+                    "quantity": "density",
+                    "substance": "PM2.5",
+                    "unit": "ug/m^3",
+                }
+            },
+            "config": {"on": True, "reachable": True},
+            "ep": 1,
+            "etag": "2a67a4b5cbcc20532c0ee75e2abac0c3",
+            "lastannounced": None,
+            "lastseen": "2023-10-29T12:59Z",
+            "manufacturername": "IKEA of Sweden",
+            "modelid": "STARKVIND Air purifier table",
+            "name": "STARKVIND AirPurifier",
+            "productid": "E2006",
+            "state": {
+                "airquality": "excellent",
+                "lastupdated": "2023-10-29T12:59:27.976",
+                "measured_value": 1,
+                "pm2_5": 1,
+            },
+            "swversion": "1.1.001",
+            "type": "ZHAParticulateMatter",
+            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-042a",
+        },
+        {
+            "entity_count": 1,
+            "device_count": 3,
+            "entity_id": "sensor.starkvind_airpurifier_pm25",
+            "unique_id": "xx:xx:xx:xx:xx:xx:xx:xx-01-042a-particulate_matter_pm2_5",
+            "state": "1",
+            "entity_category": None,
+            "device_class": SensorDeviceClass.PM25,
+            "state_class": SensorStateClass.MEASUREMENT,
+            "attributes": {
+                "friendly_name": "STARKVIND AirPurifier PM25",
+                "device_class": SensorDeviceClass.PM25,
+                "state_class": SensorStateClass.MEASUREMENT,
+                "unit_of_measurement": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+            },
+            "websocket_event": {"state": {"measured_value": 2}},
+            "next_state": "2",
+        },
+    ),
     (  # Power sensor
         {
             "config": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/Kane610/deconz/compare/v113...v114
Old air quality pm25 endpoint has been replaced by a new particulate matter endpoint.

Related reports
https://github.com/Kane610/deconz/issues/531
https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7339
https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7284


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
