### PR TITLE
Deprecate legacy api auth provider

### DIFF
--- a/homeassistant/auth/providers/legacy_api_password.py
+++ b/homeassistant/auth/providers/legacy_api_password.py
@@ -10,10 +10,11 @@ from typing import Any, cast
 
 import voluptuous as vol
 
-from homeassistant.core import callback
+from homeassistant.core import async_get_hass, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 
 from ..models import Credentials, UserMeta
 from . import AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, AuthProvider, LoginFlow
@@ -21,9 +22,27 @@ from . import AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, AuthProvider, LoginFlow
 AUTH_PROVIDER_TYPE = "legacy_api_password"
 CONF_API_PASSWORD = "api_password"
 
-CONFIG_SCHEMA = AUTH_PROVIDER_SCHEMA.extend(
+_CONFIG_SCHEMA = AUTH_PROVIDER_SCHEMA.extend(
     {vol.Required(CONF_API_PASSWORD): cv.string}, extra=vol.PREVENT_EXTRA
 )
+
+
+def _create_repair_and_validate(config: dict[str, Any]) -> dict[str, Any]:
+    async_create_issue(
+        async_get_hass(),
+        "auth",
+        "deprecated_legacy_api_password",
+        breaks_in_ha_version="2024.6.0",
+        is_fixable=False,
+        severity=IssueSeverity.WARNING,
+        translation_key="deprecated_legacy_api_password",
+    )
+
+    return _CONFIG_SCHEMA(config)  # type: ignore[no-any-return]
+
+
+CONFIG_SCHEMA = _create_repair_and_validate
+
 
 LEGACY_USER_NAME = "Legacy API password user"
 

--- a/homeassistant/components/auth/strings.json
+++ b/homeassistant/components/auth/strings.json
@@ -31,5 +31,11 @@
         "invalid_code": "Invalid code, please try again."
       }
     }
+  },
+  "issues": {
+    "deprecated_legacy_api_password": {
+      "title": "The legacy API password is deprecated",
+      "description": "The legacy API password is deprecated and will be removed in Home Assistant 2024.6. Please use home assistant or any other auth provider instead."
+    }
   }
 }

--- a/homeassistant/components/auth/strings.json
+++ b/homeassistant/components/auth/strings.json
@@ -35,7 +35,7 @@
   "issues": {
     "deprecated_legacy_api_password": {
       "title": "The legacy API password is deprecated",
-      "description": "The legacy API password is deprecated and will be removed. Please use home assistant or any other auth provider instead."
+      "description": "The legacy API password authentication provider is deprecated and will be removed. Please remove it from your YAML configuration and use the default Home Assistant authentication provider instead."
     }
   }
 }

--- a/homeassistant/components/auth/strings.json
+++ b/homeassistant/components/auth/strings.json
@@ -35,7 +35,7 @@
   "issues": {
     "deprecated_legacy_api_password": {
       "title": "The legacy API password is deprecated",
-      "description": "The legacy API password is deprecated and will be removed in Home Assistant 2024.6. Please use home assistant or any other auth provider instead."
+      "description": "The legacy API password is deprecated and will be removed. Please use home assistant or any other auth provider instead."
     }
   }
 }

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -215,6 +215,29 @@ def gen_data_entry_schema(
     return vol.All(*validators)
 
 
+def gen_issues_schema(config: Config, integration: Integration) -> dict[str, Any]:
+    """Generate the issues schema."""
+    return {
+        str: vol.All(
+            cv.has_at_least_one_key("description", "fix_flow"),
+            vol.Schema(
+                {
+                    vol.Required("title"): translation_value_validator,
+                    vol.Exclusive(
+                        "description", "fixable"
+                    ): translation_value_validator,
+                    vol.Exclusive("fix_flow", "fixable"): gen_data_entry_schema(
+                        config=config,
+                        integration=integration,
+                        flow_title=UNDEFINED,
+                        require_step_title=False,
+                    ),
+                },
+            ),
+        )
+    }
+
+
 def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
     """Generate a strings schema."""
     return vol.Schema(
@@ -266,25 +289,7 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
             vol.Optional("application_credentials"): {
                 vol.Optional("description"): translation_value_validator,
             },
-            vol.Optional("issues"): {
-                str: vol.All(
-                    cv.has_at_least_one_key("description", "fix_flow"),
-                    vol.Schema(
-                        {
-                            vol.Required("title"): translation_value_validator,
-                            vol.Exclusive(
-                                "description", "fixable"
-                            ): translation_value_validator,
-                            vol.Exclusive("fix_flow", "fixable"): gen_data_entry_schema(
-                                config=config,
-                                integration=integration,
-                                flow_title=UNDEFINED,
-                                require_step_title=False,
-                            ),
-                        },
-                    ),
-                )
-            },
+            vol.Optional("issues"): gen_issues_schema(config, integration),
             vol.Optional("entity_component"): cv.schema_with_slug_keys(
                 {
                     vol.Optional("name"): str,
@@ -362,7 +367,8 @@ def gen_auth_schema(config: Config, integration: Integration) -> vol.Schema:
                     flow_title=REQUIRED,
                     require_step_title=True,
                 )
-            }
+            },
+            vol.Optional("issues"): gen_issues_schema(config, integration),
         }
     )
 

--- a/tests/auth/providers/test_legacy_api_password.py
+++ b/tests/auth/providers/test_legacy_api_password.py
@@ -5,6 +5,12 @@ from homeassistant import auth, data_entry_flow
 from homeassistant.auth import auth_store
 from homeassistant.auth.providers import legacy_api_password
 from homeassistant.core import HomeAssistant
+import homeassistant.helpers.issue_registry as ir
+from homeassistant.setup import async_setup_component
+
+from tests.common import ensure_auth_manager_loaded
+
+CONFIG = {"type": "legacy_api_password", "api_password": "test-password"}
 
 
 @pytest.fixture
@@ -16,9 +22,7 @@ def store(hass):
 @pytest.fixture
 def provider(hass, store):
     """Mock provider."""
-    return legacy_api_password.LegacyApiPasswordAuthProvider(
-        hass, store, {"type": "legacy_api_password", "api_password": "test-password"}
-    )
+    return legacy_api_password.LegacyApiPasswordAuthProvider(hass, store, CONFIG)
 
 
 @pytest.fixture
@@ -68,3 +72,15 @@ async def test_login_flow_works(hass: HomeAssistant, manager) -> None:
         flow_id=result["flow_id"], user_input={"password": "test-password"}
     )
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+
+
+async def test_create_repair_issue(hass: HomeAssistant):
+    """Test legacy api password auth provider creates a reapir issue."""
+    hass.auth = await auth.auth_manager_from_config(hass, [CONFIG], [])
+    ensure_auth_manager_loaded(hass.auth)
+    await async_setup_component(hass, "auth", {})
+    issue_registry: ir.IssueRegistry = ir.async_get(hass)
+
+    assert issue_registry.async_get_issue(
+        domain="auth", issue_id="deprecated_legacy_api_password"
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Deprecate legacy API password auth provider. User should use homeassistant or any other auth provider

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30019

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
