### PR TITLE
Add MELCloud token refresh upon firmware upgrade

### DIFF
--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -68,7 +68,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     conf = entry.data
     try:
         mel_devices = await mel_devices_setup(hass, conf[CONF_TOKEN])
-        _LOGGER.debug("Token used: %s", conf[CONF_TOKEN])
     except (ClientResponseError) as ex:
         if isinstance(ex, ClientResponseError) and ex.code == 401:
             raise ConfigEntryAuthFailed from ex

--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -73,7 +73,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.error("Failed to connect to MELCloud, with exception: %s", ex)
         if ex.code == 401:
             raise ConfigEntryAuthFailed(ex) from ex
-        return False
+        raise ConfigEntryNotReady from ex
 
     hass.data.setdefault(DOMAIN, {}).update({entry.entry_id: mel_devices})
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -69,9 +69,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         mel_devices = await mel_devices_setup(hass, conf[CONF_TOKEN])
         _LOGGER.debug("Token used: %s", conf[CONF_TOKEN])
-    except ClientResponseError as ex:
+    except (ClientResponseError, ConfigEntryNotReady) as ex:
         _LOGGER.error("Failed to connect to MELCloud, with exception: %s", ex)
-        if ex.code == 401:
+        if isinstance(ex, ClientResponseError) and ex.code == 401:
             raise ConfigEntryAuthFailed(ex) from ex
         raise ConfigEntryNotReady from ex
 

--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -69,11 +69,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         mel_devices = await mel_devices_setup(hass, conf[CONF_TOKEN])
         _LOGGER.debug("Token used: %s", conf[CONF_TOKEN])
-    except (ClientResponseError, ConfigEntryNotReady) as ex:
-        _LOGGER.error("Failed to connect to MELCloud, with exception: %s", ex)
+    except (ClientResponseError) as ex:
         if isinstance(ex, ClientResponseError) and ex.code == 401:
-            raise ConfigEntryAuthFailed(ex) from ex
+            raise ConfigEntryAuthFailed from ex
         raise ConfigEntryNotReady from ex
+        except (asyncio.TimeoutError, ClientConnectionError) as ex:
+            raise ConfigEntryNotReady from ex
 
     hass.data.setdefault(DOMAIN, {}).update({entry.entry_id: mel_devices})
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/melcloud/config_flow.py
+++ b/homeassistant/components/melcloud/config_flow.py
@@ -187,9 +187,6 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             ):
                 errors["base"] = "invalid_auth"
             elif isinstance(err, AttributeError) and err.name == "get":
-                _LOGGER.warning(
-                    "Login.ContextKey not found, the user needs to try again"
-                )
                 errors["base"] = "invalid_auth"
             else:
                 errors["base"] = "cannot_connect"

--- a/homeassistant/components/melcloud/config_flow.py
+++ b/homeassistant/components/melcloud/config_flow.py
@@ -2,7 +2,10 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Mapping
 from http import HTTPStatus
+import logging
+from typing import Any
 
 from aiohttp import ClientError, ClientResponseError
 import pymelcloud
@@ -11,11 +14,13 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME
 from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
