### PR TITLE
Fix hassio mqtt discovery CI test

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1304,11 +1304,12 @@ async def get_system_health_info(hass: HomeAssistant, domain: str) -> dict[str, 
 @contextmanager
 def mock_config_flow(domain: str, config_flow: type[ConfigFlow]) -> None:
     """Mock a config flow handler."""
-    assert domain not in config_entries.HANDLERS
+    handler = config_entries.HANDLERS.get(domain)
     config_entries.HANDLERS[domain] = config_flow
     _LOGGER.info("Adding mock config flow: %s", domain)
     yield
-    config_entries.HANDLERS.pop(domain)
+    if handler:
+        config_entries.HANDLERS[domain] = handler
 
 
 def mock_integration(

--- a/tests/components/hassio/test_discovery.py
+++ b/tests/components/hassio/test_discovery.py
@@ -19,8 +19,6 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 @pytest.fixture(name="mock_mqtt")
 async def mock_mqtt_fixture(hass):
     """Mock the MQTT integration's config flow."""
-    mock_integration(hass, MockModule(MQTT_DOMAIN))
-    mock_platform(hass, f"{MQTT_DOMAIN}.config_flow", None)
 
     class MqttFlow(config_entries.ConfigFlow):
         """Test flow."""
@@ -30,11 +28,13 @@ async def mock_mqtt_fixture(hass):
         async_step_hassio = AsyncMock(return_value={"type": "abort"})
 
     with mock_config_flow(MQTT_DOMAIN, MqttFlow):
+        mock_integration(hass, MockModule(MQTT_DOMAIN))
+        mock_platform(hass, f"{MQTT_DOMAIN}.config_flow", None)
         yield MqttFlow
 
 
 async def test_hassio_discovery_startup(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_mqtt, hassio_client
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, hassio_client, mock_mqtt
 ) -> None:
     """Test startup and discovery after event."""
     aioclient_mock.get(

--- a/tests/components/hassio/test_discovery.py
+++ b/tests/components/hassio/test_discovery.py
@@ -34,7 +34,7 @@ async def mock_mqtt_fixture(hass):
 
 
 async def test_hassio_discovery_startup(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, hassio_client, mock_mqtt
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_mqtt, hassio_client
 ) -> None:
     """Test startup and discovery after event."""
     aioclient_mock.get(

--- a/tests/components/hassio/test_discovery.py
+++ b/tests/components/hassio/test_discovery.py
@@ -19,6 +19,8 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 @pytest.fixture(name="mock_mqtt")
 async def mock_mqtt_fixture(hass):
     """Mock the MQTT integration's config flow."""
+    mock_integration(hass, MockModule(MQTT_DOMAIN))
+    mock_platform(hass, f"{MQTT_DOMAIN}.config_flow", None)
 
     class MqttFlow(config_entries.ConfigFlow):
         """Test flow."""
@@ -28,8 +30,6 @@ async def mock_mqtt_fixture(hass):
         async_step_hassio = AsyncMock(return_value={"type": "abort"})
 
     with mock_config_flow(MQTT_DOMAIN, MqttFlow):
-        mock_integration(hass, MockModule(MQTT_DOMAIN))
-        mock_platform(hass, f"{MQTT_DOMAIN}.config_flow", None)
         yield MqttFlow
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `mock_config_flow` as this fails if a config flow was already added through a previous test.
After the test has finished the original handler (if it existed) will be restored.

Example failing CI test:
```log
 =========================== short test summary info ============================
ERROR tests/components/hassio/test_discovery.py::test_hassio_discovery_startup - AssertionError: assert 'mqtt' not in {'airvisual': <class 'homeassistant.components.airvisual.config_flow.AirVisualFlowHandler'>, 'arcam_fmj': <class 'home...dkernel.config_flow.HardkernelConfigFlow'>, 'hassio': <class 'homeassistant.components.hassio.config_flow.ConfigFlow'>}
 +  where {'airvisual': <class 'homeassistant.components.airvisual.config_flow.AirVisualFlowHandler'>, 'arcam_fmj': <class 'home...dkernel.config_flow.HardkernelConfigFlow'>, 'hassio': <class 'homeassistant.components.hassio.config_flow.ConfigFlow'>} = config_entries.HANDLERS
ERROR tests/components/hassio/test_discovery.py::test_hassio_discovery_startup_done - AssertionError: assert 'mqtt' not in {'airvisual': <class 'homeassistant.components.airvisual.config_flow.AirVisualFlowHandler'>, 'arcam_fmj': <class 'home...dkernel.config_flow.HardkernelConfigFlow'>, 'hassio': <class 'homeassistant.components.hassio.config_flow.ConfigFlow'>}
 +  where {'airvisual': <class 'homeassistant.components.airvisual.config_flow.AirVisualFlowHandler'>, 'arcam_fmj': <class 'home...dkernel.config_flow.HardkernelConfigFlow'>, 'hassio': <class 'homeassistant.components.hassio.config_flow.ConfigFlow'>} = config_entries.HANDLERS
ERROR tests/components/hassio/test_discovery.py::test_hassio_discovery_webhook - AssertionError: assert 'mqtt' not in {'airvisual': <class 'homeassistant.components.airvisual.config_flow.AirVisualFlowHandler'>, 'arcam_fmj': <class 'home...dkernel.config_flow.HardkernelConfigFlow'>, 'hassio': <class 'homeassistant.components.hassio.config_flow.ConfigFlow'>}
 +  where {'airvisual': <class 'homeassistant.components.airvisual.config_flow.AirVisualFlowHandler'>, 'arcam_fmj': <class 'home...dkernel.config_flow.HardkernelConfigFlow'>, 'hassio': <class 'homeassistant.components.hassio.config_flow.ConfigFlow'>} = config_entries.HANDLERS
Error: Process completed with exit code 1.
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
