### PR TITLE
Add select entity for zwave_js Door Lock CC

### DIFF
--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -664,7 +664,14 @@ DISCOVERY_SCHEMAS = [
     # locks
     # Door Lock CC
     ZWaveDiscoverySchema(
-        platform=Platform.LOCK, primary_value=DOOR_LOCK_CURRENT_MODE_SCHEMA
+        platform=Platform.LOCK,
+        primary_value=DOOR_LOCK_CURRENT_MODE_SCHEMA,
+        allow_multi=True,
+    ),
+    ZWaveDiscoverySchema(
+        platform=Platform.SELECT,
+        primary_value=DOOR_LOCK_CURRENT_MODE_SCHEMA,
+        hint="door_lock",
     ),
     # Only discover the Lock CC if the Door Lock CC isn't also present on the node
     ZWaveDiscoverySchema(

--- a/tests/components/zwave_js/test_discovery.py
+++ b/tests/components/zwave_js/test_discovery.py
@@ -87,6 +87,7 @@ async def test_lock_popp_electric_strike_lock_control(
         hass.states.get("binary_sensor.node_62_the_current_status_of_the_door")
         is not None
     )
+    assert hass.states.get("select.node_62_current_lock_mode") is not None
 
 
 async def test_fortrez_ssa3_siren(

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -967,7 +967,7 @@ async def test_removed_device(
     # Check how many entities there are
     ent_reg = er.async_get(hass)
     entity_entries = er.async_entries_for_config_entry(ent_reg, integration.entry_id)
-    assert len(entity_entries) == 92
+    assert len(entity_entries) == 93
 
     # Remove a node and reload the entry
     old_node = driver.controller.nodes.pop(13)
@@ -979,7 +979,7 @@ async def test_removed_device(
     device_entries = dr.async_entries_for_config_entry(dev_reg, integration.entry_id)
     assert len(device_entries) == 2
     entity_entries = er.async_entries_for_config_entry(ent_reg, integration.entry_id)
-    assert len(entity_entries) == 61
+    assert len(entity_entries) == 62
     assert (
         dev_reg.async_get_device(identifiers={get_device_id(driver, old_node)}) is None
     )

--- a/tests/components/zwave_js/test_select.py
+++ b/tests/components/zwave_js/test_select.py
@@ -320,3 +320,30 @@ async def test_config_parameter_select(
     state = hass.states.get(select_entity_id)
     assert state
     assert state.state == "Normal"
+
+
+async def test_lock_popp_electric_strike_lock_control_select(
+    hass: HomeAssistant, client, lock_popp_electric_strike_lock_control, integration
+) -> None:
+    """Test that the Popp Electric Strike Lock Control select entity."""
+    LOCK_SELECT_ENTITY = "select.node_62_current_lock_mode"
+    state = hass.states.get(LOCK_SELECT_ENTITY)
+    assert state
+    assert state.state == "Unsecured"
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": LOCK_SELECT_ENTITY, "option": "UnsecuredWithTimeout"},
+        blocking=True,
+    )
+
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == lock_popp_electric_strike_lock_control.node_id
+    assert args["valueId"] == {
+        "endpoint": 0,
+        "commandClass": 98,
+        "property": "targetMode",
+    }
+    assert args["value"] == 1


### PR DESCRIPTION
## Proposed change
Per https://github.com/zwave-js/certification-backlog/issues/21#issuecomment-1818851068 we need to support all lock modes but we can't do that with the existing lock platform so we will use a select entity instead


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/zwave-js/certification-backlog/issues/21
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
