### PR TITLE
Remove zwave_js device on device reset

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -465,12 +465,12 @@ class ControllerEvents:
                 # Remove trailing comma if it's there
                 if identifier[-1] == ",":
                     identifier = identifier[:-1]
-                notification_msg = f"{notification_msg} {identifier}"
+                notification_msg = f"{notification_msg} {identifier}."
             else:
-                notification_msg = f"{notification_msg}"
+                notification_msg = f"{notification_msg}."
             async_create(
                 self.hass,
-                f"{notification_msg}, reloading integration.",
+                notification_msg,
                 "Device Was Factory Reset!",
                 f"{DOMAIN}.node_reset_and_removed.{dev_id[1]}",
             )

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -474,9 +474,6 @@ class ControllerEvents:
                 "Device Was Factory Reset!",
                 f"{DOMAIN}.node_reset_and_removed.{dev_id[1]}",
             )
-            self.hass.async_create_task(
-                self.hass.config_entries.async_reload(self.config_entry.entry_id)
-            )
 
         self.remove_device(device)
 

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -449,7 +449,10 @@ class ControllerEvents:
                     "remove_entity"
                 ),
             )
-        elif reason == RemoveNodeReason.RESET:
+            # We don't want to remove the device so we can keep the user customizations
+            return
+
+        if reason == RemoveNodeReason.RESET:
             device_name = device.name_by_user or device.name or f"Node {node.node_id}"
             identifier = get_network_identifier_for_notification(
                 self.hass, self.config_entry, self.driver_events.driver.controller
@@ -474,8 +477,8 @@ class ControllerEvents:
             self.hass.async_create_task(
                 self.hass.config_entries.async_reload(self.config_entry.entry_id)
             )
-        else:
-            self.remove_device(device)
+
+        self.remove_device(device)
 
     @callback
     def async_on_identify(self, event: dict) -> None:

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -462,14 +462,17 @@ class ControllerEvents:
                 # Remove trailing comma if it's there
                 if identifier[-1] == ",":
                     identifier = identifier[:-1]
-                notification_msg = f"{notification_msg} {identifier}."
+                notification_msg = f"{notification_msg} {identifier}"
             else:
-                notification_msg = f"{notification_msg}."
+                notification_msg = f"{notification_msg}"
             async_create(
                 self.hass,
-                notification_msg,
+                f"{notification_msg}, reloading integration.",
                 "Device Was Factory Reset!",
                 f"{DOMAIN}.node_reset_and_removed.{dev_id[1]}",
+            )
+            self.hass.async_create_task(
+                self.hass.config_entries.async_reload(self.config_entry.entry_id)
             )
         else:
             self.remove_device(device)

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -1650,6 +1650,7 @@ async def test_factory_reset_node(
     hass: HomeAssistant, client, multisensor_6, multisensor_6_state, integration
 ) -> None:
     """Test when a node is removed because it was reset."""
+    dev_reg = dr.async_get(hass)
     # One config entry scenario
     remove_event = Event(
         type="node removed",
@@ -1671,6 +1672,7 @@ async def test_factory_reset_node(
     assert "with the home ID" not in notifications[msg_id]["message"]
     async_dismiss(hass, msg_id)
     await hass.async_block_till_done()
+    assert not dev_reg.async_get_device(identifiers={dev_id})
 
     # Add mock config entry to simulate having multiple entries
     new_entry = MockConfigEntry(domain=DOMAIN)

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -1663,22 +1663,35 @@ async def test_factory_reset_node(
     dev_id = get_device_id(client.driver, multisensor_6)
     msg_id = f"{DOMAIN}.node_reset_and_removed.{dev_id[1]}"
 
-    client.driver.controller.receive_event(remove_event)
-    notifications = async_get_persistent_notifications(hass)
-    assert len(notifications) == 1
-    assert list(notifications)[0] == msg_id
-    assert notifications[msg_id]["message"].startswith("`Multisensor 6`")
-    assert "with the home ID" not in notifications[msg_id]["message"]
-    async_dismiss(hass, msg_id)
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_reload"
+    ) as mock_reload:
+        client.driver.controller.receive_event(remove_event)
+        assert mock_reload.called
+        notifications = async_get_persistent_notifications(hass)
+        assert len(notifications) == 1
+        assert list(notifications)[0] == msg_id
+        assert notifications[msg_id]["message"].startswith("`Multisensor 6`")
+        assert "with the home ID" not in notifications[msg_id]["message"]
+        async_dismiss(hass, msg_id)
+        await hass.async_block_till_done()
 
     # Add mock config entry to simulate having multiple entries
     new_entry = MockConfigEntry(domain=DOMAIN)
     new_entry.add_to_hass(hass)
 
     # Re-add the node then remove it again
-    client.driver.controller.nodes[multisensor_6_state["nodeId"]] = Node(
-        client, deepcopy(multisensor_6_state)
+    add_event = Event(
+        type="node added",
+        data={
+            "source": "controller",
+            "event": "node added",
+            "node": deepcopy(multisensor_6_state),
+            "result": {},
+        },
     )
+    client.driver.controller.receive_event(add_event)
+    await hass.async_block_till_done()
     remove_event.data["node"] = deepcopy(multisensor_6_state)
     client.driver.controller.receive_event(remove_event)
     # Test case where config entry title and home ID don't match
@@ -1686,19 +1699,29 @@ async def test_factory_reset_node(
     assert len(notifications) == 1
     assert list(notifications)[0] == msg_id
     assert (
-        "network `Mock Title`, with the home ID `3245146787`."
+        "network `Mock Title`, with the home ID `3245146787`"
         in notifications[msg_id]["message"]
     )
     async_dismiss(hass, msg_id)
+    await hass.async_block_till_done()
 
     # Test case where config entry title and home ID do match
     hass.config_entries.async_update_entry(integration, title="3245146787")
-    client.driver.controller.nodes[multisensor_6_state["nodeId"]] = Node(
-        client, deepcopy(multisensor_6_state)
+    add_event = Event(
+        type="node added",
+        data={
+            "source": "controller",
+            "event": "node added",
+            "node": deepcopy(multisensor_6_state),
+            "result": {},
+        },
     )
+    client.driver.controller.receive_event(add_event)
+    await hass.async_block_till_done()
     remove_event.data["node"] = deepcopy(multisensor_6_state)
     client.driver.controller.receive_event(remove_event)
     notifications = async_get_persistent_notifications(hass)
     assert len(notifications) == 1
     assert list(notifications)[0] == msg_id
     assert "network with the home ID `3245146787`" in notifications[msg_id]["message"]
+    await hass.async_block_till_done()

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -1663,18 +1663,14 @@ async def test_factory_reset_node(
     dev_id = get_device_id(client.driver, multisensor_6)
     msg_id = f"{DOMAIN}.node_reset_and_removed.{dev_id[1]}"
 
-    with patch(
-        "homeassistant.config_entries.ConfigEntries.async_reload"
-    ) as mock_reload:
-        client.driver.controller.receive_event(remove_event)
-        assert mock_reload.called
-        notifications = async_get_persistent_notifications(hass)
-        assert len(notifications) == 1
-        assert list(notifications)[0] == msg_id
-        assert notifications[msg_id]["message"].startswith("`Multisensor 6`")
-        assert "with the home ID" not in notifications[msg_id]["message"]
-        async_dismiss(hass, msg_id)
-        await hass.async_block_till_done()
+    client.driver.controller.receive_event(remove_event)
+    notifications = async_get_persistent_notifications(hass)
+    assert len(notifications) == 1
+    assert list(notifications)[0] == msg_id
+    assert notifications[msg_id]["message"].startswith("`Multisensor 6`")
+    assert "with the home ID" not in notifications[msg_id]["message"]
+    async_dismiss(hass, msg_id)
+    await hass.async_block_till_done()
 
     # Add mock config entry to simulate having multiple entries
     new_entry = MockConfigEntry(domain=DOMAIN)
@@ -1703,7 +1699,6 @@ async def test_factory_reset_node(
         in notifications[msg_id]["message"]
     )
     async_dismiss(hass, msg_id)
-    await hass.async_block_till_done()
 
     # Test case where config entry title and home ID do match
     hass.config_entries.async_update_entry(integration, title="3245146787")
@@ -1724,4 +1719,3 @@ async def test_factory_reset_node(
     assert len(notifications) == 1
     assert list(notifications)[0] == msg_id
     assert "network with the home ID `3245146787`" in notifications[msg_id]["message"]
-    await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
Per https://github.com/zwave-js/certification-backlog/issues/6#issuecomment-1818905232 we must remove the device when the device is reset.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/zwave-js/certification-backlog/issues/6
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
