### PR TITLE
Improve user-facing error messages in HomeWizard Energy

### DIFF
--- a/homeassistant/components/homewizard/helpers.py
+++ b/homeassistant/components/homewizard/helpers.py
@@ -8,6 +8,7 @@ from homewizard_energy.errors import DisabledError, RequestError
 
 from homeassistant.exceptions import HomeAssistantError
 
+from .const import DOMAIN
 from .entity import HomeWizardEntity
 
 _HomeWizardEntityT = TypeVar("_HomeWizardEntityT", bound=HomeWizardEntity)
@@ -30,11 +31,19 @@ def homewizard_exception_handler(
         try:
             await func(self, *args, **kwargs)
         except RequestError as ex:
-            raise HomeAssistantError from ex
+            raise HomeAssistantError(
+                "An error occurred while communicating with HomeWizard device",
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+            ) from ex
         except DisabledError as ex:
             await self.hass.config_entries.async_reload(
                 self.coordinator.config_entry.entry_id
             )
-            raise HomeAssistantError from ex
+            raise HomeAssistantError(
+                "The local API of the HomeWizard device is disabled",
+                translation_domain=DOMAIN,
+                translation_key="api_disabled",
+            ) from ex
 
     return handler

--- a/homeassistant/components/homewizard/strings.json
+++ b/homeassistant/components/homewizard/strings.json
@@ -167,5 +167,13 @@
         "name": "Cloud connection"
       }
     }
+  },
+  "exceptions": {
+    "api_disabled": {
+      "message": "The local API of the HomeWizard device is disabled"
+    },
+    "communication_error": {
+      "message": "An error occurred while communicating with HomeWizard device"
+    }
   }
 }

--- a/tests/components/homewizard/test_button.py
+++ b/tests/components/homewizard/test_button.py
@@ -58,7 +58,10 @@ async def test_identify_button(
     # Raise RequestError when identify is called
     mock_homewizardenergy.identify.side_effect = RequestError()
 
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(
+        HomeAssistantError,
+        match=r"^An error occurred while communicating with HomeWizard device$",
+    ):
         await hass.services.async_call(
             button.DOMAIN,
             button.SERVICE_PRESS,
@@ -73,7 +76,10 @@ async def test_identify_button(
     # Raise RequestError when identify is called
     mock_homewizardenergy.identify.side_effect = DisabledError()
 
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(
+        HomeAssistantError,
+        match=r"^The local API of the HomeWizard device is disabled$",
+    ):
         await hass.services.async_call(
             button.DOMAIN,
             button.SERVICE_PRESS,

--- a/tests/components/homewizard/test_number.py
+++ b/tests/components/homewizard/test_number.py
@@ -67,7 +67,10 @@ async def test_number_entities(
     mock_homewizardenergy.state_set.assert_called_with(brightness=127)
 
     mock_homewizardenergy.state_set.side_effect = RequestError
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(
+        HomeAssistantError,
+        match=r"^An error occurred while communicating with HomeWizard device$",
+    ):
         await hass.services.async_call(
             number.DOMAIN,
             SERVICE_SET_VALUE,
@@ -79,7 +82,10 @@ async def test_number_entities(
         )
 
     mock_homewizardenergy.state_set.side_effect = DisabledError
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(
+        HomeAssistantError,
+        match=r"^The local API of the HomeWizard device is disabled$",
+    ):
         await hass.services.async_call(
             number.DOMAIN,
             SERVICE_SET_VALUE,

--- a/tests/components/homewizard/test_switch.py
+++ b/tests/components/homewizard/test_switch.py
@@ -120,7 +120,10 @@ async def test_switch_entities(
     # Test request error handling
     mocked_method.side_effect = RequestError
 
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(
+        HomeAssistantError,
+        match=r"^An error occurred while communicating with HomeWizard device$",
+    ):
         await hass.services.async_call(
             switch.DOMAIN,
             SERVICE_TURN_ON,
@@ -128,7 +131,10 @@ async def test_switch_entities(
             blocking=True,
         )
 
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(
+        HomeAssistantError,
+        match=r"^An error occurred while communicating with HomeWizard device$",
+    ):
         await hass.services.async_call(
             switch.DOMAIN,
             SERVICE_TURN_OFF,
@@ -139,7 +145,10 @@ async def test_switch_entities(
     # Test disabled error handling
     mocked_method.side_effect = DisabledError
 
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(
+        HomeAssistantError,
+        match=r"^The local API of the HomeWizard device is disabled$",
+    ):
         await hass.services.async_call(
             switch.DOMAIN,
             SERVICE_TURN_ON,
@@ -147,7 +156,10 @@ async def test_switch_entities(
             blocking=True,
         )
 
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(
+        HomeAssistantError,
+        match=r"^The local API of the HomeWizard device is disabled$",
+    ):
         await hass.services.async_call(
             switch.DOMAIN,
             SERVICE_TURN_OFF,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

SSIA, small improvement to the error messages that may be user-facing (shown in the UI). Also added translation support to them.

Adjusts the tests to explicitly check for the message to match.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