-from homeassistant.data_entry_flow import AbortFlow, FlowResultType
+from homeassistant.data_entry_flow import AbortFlow, FlowResult, FlowResultType
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 
 from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_create_import_issue(
@@ -55,6 +60,8 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow."""
 
     VERSION = 1
+
+    entry: config_entries.ConfigEntry | None = None
 
     async def _create_entry(self, username: str, token: str):
         """Register new entry."""
@@ -126,3 +133,70 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if result["type"] == FlowResultType.CREATE_ENTRY:
             await async_create_import_issue(self.hass, self.context["source"], "", True)
         return result
+
+    async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> FlowResult:
+        """Handle initiation of re-authentication with MELCloud."""
+        self.entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle re-authentication with MELCloud."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None and self.entry:
+            aquired_token, errors = await self.async_reauthenticate_client(user_input)
+
+            if not errors:
+                self.hass.config_entries.async_update_entry(
+                    self.entry,
+                    data={CONF_TOKEN: aquired_token},
+                )
+                self.hass.async_create_task(
+                    self.hass.config_entries.async_reload(self.entry.entry_id)
+                )
+                return self.async_abort(reason="reauth_successful")
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema(
+                {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
+            ),
+            errors=errors,
+        )
+
+    async def async_reauthenticate_client(
+        self, user_input: dict[str, Any]
+    ) -> tuple[str | None, dict[str, str]]:
+        """Reauthenticate with MELCloud."""
+        errors: dict[str, str] = {}
+        acquired_token = None
+
+        try:
+            async with asyncio.timeout(10):
+                acquired_token = await pymelcloud.login(
+                    user_input[CONF_USERNAME],
+                    user_input[CONF_PASSWORD],
+                    async_get_clientsession(self.hass),
+                )
+        except (ClientResponseError, AttributeError) as err:
+            if isinstance(err, ClientResponseError) and err.status in (
+                HTTPStatus.UNAUTHORIZED,
+                HTTPStatus.FORBIDDEN,
+            ):
+                errors["base"] = "invalid_auth"
+            elif isinstance(err, AttributeError) and err.name == "get":
+                _LOGGER.warning(
+                    "Login.ContextKey not found, the user needs to try again"
+                )
+                errors["base"] = "invalid_auth"
+            else:
+                errors["base"] = "cannot_connect"
+        except (
+            asyncio.TimeoutError,
+            ClientError,
+        ):
+            errors["base"] = "cannot_connect"
+
+        return acquired_token, errors

--- a/homeassistant/components/melcloud/strings.json
+++ b/homeassistant/components/melcloud/strings.json
@@ -8,6 +8,14 @@
           "username": "[%key:common::config_flow::data::email%]",
           "password": "[%key:common::config_flow::data::password%]"
         }
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "The Melcloud integration needs to re-authenticate your connection details",
+        "data": {
+          "username": "[%key:common::config_flow::data::email%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
       }
     },
     "error": {
@@ -16,6 +24,7 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "already_configured": "MELCloud integration already configured for this email. Access token has been refreshed."
     }
   },

--- a/tests/components/melcloud/test_config_flow.py
+++ b/tests/components/melcloud/test_config_flow.py
@@ -373,6 +373,20 @@ async def test_form_errors_reauthentication(
     assert result["type"] == FlowResultType.FORM
     assert result["errors"]["base"] == reason
 
+    mock_login.side_effect = None
+    with patch(
+        "homeassistant.components.melcloud.async_setup_entry",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": "test-email@test-domain.com", "password": "test-password"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+
 
 @pytest.mark.parametrize(
     ("error", "reason"),
@@ -416,3 +430,17 @@ async def test_client_errors_reauthentication(
 
     assert result["errors"]["base"] == reason
     assert result["type"] == FlowResultType.FORM
+
+    mock_login.side_effect = None
+    with patch(
+        "homeassistant.components.melcloud.async_setup_entry",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": "test-email@test-domain.com", "password": "test-password"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"

--- a/tests/components/melcloud/test_config_flow.py
+++ b/tests/components/melcloud/test_config_flow.py
@@ -9,7 +9,9 @@ import pytest
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.melcloud.const import DOMAIN
+from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 import homeassistant.helpers.issue_registry as ir
 
 from tests.common import MockConfigEntry
@@ -287,3 +289,130 @@ async def test_token_refresh(hass: HomeAssistant, mock_login, mock_get_devices) 
     entry = entries[0]
     assert entry.data["username"] == "test-email@test-domain.com"
     assert entry.data["token"] == "test-token"
+
+
+async def test_token_reauthentication(
+    hass: HomeAssistant,
+    mock_login,
+    mock_get_devices,
+) -> None:
+    """Re-configuration with existing username should refresh token, if made invalid."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"username": "test-email@test-domain.com", "token": "test-original-token"},
+        unique_id="test-email@test-domain.com",
+    )
+    mock_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": SOURCE_REAUTH,
+            "unique_id": mock_entry.unique_id,
+            "entry_id": mock_entry.entry_id,
+        },
+        data=mock_entry.data,
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    with patch(
+        "homeassistant.components.melcloud.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": "test-email@test-domain.com", "password": "test-password"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("error", "reason"),
+    [
+        (asyncio.TimeoutError(), "cannot_connect"),
+        (AttributeError(name="get"), "invalid_auth"),
+    ],
+)
+async def test_form_errors_reauthentication(
+    hass: HomeAssistant, mock_login, error, reason
+) -> None:
+    """Test we handle cannot connect error."""
+    mock_login.side_effect = error
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"username": "test-email@test-domain.com", "token": "test-original-token"},
+        unique_id="test-email@test-domain.com",
+    )
+    mock_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": SOURCE_REAUTH,
+            "unique_id": mock_entry.unique_id,
+            "entry_id": mock_entry.entry_id,
+        },
+        data=mock_entry.data,
+    )
+
+    with patch(
+        "homeassistant.components.melcloud.async_setup_entry",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": "test-email@test-domain.com", "password": "test-password"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"]["base"] == reason
+
+
+@pytest.mark.parametrize(
+    ("error", "reason"),
+    [
+        (HTTPStatus.UNAUTHORIZED, "invalid_auth"),
+        (HTTPStatus.FORBIDDEN, "invalid_auth"),
+        (HTTPStatus.INTERNAL_SERVER_ERROR, "cannot_connect"),
+    ],
+)
+async def test_client_errors_reauthentication(
+    hass: HomeAssistant, mock_login, mock_request_info, error, reason
+) -> None:
+    """Test we handle cannot connect error."""
+    mock_login.side_effect = ClientResponseError(mock_request_info(), (), status=error)
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"username": "test-email@test-domain.com", "token": "test-original-token"},
+        unique_id="test-email@test-domain.com",
+    )
+    mock_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": SOURCE_REAUTH,
+            "unique_id": mock_entry.unique_id,
+            "entry_id": mock_entry.entry_id,
+        },
+        data=mock_entry.data,
+    )
+
+    with patch(
+        "homeassistant.components.melcloud.async_setup_entry",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": "test-email@test-domain.com", "password": "test-password"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["errors"]["base"] == reason
+    assert result["type"] == FlowResultType.FORM


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Resolves the behavior when MELCloud pushes a firmware update and renders the token expired. This is a more user-friendly solution in the form of a `reauth_step`. When an HTTP 401 (unauthorized) is caught in `async_setup_entry`, the reauthentication steps are now offered.
This saves a lot of people their own debugging and the nasty workaround to delete the integration and add it back in.

**Example**
![image](https://github.com/home-assistant/core/assets/5011203/480da5c0-6632-49ff-8cb5-fb95ae379f38)

![image](https://github.com/home-assistant/core/assets/5011203/403816df-b425-44bc-bcfe-3cde24c807e9)

![image](https://github.com/home-assistant/core/assets/5011203/a419d89c-f53d-4a0d-aaa5-3bbe3767891c)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #104261 & #104294
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
