### PR TITLE
Allow ibeacons with no name but a allowlisted minor

### DIFF
--- a/homeassistant/components/ibeacon/const.py
+++ b/homeassistant/components/ibeacon/const.py
@@ -44,5 +44,8 @@ MIN_SEEN_TRANSIENT_NEW = (
     + 1
 )
 
+# Beacons with the following minors are processed even if they have empty name.
+WHITELISTED_MINORS = [40004]
+
 CONF_IGNORE_ADDRESSES = "ignore_addresses"
 CONF_IGNORE_UUIDS = "ignore_uuids"


### PR DESCRIPTION
## Proposed change

This is an attempt to workaround #80357.  The ibeacon integration ignores beacons with empty/default name, to avoid some users getting lots of "garbage" devices.
The problem with this, however, is that several "software" beacons do not allow the user to set a name.

Most notably, this is the case of the HA android companion app, setting a name seems to be [techincally challenging](https://github.com/home-assistant/android/issues/3948). As a consequence, users get the totally unexpected behaviour that HA does not recognize beacons from its own app! (Other android beacon simulator apps have the same issue.)

Whitelisting UUIDs could be a solution, but it's not an ideal user experience. Each user would need to find and configure their UUID, which could in principle be automated, but with further complications.

So the workaround proposed by this PR is to whitelist a list of __magic minor__ values instead (currently set to `40004`). Any beacon with minor `40004` is accepted, even if its name is empty.

Then, the companion app can be configured to have `40004` as the default minor (and document its meaning).

Advantages:
- Simple solution
- Completely transparent to the user (after changing the default value in the companion app)
- Can be used with any software or hardware beacon that allows changing the minor (very common) 
- Can be easily combined with other solutions (eg UUID whitelist) in the future

Drawbacks:
- A bit hacky solution, with hard-coded whitelist
- The user is no longer free to choose its own minor value (but the major can still be used)
- Small risk of still getting some garbage devices that coincidentally use `40004` (in my limited testing I didn't see any).






## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #80357
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29981

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
