### PR TITLE
Fix Tractive switch availability

### DIFF
--- a/homeassistant/components/tractive/__init__.py
+++ b/homeassistant/components/tractive/__init__.py
@@ -24,11 +24,8 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .const import (
     ATTR_ACTIVITY_LABEL,
-    ATTR_BUZZER,
     ATTR_CALORIES,
     ATTR_DAILY_GOAL,
-    ATTR_LED,
-    ATTR_LIVE_TRACKING,
     ATTR_MINUTES_ACTIVE,
     ATTR_MINUTES_DAY_SLEEP,
     ATTR_MINUTES_NIGHT_SLEEP,
@@ -40,10 +37,12 @@ from .const import (
     DOMAIN,
     RECONNECT_INTERVAL,
     SERVER_UNAVAILABLE,
+    SWITCH_KEY_MAP,
     TRACKABLES,
     TRACKER_ACTIVITY_STATUS_UPDATED,
     TRACKER_HARDWARE_STATUS_UPDATED,
     TRACKER_POSITION_UPDATED,
+    TRACKER_SWITCH_STATUS_UPDATED,
     TRACKER_WELLNESS_STATUS_UPDATED,
 )
 
@@ -225,13 +224,16 @@ class TractiveClient:
                     ):
                         self._last_hw_time = event["hardware"]["time"]
                         self._send_hardware_update(event)
-
                     if (
                         "position" in event
                         and self._last_pos_time != event["position"]["time"]
                     ):
                         self._last_pos_time = event["position"]["time"]
                         self._send_position_update(event)
+                    # If any key belonging to the switch is present in the event,
+                    # we send a switch status update
+                    if bool(set(SWITCH_KEY_MAP.values()).intersection(event)):
+                        self._send_switch_update(event)
             except aiotractive.exceptions.UnauthorizedError:
                 self._config_entry.async_start_reauth(self._hass)
                 await self.unsubscribe()
@@ -266,12 +268,19 @@ class TractiveClient:
             ATTR_BATTERY_LEVEL: event["hardware"]["battery_level"],
             ATTR_TRACKER_STATE: event["tracker_state"].lower(),
             ATTR_BATTERY_CHARGING: event["charging_state"] == "CHARGING",
-            ATTR_LIVE_TRACKING: event.get("live_tracking", {}).get("active"),
-            ATTR_BUZZER: event.get("buzzer_control", {}).get("active"),
-            ATTR_LED: event.get("led_control", {}).get("active"),
         }
         self._dispatch_tracker_event(
             TRACKER_HARDWARE_STATUS_UPDATED, event["tracker_id"], payload
+        )
+
+    def _send_switch_update(self, event: dict[str, Any]) -> None:
+        # Sometimes the event contains data for all switches, sometimes only for one.
+        payload = {}
+        for switch, key in SWITCH_KEY_MAP.items():
+            if switch_data := event.get(key):
+                payload[switch] = switch_data["active"]
+        self._dispatch_tracker_event(
+            TRACKER_SWITCH_STATUS_UPDATED, event["tracker_id"], payload
         )
 
     def _send_activity_update(self, event: dict[str, Any]) -> None:

--- a/homeassistant/components/tractive/const.py
+++ b/homeassistant/components/tractive/const.py
@@ -29,7 +29,7 @@ TRACKABLES = "trackables"
 TRACKER_ACTIVITY_STATUS_UPDATED = f"{DOMAIN}_tracker_activity_updated"
 TRACKER_HARDWARE_STATUS_UPDATED = f"{DOMAIN}_tracker_hardware_status_updated"
 TRACKER_POSITION_UPDATED = f"{DOMAIN}_tracker_position_updated"
-TRACKER_SWITCH_STATUS_UPDATED = f"{DOMAIN}_tracker_wellness_updated"
+TRACKER_SWITCH_STATUS_UPDATED = f"{DOMAIN}_tracker_switch_updated"
 TRACKER_WELLNESS_STATUS_UPDATED = f"{DOMAIN}_tracker_wellness_updated"
 
 SERVER_UNAVAILABLE = f"{DOMAIN}_server_unavailable"

--- a/homeassistant/components/tractive/const.py
+++ b/homeassistant/components/tractive/const.py
@@ -26,9 +26,16 @@ CLIENT_ID = "625e5349c3c3b41c28a669f1"
 CLIENT = "client"
 TRACKABLES = "trackables"
 
+TRACKER_ACTIVITY_STATUS_UPDATED = f"{DOMAIN}_tracker_activity_updated"
 TRACKER_HARDWARE_STATUS_UPDATED = f"{DOMAIN}_tracker_hardware_status_updated"
 TRACKER_POSITION_UPDATED = f"{DOMAIN}_tracker_position_updated"
