### PR TITLE
Bump yeelight to 0.7.14

### DIFF
--- a/homeassistant/components/yeelight/manifest.json
+++ b/homeassistant/components/yeelight/manifest.json
@@ -17,7 +17,7 @@
   "iot_class": "local_push",
   "loggers": ["async_upnp_client", "yeelight"],
   "quality_scale": "platinum",
-  "requirements": ["yeelight==0.7.13", "async-upnp-client==0.36.2"],
+  "requirements": ["yeelight==0.7.14", "async-upnp-client==0.36.2"],
   "zeroconf": [
     {
       "type": "_miio._udp.local.",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2787,7 +2787,7 @@ yalexs-ble==2.3.2
 yalexs==1.10.0
 
 # homeassistant.components.yeelight
-yeelight==0.7.13
+yeelight==0.7.14
 
 # homeassistant.components.yeelightsunflower
 yeelightsunflower==0.0.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2085,7 +2085,7 @@ yalexs-ble==2.3.2
 yalexs==1.10.0
 
 # homeassistant.components.yeelight
-yeelight==0.7.13
+yeelight==0.7.14
 
 # homeassistant.components.yolink
 yolink-api==0.3.1


### PR DESCRIPTION
## Proposed change
Adds support for `ceild` model

changelog: https://gitlab.com/stavros/python-yeelight/-/compare/v0.7.13...v0.7.14?from_project_id=1999077&straight=false

## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
