### PR TITLE
Replace apcaccess dependency with aioapcaccess in apcupsd

### DIFF
--- a/homeassistant/components/apcupsd/coordinator.py
+++ b/homeassistant/components/apcupsd/coordinator.py
@@ -93,5 +93,5 @@ class APCUPSdCoordinator(DataUpdateCoordinator[OrderedDict[str, str]]):
         async with asyncio.timeout(10):
             try:
                 return await aioapcaccess.request_status(self._host, self._port)
-            except OSError as error:
+            except (OSError, asyncio.IncompleteReadError) as error:
                 raise UpdateFailed(error) from error

--- a/homeassistant/components/apcupsd/coordinator.py
+++ b/homeassistant/components/apcupsd/coordinator.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 import logging
 from typing import Final
 
-from apcaccess import status
+import aioapcaccess
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.debounce import Debouncer
@@ -90,13 +90,8 @@ class APCUPSdCoordinator(DataUpdateCoordinator[OrderedDict[str, str]]):
         Note that the result dict uses upper case for each resource, where our
         integration uses lower cases as keys internally.
         """
-
         async with asyncio.timeout(10):
             try:
-                raw = await self.hass.async_add_executor_job(
-                    status.get, self._host, self._port
-                )
-                result: OrderedDict[str, str] = status.parse(raw)
-                return result
+                return await aioapcaccess.request_status(self._host, self._port)
             except OSError as error:
                 raise UpdateFailed(error) from error

--- a/homeassistant/components/apcupsd/manifest.json
+++ b/homeassistant/components/apcupsd/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "loggers": ["apcaccess"],
   "quality_scale": "silver",
-  "requirements": ["aioapcaccess==0.4.1"]
+  "requirements": ["aioapcaccess==0.4.2"]
 }

--- a/homeassistant/components/apcupsd/manifest.json
+++ b/homeassistant/components/apcupsd/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "loggers": ["apcaccess"],
   "quality_scale": "silver",
-  "requirements": ["apcaccess==0.0.13"]
+  "requirements": ["aioapcaccess==0.4.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -197,7 +197,7 @@ aioairzone==0.6.9
 aioambient==2023.04.0
 
 # homeassistant.components.apcupsd
-aioapcaccess==0.4.1
+aioapcaccess==0.4.2
 
 # homeassistant.components.aseko_pool_live
 aioaseko==0.0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -196,6 +196,9 @@ aioairzone==0.6.9
 # homeassistant.components.ambient_station
 aioambient==2023.04.0
 
+# homeassistant.components.apcupsd
+aioapcaccess==0.4.1
+
 # homeassistant.components.aseko_pool_live
 aioaseko==0.0.2
 
@@ -432,9 +435,6 @@ anova-wifi==0.10.0
 
 # homeassistant.components.anthemav
 anthemav==1.4.1
-
-# homeassistant.components.apcupsd
-apcaccess==0.0.13
 
 # homeassistant.components.weatherkit
 apple_weatherkit==1.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -175,6 +175,9 @@ aioairzone==0.6.9
 # homeassistant.components.ambient_station
 aioambient==2023.04.0
 
+# homeassistant.components.apcupsd
+aioapcaccess==0.4.1
+
 # homeassistant.components.aseko_pool_live
 aioaseko==0.0.2
 
@@ -396,9 +399,6 @@ anova-wifi==0.10.0
 
 # homeassistant.components.anthemav
 anthemav==1.4.1
-
-# homeassistant.components.apcupsd
-apcaccess==0.0.13
 
 # homeassistant.components.weatherkit
 apple_weatherkit==1.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -176,7 +176,7 @@ aioairzone==0.6.9
 aioambient==2023.04.0
 
 # homeassistant.components.apcupsd
-aioapcaccess==0.4.1
+aioapcaccess==0.4.2
 
 # homeassistant.components.aseko_pool_live
 aioaseko==0.0.2

--- a/tests/components/apcupsd/__init__.py
+++ b/tests/components/apcupsd/__init__.py
@@ -95,10 +95,7 @@ async def async_init_integration(
 
     entry.add_to_hass(hass)
 
-    with (
-        patch("apcaccess.status.parse", return_value=status),
-        patch("apcaccess.status.get", return_value=b""),
-    ):
+    with patch("aioapcaccess.request_status", return_value=status):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR replaces the synchronous version of the dependency `apcaccess` (used to communicate with the device) with the asynchronous and fully-typed one `aioapcaccess`. As a result of this, we no longer have to (1) fetch updates in executors (i.e., `async_add_executor_job`), and (2) have local variable type annotations to make mypy happy.

Mocks in tests are also properly updated.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