-TRACKER_ACTIVITY_STATUS_UPDATED = f"{DOMAIN}_tracker_activity_updated"
+TRACKER_SWITCH_STATUS_UPDATED = f"{DOMAIN}_tracker_wellness_updated"
 TRACKER_WELLNESS_STATUS_UPDATED = f"{DOMAIN}_tracker_wellness_updated"
 
 SERVER_UNAVAILABLE = f"{DOMAIN}_server_unavailable"
+
+SWITCH_KEY_MAP = {
+    ATTR_LIVE_TRACKING: "live_tracking",
+    ATTR_BUZZER: "buzzer_control",
+    ATTR_LED: "led_control",
+}

--- a/homeassistant/components/tractive/entity.py
+++ b/homeassistant/components/tractive/entity.py
@@ -62,10 +62,7 @@ class TractiveEntity(Entity):
     @callback
     def handle_status_update(self, event: dict[str, Any]) -> None:
         """Handle status update."""
-        # Switch data is sometimes not present in the event and we do not want to mark
-        # these entities as unavailable.
-        if self.__module__.rsplit(".", maxsplit=1)[-1] != "switch":
-            self._attr_available = event[self.entity_description.key] is not None
+        self._attr_available = event[self.entity_description.key] is not None
 
         self.async_write_ha_state()
 

--- a/homeassistant/components/tractive/entity.py
+++ b/homeassistant/components/tractive/entity.py
@@ -62,7 +62,11 @@ class TractiveEntity(Entity):
     @callback
     def handle_status_update(self, event: dict[str, Any]) -> None:
         """Handle status update."""
-        self._attr_available = event[self.entity_description.key] is not None
+        # Switch data is sometimes not present in the event and we do not want to mark
+        # these entities as unavailable.
+        if self.__module__.rsplit(".", maxsplit=1)[-1] != "switch":
+            self._attr_available = event[self.entity_description.key] is not None
+
         self.async_write_ha_state()
 
     @callback

--- a/homeassistant/components/tractive/entity.py
+++ b/homeassistant/components/tractive/entity.py
@@ -63,7 +63,6 @@ class TractiveEntity(Entity):
     def handle_status_update(self, event: dict[str, Any]) -> None:
         """Handle status update."""
         self._attr_available = event[self.entity_description.key] is not None
-
         self.async_write_ha_state()
 
     @callback

--- a/homeassistant/components/tractive/switch.py
+++ b/homeassistant/components/tractive/switch.py
@@ -113,6 +113,9 @@ class TractiveSwitch(TractiveEntity, SwitchEntity):
         if self.entity_description.key not in event:
             return
 
+        # We received an event, so the service is online and the switch entities should
+        #  be available.
+        self._attr_available = True
         self._attr_is_on = event[self.entity_description.key]
 
         self.async_write_ha_state()

--- a/homeassistant/components/tractive/switch.py
+++ b/homeassistant/components/tractive/switch.py
@@ -21,7 +21,7 @@ from .const import (
     CLIENT,
     DOMAIN,
     TRACKABLES,
-    TRACKER_HARDWARE_STATUS_UPDATED,
+    TRACKER_SWITCH_STATUS_UPDATED,
 )
 from .entity import TractiveEntity
 
@@ -99,11 +99,10 @@ class TractiveSwitch(TractiveEntity, SwitchEntity):
             client,
             item.trackable,
             item.tracker_details,
-            f"{TRACKER_HARDWARE_STATUS_UPDATED}-{item.tracker_details['_id']}",
+            f"{TRACKER_SWITCH_STATUS_UPDATED}-{item.tracker_details['_id']}",
         )
 
         self._attr_unique_id = f"{item.trackable['_id']}_{description.key}"
-        self._attr_available = False
         self._tracker = item.tracker
         self._method = getattr(self, description.method)
         self.entity_description = description
@@ -111,6 +110,9 @@ class TractiveSwitch(TractiveEntity, SwitchEntity):
     @callback
     def handle_status_update(self, event: dict[str, Any]) -> None:
         """Handle status update."""
+        if self.entity_description.key not in event:
+            return
+
         self._attr_is_on = event[self.entity_description.key]
 
         super().handle_status_update(event)

--- a/homeassistant/components/tractive/switch.py
+++ b/homeassistant/components/tractive/switch.py
@@ -115,7 +115,7 @@ class TractiveSwitch(TractiveEntity, SwitchEntity):
 
         self._attr_is_on = event[self.entity_description.key]
 
-        super().handle_status_update(event)
+        self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on a switch."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After analyzing logs from users, it turned out that events related to switches often contain only part of the data, e.g. data regarding only one switch. Which caused switch entities to be marked as unavailable.

Currently, switch state will be sent by the dispatcher with a separate signal and the availability of the switch entity will not depend on the presence of complete data in the event, but only on whether the Tractive API is online/offline.

Now the switch entities have been available all the time for the last 24 hours.

![obraz](https://github.com/home-assistant/core/assets/478555/44966ae2-a757-4909-966f-cf001ad8db88)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #102779
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
