### PR TITLE
Add sensor tests to co2signal

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -186,7 +186,6 @@ omit =
     homeassistant/components/control4/director_utils.py
     homeassistant/components/control4/light.py
     homeassistant/components/coolmaster/coordinator.py
-    homeassistant/components/co2signal/coordinator.py
     homeassistant/components/cppm_tracker/device_tracker.py
     homeassistant/components/crownstone/__init__.py
     homeassistant/components/crownstone/devices.py

--- a/tests/components/co2signal/snapshots/test_sensor.ambr
+++ b/tests/components/co2signal/snapshots/test_sensor.ambr
@@ -1,0 +1,101 @@
+# serializer version: 1
+# name: test_sensor[sensor.electricity_maps_co2_intensity]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.electricity_maps_co2_intensity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:molecule-co2',
+    'original_name': 'CO2 intensity',
+    'platform': 'co2signal',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'carbon_intensity',
+    'unique_id': '904a74160aa6f335526706bee85dfb83_co2intensity',
+    'unit_of_measurement': 'gCO2eq/kWh',
+  })
+# ---
+# name: test_sensor[sensor.electricity_maps_co2_intensity].1
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Electricity Maps',
+      'country_code': 'FR',
+      'friendly_name': 'Electricity Maps CO2 intensity',
+      'icon': 'mdi:molecule-co2',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'gCO2eq/kWh',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.electricity_maps_co2_intensity',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '45.9862319009581',
+  })
+# ---
+# name: test_sensor[sensor.electricity_maps_grid_fossil_fuel_percentage]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.electricity_maps_grid_fossil_fuel_percentage',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:molecule-co2',
+    'original_name': 'Grid fossil fuel percentage',
+    'platform': 'co2signal',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'fossil_fuel_percentage',
+    'unique_id': '904a74160aa6f335526706bee85dfb83_fossilFuelPercentage',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor[sensor.electricity_maps_grid_fossil_fuel_percentage].1
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Electricity Maps',
+      'country_code': 'FR',
+      'friendly_name': 'Electricity Maps Grid fossil fuel percentage',
+      'icon': 'mdi:molecule-co2',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.electricity_maps_grid_fossil_fuel_percentage',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '5.4611827419371',
+  })
+# ---

--- a/tests/components/co2signal/test_sensor.py
+++ b/tests/components/co2signal/test_sensor.py
@@ -1,0 +1,84 @@
+"""Tests Electricity Maps sensor platform."""
+from datetime import timedelta
+from unittest.mock import AsyncMock
+
+from aioelectricitymaps.exceptions import (
+    ElectricityMapsDecodeError,
+    ElectricityMapsError,
+    InvalidToken,
+)
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+from syrupy import SnapshotAssertion
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import async_fire_time_changed
+
+
+@pytest.mark.parametrize(
+    "entity_name",
+    [
+        "sensor.electricity_maps_co2_intensity",
+        "sensor.electricity_maps_grid_fossil_fuel_percentage",
+    ],
+)
+@pytest.mark.usefixtures("setup_integration")
+async def test_sensor(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    entity_name: str,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test sensor setup and update."""
+    assert (entry := entity_registry.async_get(entity_name))
+    assert entry == snapshot
+
+    assert (state := hass.states.get(entity_name))
+    assert state == snapshot
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        InvalidToken,
+        ElectricityMapsDecodeError,
+        ElectricityMapsError,
+        Exception,
+    ],
+)
+@pytest.mark.usefixtures("setup_integration")
+async def test_sensor_update_fail(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    electricity_maps: AsyncMock,
+    error: Exception,
+) -> None:
+    """Test sensor error handling."""
+    assert (state := hass.states.get("sensor.electricity_maps_co2_intensity"))
+    assert state.state == "45.9862319009581"
+    assert len(electricity_maps.mock_calls) == 1
+
+    electricity_maps.latest_carbon_intensity_by_coordinates.side_effect = error
+    electricity_maps.latest_carbon_intensity_by_country_code.side_effect = error
+
+    freezer.tick(timedelta(minutes=20))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get("sensor.electricity_maps_co2_intensity"))
+    assert state.state == "unavailable"
+    assert len(electricity_maps.mock_calls) == 2
+
+    # reset mock and test if entity is available again
+    electricity_maps.latest_carbon_intensity_by_coordinates.side_effect = None
+    electricity_maps.latest_carbon_intensity_by_country_code.side_effect = None
+
+    freezer.tick(timedelta(minutes=20))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get("sensor.electricity_maps_co2_intensity"))
+    assert state.state == "45.9862319009581"
+    assert len(electricity_maps.mock_calls) == 3


### PR DESCRIPTION
## Proposed change
This adds tests for the sensor platform to co2signal to reach full test coverage.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
