### PR TITLE
Add issue when Netatmo webhook is not registered or receiving events

### DIFF
--- a/homeassistant/components/netatmo/__init__.py
+++ b/homeassistant/components/netatmo/__init__.py
@@ -57,7 +57,7 @@ from .const import (
     WEBHOOK_PUSH_TYPE,
 )
 from .data_handler import NetatmoDataHandler
-from .webhook import async_handle_webhook
+from .webhook import async_create_webhook_not_active_issue, async_handle_webhook
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -169,6 +169,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id][DATA_HANDLER] = data_handler
     await data_handler.async_setup()
 
+    async_create_webhook_not_active_issue(hass)
+
     async def unregister_webhook(
         _: Any,
     ) -> None:
@@ -181,6 +183,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             {"type": "None", "data": {WEBHOOK_PUSH_TYPE: WEBHOOK_DEACTIVATION}},
         )
         webhook_unregister(hass, entry.data[CONF_WEBHOOK_ID])
+        async_create_webhook_not_active_issue(hass)
         try:
             await hass.data[DOMAIN][entry.entry_id][AUTH].async_dropwebhook()
         except pyatmo.ApiError:

--- a/homeassistant/components/netatmo/const.py
+++ b/homeassistant/components/netatmo/const.py
@@ -37,6 +37,8 @@ API_SCOPES_EXCLUDED_FROM_CLOUD = [
     "write_mhs1",
 ]
 
+ISSUE_ID_WEBHOOK_NOT_ACTIVE = "webhook_not_active"
+
 NETATMO_CREATE_BATTERY = "netatmo_create_battery"
 NETATMO_CREATE_CAMERA = "netatmo_create_camera"
 NETATMO_CREATE_CAMERA_LIGHT = "netatmo_create_camera_light"

--- a/homeassistant/components/netatmo/data_handler.py
+++ b/homeassistant/components/netatmo/data_handler.py
@@ -24,12 +24,18 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_send,
 )
 from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.issue_registry import (
+    IssueSeverity,
+    async_create_issue,
+    async_delete_issue,
+)
 
 from .const import (
     AUTH,
     DATA_PERSONS,
     DATA_SCHEDULES,
     DOMAIN,
+    ISSUE_ID_WEBHOOK_NOT_ACTIVE,
     MANUFACTURER,
     NETATMO_CREATE_BATTERY,
     NETATMO_CREATE_CAMERA,
@@ -152,6 +158,9 @@ class NetatmoDataHandler:
             )
         )
 
+        self.config_entry.async_on_unload(self.async_delete_webhook_not_active_issue)
+        self.async_create_webhook_not_active_issue()
+
         self.account = pyatmo.AsyncAccount(self._auth)
 
         await self.subscribe(ACCOUNT, ACCOUNT, None)
@@ -160,6 +169,24 @@ class NetatmoDataHandler:
             self.config_entry, PLATFORMS
         )
         await self.async_dispatch()
