### PR TITLE
Add coordinator to ring integration

### DIFF
--- a/homeassistant/components/ring/__init__.py
+++ b/homeassistant/components/ring/__init__.py
@@ -1,37 +1,26 @@
 """Support for Ring Doorbell/Chimes."""
 from __future__ import annotations
 
-import asyncio
-from collections.abc import Callable
-from datetime import timedelta
 from functools import partial
 import logging
-from typing import Any
 
 import ring_doorbell
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import APPLICATION_NAME, CONF_TOKEN, __version__
-from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util.async_ import run_callback_threadsafe
 
 from .const import (
-    DEVICES_SCAN_INTERVAL,
     DOMAIN,
-    HEALTH_SCAN_INTERVAL,
-    HISTORY_SCAN_INTERVAL,
-    NOTIFICATIONS_SCAN_INTERVAL,
     PLATFORMS,
     RING_API,
     RING_DEVICES,
     RING_DEVICES_COORDINATOR,
-    RING_HEALTH_COORDINATOR,
-    RING_HISTORY_COORDINATOR,
     RING_NOTIFICATIONS_COORDINATOR,
 )
+from .coordinator import RingDataCoordinator, RingNotificationsCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,42 +44,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     ring = ring_doorbell.Ring(auth)
 
-    try:
-        await hass.async_add_executor_job(ring.update_data)
-    except ring_doorbell.AuthenticationError as err:
-        _LOGGER.warning("Ring access token is no longer valid, need to re-authenticate")
-        raise ConfigEntryAuthFailed(err) from err
+    coordinator = RingDataCoordinator(hass, ring)
+    await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         RING_API: ring,
         RING_DEVICES: ring.devices(),
-        RING_DEVICES_COORDINATOR: GlobalDataUpdater(
-            hass, "device", entry, ring, "update_devices", DEVICES_SCAN_INTERVAL
-        ),
-        RING_NOTIFICATIONS_COORDINATOR: GlobalDataUpdater(
-            hass,
-            "active dings",
-            entry,
-            ring,
-            "update_dings",
-            NOTIFICATIONS_SCAN_INTERVAL,
-        ),
-        RING_HISTORY_COORDINATOR: DeviceDataUpdater(
-            hass,
-            "history",
-            entry,
-            ring,
-            lambda device: device.history(limit=10),
-            HISTORY_SCAN_INTERVAL,
-        ),
-        RING_HEALTH_COORDINATOR: DeviceDataUpdater(
-            hass,
-            "health",
-            entry,
-            ring,
-            lambda device: device.update_health_data(),
-            HEALTH_SCAN_INTERVAL,
-        ),
+        RING_DEVICES_COORDINATOR: coordinator,
+        RING_NOTIFICATIONS_COORDINATOR: RingNotificationsCoordinator(hass, ring),
     }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -101,10 +62,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def async_refresh_all(_: ServiceCall) -> None:
         """Refresh all ring data."""
         for info in hass.data[DOMAIN].values():
-            await info["device_data"].async_refresh_all()
-            await info["dings_data"].async_refresh_all()
-            await hass.async_add_executor_job(info["history_data"].refresh_all)
-            await hass.async_add_executor_job(info["health_data"].refresh_all)
+            await info[RING_DEVICES_COORDINATOR].async_refresh()
+            await info[RING_NOTIFICATIONS_COORDINATOR].async_refresh()
 
     # register service
     hass.services.async_register(DOMAIN, "update", async_refresh_all)
@@ -133,173 +92,3 @@ async def async_remove_config_entry_device(
 ) -> bool:
     """Remove a config entry from a device."""
     return True
