### PR TITLE
Improve Unifi switch entity unique ID naming function

### DIFF
--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -199,6 +199,12 @@ class UnifiSwitchEntityDescription(
     only_event_for_state_change: bool = False
 
 
+def _make_unique_id(obj_id: str, type_name: str) -> str:
+    """Split an object id by the first underscore and interpose the given type."""
+    prefix, _, suffix = obj_id.partition("_")
+    return f"{prefix}-{type_name}-{suffix}"
+
+
 ENTITY_DESCRIPTIONS: tuple[UnifiSwitchEntityDescription, ...] = (
     UnifiSwitchEntityDescription[Clients, Client](
         key="Block client",
@@ -256,7 +262,7 @@ ENTITY_DESCRIPTIONS: tuple[UnifiSwitchEntityDescription, ...] = (
         object_fn=lambda api, obj_id: api.outlets[obj_id],
         should_poll=False,
         supported_fn=async_outlet_supports_switching_fn,
-        unique_id_fn=lambda controller, obj_id: f"{obj_id.split('_', 1)[0]}-outlet-{obj_id.split('_', 1)[1]}",
+        unique_id_fn=lambda controller, obj_id: _make_unique_id(obj_id, "outlet"),
     ),
     UnifiSwitchEntityDescription[PortForwarding, PortForward](
         key="Port forward control",
@@ -297,7 +303,7 @@ ENTITY_DESCRIPTIONS: tuple[UnifiSwitchEntityDescription, ...] = (
         object_fn=lambda api, obj_id: api.ports[obj_id],
         should_poll=False,
         supported_fn=lambda controller, obj_id: controller.api.ports[obj_id].port_poe,
-        unique_id_fn=lambda controller, obj_id: f"{obj_id.split('_', 1)[0]}-poe-{obj_id.split('_', 1)[1]}",
+        unique_id_fn=lambda controller, obj_id: _make_unique_id(obj_id, "poe"),
     ),
     UnifiSwitchEntityDescription[Wlans, Wlan](
         key="WLAN control",


### PR DESCRIPTION
## Proposed change

This refactors the duplicated `unique_id_fn` code in unifi/switch to a small helper function, and changes it to use `partition` in the process.

This was inspired by #102893, where those current `unique_id_fn`s would get reformatted in a harder-to-read way, and I didn't think it'd be a good idea to do this change in that PR.

There is no functional change (aside from `partition` being faster than `split`, and the splitting work only being done once).

I don't know enough about Unifi entity naming to apply this to the entities where the name wasn't previously split-and-interposed, but if it's just a matter of whether they have an underscore, then this function could be easily used for all of them, by just checking whether there is a second part returned by `partition`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
