### PR TITLE
Add support for placeholders in entity name translations

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -540,7 +540,7 @@ class Entity(
     _attr_state: StateType = STATE_UNKNOWN
     _attr_supported_features: int | None = None
     _attr_translation_key: str | None
-    _attr_translation_placeholders: Mapping[str, str] | None
+    _attr_translation_placeholders: Mapping[str, str]
     _attr_unique_id: str | None = None
     _attr_unit_of_measurement: str | None
 
@@ -637,14 +637,10 @@ class Entity(
         tuples = list(string.Formatter().parse(name))
         if tuples[0][1] is None:
             return name
-        if (translation_placeholders := self.translation_placeholders) is not None:
-            if TYPE_CHECKING:
-                assert isinstance(translation_placeholders, Mapping)
-            try:
-                return name.format(**translation_placeholders)
-            except KeyError as err:
-                raise HomeAssistantError("Missing placeholder %s" % err) from err
-        raise HomeAssistantError("Missing property _attr_translation_placeholders")
+        try:
+            return name.format(**self.translation_placeholders)
+        except KeyError as err:
+            raise HomeAssistantError("Missing placeholder %s" % err) from err
 
     def _name_internal(
         self,
@@ -873,13 +869,13 @@ class Entity(
 
     @final
     @cached_property
-    def translation_placeholders(self) -> Mapping[str, str] | None:
+    def translation_placeholders(self) -> Mapping[str, str]:
         """Return the translation placeholders for translated entity's name."""
         if hasattr(self, "_attr_translation_placeholders"):
             return self._attr_translation_placeholders
         if hasattr(self, "entity_description"):
-            return self.entity_description.translation_placeholders
-        return None
+            return self.entity_description.translation_placeholders or {}
+        return {}
 
     # DO NOT OVERWRITE
     # These properties and methods are either managed by Home Assistant or they

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -431,6 +431,7 @@ CACHED_PROPERTIES_WITH_ATTR_ = {
     "state",
     "supported_features",
     "translation_key",
+    "translation_placeholders",
     "unique_id",
     "unit_of_measurement",
 }
@@ -870,7 +871,8 @@ class Entity(
             return self.entity_description.translation_key
         return None
 
-    @property
+    @final
+    @cached_property
     def translation_placeholders(self) -> Mapping[str, str] | None:
         """Return the translation placeholders for translated entity's name."""
         if hasattr(self, "_attr_translation_placeholders"):

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -633,8 +633,8 @@ class Entity(
 
     def _name_placeholders(self, name: str) -> str:
         """Process possible placeholders in entity name."""
-        tuples = string.Formatter().parse(name)
-        if len(tuple(tuples)) == 1:
+        tuples = list(string.Formatter().parse(name))
+        if tuples[0][1] is None:
             return name
         if (translation_placeholders := self.translation_placeholders) is not None:
             if TYPE_CHECKING:

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -640,7 +640,7 @@ class Entity(
             f".{self.translation_key}.name"
         )
 
-    def _substitue_name_placeholders(self, name: str) -> str:
+    def _substitute_name_placeholders(self, name: str) -> str:
         """Substitute placeholders in entity name."""
         try:
             return name.format(**self.translation_placeholders)
@@ -678,7 +678,7 @@ class Entity(
         ):
             if TYPE_CHECKING:
                 assert isinstance(name, str)
-            return self._substitue_name_placeholders(name)
+            return self._substitute_name_placeholders(name)
         if hasattr(self, "entity_description"):
             description_name = self.entity_description.name
             if description_name is UNDEFINED and self._default_to_device_class_name():

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -43,7 +43,13 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     EntityCategory,
 )
-from homeassistant.core import CALLBACK_TYPE, Context, HomeAssistant, callback
+from homeassistant.core import (
+    CALLBACK_TYPE,
+    Context,
+    HomeAssistant,
+    callback,
+    get_release_channel,
+)
 from homeassistant.exceptions import (
     HomeAssistantError,
     InvalidStateError,
@@ -638,8 +644,10 @@ class Entity(
         """Substitute placeholders in entity name."""
         try:
             return name.format(**self.translation_placeholders)
-        except KeyError:
+        except KeyError as err:
             if not self._name_translation_placeholders_reported:
+                if get_release_channel() != "stable":
+                    raise HomeAssistantError("Missing placeholder %s" % err) from err
                 report_issue = self._suggest_report_issue()
                 _LOGGER.warning(
                     (

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -872,7 +872,7 @@ class Entity(
 
     @property
     def translation_placeholders(self) -> Mapping[str, str] | None:
-        """Return if the name of the entity is describing only the entity itself."""
+        """Return the translation placeholders for translated entity's name."""
         if hasattr(self, "_attr_translation_placeholders"):
             return self._attr_translation_placeholders
         if hasattr(self, "entity_description"):

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Iterable, Mapping
 import logging
+import string
 from typing import Any
 
 from homeassistant.core import HomeAssistant, callback
@@ -242,6 +243,52 @@ class _TranslationCache:
 
         self.loaded[language].update(components)
 
+    def _compare_placeholders(
+        self,
+        language: str,
+        updated_resources: dict[str, Any],
+        cached_resources: dict[str, Any] | None = None,
+    ) -> bool:
+        """Validate if updated resources has same placeholders as cached resources."""
+        if cached_resources is None:
+            return True
+
+        cached_resources_placholders: dict[str, set[str]] = {}
+        updated_resources_placholders: dict[str, set[str]] = {}
+        has_placeholders = False
+
+        for key, value in cached_resources.items():
+            tuples = list(string.Formatter().parse(value))
+            if tuples[0][1] is None:
+                continue
+            cached_resources_placholders[key] = {
+                tup[1] for tup in tuples if tup[1] is not None
+            }
+            has_placeholders = True
+
+        if not has_placeholders:
+            return True
+
+        for key, value in updated_resources.items():
+            tuples = list(string.Formatter().parse(value))
+            if tuples[0][1] is None:
+                continue
+            updated_resources_placholders[key] = {
+                tup[1] for tup in tuples if tup[1] is not None
+            }
+
+        if cached_resources_placholders != updated_resources_placholders:
+            _LOGGER.error(
+                "Validation of placeholders for localized (%s) strings failed."
+                " Expected placeholders: %s"
+                " Gathered placeholders: %s",
+                language,
+                cached_resources_placholders,
+                updated_resources_placholders,
+            )
+            return False
+        return True
+
     @callback
     def _build_category_cache(
         self,
@@ -274,12 +321,14 @@ class _TranslationCache:
                 ).setdefault(category, {})
 
                 if isinstance(resource, dict):
-                    category_cache.update(
-                        recursive_flatten(
-                            f"component.{component}.{category}.",
-                            resource,
-                        )
+                    resources_flatten = recursive_flatten(
+                        f"component.{component}.{category}.",
+                        resource,
                     )
+                    if self._compare_placeholders(
+                        language, resources_flatten, category_cache
+                    ):
+                        category_cache.update(resources_flatten)
                 else:
                     category_cache[f"component.{component}.{category}"] = resource
 

--- a/tests/helpers/snapshots/test_entity.ambr
+++ b/tests/helpers/snapshots/test_entity.ambr
@@ -11,11 +11,12 @@
     'key': 'blah',
     'name': <UndefinedType._singleton: 0>,
     'translation_key': None,
+    'translation_placeholders': None,
     'unit_of_measurement': None,
   })
 # ---
 # name: test_entity_description_as_dataclass.1
-  "EntityDescription(key='blah', device_class='test', entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name=<UndefinedType._singleton: 0>, translation_key=None, unit_of_measurement=None)"
+  "EntityDescription(key='blah', device_class='test', entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name=<UndefinedType._singleton: 0>, translation_key=None, translation_placeholders=None, unit_of_measurement=None)"
 # ---
 # name: test_extending_entity_description
   dict({
@@ -30,11 +31,12 @@
     'key': 'blah',
     'name': 'name',
     'translation_key': None,
+    'translation_placeholders': None,
     'unit_of_measurement': None,
   })
 # ---
 # name: test_extending_entity_description.1
-  "test_extending_entity_description.<locals>.FrozenEntityDescription(key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.FrozenEntityDescription(key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, translation_placeholders=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.10
   dict({
@@ -50,11 +52,12 @@
     'mixin': 'mixin',
     'name': 'name',
     'translation_key': None,
+    'translation_placeholders': None,
     'unit_of_measurement': None,
   })
 # ---
 # name: test_extending_entity_description.11
-  "test_extending_entity_description.<locals>.ComplexEntityDescription1C(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription1C(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, translation_placeholders=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.12
   dict({
@@ -70,11 +73,12 @@
     'mixin': 'mixin',
     'name': 'name',
     'translation_key': None,
+    'translation_placeholders': None,
     'unit_of_measurement': None,
   })
 # ---
 # name: test_extending_entity_description.13
-  "test_extending_entity_description.<locals>.ComplexEntityDescription1D(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription1D(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, translation_placeholders=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.14
   dict({
@@ -90,11 +94,12 @@
     'mixin': 'mixin',
     'name': 'name',
     'translation_key': None,
+    'translation_placeholders': None,
     'unit_of_measurement': None,
   })
 # ---
 # name: test_extending_entity_description.15
-  "test_extending_entity_description.<locals>.ComplexEntityDescription2A(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription2A(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, translation_placeholders=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.16
   dict({
@@ -110,11 +115,12 @@
     'mixin': 'mixin',
     'name': 'name',
     'translation_key': None,
+    'translation_placeholders': None,
     'unit_of_measurement': None,
   })
 # ---
 # name: test_extending_entity_description.17
-  "test_extending_entity_description.<locals>.ComplexEntityDescription2B(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription2B(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, translation_placeholders=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.18
   dict({
@@ -130,11 +136,12 @@
     'mixin': 'mixin',
     'name': 'name',
     'translation_key': None,
+    'translation_placeholders': None,
     'unit_of_measurement': None,
   })
 # ---
 # name: test_extending_entity_description.19
-  "test_extending_entity_description.<locals>.ComplexEntityDescription2C(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription2C(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, translation_placeholders=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.2
   dict({
@@ -149,6 +156,7 @@
     'key': 'blah',
     'name': 'name',
     'translation_key': None,
+    'translation_placeholders': None,
     'unit_of_measurement': None,
   })
 # ---
@@ -166,11 +174,12 @@
     'mixin': 'mixin',
     'name': 'name',
     'translation_key': None,
+    'translation_placeholders': None,
     'unit_of_measurement': None,
   })
 # ---
 # name: test_extending_entity_description.21
-  "test_extending_entity_description.<locals>.ComplexEntityDescription2D(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription2D(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, translation_placeholders=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.22
   dict({
@@ -186,11 +195,12 @@
     'mixin': 'mixin',
     'name': 'name',
     'translation_key': None,
+    'translation_placeholders': None,
     'unit_of_measurement': None,
   })
 # ---
 # name: test_extending_entity_description.23
-  "test_extending_entity_description.<locals>.ComplexEntityDescription3A(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription3A(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, translation_placeholders=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.24
   dict({
@@ -206,11 +216,12 @@
     'mixin': 'mixin',
     'name': 'name',
     'translation_key': None,
+    'translation_placeholders': None,
     'unit_of_measurement': None,
   })
 # ---
 # name: test_extending_entity_description.25
-  "test_extending_entity_description.<locals>.ComplexEntityDescription3B(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription3B(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, translation_placeholders=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.26
   dict({
@@ -226,11 +237,12 @@
     'mixin': 'mixin',
     'name': 'name',
     'translation_key': None,
+    'translation_placeholders': None,
     'unit_of_measurement': None,
   })
 # ---
 # name: test_extending_entity_description.27
-  "test_extending_entity_description.<locals>.ComplexEntityDescription4A(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription4A(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, translation_placeholders=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.28
   dict({
@@ -246,14 +258,15 @@
     'mixin': 'mixin',
     'name': 'name',
     'translation_key': None,
+    'translation_placeholders': None,
     'unit_of_measurement': None,
   })
 # ---
 # name: test_extending_entity_description.29
-  "test_extending_entity_description.<locals>.ComplexEntityDescription4B(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription4B(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, translation_placeholders=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.3
-  "test_extending_entity_description.<locals>.ThawedEntityDescription(key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ThawedEntityDescription(key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, translation_placeholders=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.30
   dict({
@@ -267,11 +280,12 @@
     'key': 'blah',
     'name': 'name',
     'translation_key': None,
+    'translation_placeholders': None,
     'unit_of_measurement': None,
   })
 # ---
 # name: test_extending_entity_description.31
-  "test_extending_entity_description.<locals>.CustomInitEntityDescription(key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None)"
+  "test_extending_entity_description.<locals>.CustomInitEntityDescription(key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, translation_placeholders=None, unit_of_measurement=None)"
 # ---
 # name: test_extending_entity_description.4
   dict({
@@ -287,11 +301,12 @@
     'key': 'blah',
     'name': 'name',
     'translation_key': None,
+    'translation_placeholders': None,
     'unit_of_measurement': None,
   })
 # ---
 # name: test_extending_entity_description.5
-  "test_extending_entity_description.<locals>.MyExtendedEntityDescription(key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extension='ext', extra='foo')"
+  "test_extending_entity_description.<locals>.MyExtendedEntityDescription(key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, translation_placeholders=None, unit_of_measurement=None, extension='ext', extra='foo')"
 # ---
 # name: test_extending_entity_description.6
   dict({
@@ -307,11 +322,12 @@
     'mixin': 'mixin',
     'name': 'name',
     'translation_key': None,
+    'translation_placeholders': None,
     'unit_of_measurement': None,
   })
 # ---
 # name: test_extending_entity_description.7
-  "test_extending_entity_description.<locals>.ComplexEntityDescription1A(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription1A(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, translation_placeholders=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.8
   dict({
@@ -327,9 +343,10 @@
     'mixin': 'mixin',
     'name': 'name',
     'translation_key': None,
+    'translation_placeholders': None,
     'unit_of_measurement': None,
   })
 # ---
 # name: test_extending_entity_description.9
-  "test_extending_entity_description.<locals>.ComplexEntityDescription1B(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription1B(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, translation_placeholders=None, unit_of_measurement=None, extra='foo')"
 # ---

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1242,7 +1242,10 @@ async def test_entity_name_translation_placeholders(
                 },
             },
             {"placeholder": "special"},
-            "HomeAssistantError: Missing placeholder '2ndplaceholder'",
+            (
+                "has translation placeholders '{'placeholder': 'special'}' which do "
+                "not match the name '{placeholder} English ent {2ndplaceholder}'"
+            ),
         ),
         (
             "test_entity",
@@ -1252,7 +1255,10 @@ async def test_entity_name_translation_placeholders(
                 },
             },
             None,
-            "HomeAssistantError: Missing property _attr_translation_placeholders",
+            (
+                "has translation placeholders '{}' which do "
+                "not match the name '{placeholder} English ent'"
+            ),
         ),
     ),
 )

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1231,6 +1231,7 @@ async def test_entity_name_translation_placeholders(
         "translation_key",
         "translations",
         "placeholders",
+        "release_channel",
         "expected_error",
     ),
     (
@@ -1242,6 +1243,7 @@ async def test_entity_name_translation_placeholders(
                 },
             },
             {"placeholder": "special"},
+            "stable",
             (
                 "has translation placeholders '{'placeholder': 'special'}' which do "
                 "not match the name '{placeholder} English ent {2ndplaceholder}'"
@@ -1251,10 +1253,22 @@ async def test_entity_name_translation_placeholders(
             "test_entity",
             {
                 "en": {
+                    "component.test.entity.test_domain.test_entity.name": "{placeholder} English ent {2ndplaceholder}"
+                },
+            },
+            {"placeholder": "special"},
+            "beta",
+            "HomeAssistantError: Missing placeholder '2ndplaceholder'",
+        ),
+        (
+            "test_entity",
+            {
+                "en": {
                     "component.test.entity.test_domain.test_entity.name": "{placeholder} English ent"
                 },
             },
             None,
+            "stable",
             (
                 "has translation placeholders '{}' which do "
                 "not match the name '{placeholder} English ent'"
@@ -1267,6 +1281,7 @@ async def test_entity_name_translation_placeholder_errors(
     translation_key: str | None,
     translations: dict[str, str] | None,
     placeholders: dict[str, str] | None,
+    release_channel: str,
     expected_error: str,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -1311,6 +1326,8 @@ async def test_entity_name_translation_placeholder_errors(
     with patch(
         "homeassistant.helpers.entity_platform.translation.async_get_translations",
         side_effect=async_get_translations,
+    ), patch(
+        "homeassistant.helpers.entity.get_release_channel", return_value=release_channel
     ):
         await entity_platform.async_setup_entry(config_entry)
 

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1170,6 +1170,17 @@ async def test_friendly_name_description_device_class_name(
             {"placeholder": "special"},
             "Device Bla special English ent",
         ),
+        (
+            True,
+            "test_entity",
+            {
+                "en": {
+                    "component.test.entity.test_domain.test_entity.name": "English ent {placeholder}"
+                },
+            },
+            {"placeholder": "special"},
+            "Device Bla English ent special",
+        ),
     ),
 )
 async def test_entity_name_translation_placeholders(

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -164,7 +164,7 @@ async def test_load_translations_files_invalid_localized_placeholders(
     )
     for expected_error in expected_errors:
         assert (
-            f"Validation of translation placeholders for localized ({language}) string {expected_error} failed."
+            f"Validation of translation placeholders for localized ({language}) string {expected_error} failed"
             in caplog.text
         )
 

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -98,6 +98,47 @@ def test_load_translations_files(hass: HomeAssistant) -> None:
     }
 
 
+@pytest.mark.parametrize(
+    ("language", "expected_translation", "expect_error"),
+    (
+        (
+            "en",
+            {"component.test.entity.switch.outlet.name": "Outlet {placeholder}"},
+            False,
+        ),
+        (
+            "es",
+            {"component.test.entity.switch.outlet.name": "Enchufe {placeholder}"},
+            False,
+        ),
+        (
+            "de",
+            {"component.test.entity.switch.outlet.name": "Outlet {placeholder}"},
+            True,
+        ),
+    ),
+)
+async def test_load_translations_files_invalid_localized_placeholders(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    caplog: pytest.LogCaptureFixture,
+    language: str,
+    expected_translation: dict,
+    expect_error: bool,
+) -> None:
+    """Test the load translation files with invalid localized placeholders."""
+    caplog.clear()
+    translations = await translation.async_get_translations(
+        hass, language, "entity", ["test"]
+    )
+    assert translations == expected_translation
+
+    assert (
+        f"Validation of placeholders for localized ({language}) strings failed."
+        in caplog.text
+    ) == expect_error
+
+
 async def test_get_translations(
     hass: HomeAssistant, mock_config_flows, enable_custom_integrations: None
 ) -> None:

--- a/tests/testing_config/custom_components/test/translations/de.json
+++ b/tests/testing_config/custom_components/test/translations/de.json
@@ -1,6 +1,9 @@
 {
   "entity": {
     "switch": {
+      "other1": { "name": "Anderes 1" },
+      "other2": { "name": "Anderes 2 {placeholder}" },
+      "other3": { "name": "" },
       "outlet": { "name": "Steckdose {something}" }
     }
   }

--- a/tests/testing_config/custom_components/test/translations/de.json
+++ b/tests/testing_config/custom_components/test/translations/de.json
@@ -1,0 +1,7 @@
+{
+  "entity": {
+    "switch": {
+      "outlet": { "name": "Steckdose {something}" }
+    }
+  }
+}

--- a/tests/testing_config/custom_components/test/translations/en.json
+++ b/tests/testing_config/custom_components/test/translations/en.json
@@ -1,6 +1,10 @@
 {
   "entity": {
     "switch": {
+      "other1": { "name": "Other 1" },
+      "other2": { "name": "Other 2" },
+      "other3": { "name": "Other 3" },
+      "other4": { "name": "Other 4" },
       "outlet": { "name": "Outlet {placeholder}" }
     }
   }

--- a/tests/testing_config/custom_components/test/translations/en.json
+++ b/tests/testing_config/custom_components/test/translations/en.json
@@ -1,0 +1,7 @@
+{
+  "entity": {
+    "switch": {
+      "outlet": { "name": "Outlet {placeholder}" }
+    }
+  }
+}

--- a/tests/testing_config/custom_components/test/translations/es.json
+++ b/tests/testing_config/custom_components/test/translations/es.json
@@ -1,6 +1,10 @@
 {
   "entity": {
     "switch": {
+      "other1": { "name": "Otra 1" },
+      "other2": { "name": "Otra 2" },
+      "other3": { "name": "Otra 3" },
+      "other4": { "name": "Otra 4" },
       "outlet": { "name": "Enchufe {placeholder}" }
     }
   }

--- a/tests/testing_config/custom_components/test/translations/es.json
+++ b/tests/testing_config/custom_components/test/translations/es.json
@@ -1,0 +1,7 @@
+{
+  "entity": {
+    "switch": {
+      "outlet": { "name": "Enchufe {placeholder}" }
+    }
+  }
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will add support for placeholders in entity name translation strings.
I think the error handling could be improved, further i'm not sure if we have to care about something related to lokalise.com 🤔 

todo

- [x] update dev docs

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1989

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
