### PR TITLE
Add support for Ring Intercom (bypass #91600)

### DIFF
--- a/homeassistant/components/ring/__init__.py
+++ b/homeassistant/components/ring/__init__.py
@@ -38,6 +38,7 @@ PLATFORMS = [
     Platform.SWITCH,
     Platform.CAMERA,
     Platform.SIREN,
+    Platform.BUTTON
 ]
 
 

--- a/homeassistant/components/ring/binary_sensor.py
+++ b/homeassistant/components/ring/binary_sensor.py
@@ -35,7 +35,7 @@ BINARY_SENSOR_TYPES: tuple[RingBinarySensorEntityDescription, ...] = (
     RingBinarySensorEntityDescription(
         key="ding",
         name="Ding",
-        category=["doorbots", "authorized_doorbots"],
+        category=["doorbots", "authorized_doorbots", "other"],
         device_class=BinarySensorDeviceClass.OCCUPANCY,
     ),
     RingBinarySensorEntityDescription(
@@ -56,9 +56,12 @@ async def async_setup_entry(
     ring = hass.data[DOMAIN][config_entry.entry_id]["api"]
     devices = hass.data[DOMAIN][config_entry.entry_id]["devices"]
 
+    # Some accounts return data without intercom devices
+    devices.setdefault("other", [])
+
     entities = [
         RingBinarySensor(config_entry.entry_id, ring, device, description)
-        for device_type in ("doorbots", "authorized_doorbots", "stickup_cams")
+        for device_type in ("doorbots", "authorized_doorbots", "stickup_cams", "other")
         for description in BINARY_SENSOR_TYPES
         if device_type in description.category
         for device in devices[device_type]

--- a/homeassistant/components/ring/button.py
+++ b/homeassistant/components/ring/button.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import DOMAIN
+from .entity import RingEntityMixin
+
+
+@dataclass
+class RingButtonEntityDescription(ButtonEntityDescription, RingRequiredKeysMixin):
+    kind: str | None = None
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    devices = hass.data[DOMAIN][config_entry.entry_id]["devices"]
+
+    # Some accounts return data without intercom devices
+    devices.setdefault("other", [])
+
+    entities = [
+        description.cls(config_entry.entry_id, device, description)
+        for device_type in ("doorbots", "other")
+        for description in BUTTON_TYPES
+        if device_type in description.category
+        for device in devices[device_type]
+    ]
+
+    async_add_entities(entities)
+
+@dataclass
+class RingRequiredKeysMixin:
+    category: list[str]
+    cls: type[RingButton]
+
+
+class RingDoorButton(RingEntityMixin, ButtonEntity):
+    entity_description: RingButtonEntityDescription
+
+    def __init__(
+        self,
+        config_entry_id,
+        device,
+        description: RingButtonEntityDescription,
+    ) -> None:
+        super().__init__(config_entry_id, device)
+        self.entity_description = description
+        self._extra = None
+        self._attr_name = f"{device.name} {description.name}"
+        self._attr_unique_id = f"{device.id}-{description.key}"
+
+    def press(self) -> None:
+        self._device.open_door()
+
+BUTTON_TYPES: tuple[RingButtonEntityDescription, ...] = (
+    RingButtonEntityDescription(
+        key="open_door",
+        name="Open door",
+        category=["other"],
+        icon="mdi:door-closed-lock",
+        cls=RingDoorButton,
+    ),
+)

--- a/homeassistant/components/ring/manifest.json
+++ b/homeassistant/components/ring/manifest.json
@@ -1,17 +1,17 @@
 {
   "domain": "ring",
   "name": "Ring",
-  "documentation": "https://www.home-assistant.io/integrations/ring",
-  "requirements": ["ring_doorbell==0.7.2"],
-  "dependencies": ["ffmpeg"],
   "codeowners": [],
   "config_flow": true,
+  "dependencies": ["ffmpeg"],
   "dhcp": [
     {
       "hostname": "ring*",
       "macaddress": "0CAE7D*"
     }
   ],
+  "documentation": "https://www.home-assistant.io/integrations/ring",
   "iot_class": "cloud_polling",
-  "loggers": ["ring_doorbell"]
+  "loggers": ["ring_doorbell"],
+  "requirements": ["ring_doorbell==0.7.2"]
 }

--- a/homeassistant/components/ring/sensor.py
+++ b/homeassistant/components/ring/sensor.py
@@ -26,9 +26,18 @@ async def async_setup_entry(
     """Set up a sensor for a Ring device."""
     devices = hass.data[DOMAIN][config_entry.entry_id]["devices"]
 
+    # Some accounts return data without intercom devices
+    devices.setdefault("other", [])
+
     entities = [
         description.cls(config_entry.entry_id, device, description)
-        for device_type in ("chimes", "doorbots", "authorized_doorbots", "stickup_cams")
+        for device_type in (
+            "authorized_doorbots",
+            "chimes",
+            "doorbots",
+            "other",
+            "stickup_cams",
+        )
         for description in SENSOR_TYPES
         if device_type in description.category
         for device in devices[device_type]
@@ -62,6 +71,12 @@ class RingSensor(RingEntityMixin, SensorEntity):
         sensor_type = self.entity_description.key
         if sensor_type == "volume":
             return self._device.volume
+        if sensor_type == "doorbell_volume":
+            return self._device.doorbell_volume
+        if sensor_type == "mic_volume":
+            return self._device.mic_volume
+        if sensor_type == "voice_volume":
+            return self._device.voice_volume
 
         if sensor_type == "battery":
             return self._device.battery_life
@@ -204,7 +219,7 @@ SENSOR_TYPES: tuple[RingSensorEntityDescription, ...] = (
     RingSensorEntityDescription(
         key="battery",
         name="Battery",
-        category=["doorbots", "authorized_doorbots", "stickup_cams"],
+        category=["doorbots", "authorized_doorbots", "stickup_cams", "other"],
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         cls=RingSensor,
@@ -239,6 +254,27 @@ SENSOR_TYPES: tuple[RingSensorEntityDescription, ...] = (
         key="volume",
         name="Volume",
         category=["chimes", "doorbots", "authorized_doorbots", "stickup_cams"],
+        icon="mdi:bell-ring",
+        cls=RingSensor,
+    ),
+    RingSensorEntityDescription(
+        key="doorbell_volume",
+        name="Doorbell Volume",
+        category=["other"],
+        icon="mdi:bell-ring",
+        cls=RingSensor,
+    ),
+    RingSensorEntityDescription(
+        key="mic_volume",
+        name="Mic Volume",
+        category=["other"],
+        icon="mdi:bell-ring",
+        cls=RingSensor,
+    ),
+    RingSensorEntityDescription(
+        key="voice_volume",
+        name="Voice Volume",
+        category=["other"],
         icon="mdi:bell-ring",
         cls=RingSensor,
     ),

--- a/tests/components/ring/test_sensor.py
+++ b/tests/components/ring/test_sensor.py
@@ -1,10 +1,14 @@
-"""The tests for the Ring sensor platform."""
+"""The tests for the Ring button platform."""
+import requests_mock
+
+from homeassistant.core import HomeAssistant
+
 from .common import setup_platform
 
 WIFI_ENABLED = False
 
 
-async def test_sensor(hass, requests_mock):
+async def test_intercom_ring_button(hass: HomeAssistant, requests_mock: requests_mock.Mocker) -> None:
     """Test the Ring sensors."""
     await setup_platform(hass, "sensor")
 


### PR DESCRIPTION
Note to maintainers: this is simply a bypass to PR #91600 (whose author, @martinpham has been inactive for several months) incorporating the required fixes as provided by [seik@9728a5a](https://github.com/seik/core/commit/9728a5afb0016892c27f054061ad32ff467a490e). Hopefully this will get the ball rolling again.

> ## Breaking change
> ## Proposed change
> The current Ring intergration is not supporting Ring Intercom devices (https://it-it.ring.com/products/intercom), as described here #82565. I've added support for it, introducing new sensors, and button to open door ![image](https://user-images.githubusercontent.com/2064515/232764912-23f7a565-b509-4ae0-b9dc-7506a0b3cae7.png)
> 
> ## Type of change
> * [ ]  Dependency upgrade
> * [ ]  Bugfix (non-breaking change which fixes an issue)
> * [ ]  New integration (thank you!)
> * [x]  New feature (which adds functionality to an existing integration)
> * [ ]  Deprecation (breaking change to happen in the future)
> * [ ]  Breaking change (fix/feature causing existing functionality to break)
> * [ ]  Code quality improvements to existing code or addition of tests
> 
> ## Additional information
> * This PR fixes or closes issue: fixes [Ring Integration does not show Ring Intercom device/entities #82565](https://github.com/home-assistant/core/issues/82565)
> * This PR is related to issue:
> * Link to documentation pull request: [Add support for Ring Intercom home-assistant.io#27050](https://github.com/home-assistant/home-assistant.io/pull/27050)
> 
> ## Checklist
> * [x]  The code change is tested and works locally.
> * [x]  Local tests pass. **Your PR cannot be merged unless tests pass**
> * [x]  There is no commented out code in this PR.
> * [x]  I have followed the [development checklist](https://developers.home-assistant.io/docs/en/development_checklist.html)
> * [x]  I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr)
> * [x]  The code has been formatted using Black (`black --fast homeassistant tests`)
> * [x]  Tests have been added to verify that the new code works.
> 
> If user exposed functionality or configuration variables are added/changed:
> 
> * [x]  Documentation added/updated for [www.home-assistant.io](https://github.com/home-assistant/home-assistant.io)
> 
> If the code communicates with devices, web services, or third-party tools:
> 
> * [ ]  The [manifest file](https://developers.home-assistant.io/docs/en/creating_integration_manifest.html) has all fields filled out correctly.
>   Updated and included derived files by running: `python3 -m script.hassfest`.
> * [ ]  New or updated dependencies have been added to `requirements_all.txt`.
>   Updated by running `python3 -m script.gen_requirements_all`.
> * [ ]  For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
> * [ ]  Untested files have been added to `.coveragerc`.
> 
> To help with the load of incoming pull requests:
> 
> * [ ]  I have reviewed two other [open pull requests](https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure) in this repository.

