### PR TITLE
Remove Picnic Cart items count sensor

### DIFF
--- a/homeassistant/components/picnic/const.py
+++ b/homeassistant/components/picnic/const.py
@@ -23,7 +23,6 @@ SLOT_DATA = "slot_data"
 NEXT_DELIVERY_DATA = "next_delivery_data"
 LAST_ORDER_DATA = "last_order_data"
 
-SENSOR_CART_ITEMS_COUNT = "cart_items_count"
 SENSOR_CART_TOTAL_PRICE = "cart_total_price"
 SENSOR_SELECTED_SLOT_START = "selected_slot_start"
 SENSOR_SELECTED_SLOT_END = "selected_slot_end"

--- a/homeassistant/components/picnic/sensor.py
+++ b/homeassistant/components/picnic/sensor.py
@@ -27,7 +27,6 @@ from .const import (
     ATTRIBUTION,
     CONF_COORDINATOR,
     DOMAIN,
-    SENSOR_CART_ITEMS_COUNT,
     SENSOR_CART_TOTAL_PRICE,
     SENSOR_LAST_ORDER_DELIVERY_TIME,
     SENSOR_LAST_ORDER_MAX_ORDER_TIME,
@@ -64,13 +63,6 @@ class PicnicSensorEntityDescription(SensorEntityDescription, PicnicRequiredKeysM
 
 
 SENSOR_TYPES: tuple[PicnicSensorEntityDescription, ...] = (
-    PicnicSensorEntityDescription(
-        key=SENSOR_CART_ITEMS_COUNT,
-        translation_key=SENSOR_CART_ITEMS_COUNT,
-        icon="mdi:format-list-numbered",
-        data_type="cart_data",
-        value_fn=lambda cart: cart.get("total_count", 0),
-    ),
     PicnicSensorEntityDescription(
         key=SENSOR_CART_TOTAL_PRICE,
         translation_key=SENSOR_CART_TOTAL_PRICE,

--- a/homeassistant/components/picnic/strings.json
+++ b/homeassistant/components/picnic/strings.json
@@ -27,9 +27,6 @@
       }
     },
     "sensor": {
-      "cart_items_count": {
-        "name": "Cart items count"
-      },
       "cart_total_price": {
         "name": "Cart total price"
       },

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -213,7 +213,6 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         """Test the default sensor setup behaviour."""
         await self._setup_platform(use_default_responses=True)
 
-        self._assert_sensor("sensor.mock_title_cart_items_count", "10")
         self._assert_sensor(
             "sensor.mock_title_cart_total_price",
             "25.35",
@@ -289,7 +288,6 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         """Test that some sensors are disabled by default."""
         await self._setup_platform(use_default_responses=True, enable_all_sensors=False)
 
-        self._assert_sensor("sensor.mock_title_cart_items_count", disabled=True)
         self._assert_sensor(
             "sensor.mock_title_start_of_last_order_s_slot", disabled=True
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Picnic 'Cart items count' sensor has been removed, as the same value now is exposed by the Picnic Shopping cart To-do sensor.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Sensor is duplicate and has no use anymore.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29960

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
