### PR TITLE
Cleanup Discovergy a bit

### DIFF
--- a/homeassistant/components/discovergy/__init__.py
+++ b/homeassistant/components/discovergy/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-import pydiscovergy
+from pydiscovergy import Discovergy
 from pydiscovergy.authentication import BasicAuth
 import pydiscovergy.error as discovergyError
 from pydiscovergy.models import Meter
@@ -24,7 +24,7 @@ PLATFORMS = [Platform.SENSOR]
 class DiscovergyData:
     """Discovergy data class to share meters and api client."""
 
-    api_client: pydiscovergy.Discovergy
+    api_client: Discovergy
     meters: list[Meter]
     coordinators: dict[str, DiscovergyUpdateCoordinator]
 
@@ -35,7 +35,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # init discovergy data class
     discovergy_data = DiscovergyData(
-        api_client=pydiscovergy.Discovergy(
+        api_client=Discovergy(
             email=entry.data[CONF_EMAIL],
             password=entry.data[CONF_PASSWORD],
             httpx_client=get_async_client(hass),

--- a/homeassistant/components/discovergy/config_flow.py
+++ b/homeassistant/components/discovergy/config_flow.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping
 import logging
 from typing import Any
 
-import pydiscovergy
+from pydiscovergy import Discovergy
 from pydiscovergy.authentication import BasicAuth
 import pydiscovergy.error as discovergyError
 import voluptuous as vol
@@ -70,7 +70,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input:
             try:
-                await pydiscovergy.Discovergy(
+                await Discovergy(
                     email=user_input[CONF_EMAIL],
                     password=user_input[CONF_PASSWORD],
                     httpx_client=get_async_client(self.hass),

--- a/homeassistant/components/discovergy/coordinator.py
+++ b/homeassistant/components/discovergy/coordinator.py
@@ -31,7 +31,7 @@ class DiscovergyUpdateCoordinator(DataUpdateCoordinator[Reading]):
         super().__init__(
             hass,
             _LOGGER,
-            name=f"Discovergy meter {self.meter.meter_id}",
+            name=f"Discovergy meter {meter.meter_id}",
             update_interval=timedelta(seconds=30),
         )
 

--- a/homeassistant/components/discovergy/coordinator.py
+++ b/homeassistant/components/discovergy/coordinator.py
@@ -12,16 +12,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN
-
 _LOGGER = logging.getLogger(__name__)
 
 
 class DiscovergyUpdateCoordinator(DataUpdateCoordinator[Reading]):
     """The Discovergy update coordinator."""
-
-    discovergy_client: Discovergy
-    meter: Meter
 
     def __init__(
         self,
@@ -36,7 +31,7 @@ class DiscovergyUpdateCoordinator(DataUpdateCoordinator[Reading]):
         super().__init__(
             hass,
             _LOGGER,
-            name=DOMAIN,
+            name=f"Discovergy meter {self.meter.meter_id}",
             update_interval=timedelta(seconds=30),
         )
 

--- a/homeassistant/components/discovergy/diagnostics.py
+++ b/homeassistant/components/discovergy/diagnostics.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 from dataclasses import asdict
 from typing import Any
 
-from pydiscovergy.models import Meter
-
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -30,9 +28,8 @@ async def async_get_config_entry_diagnostics(
     flattened_meter: list[dict] = []
     last_readings: dict[str, dict] = {}
     data: DiscovergyData = hass.data[DOMAIN][entry.entry_id]
-    meters: list[Meter] = data.meters  # always returns a list
 
-    for meter in meters:
+    for meter in data.meters:
         # make a dict of meter data and redact some data
         flattened_meter.append(async_redact_data(asdict(meter), TO_REDACT_METER))
 

--- a/homeassistant/components/discovergy/sensor.py
+++ b/homeassistant/components/discovergy/sensor.py
@@ -27,8 +27,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from . import DiscovergyData, DiscovergyUpdateCoordinator
 from .const import DOMAIN, MANUFACTURER
 
-PARALLEL_UPDATES = 1
-
 
 def _get_and_scale(reading: Reading, key: str, scale: int) -> datetime | float | None:
     """Get a value from a Reading and divide with scale it."""
@@ -168,10 +166,9 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Discovergy sensors."""
     data: DiscovergyData = hass.data[DOMAIN][entry.entry_id]
-    meters: list[Meter] = data.meters  # always returns a list
 
     entities: list[DiscovergySensor] = []
-    for meter in meters:
+    for meter in data.meters:
         sensors: tuple[DiscovergySensorEntityDescription, ...] = ()
         coordinator: DiscovergyUpdateCoordinator = data.coordinators[meter.meter_id]
 

--- a/tests/components/discovergy/conftest.py
+++ b/tests/components/discovergy/conftest.py
@@ -2,7 +2,6 @@
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
-from pydiscovergy import Discovergy
 from pydiscovergy.models import Reading
 import pytest
 
@@ -27,14 +26,16 @@ def _meter_last_reading(meter_id: str) -> Reading:
 @pytest.fixture(name="discovergy")
 def mock_discovergy() -> Generator[AsyncMock, None, None]:
     """Mock the pydiscovergy client."""
-    mock = AsyncMock(spec=Discovergy)
-    mock.meters.return_value = GET_METERS
-    mock.meter_last_reading.side_effect = _meter_last_reading
-
     with patch(
-        "homeassistant.components.discovergy.pydiscovergy.Discovergy",
-        return_value=mock,
+        "homeassistant.components.discovergy.Discovergy",
+        autospec=True,
+    ) as mock_discovergy, patch(
+        "homeassistant.components.discovergy.config_flow.Discovergy",
+        new=mock_discovergy,
     ):
+        mock = mock_discovergy.return_value
+        mock.meters.return_value = GET_METERS
+        mock.meter_last_reading.side_effect = _meter_last_reading
         yield mock
 
 


### PR DESCRIPTION
## Proposed change
Cleanup the Discovergy integration and its tests a little bit, e.g. just import the stuff that is needed instead of the whole package, make use of `autospec=True`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