+
+    def async_create_webhook_not_active_issue(self) -> None:
+        """Create the issue indicating the web hook is not registered or is not receiving events."""
+        async_create_issue(
+            self.hass,
+            DOMAIN,
+            ISSUE_ID_WEBHOOK_NOT_ACTIVE,
+            is_fixable=False,
+            is_persistent=True,
+            issue_domain=DOMAIN,
+            learn_more_url="https://www.home-assistant.io/integrations/netatmo/#webhook-events",
+            severity=IssueSeverity.WARNING,
+            translation_key=ISSUE_ID_WEBHOOK_NOT_ACTIVE,
+        )
+
+    def async_delete_webhook_not_active_issue(self) -> None:
+        """Delete the issue indicating the web hook is not registered or not receiving events."""
+        async_delete_issue(self.hass, DOMAIN, ISSUE_ID_WEBHOOK_NOT_ACTIVE)
 
     async def async_update(self, event_time: datetime) -> None:
         """Update device.
@@ -186,13 +213,18 @@ class NetatmoDataHandler:
 
     async def handle_event(self, event: dict) -> None:
         """Handle webhook events."""
+        if event["data"][WEBHOOK_PUSH_TYPE] == WEBHOOK_DEACTIVATION:
+            _LOGGER.info("%s webhook unregistered", MANUFACTURER)
+            self._webhook = False
+            self.async_create_webhook_not_active_issue()
+            return
+
+        self.async_delete_webhook_not_active_issue()
+
         if event["data"][WEBHOOK_PUSH_TYPE] == WEBHOOK_ACTIVATION:
             _LOGGER.info("%s webhook successfully registered", MANUFACTURER)
             self._webhook = True
-
-        elif event["data"][WEBHOOK_PUSH_TYPE] == WEBHOOK_DEACTIVATION:
-            _LOGGER.info("%s webhook unregistered", MANUFACTURER)
-            self._webhook = False
+            self.async_delete_webhook_not_active_issue()
 
         elif event["data"][WEBHOOK_PUSH_TYPE] == WEBHOOK_NACAMERA_CONNECTION:
             _LOGGER.debug("%s camera reconnected", MANUFACTURER)

--- a/homeassistant/components/netatmo/strings.json
+++ b/homeassistant/components/netatmo/strings.json
@@ -134,5 +134,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "webhook_not_active": {
+      "title": "Netatmo webhook is not active",
+      "description": "The webhook for the Netatmo integration is not registered or does not appear to be receiving events. The status of your devices and entities may take a long time to update as a result."
+    }
   }
 }

--- a/homeassistant/components/netatmo/webhook.py
+++ b/homeassistant/components/netatmo/webhook.py
@@ -6,6 +6,11 @@ from aiohttp.web import Request
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_ID, ATTR_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.issue_registry import (
+    IssueSeverity,
+    async_create_issue,
+    async_delete_issue,
+)
 
 from .const import (
     ATTR_EVENT_TYPE,
@@ -18,6 +23,7 @@ from .const import (
     DEFAULT_PERSON,
     DOMAIN,
     EVENT_ID_MAP,
+    ISSUE_ID_WEBHOOK_NOT_ACTIVE,
     NETATMO_EVENT,
 )
 
@@ -97,3 +103,24 @@ def async_send_event(hass: HomeAssistant, event_type: str, data: dict) -> None:
         event_type=NETATMO_EVENT,
         event_data=event_data,
     )
+    async_delete_webhook_not_active_issue(hass)
+
+
+def async_create_webhook_not_active_issue(hass: HomeAssistant) -> None:
+    """Create the issue indicating the web hook is not registered or is not receiving events."""
+    async_create_issue(
+        hass,
+        DOMAIN,
+        ISSUE_ID_WEBHOOK_NOT_ACTIVE,
+        is_fixable=False,
+        is_persistent=True,
+        issue_domain=DOMAIN,
+        learn_more_url="https://www.home-assistant.io/integrations/netatmo/#webhook-events",
+        severity=IssueSeverity.WARNING,
+        translation_key=ISSUE_ID_WEBHOOK_NOT_ACTIVE,
+    )
+
+
+def async_delete_webhook_not_active_issue(hass: HomeAssistant) -> None:
+    """Delete the issue indicating the web hook is not registered or not receiving events."""
+    async_delete_issue(hass, DOMAIN, ISSUE_ID_WEBHOOK_NOT_ACTIVE)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add an issue within Home Assistant if the Netatmo webhook is not registered, or has not received any events. This issue is flagged as persistent so will reappear on restart (so that it can be used for diagnostics).

![image](https://github.com/home-assistant/core/assets/50599779/9f895e3b-0655-40b3-aa9c-2a2716be681b)
![image](https://github.com/home-assistant/core/assets/50599779/c6f6625f-107f-49c4-a14b-edb45ae9594a)

**NOTE:** I have only been able to test this by triggering the webhook with postman. I don't have a working Netatmo webhook to test this with Netatmo directly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