-
-
-class GlobalDataUpdater:
-    """Data storage for single API endpoint."""
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        data_type: str,
-        config_entry: ConfigEntry,
-        ring: ring_doorbell.Ring,
-        update_method: str,
-        update_interval: timedelta,
-    ) -> None:
-        """Initialize global data updater."""
-        self.hass = hass
-        self.data_type = data_type
-        self.config_entry = config_entry
-        self.ring = ring
-        self.update_method = update_method
-        self.update_interval = update_interval
-        self.listeners: list[Callable[[], None]] = []
-        self._unsub_interval = None
-
-    @callback
-    def async_add_listener(self, update_callback):
-        """Listen for data updates."""
-        # This is the first listener, set up interval.
-        if not self.listeners:
-            self._unsub_interval = async_track_time_interval(
-                self.hass, self.async_refresh_all, self.update_interval
-            )
-
-        self.listeners.append(update_callback)
-
-    @callback
-    def async_remove_listener(self, update_callback):
-        """Remove data update."""
-        self.listeners.remove(update_callback)
-
-        if not self.listeners:
-            self._unsub_interval()
-            self._unsub_interval = None
-
-    async def async_refresh_all(self, _now: int | None = None) -> None:
-        """Time to update."""
-        if not self.listeners:
-            return
-
-        try:
-            await self.hass.async_add_executor_job(
-                getattr(self.ring, self.update_method)
-            )
-        except ring_doorbell.AuthenticationError:
-            _LOGGER.warning(
-                "Ring access token is no longer valid, need to re-authenticate"
-            )
-            self.config_entry.async_start_reauth(self.hass)
-            return
-        except ring_doorbell.RingTimeout:
-            _LOGGER.warning(
-                "Time out fetching Ring %s data",
-                self.data_type,
-            )
-            return
-        except ring_doorbell.RingError as err:
-            _LOGGER.warning(
-                "Error fetching Ring %s data: %s",
-                self.data_type,
-                err,
-            )
-            return
-
-        for update_callback in self.listeners:
-            update_callback()
-
-
-class DeviceDataUpdater:
-    """Data storage for device data."""
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        data_type: str,
-        config_entry: ConfigEntry,
-        ring: ring_doorbell.Ring,
-        update_method: Callable[[ring_doorbell.Ring], Any],
-        update_interval: timedelta,
-    ) -> None:
-        """Initialize device data updater."""
-        self.data_type = data_type
-        self.hass = hass
-        self.config_entry = config_entry
-        self.ring = ring
-        self.update_method = update_method
-        self.update_interval = update_interval
-        self.devices: dict = {}
-        self._unsub_interval = None
-
-    async def async_track_device(self, device, update_callback):
-        """Track a device."""
-        if not self.devices:
-            self._unsub_interval = async_track_time_interval(
-                self.hass, self.refresh_all, self.update_interval
-            )
-
-        if device.device_id not in self.devices:
-            self.devices[device.device_id] = {
-                "device": device,
-                "update_callbacks": [update_callback],
-                "data": None,
-            }
-            # Store task so that other concurrent requests can wait for us to finish and
-            # data be available.
-            self.devices[device.device_id]["task"] = asyncio.current_task()
-            self.devices[device.device_id][
-                "data"
-            ] = await self.hass.async_add_executor_job(self.update_method, device)
-            self.devices[device.device_id].pop("task")
-        else:
-            self.devices[device.device_id]["update_callbacks"].append(update_callback)
-            # If someone is currently fetching data as part of the initialization, wait for them
-            if "task" in self.devices[device.device_id]:
-                await self.devices[device.device_id]["task"]
-
-        update_callback(self.devices[device.device_id]["data"])
-
-    @callback
-    def async_untrack_device(self, device, update_callback):
-        """Untrack a device."""
-        self.devices[device.device_id]["update_callbacks"].remove(update_callback)
-
-        if not self.devices[device.device_id]["update_callbacks"]:
-            self.devices.pop(device.device_id)
-
-        if not self.devices:
-            self._unsub_interval()
-            self._unsub_interval = None
-
-    def refresh_all(self, _=None):
-        """Refresh all registered devices."""
-        for device_id, info in self.devices.items():
-            try:
-                data = info["data"] = self.update_method(info["device"])
-            except ring_doorbell.AuthenticationError:
-                _LOGGER.warning(
-                    "Ring access token is no longer valid, need to re-authenticate"
-                )
-                self.hass.loop.call_soon_threadsafe(
-                    self.config_entry.async_start_reauth, self.hass
-                )
-                return
-            except ring_doorbell.RingTimeout:
-                _LOGGER.warning(
-                    "Time out fetching Ring %s data for device %s",
-                    self.data_type,
-                    device_id,
-                )
-                continue
-            except ring_doorbell.RingError as err:
-                _LOGGER.warning(
-                    "Error fetching Ring %s data for device %s: %s",
-                    self.data_type,
-                    device_id,
-                    err,
-                )
-                continue
-
-            for update_callback in info["update_callbacks"]:
-                self.hass.loop.call_soon_threadsafe(update_callback, data)

