### PR TITLE
Fix async issue in ViCare integration

### DIFF
--- a/homeassistant/components/vicare/binary_sensor.py
+++ b/homeassistant/components/vicare/binary_sensor.py
@@ -159,8 +159,9 @@ async def async_setup_entry(
         if entity is not None:
             entities.append(entity)
 
+    circuits = await hass.async_add_executor_job(get_circuits, api)
     await _entities_from_descriptions(
-        hass, entities, CIRCUIT_SENSORS, get_circuits(api), config_entry
+        hass, entities, CIRCUIT_SENSORS, circuits, config_entry
     )
 
     await _entities_from_descriptions(

--- a/homeassistant/components/vicare/binary_sensor.py
+++ b/homeassistant/components/vicare/binary_sensor.py
@@ -164,12 +164,14 @@ async def async_setup_entry(
         hass, entities, CIRCUIT_SENSORS, circuits, config_entry
     )
 
+    burners = await hass.async_add_executor_job(get_burners, api)
     await _entities_from_descriptions(
-        hass, entities, BURNER_SENSORS, get_burners(api), config_entry
+        hass, entities, BURNER_SENSORS, burners, config_entry
     )
 
+    compressors = await hass.async_add_executor_job(get_compressors, api)
     await _entities_from_descriptions(
-        hass, entities, COMPRESSOR_SENSORS, get_compressors(api), config_entry
+        hass, entities, COMPRESSOR_SENSORS, compressors, config_entry
     )
 
     async_add_entities(entities)

--- a/homeassistant/components/vicare/climate.py
+++ b/homeassistant/components/vicare/climate.py
@@ -103,7 +103,7 @@ async def async_setup_entry(
     entities = []
     api = hass.data[DOMAIN][config_entry.entry_id][VICARE_API]
     device_config = hass.data[DOMAIN][config_entry.entry_id][VICARE_DEVICE_CONFIG]
-    circuits = get_circuits(api)
+    circuits = await hass.async_add_executor_job(get_circuits, api)
 
     for circuit in circuits:
         entity = ViCareClimate(

--- a/homeassistant/components/vicare/climate.py
+++ b/homeassistant/components/vicare/climate.py
@@ -154,7 +154,7 @@ class ViCareClimate(ViCareEntity, ClimateEntity):
         self._current_program = None
         self._attr_translation_key = translation_key
 
-    def update(self) -> None:
+    async def async_update(self) -> None:
         """Let HA know there has been an update from the ViCare API."""
         try:
             _room_temperature = None
@@ -205,11 +205,15 @@ class ViCareClimate(ViCareEntity, ClimateEntity):
             self._current_action = False
             # Update the specific device attributes
             with suppress(PyViCareNotSupportedFeatureError):
-                for burner in get_burners(self._api):
+                burners = await self.hass.async_add_executor_job(get_burners, self._api)
+                for burner in burners:
                     self._current_action = self._current_action or burner.getActive()
 
             with suppress(PyViCareNotSupportedFeatureError):
-                for compressor in get_compressors(self._api):
+                compressors = await self.hass.async_add_executor_job(
+                    get_compressors, self._api
+                )
+                for compressor in compressors:
                     self._current_action = (
                         self._current_action or compressor.getActive()
                     )

--- a/homeassistant/components/vicare/number.py
+++ b/homeassistant/components/vicare/number.py
@@ -28,7 +28,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import ViCareRequiredKeysMixin
 from .const import DOMAIN, VICARE_API, VICARE_DEVICE_CONFIG
 from .entity import ViCareEntity
-from .utils import is_supported
+from .utils import get_circuits, is_supported
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -93,10 +93,11 @@ async def async_setup_entry(
 ) -> None:
     """Create the ViCare number devices."""
     api = hass.data[DOMAIN][config_entry.entry_id][VICARE_API]
+    circuits = await hass.async_add_executor_job(get_circuits, api)
 
     entities: list[ViCareNumber] = []
     try:
-        for circuit in api.circuits:
+        for circuit in circuits:
             for description in CIRCUIT_ENTITY_DESCRIPTIONS:
                 entity = await hass.async_add_executor_job(
                     _build_entity,

--- a/homeassistant/components/vicare/sensor.py
+++ b/homeassistant/components/vicare/sensor.py
@@ -650,8 +650,9 @@ async def async_setup_entry(
         if entity is not None:
             entities.append(entity)
 
+    circuits = await hass.async_add_executor_job(get_circuits, api)
     await _entities_from_descriptions(
-        hass, entities, CIRCUIT_SENSORS, get_circuits(api), config_entry
+        hass, entities, CIRCUIT_SENSORS, circuits, config_entry
     )
 
     await _entities_from_descriptions(

--- a/homeassistant/components/vicare/sensor.py
+++ b/homeassistant/components/vicare/sensor.py
@@ -655,12 +655,14 @@ async def async_setup_entry(
         hass, entities, CIRCUIT_SENSORS, circuits, config_entry
     )
 
+    burners = await hass.async_add_executor_job(get_burners, api)
     await _entities_from_descriptions(
-        hass, entities, BURNER_SENSORS, get_burners(api), config_entry
+        hass, entities, BURNER_SENSORS, burners, config_entry
     )
 
+    compressors = await hass.async_add_executor_job(get_compressors, api)
     await _entities_from_descriptions(
-        hass, entities, COMPRESSOR_SENSORS, get_compressors(api), config_entry
+        hass, entities, COMPRESSOR_SENSORS, compressors, config_entry
     )
 
     async_add_entities(entities)

--- a/homeassistant/components/vicare/water_heater.py
+++ b/homeassistant/components/vicare/water_heater.py
@@ -67,7 +67,7 @@ async def async_setup_entry(
     entities = []
     api = hass.data[DOMAIN][config_entry.entry_id][VICARE_API]
     device_config = hass.data[DOMAIN][config_entry.entry_id][VICARE_DEVICE_CONFIG]
-    circuits = get_circuits(api)
+    circuits = await hass.async_add_executor_job(get_circuits, api)
 
     for circuit in circuits:
         entity = ViCareWater(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As discussed in https://github.com/home-assistant/core/pull/104371#discussion_r1405307487 the async executor is still required.

This also implies #104524.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
