### PR TITLE
Bump aiolifx and aiolifx-themes to support new LIFX devices

### DIFF
--- a/homeassistant/components/lifx/manifest.json
+++ b/homeassistant/components/lifx/manifest.json
@@ -29,9 +29,11 @@
       "LIFX GU10",
       "LIFX Lightstrip",
       "LIFX Mini",
+      "LIFX Neon",
       "LIFX Nightvision",
       "LIFX Pls",
       "LIFX Plus",
+      "LIFX String",
       "LIFX Tile",
       "LIFX White",
       "LIFX Z"
@@ -40,8 +42,8 @@
   "iot_class": "local_polling",
   "loggers": ["aiolifx", "aiolifx_effects", "bitstring"],
   "requirements": [
-    "aiolifx==0.8.10",
+    "aiolifx==1.0.0",
     "aiolifx-effects==0.3.2",
-    "aiolifx-themes==0.4.5"
+    "aiolifx-themes==0.4.10"
   ]
 }

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -116,6 +116,10 @@ HOMEKIT = {
         "always_discover": True,
         "domain": "lifx",
     },
+    "LIFX Neon": {
+        "always_discover": True,
+        "domain": "lifx",
+    },
     "LIFX Nightvision": {
         "always_discover": True,
         "domain": "lifx",
@@ -125,6 +129,10 @@ HOMEKIT = {
         "domain": "lifx",
     },
     "LIFX Plus": {
+        "always_discover": True,
+        "domain": "lifx",
+    },
+    "LIFX String": {
         "always_discover": True,
         "domain": "lifx",
     },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -282,10 +282,10 @@ aiokef==0.2.16
 aiolifx-effects==0.3.2
 
 # homeassistant.components.lifx
-aiolifx-themes==0.4.5
+aiolifx-themes==0.4.10
 
 # homeassistant.components.lifx
-aiolifx==0.8.10
+aiolifx==1.0.0
 
 # homeassistant.components.livisi
 aiolivisi==0.0.19

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -255,10 +255,10 @@ aiokafka==0.7.2
 aiolifx-effects==0.3.2
 
 # homeassistant.components.lifx
-aiolifx-themes==0.4.5
+aiolifx-themes==0.4.10
 
 # homeassistant.components.lifx
-aiolifx==0.8.10
+aiolifx==1.0.0
 
 # homeassistant.components.livisi
 aiolivisi==0.0.19


### PR DESCRIPTION
## Proposed change

Bump to [`aiolifx 1.0.0`](https://github.com/frawau/aiolifx/releases/tag/1.0.0) to support the new LIFX Neon and LIFX String products.

Bump to [`aiolifx-themes 0.4.10`](https://github.com/Djelibeybi/aiolifx-themes/releases/tag/v0.4.10) as the new products are linear multizone devices.

Full `aiolifx` changelog: https://github.com/frawau/aiolifx/compare/0.8.10...1.0.0
Full `aiolifx-themes` changelog: https://github.com/Djelibeybi/aiolifx-themes/compare/v0.4.5...v0.4.10

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
