### PR TITLE
Fix rainbird duplicate devices

### DIFF
--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -149,9 +149,9 @@ def _async_device_entry_to_keep(
     """Determine which device entry to keep when there are duplicates.
 
     As we transitioned to new unique ids, we did not update existing device entries
-    and as a result there are devies with both the old and new unique id format. We
+    and as a result there are devices with both the old and new unique id format. We
     have to pick which one to keep, and preferably this can repair things if the
-    user previously picked renamed devices.
+    user previously renamed devices.
     """
     # Prefer the new device if the user already gave it a name or area. Otherwise,
     # do the same for the old entry. If no entries have been modified then keep the new one.

--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -10,10 +10,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PASSWORD, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import format_mac
-from homeassistant.helpers.entity_registry import async_entries_for_config_entry
 
 from .const import CONF_SERIAL_NUMBER
 from .coordinator import RainbirdData
@@ -51,6 +50,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _async_fix_entity_unique_id(
             hass,
             er.async_get(hass),
+            entry.entry_id,
+            format_mac(mac_address),
+            str(entry.data[CONF_SERIAL_NUMBER]),
+        )
+        _async_fix_device_id(
+            hass,
+            dr.async_get(hass),
             entry.entry_id,
             format_mac(mac_address),
             str(entry.data[CONF_SERIAL_NUMBER]),
@@ -124,7 +130,7 @@ def _async_fix_entity_unique_id(
     serial_number: str,
 ) -> None:
     """Migrate existing entity if current one can't be found and an old one exists."""
-    entity_entries = async_entries_for_config_entry(entity_registry, config_entry_id)
+    entity_entries = er.async_entries_for_config_entry(entity_registry, config_entry_id)
     for entity_entry in entity_entries:
         unique_id = str(entity_entry.unique_id)
         if unique_id.startswith(mac_address):
@@ -135,6 +141,70 @@ def _async_fix_entity_unique_id(
             entity_registry.async_update_entity(
                 entity_entry.entity_id, new_unique_id=new_unique_id
             )
+
+
+def _async_device_entry_to_keep(
+    old_entry: dr.DeviceEntry, new_entry: dr.DeviceEntry
+) -> dr.DeviceEntry:
+    """Determine which device entry to keep when there are duplicates.
+
+    As we transitioned to new unique ids, we did not update existing device entries
+    and as a result there are devies with both the old and new unique id format. We
+    have to pick which one to keep, and preferably this can repair things if the
+    user previously picked renamed devices.
+    """
+    # Prefer the new device if the user already gave it a name or area. Otherwise,
+    # do the same for the old entry. If no entries have been modified then keep the new one.
+    if new_entry.disabled_by is None and (
+        new_entry.area_id is not None or new_entry.name_by_user is not None
+    ):
+        return new_entry
+    if old_entry.disabled_by is None and (
+        old_entry.area_id is not None or old_entry.name_by_user is not None
+    ):
+        return old_entry
+    return new_entry if new_entry.disabled_by is None else old_entry
+
+
+def _async_fix_device_id(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    config_entry_id: str,
+    mac_address: str,
+    serial_number: str,
+) -> None:
+    """Migrate existing device identifiers to the new format.
+
+    This will rename any device ids that are prefixed with the serial number to be prefixed
+    with the mac address. This also cleans up from a bug that allowed devices to exist
+    in both the old and new format.
+    """
+    device_entries = dr.async_entries_for_config_entry(device_registry, config_entry_id)
+    device_entry_map = {}
+    migrations = {}
+    for device_entry in device_entries:
+        unique_id = next(iter(device_entry.identifiers))[1]
+        device_entry_map[unique_id] = device_entry
+        if (suffix := unique_id.removeprefix(str(serial_number))) != unique_id:
+            migrations[unique_id] = f"{mac_address}{suffix}"
+
+    for unique_id, new_unique_id in migrations.items():
+        old_entry = device_entry_map[unique_id]
+        if (new_entry := device_entry_map.get(new_unique_id)) is not None:
+            # Device entries exist for both the old and new format and one must be removed
+            entry_to_keep = _async_device_entry_to_keep(old_entry, new_entry)
+            if entry_to_keep == new_entry:
+                _LOGGER.debug("Removing device entry %s", unique_id)
+                device_registry.async_remove_device(old_entry.id)
+                continue
+            # Remove new entry and update old entry to new id below
+            _LOGGER.debug("Removing device entry %s", new_unique_id)
+            device_registry.async_remove_device(new_entry.id)
+
+        _LOGGER.debug("Updating device id from %s to %s", unique_id, new_unique_id)
+        device_registry.async_update_device(
+            old_entry.id, new_identifiers={(DOMAIN, new_unique_id)}
+        )
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/tests/components/rainbird/test_init.py
+++ b/tests/components/rainbird/test_init.py
@@ -36,7 +36,7 @@ async def test_init_success(
 ) -> None:
     """Test successful setup and unload."""
 
-    await config_entry.async_setup(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
     assert config_entry.state == ConfigEntryState.LOADED
 
     await hass.config_entries.async_unload(config_entry.entry_id)
@@ -87,7 +87,7 @@ async def test_communication_failure(
     config_entry_state: list[ConfigEntryState],
 ) -> None:
     """Test unable to talk to device on startup, which fails setup."""
-    await config_entry.async_setup(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
     assert config_entry.state == config_entry_state
 
 
@@ -116,7 +116,7 @@ async def test_fix_unique_id(
     assert entries[0].unique_id is None
     assert entries[0].data.get(CONF_MAC) is None
 
-    await config_entry.async_setup(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
     assert config_entry.state == ConfigEntryState.LOADED
 
     # Verify config entry now has a unique id
@@ -168,7 +168,7 @@ async def test_fix_unique_id_failure(
 
     responses.insert(0, initial_response)
 
-    await config_entry.async_setup(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
     # Config entry is loaded, but not updated
     assert config_entry.state == ConfigEntryState.LOADED
     assert config_entry.unique_id is None
@@ -203,13 +203,9 @@ async def test_fix_unique_id_duplicate(
     responses.append(mock_json_response(WIFI_PARAMS_RESPONSE))
     responses.extend(responses_copy)
 
-    await config_entry.async_setup(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
     assert config_entry.state == ConfigEntryState.LOADED
     assert config_entry.unique_id == MAC_ADDRESS_UNIQUE_ID
-
-    await other_entry.async_setup(hass)
-    # Config entry unique id could not be updated since it already exists
-    assert other_entry.state == ConfigEntryState.SETUP_ERROR
 
     assert "Unable to fix missing unique id (already exists)" in caplog.text
 
@@ -299,7 +295,7 @@ async def test_fix_entity_unique_ids(
         serial_number=config_entry.data["serial_number"],
     )
 
-    await config_entry.async_setup(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
     assert config_entry.state == ConfigEntryState.LOADED
 
     entity_entry = entity_registry.async_get(entity_entry.id)
@@ -415,7 +411,7 @@ async def test_fix_duplicate_device_ids(
     )
     assert len(device_entries) == 2
 
-    await config_entry.async_setup(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
     assert config_entry.state == ConfigEntryState.LOADED
 
     # Only the device with the new format exists

--- a/tests/components/rainbird/test_init.py
+++ b/tests/components/rainbird/test_init.py
@@ -429,6 +429,3 @@ async def test_fix_duplicate_device_ids(
     assert device_entry.identifiers == {(DOMAIN, MAC_ADDRESS_UNIQUE_ID)}
     assert device_entry.name_by_user == expected_device_name
     assert device_entry.disabled_by == expected_disabled_by
-
-
-## TODO Fix device ids that already exist


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix rainbird duplicate devices that were added when migrating the entity ids without cleaning up the device ids. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: #103461
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