--- a/homeassistant/components/ring/binary_sensor.py
+++ b/homeassistant/components/ring/binary_sensor.py
@@ -15,7 +15,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, RING_API, RING_DEVICES, RING_NOTIFICATIONS_COORDINATOR
-from .entity import RingEntityMixin
+from .coordinator import RingNotificationsCoordinator
+from .entity import RingEntity
 
 
 @dataclass
@@ -55,9 +56,9 @@ async def async_setup_entry(
     """Set up the Ring binary sensors from a config entry."""
     ring = hass.data[DOMAIN][config_entry.entry_id][RING_API]
     devices = hass.data[DOMAIN][config_entry.entry_id][RING_DEVICES]
-    notifications_coordinator = hass.data[DOMAIN][config_entry.entry_id][
-        RING_NOTIFICATIONS_COORDINATOR
-    ]
+    notifications_coordinator: RingNotificationsCoordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ][RING_NOTIFICATIONS_COORDINATOR]
 
     entities = [
         RingBinarySensor(ring, device, notifications_coordinator, description)
@@ -70,7 +71,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class RingBinarySensor(RingEntityMixin, BinarySensorEntity):
+class RingBinarySensor(RingEntity, BinarySensorEntity):
     """A binary sensor implementation for Ring device."""
 
     _active_alert: dict[str, Any] | None = None

--- a/homeassistant/components/ring/binary_sensor.py
+++ b/homeassistant/components/ring/binary_sensor.py
@@ -55,9 +55,12 @@ async def async_setup_entry(
     """Set up the Ring binary sensors from a config entry."""
     ring = hass.data[DOMAIN][config_entry.entry_id][RING_API]
     devices = hass.data[DOMAIN][config_entry.entry_id][RING_DEVICES]
+    notifications_coordinator = hass.data[DOMAIN][config_entry.entry_id][
+        RING_NOTIFICATIONS_COORDINATOR
+    ]
 
     entities = [
-        RingBinarySensor(config_entry.entry_id, ring, device, description)
+        RingBinarySensor(ring, device, notifications_coordinator, description)
         for device_type in ("doorbots", "authorized_doorbots", "stickup_cams")
         for description in BINARY_SENSOR_TYPES
         if device_type in description.category
@@ -75,35 +78,23 @@ class RingBinarySensor(RingEntityMixin, BinarySensorEntity):
 
     def __init__(
         self,
-        config_entry_id,
         ring,
         device,
+        coordinator,
         description: RingBinarySensorEntityDescription,
     ) -> None:
         """Initialize a sensor for Ring device."""
-        super().__init__(config_entry_id, device)
+        super().__init__(
+            device,
+            coordinator,
+        )
         self.entity_description = description
         self._ring = ring
         self._attr_unique_id = f"{device.id}-{description.key}"
         self._update_alert()
 
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-        await super().async_added_to_hass()
-        self.ring_objects[RING_NOTIFICATIONS_COORDINATOR].async_add_listener(
-            self._dings_update_callback
-        )
-        self._dings_update_callback()
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Disconnect callbacks."""
-        await super().async_will_remove_from_hass()
-        self.ring_objects[RING_NOTIFICATIONS_COORDINATOR].async_remove_listener(
-            self._dings_update_callback
-        )
-
     @callback
-    def _dings_update_callback(self):
+    def _handle_coordinator_update(self, _=None):
         """Call update method."""
         self._update_alert()
         self.async_write_ha_state()

--- a/homeassistant/components/ring/camera.py
+++ b/homeassistant/components/ring/camera.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.aiohttp_client import async_aiohttp_proxy_stream
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN, RING_DEVICES, RING_HISTORY_COORDINATOR
+from .const import DOMAIN, RING_DEVICES, RING_DEVICES_COORDINATOR
 from .entity import RingEntityMixin
 
 FORCE_REFRESH_INTERVAL = timedelta(minutes=3)
@@ -31,6 +31,9 @@ async def async_setup_entry(
 ) -> None:
     """Set up a Ring Door Bell and StickUp Camera."""
     devices = hass.data[DOMAIN][config_entry.entry_id][RING_DEVICES]
+    devices_coordinator = hass.data[DOMAIN][config_entry.entry_id][
+        RING_DEVICES_COORDINATOR
+    ]
     ffmpeg_manager = ffmpeg.get_ffmpeg_manager(hass)
 
     cams = []
@@ -40,7 +43,7 @@ async def async_setup_entry(
         if not camera.has_subscription:
             continue
 
-        cams.append(RingCam(config_entry.entry_id, ffmpeg_manager, camera))
+        cams.append(RingCam(camera, devices_coordinator, ffmpeg_manager))
 
     async_add_entities(cams)
 
@@ -50,9 +53,10 @@ class RingCam(RingEntityMixin, Camera):
 
     _attr_name = None
 
-    def __init__(self, config_entry_id, ffmpeg_manager, device):
+    def __init__(self, device, coordinator, ffmpeg_manager):
         """Initialize a Ring Door Bell camera."""
-        super().__init__(config_entry_id, device)
+        super().__init__(device, coordinator)
+        Camera.__init__(self)
 
         self._ffmpeg_manager = ffmpeg_manager
         self._last_event = None
@@ -62,25 +66,11 @@ class RingCam(RingEntityMixin, Camera):
         self._expires_at = dt_util.utcnow() - FORCE_REFRESH_INTERVAL
         self._attr_unique_id = device.id
 
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-        await super().async_added_to_hass()
-
-        await self.ring_objects[RING_HISTORY_COORDINATOR].async_track_device(
-            self._device, self._history_update_callback
-        )
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Disconnect callbacks."""
-        await super().async_will_remove_from_hass()
-
-        self.ring_objects[RING_HISTORY_COORDINATOR].async_untrack_device(
-            self._device, self._history_update_callback
-        )
-
     @callback
-    def _history_update_callback(self, history_data):
+    def _handle_coordinator_update(self):
         """Call update method."""
+        if not (history_data := self._get_coordinator_history()):
+            return
         if history_data:
             self._last_event = history_data[0]
             self.async_schedule_update_ha_state(True)

--- a/homeassistant/components/ring/const.py
+++ b/homeassistant/components/ring/const.py
@@ -23,17 +23,13 @@ PLATFORMS = [
 ]
 
 
-DEVICES_SCAN_INTERVAL = timedelta(minutes=1)
+SCAN_INTERVAL = timedelta(minutes=1)
 NOTIFICATIONS_SCAN_INTERVAL = timedelta(seconds=5)
-HISTORY_SCAN_INTERVAL = timedelta(minutes=1)
-HEALTH_SCAN_INTERVAL = timedelta(minutes=1)
 
 RING_API = "api"
 RING_DEVICES = "devices"
 
 RING_DEVICES_COORDINATOR = "device_data"
 RING_NOTIFICATIONS_COORDINATOR = "dings_data"
-RING_HISTORY_COORDINATOR = "history_data"
-RING_HEALTH_COORDINATOR = "health_data"
 
 CONF_2FA = "2fa"

--- a/homeassistant/components/ring/coordinator.py
+++ b/homeassistant/components/ring/coordinator.py
@@ -1,0 +1,102 @@
+"""Data coordinators for the ring integration."""
+from dataclasses import dataclass
+import logging
+from typing import Optional
+
+import ring_doorbell
+from ring_doorbell.generic import RingGeneric
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import NOTIFICATIONS_SCAN_INTERVAL, SCAN_INTERVAL
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def _call_api(hass: HomeAssistant, target, *args, msg_suffix=""):
+    try:
+        return await hass.async_add_executor_job(target, *args)
+    except ring_doorbell.AuthenticationError as err:
+        # Raising ConfigEntryAuthFailed will cancel future updates
+        # and start a config flow with SOURCE_REAUTH (async_step_reauth)
+        raise ConfigEntryAuthFailed from err
+    except ring_doorbell.RingTimeout as err:
+        raise UpdateFailed(
+            f"Timeout communicating with API{msg_suffix}: {err}"
+        ) from err
+    except ring_doorbell.RingError as err:
+        raise UpdateFailed(f"Error communicating with API{msg_suffix}: {err}") from err
+
+
+@dataclass
+class RingDeviceData:
+    """RingDeviceData."""
+
+    device: RingGeneric
+    history: Optional[list] = None
+
+
+class RingDataCoordinator(DataUpdateCoordinator[dict[int, RingDeviceData]]):
+    """Base class for device coordinators."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        ring_api,
+    ) -> None:
+        """Initialize my coordinator."""
+        super().__init__(
+            hass,
+            name="devices",
+            logger=_LOGGER,
+            update_interval=SCAN_INTERVAL,
+        )
+        self.ring_api = ring_api
+        self.first_call = True
+
+    async def _async_update_data(self):
+        """Fetch data from API endpoint."""
+        update_method = "update_data" if self.first_call else "update_devices"
+        await _call_api(self.hass, getattr(self.ring_api, update_method))
+        self.first_call = False
+        data = {}
+        devices = self.ring_api.devices()
+        for device_type in devices:
+            for device in devices[device_type]:
+                # Don't update all devices in the ring api, only those that set
+                # their device id as context when they subscribed.
+                if device.id in set(self.async_contexts()):
+                    data[device.id] = RingDeviceData(device=device)
+                    if hasattr(device, "history"):
+                        data[device.id].history = await _call_api(
+                            self.hass,
+                            lambda device: device.history(limit=10),
+                            device,
+                            msg_suffix=f" for device {device.name}",  # device_id is the mac
+                        )
+                    await _call_api(
+                        self.hass,
+                        device.update_health_data,
+                        msg_suffix=f" for device {device.name}",
+                    )
+        return data
+
+
+class RingNotificationsCoordinator(DataUpdateCoordinator[None]):
+    """Global notifications coordinator."""
+
+    def __init__(self, hass: HomeAssistant, ring_api) -> None:
+        """Initialize my coordinator."""
+        super().__init__(
+            hass,
+            logger=_LOGGER,
+            name="active dings",
+            update_interval=NOTIFICATIONS_SCAN_INTERVAL,
+        )
+        self.ring_api = ring_api
+
+    async def _async_update_data(self):
+        """Fetch data from API endpoint."""
+        await _call_api(self.hass, self.ring_api.update_dings)

--- a/homeassistant/components/ring/entity.py
+++ b/homeassistant/components/ring/entity.py
@@ -16,7 +16,7 @@ _RingCoordinatorT = TypeVar(
 )
 
 
-class RingEntityMixin(CoordinatorEntity[_RingCoordinatorT]):
+class RingEntity(CoordinatorEntity[_RingCoordinatorT]):
     """Base implementation for Ring device."""
 
     _attr_attribution = ATTRIBUTION
@@ -25,7 +25,7 @@ class RingEntityMixin(CoordinatorEntity[_RingCoordinatorT]):
 
     def __init__(
         self,
-        device,
+        device: RingGeneric,
         coordinator: _RingCoordinatorT,
     ) -> None:
         """Initialize a sensor for Ring device."""

--- a/homeassistant/components/ring/sensor.py
+++ b/homeassistant/components/ring/sensor.py
@@ -14,12 +14,7 @@ from homeassistant.const import PERCENTAGE, SIGNAL_STRENGTH_DECIBELS_MILLIWATT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import (
-    DOMAIN,
-    RING_DEVICES,
-    RING_HEALTH_COORDINATOR,
-    RING_HISTORY_COORDINATOR,
-)
+from .const import DOMAIN, RING_DEVICES, RING_DEVICES_COORDINATOR
 from .entity import RingEntityMixin
 
 
@@ -30,9 +25,12 @@ async def async_setup_entry(
 ) -> None:
     """Set up a sensor for a Ring device."""
     devices = hass.data[DOMAIN][config_entry.entry_id][RING_DEVICES]
+    devices_coordinator = hass.data[DOMAIN][config_entry.entry_id][
+        RING_DEVICES_COORDINATOR
+    ]
 
     entities = [
-        description.cls(config_entry.entry_id, device, description)
+        description.cls(device, devices_coordinator, description)
         for device_type in ("chimes", "doorbots", "authorized_doorbots", "stickup_cams")
         for description in SENSOR_TYPES
         if device_type in description.category
@@ -50,12 +48,12 @@ class RingSensor(RingEntityMixin, SensorEntity):
 
     def __init__(
         self,
-        config_entry_id,
         device,
+        coordinator,
         description: RingSensorEntityDescription,
     ) -> None:
         """Initialize a sensor for Ring device."""
-        super().__init__(config_entry_id, device)
+        super().__init__(device, coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{device.id}-{description.key}"
 
@@ -76,27 +74,6 @@ class HealthDataRingSensor(RingSensor):
     # These sensors are data hungry and not useful. Disable by default.
     _attr_entity_registry_enabled_default = False
 
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-        await super().async_added_to_hass()
-
-        await self.ring_objects[RING_HEALTH_COORDINATOR].async_track_device(
-            self._device, self._health_update_callback
-        )
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Disconnect callbacks."""
-        await super().async_will_remove_from_hass()
-
-        self.ring_objects[RING_HEALTH_COORDINATOR].async_untrack_device(
-            self._device, self._health_update_callback
-        )
-
-    @callback
-    def _health_update_callback(self, _health_data):
-        """Call update method."""
-        self.async_write_ha_state()
-
     @property
     def native_value(self):
         """Return the state of the sensor."""
@@ -113,26 +90,10 @@ class HistoryRingSensor(RingSensor):
 
     _latest_event: dict[str, Any] | None = None
 
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-        await super().async_added_to_hass()
-
-        await self.ring_objects[RING_HISTORY_COORDINATOR].async_track_device(
-            self._device, self._history_update_callback
-        )
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Disconnect callbacks."""
-        await super().async_will_remove_from_hass()
-
-        self.ring_objects[RING_HISTORY_COORDINATOR].async_untrack_device(
-            self._device, self._history_update_callback
-        )
-
     @callback
-    def _history_update_callback(self, history_data):
+    def _handle_coordinator_update(self):
         """Call update method."""
-        if not history_data:
+        if not (history_data := self._get_coordinator_history()):
             return
 
         kind = self.entity_description.kind
@@ -149,7 +110,7 @@ class HistoryRingSensor(RingSensor):
             return
 
         self._latest_event = found
-        self.async_write_ha_state()
+        super()._handle_coordinator_update()
 
     @property
     def native_value(self):

--- a/homeassistant/components/ring/sensor.py
+++ b/homeassistant/components/ring/sensor.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Optional
+
+from ring_doorbell.generic import RingGeneric
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -15,7 +17,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, RING_DEVICES, RING_DEVICES_COORDINATOR
-from .entity import RingEntityMixin
+from .coordinator import RingDataCoordinator
+from .entity import RingEntity
 
 
 async def async_setup_entry(
@@ -25,7 +28,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up a sensor for a Ring device."""
     devices = hass.data[DOMAIN][config_entry.entry_id][RING_DEVICES]
-    devices_coordinator = hass.data[DOMAIN][config_entry.entry_id][
+    devices_coordinator: RingDataCoordinator = hass.data[DOMAIN][config_entry.entry_id][
         RING_DEVICES_COORDINATOR
     ]
 
@@ -41,15 +44,15 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class RingSensor(RingEntityMixin, SensorEntity):
+class RingSensor(RingEntity, SensorEntity):
     """A sensor implementation for Ring device."""
 
     entity_description: RingSensorEntityDescription
 
     def __init__(
         self,
-        device,
-        coordinator,
+        device: RingGeneric,
+        coordinator: RingDataCoordinator,
         description: RingSensorEntityDescription,
     ) -> None:
         """Initialize a sensor for Ring device."""
@@ -93,6 +96,7 @@ class HistoryRingSensor(RingSensor):
     @callback
     def _handle_coordinator_update(self):
         """Call update method."""
+        history_data: Optional[RingGeneric]
         if not (history_data := self._get_coordinator_history()):
             return
 

--- a/homeassistant/components/ring/siren.py
+++ b/homeassistant/components/ring/siren.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any
 
 from ring_doorbell.const import CHIME_TEST_SOUND_KINDS, KIND_DING
+from ring_doorbell.generic import RingGeneric
 
 from homeassistant.components.siren import ATTR_TONE, SirenEntity, SirenEntityFeature
 from homeassistant.config_entries import ConfigEntry
@@ -10,7 +11,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, RING_DEVICES, RING_DEVICES_COORDINATOR
-from .entity import RingEntityMixin
+from .coordinator import RingDataCoordinator
+from .entity import RingEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,7 +24,9 @@ async def async_setup_entry(
 ) -> None:
     """Create the sirens for the Ring devices."""
     devices = hass.data[DOMAIN][config_entry.entry_id][RING_DEVICES]
-    coordinator = hass.data[DOMAIN][config_entry.entry_id][RING_DEVICES_COORDINATOR]
+    coordinator: RingDataCoordinator = hass.data[DOMAIN][config_entry.entry_id][
+        RING_DEVICES_COORDINATOR
+    ]
     sirens = []
 
     for device in devices["chimes"]:
@@ -31,14 +35,14 @@ async def async_setup_entry(
     async_add_entities(sirens)
 
 
-class RingChimeSiren(RingEntityMixin, SirenEntity):
+class RingChimeSiren(RingEntity, SirenEntity):
     """Creates a siren to play the test chimes of a Chime device."""
 
     _attr_available_tones = CHIME_TEST_SOUND_KINDS
     _attr_supported_features = SirenEntityFeature.TURN_ON | SirenEntityFeature.TONES
     _attr_translation_key = "siren"
 
-    def __init__(self, device, coordinator) -> None:
+    def __init__(self, device: RingGeneric, coordinator: RingDataCoordinator) -> None:
         """Initialize a Ring Chime siren."""
         super().__init__(device, coordinator)
         # Entity class attributes

--- a/homeassistant/components/ring/siren.py
+++ b/homeassistant/components/ring/siren.py
@@ -9,7 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, RING_DEVICES
+from .const import DOMAIN, RING_DEVICES, RING_DEVICES_COORDINATOR
 from .entity import RingEntityMixin
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,10 +22,11 @@ async def async_setup_entry(
 ) -> None:
     """Create the sirens for the Ring devices."""
     devices = hass.data[DOMAIN][config_entry.entry_id][RING_DEVICES]
+    coordinator = hass.data[DOMAIN][config_entry.entry_id][RING_DEVICES_COORDINATOR]
     sirens = []
 
     for device in devices["chimes"]:
-        sirens.append(RingChimeSiren(config_entry, device))
+        sirens.append(RingChimeSiren(device, coordinator))
 
     async_add_entities(sirens)
 
@@ -37,9 +38,9 @@ class RingChimeSiren(RingEntityMixin, SirenEntity):
     _attr_supported_features = SirenEntityFeature.TURN_ON | SirenEntityFeature.TONES
     _attr_translation_key = "siren"
 
-    def __init__(self, config_entry: ConfigEntry, device) -> None:
+    def __init__(self, device, coordinator) -> None:
         """Initialize a Ring Chime siren."""
-        super().__init__(config_entry.entry_id, device)
+        super().__init__(device, coordinator)
         # Entity class attributes
         self._attr_unique_id = f"{self._device.id}-siren"
 

--- a/homeassistant/components/ring/switch.py
+++ b/homeassistant/components/ring/switch.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
 
-from .const import DOMAIN, RING_DEVICES
+from .const import DOMAIN, RING_DEVICES, RING_DEVICES_COORDINATOR
 from .entity import RingEntityMixin
 
 _LOGGER = logging.getLogger(__name__)
@@ -34,11 +34,12 @@ async def async_setup_entry(
 ) -> None:
     """Create the switches for the Ring devices."""
     devices = hass.data[DOMAIN][config_entry.entry_id][RING_DEVICES]
+    coordinator = hass.data[DOMAIN][config_entry.entry_id][RING_DEVICES_COORDINATOR]
     switches = []
 
     for device in devices["stickup_cams"]:
         if device.has_capability("siren"):
-            switches.append(SirenSwitch(config_entry.entry_id, device))
+            switches.append(SirenSwitch(device, coordinator))
 
     async_add_entities(switches)
 
@@ -46,9 +47,9 @@ async def async_setup_entry(
 class BaseRingSwitch(RingEntityMixin, SwitchEntity):
     """Represents a switch for controlling an aspect of a ring device."""
 
-    def __init__(self, config_entry_id, device, device_type):
+    def __init__(self, device, coordinator, device_type):
         """Initialize the switch."""
-        super().__init__(config_entry_id, device)
+        super().__init__(device, coordinator)
         self._device_type = device_type
         self._attr_unique_id = f"{self._device.id}-{self._device_type}"
 
@@ -59,20 +60,21 @@ class SirenSwitch(BaseRingSwitch):
     _attr_translation_key = "siren"
     _attr_icon = SIREN_ICON
 
-    def __init__(self, config_entry_id, device):
+    def __init__(self, device, coordinator):
         """Initialize the switch for a device with a siren."""
-        super().__init__(config_entry_id, device, "siren")
+        super().__init__(device, coordinator, "siren")
         self._no_updates_until = dt_util.utcnow()
         self._attr_is_on = device.siren > 0
 
     @callback
-    def _update_callback(self):
+    def _handle_coordinator_update(self):
         """Call update method."""
         if self._no_updates_until > dt_util.utcnow():
             return
 
-        self._attr_is_on = self._device.siren > 0
-        self.async_write_ha_state()
+        if device := self._get_coordinator_device():
+            self._attr_is_on = device.siren > 0
+        super()._handle_coordinator_update()
 
     def _set_switch(self, new_state):
         """Update switch state, and causes Home Assistant to correctly update."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Replace bespoke `DataUpdater` classes with `DataUpdateCoordinator` derived classes from helpers.update_coordinator.

This will prevent errors spamming the logs in error conditions and should get the integration quality to silver (and then gold once test coverage is improved elsewhere.)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

The change consolidates 3 of the DataUpdater classes into 1 DataUpdateCoordinator class.  This will prevent 3 seperate log messages if the api is unavailable and also makes the code simpler.

The NotificationUpdateCoordinator will be replaced with a Push listener in a subsequent change.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
