### PR TITLE
Reolink ptz service to specify move speed

### DIFF
--- a/homeassistant/components/reolink/button.py
+++ b/homeassistant/components/reolink/button.py
@@ -174,9 +174,9 @@ async def async_setup_entry(
 
     platform = async_get_current_platform()
     platform.async_register_entity_service(
-        "set_ptz_speed",
+        "ptz_move",
         {vol.Required(ATTR_SPEED): cv.positive_int},
-        "async_ptz_speed",
+        "async_ptz_move",
         [SUPPORT_PTZ_SPEED],
     )
 
@@ -217,7 +217,7 @@ class ReolinkButtonEntity(ReolinkChannelCoordinatorEntity, ButtonEntity):
         except ReolinkError as err:
             raise HomeAssistantError(err) from err
 
-    async def async_ptz_speed(self, **kwargs) -> None:
+    async def async_ptz_move(self, **kwargs) -> None:
         """PTZ move with speed."""
         speed = kwargs[ATTR_SPEED]
         try:

--- a/homeassistant/components/reolink/button.py
+++ b/homeassistant/components/reolink/button.py
@@ -14,6 +14,7 @@ from homeassistant.components.button import (
     ButtonEntity,
     ButtonEntityDescription,
 )
+from homeassistant.components.camera import CameraEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
@@ -29,7 +30,7 @@ from .const import DOMAIN
 from .entity import ReolinkChannelCoordinatorEntity, ReolinkHostCoordinatorEntity
 
 ATTR_SPEED = "speed"
-SUPPORT_PTZ_SPEED = 1024
+SUPPORT_PTZ_SPEED = CameraEntityFeature.STREAM
 
 
 @dataclass(kw_only=True)

--- a/homeassistant/components/reolink/button.py
+++ b/homeassistant/components/reolink/button.py
@@ -17,11 +17,14 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback, async_get_current_platform
 
 from . import ReolinkData
 from .const import DOMAIN
 from .entity import ReolinkChannelCoordinatorEntity, ReolinkHostCoordinatorEntity
+
+ATTR_SPEED = "speed"
+SUPPORT_PTZ_SPEED = 1024
 
 
 @dataclass(kw_only=True)
@@ -33,6 +36,7 @@ class ReolinkButtonEntityDescription(
     enabled_default: Callable[[Host, int], bool] | None = None
     method: Callable[[Host, int], Any]
     supported: Callable[[Host, int], bool] = lambda api, ch: True
+    ptz_cmd: str | None = None
 
 
 @dataclass(kw_only=True)
@@ -59,6 +63,7 @@ BUTTON_ENTITIES = (
         icon="mdi:pan",
         supported=lambda api, ch: api.supported(ch, "pan"),
         method=lambda api, ch: api.set_ptz_command(ch, command=PtzEnum.left.value),
+        ptz_cmd=PtzEnum.left.value,
     ),
     ReolinkButtonEntityDescription(
         key="ptz_right",
@@ -66,6 +71,7 @@ BUTTON_ENTITIES = (
         icon="mdi:pan",
         supported=lambda api, ch: api.supported(ch, "pan"),
         method=lambda api, ch: api.set_ptz_command(ch, command=PtzEnum.right.value),
+        ptz_cmd=PtzEnum.right.value,
     ),
     ReolinkButtonEntityDescription(
         key="ptz_up",
@@ -73,6 +79,7 @@ BUTTON_ENTITIES = (
         icon="mdi:pan",
         supported=lambda api, ch: api.supported(ch, "tilt"),
         method=lambda api, ch: api.set_ptz_command(ch, command=PtzEnum.up.value),
+        ptz_cmd=PtzEnum.up.value,
     ),
     ReolinkButtonEntityDescription(
         key="ptz_down",
@@ -80,6 +87,7 @@ BUTTON_ENTITIES = (
         icon="mdi:pan",
         supported=lambda api, ch: api.supported(ch, "tilt"),
         method=lambda api, ch: api.set_ptz_command(ch, command=PtzEnum.down.value),
+        ptz_cmd=PtzEnum.down.value,
     ),
     ReolinkButtonEntityDescription(
         key="ptz_zoom_in",
@@ -88,6 +96,7 @@ BUTTON_ENTITIES = (
         entity_registry_enabled_default=False,
         supported=lambda api, ch: api.supported(ch, "zoom_basic"),
         method=lambda api, ch: api.set_ptz_command(ch, command=PtzEnum.zoomin.value),
+        ptz_cmd=PtzEnum.zoomin.value,
     ),
     ReolinkButtonEntityDescription(
         key="ptz_zoom_out",
@@ -96,6 +105,7 @@ BUTTON_ENTITIES = (
         entity_registry_enabled_default=False,
         supported=lambda api, ch: api.supported(ch, "zoom_basic"),
         method=lambda api, ch: api.set_ptz_command(ch, command=PtzEnum.zoomout.value),
+        ptz_cmd=PtzEnum.zoomout.value,
     ),
     ReolinkButtonEntityDescription(
         key="ptz_calibrate",
@@ -157,6 +167,14 @@ async def async_setup_entry(
     )
     async_add_entities(entities)
 
+    platform = async_get_current_platform()
+    platform.async_register_entity_service(
+        "set_ptz_speed",
+        {vol.Required(ATTR_SPEED): cv.positive_int},
+        "async_ptz_speed",
+        [SUPPORT_PTZ_SPEED],
+    )
+
 
 class ReolinkButtonEntity(ReolinkChannelCoordinatorEntity, ButtonEntity):
     """Base button entity class for Reolink IP cameras."""
@@ -181,10 +199,21 @@ class ReolinkButtonEntity(ReolinkChannelCoordinatorEntity, ButtonEntity):
                 entity_description.enabled_default(self._host.api, self._channel)
             )
 
+        if self._host.api.supported(channel, "ptz_speed") and entity_description.ptz_cmd is not None:
+            self._attr_supported_features = SUPPORT_PTZ_SPEED
+
     async def async_press(self) -> None:
         """Execute the button action."""
         try:
             await self.entity_description.method(self._host.api, self._channel)
+        except ReolinkError as err:
+            raise HomeAssistantError(err) from err
+
+    async def async_ptz_speed(self, **kwargs) -> None:
+        """PTZ move with speed."""
+        speed = kwargs[ATTR_SPEED]
+        try:
+            await self._host.api.set_ptz_command(self._channel, command=ptz_cmd, speed=speed)
         except ReolinkError as err:
             raise HomeAssistantError(err) from err
 

--- a/homeassistant/components/reolink/button.py
+++ b/homeassistant/components/reolink/button.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from reolink_aio.api import GuardEnum, Host, PtzEnum
 from reolink_aio.exceptions import ReolinkError
+import voluptuous as vol
 
 from homeassistant.components.button import (
     ButtonDeviceClass,
@@ -17,7 +18,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.entity_platform import AddEntitiesCallback, async_get_current_platform
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.entity_platform import (
+    AddEntitiesCallback,
+    async_get_current_platform,
+)
 
 from . import ReolinkData
 from .const import DOMAIN
@@ -199,7 +204,10 @@ class ReolinkButtonEntity(ReolinkChannelCoordinatorEntity, ButtonEntity):
                 entity_description.enabled_default(self._host.api, self._channel)
             )
 
-        if self._host.api.supported(channel, "ptz_speed") and entity_description.ptz_cmd is not None:
+        if (
+            self._host.api.supported(channel, "ptz_speed")
+            and entity_description.ptz_cmd is not None
+        ):
             self._attr_supported_features = SUPPORT_PTZ_SPEED
 
     async def async_press(self) -> None:
@@ -213,7 +221,9 @@ class ReolinkButtonEntity(ReolinkChannelCoordinatorEntity, ButtonEntity):
         """PTZ move with speed."""
         speed = kwargs[ATTR_SPEED]
         try:
-            await self._host.api.set_ptz_command(self._channel, command=ptz_cmd, speed=speed)
+            await self._host.api.set_ptz_command(
+                self._channel, command=self.entity_description.ptz_cmd, speed=speed
+            )
         except ReolinkError as err:
             raise HomeAssistantError(err) from err
 

--- a/homeassistant/components/reolink/services.yaml
+++ b/homeassistant/components/reolink/services.yaml
@@ -5,6 +5,8 @@ ptz_move:
     entity:
       integration: reolink
       domain: button
+      supported_features:
+        - camera.CameraEntityFeature.STREAM
   fields:
     speed:
       required: true

--- a/homeassistant/components/reolink/services.yaml
+++ b/homeassistant/components/reolink/services.yaml
@@ -11,3 +11,5 @@ set_ptz_speed:
       selector:
         number:
           min: 1
+          max: 64
+          step: 1

--- a/homeassistant/components/reolink/services.yaml
+++ b/homeassistant/components/reolink/services.yaml
@@ -1,0 +1,13 @@
+# Describes the format for available reolink services
+
+set_ptz_speed:
+  target:
+    entity:
+      integration: reolink
+      domain: button
+  fields:
+    speed:
+      required: true
+      selector:
+        number:
+          min: 1

--- a/homeassistant/components/reolink/services.yaml
+++ b/homeassistant/components/reolink/services.yaml
@@ -1,6 +1,6 @@
 # Describes the format for available reolink services
 
-set_ptz_speed:
+ptz_move:
   target:
     entity:
       integration: reolink
@@ -8,6 +8,7 @@ set_ptz_speed:
   fields:
     speed:
       required: true
+      default: 10
       selector:
         number:
           min: 1

--- a/homeassistant/components/reolink/strings.json
+++ b/homeassistant/components/reolink/strings.json
@@ -61,6 +61,18 @@
       "description": "\"{name}\" with model \"{model}\" and hardware version \"{hw_version}\" is running a old firmware version \"{current_firmware}\", while at least firmware version \"{required_firmware}\" is required for proper operation of the Reolink integration. The latest firmware can be downloaded from the [Reolink download center]({download_link})."
     }
   },
+  "services": {
+    "set_ptz_speed": {
+      "name": "PTZ move",
+      "description": "Move the camera with a specific speed.",
+      "fields": {
+        "speed": {
+          "name": "Speed",
+          "description": "PTZ move speed."
+        }
+      }
+    }
+  },
   "entity": {
     "binary_sensor": {
       "face": {

--- a/homeassistant/components/reolink/strings.json
+++ b/homeassistant/components/reolink/strings.json
@@ -62,7 +62,7 @@
     }
   },
   "services": {
-    "set_ptz_speed": {
+    "ptz_move": {
       "name": "PTZ move",
       "description": "Move the camera with a specific speed.",
       "fields": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add custom service to Reolink to allow PTZ movements of the camera with a custom move speed.


Note: I don't really like the way in which I filter the entities that support the service:
`SUPPORT_PTZ_SPEED = CameraEntityFeature.STREAM`
```
      supported_features:
        - camera.CameraEntityFeature.STREAM
```

I would be really happy if someone could come up with a cleaner solution to filter the entities based on the camera features: `self._host.api.supported(channel, "ptz_speed")`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29961

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
