### PR TITLE
Add reauth flow to co2signal

### DIFF
--- a/homeassistant/components/co2signal/coordinator.py
+++ b/homeassistant/components/co2signal/coordinator.py
@@ -10,7 +10,7 @@ from aioelectricitymaps.models import CarbonIntensityResponse
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryError
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
@@ -44,6 +44,6 @@ class CO2SignalCoordinator(DataUpdateCoordinator[CarbonIntensityResponse]):
                 self.hass, self.client, self.config_entry.data
             )
         except InvalidToken as err:
-            raise ConfigEntryError from err
+            raise ConfigEntryAuthFailed from err
         except ElectricityMapsError as err:
             raise UpdateFailed(str(err)) from err

--- a/homeassistant/components/co2signal/helpers.py
+++ b/homeassistant/components/co2signal/helpers.py
@@ -1,5 +1,5 @@
 """Helper functions for the CO2 Signal integration."""
-from types import MappingProxyType
+from collections.abc import Mapping
 from typing import Any
 
 from aioelectricitymaps import ElectricityMaps
@@ -14,7 +14,7 @@ from .const import CONF_COUNTRY_CODE
 async def fetch_latest_carbon_intensity(
     hass: HomeAssistant,
     em: ElectricityMaps,
-    config: dict[str, Any] | MappingProxyType[str, Any],
+    config: Mapping[str, Any],
 ) -> CarbonIntensityResponse:
     """Fetch the latest carbon intensity based on country code or location coordinates."""
     if CONF_COUNTRY_CODE in config:

--- a/homeassistant/components/co2signal/strings.json
+++ b/homeassistant/components/co2signal/strings.json
@@ -18,6 +18,11 @@
         "data": {
           "country_code": "Country code"
         }
+      },
+      "reauth": {
+        "data": {
+          "api_key": "[%key:common::config_flow::data::access_token%]"
+        }
       }
     },
     "error": {
@@ -28,7 +33,8 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "unknown": "[%key:common::config_flow::error::unknown%]",
-      "api_ratelimit": "[%key:component::co2signal::config::error::api_ratelimit%]"
+      "api_ratelimit": "[%key:component::co2signal::config::error::api_ratelimit%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
   "entity": {

--- a/tests/components/co2signal/test_config_flow.py
+++ b/tests/components/co2signal/test_config_flow.py
@@ -10,8 +10,11 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.co2signal import DOMAIN, config_flow
+from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
 
 
 @pytest.mark.usefixtures("electricity_maps")
@@ -186,3 +189,40 @@ async def test_form_error_handling(
     assert result["data"] == {
         "api_key": "api_key",
     }
+
+
+async def test_reauth(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    electricity_maps: AsyncMock,
+) -> None:
+    """Test reauth flow."""
+    config_entry.add_to_hass(hass)
+
+    init_result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": config_entry.entry_id,
+        },
+        data=None,
+    )
+
+    assert init_result["type"] == FlowResultType.FORM
+    assert init_result["step_id"] == "reauth"
+
+    with patch(
+        "homeassistant.components.co2signal.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        configure_result = await hass.config_entries.flow.async_configure(
+            init_result["flow_id"],
+            {
+                CONF_API_KEY: "api_key2",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert configure_result["type"] == FlowResultType.ABORT
+    assert configure_result["reason"] == "reauth_successful"
+    assert len(mock_setup_entry.mock_calls) == 1


### PR DESCRIPTION
## Proposed change
Add reauth flow to co2signal, although this is not really needed at the moment, because if the token is not valid for the new API, it will fall back to the old one, which currently does not require any form of authentication. But just in case, then the reauth flow is there.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
