### PR TITLE
Migrate decora_wifi (Leviton ) to UI ConfigFlow

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -248,6 +248,8 @@ build.json @home-assistant/supervisor
 /tests/components/debugpy/ @frenck
 /homeassistant/components/deconz/ @Kane610
 /tests/components/deconz/ @Kane610
+/homeassistant/components/decora_wifi/ @gtalarico
+/tests/components/decora_wifi/ @gtalarico
 /homeassistant/components/default_config/ @home-assistant/core
 /tests/components/default_config/ @home-assistant/core
 /homeassistant/components/delijn/ @bollewolle @Emilv2

--- a/homeassistant/components/agent_dvr/__init__.py
+++ b/homeassistant/components/agent_dvr/__init__.py
@@ -17,7 +17,7 @@ DEFAULT_BRAND = "Agent DVR by ispyconnect.com"
 PLATFORMS = [Platform.ALARM_CONTROL_PANEL, Platform.CAMERA]
 
 
-async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def aasync_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Set up the Agent component."""
     hass.data.setdefault(AGENT_DOMAIN, {})
 

--- a/homeassistant/components/agent_dvr/__init__.py
+++ b/homeassistant/components/agent_dvr/__init__.py
@@ -17,7 +17,7 @@ DEFAULT_BRAND = "Agent DVR by ispyconnect.com"
 PLATFORMS = [Platform.ALARM_CONTROL_PANEL, Platform.CAMERA]
 
 
-async def aasync_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Set up the Agent component."""
     hass.data.setdefault(AGENT_DOMAIN, {})
 

--- a/homeassistant/components/decora_wifi/__init__.py
+++ b/homeassistant/components/decora_wifi/__init__.py
@@ -61,9 +61,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data[DOMAIN][entry.entry_id] = session
 
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     def logout(event: Event) -> None:
         try:

--- a/homeassistant/components/decora_wifi/__init__.py
+++ b/homeassistant/components/decora_wifi/__init__.py
@@ -55,7 +55,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 _LOGGER.error("Failed to log out of myLeviton Service: %s", err)
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, logout)
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, logout)
 
     return True
 

--- a/homeassistant/components/decora_wifi/__init__.py
+++ b/homeassistant/components/decora_wifi/__init__.py
@@ -5,21 +5,36 @@ import logging
 from decora_wifi import DecoraWiFiSession
 from decora_wifi.models.person import Person
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_PASSWORD,
     CONF_USERNAME,
     EVENT_HOMEASSISTANT_STOP,
     Platform,
 )
-from homeassistant.core import HomeAssistant, Event
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
 
-
 _LOGGER = logging.getLogger(__name__)
 PLATFORMS = [Platform.LIGHT]
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up decora_wifi component."""
+
+    if DOMAIN not in config:
+        return True
+
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=config[DOMAIN]
+        )
+    )
+
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/decora_wifi/__init__.py
+++ b/homeassistant/components/decora_wifi/__init__.py
@@ -8,7 +8,6 @@ from decora_wifi.models.permission import Permission
 from decora_wifi.models.person import Person
 from decora_wifi.models.residence import Residence
 from decora_wifi.models.residential_account import ResidentialAccount
-import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -20,15 +19,10 @@ from homeassistant.const import (
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import ConfigEntryError
 
-from .config_flow import BASE_SCHEMA
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 PLATFORMS = [Platform.LIGHT]
-CONFIG_SCHEMA = vol.Schema(
-    {DOMAIN: BASE_SCHEMA},
-    extra=vol.ALLOW_EXTRA,
-)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/decora_wifi/__init__.py
+++ b/homeassistant/components/decora_wifi/__init__.py
@@ -33,7 +33,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     username = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]
     session = DecoraWiFiSession()
-    user = await hass.async_add_executor_job(lambda: session.login(username, password))
+    user = await hass.async_add_executor_job(session.login, username, password)
     if not user:
         raise ConfigEntryError("could not authenticate")
 
@@ -77,9 +77,7 @@ class DecoraWifiAsyncClient:
 
     async def get_residences(self, permissions: list[Permission]) -> list[Residence]:
         """Get all residences for the provided permissions."""
-        return await self.hass.async_add_executor_job(
-            lambda: self._get_residences(permissions)
-        )
+        return await self.hass.async_add_executor_job(self._get_residences, permissions)
 
     def _get_residences(self, permissions: list[Permission]) -> list[Residence]:
         """Get all residences for the provided permissions."""
@@ -95,7 +93,7 @@ class DecoraWifiAsyncClient:
     async def get_iot_switches(self, residences: list[Residence]) -> list[IotSwitch]:
         """Get all the iot switches for the provided residences."""
         return await self.hass.async_add_executor_job(
-            lambda: self._get_iot_switches(residences)
+            self._get_iot_switches, residences
         )
 
     def _get_iot_switches(self, residences: list[Residence]) -> list[IotSwitch]:

--- a/homeassistant/components/decora_wifi/__init__.py
+++ b/homeassistant/components/decora_wifi/__init__.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import Event, HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers.typing import ConfigType
 
 from .config_flow import BASE_SCHEMA
@@ -57,7 +57,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     session = DecoraWiFiSession()
     user = await hass.async_add_executor_job(lambda: session.login(username, password))
     if not user:
-        raise ConfigEntryAuthFailed("invalid authentication")
+        raise ConfigEntryError("could not authenticate")
 
     hass.data[DOMAIN][entry.entry_id] = session
 

--- a/homeassistant/components/decora_wifi/__init__.py
+++ b/homeassistant/components/decora_wifi/__init__.py
@@ -1,1 +1,62 @@
 """The decora_wifi component."""
+
+import logging
+
+from decora_wifi import DecoraWiFiSession
+from decora_wifi.models.person import Person
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN, PLATFORMS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up config entry."""
+
+    email = entry.data[CONF_USERNAME]
+    password = entry.data[CONF_PASSWORD]
+    session = DecoraWiFiSession()
+
+    # hass.data[DOMAIN] = AbodeSystem(abode, polling)
+    hass.data[DOMAIN] = session
+
+    # PR Need handle some config errors
+    # except ConfigEntryError as ex:
+
+    try:
+        success = await hass.async_add_executor_job(
+            lambda: session.login(email, password)
+        )
+
+        # If login failed, notify user.
+        if success is None:
+            msg = "Failed to log into myLeviton Services. Check credentials."
+            _LOGGER.error(msg)
+            # persistent_notification.create(
+            #     hass, msg, title=NOTIFICATION_TITLE, notification_id=NOTIFICATION_ID
+            # )
+            # return
+
+    except ValueError:
+        _LOGGER.error("Failed to communicate with myLeviton Service")
+
+    # Listen for the stop event and log out.
+    def logout(event):
+        """Log out..."""
+        try:
+            if session is not None:
+                Person.logout(session)
+        except ValueError:
+            _LOGGER.error("Failed to log out of myLeviton Service")
+
+    # Forward the setup to the sensor platform.
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    )
+
+    # hass.bus.listen(EVENT_HOMEASSISTANT_STOP, logout)
+    return True

--- a/homeassistant/components/decora_wifi/__init__.py
+++ b/homeassistant/components/decora_wifi/__init__.py
@@ -1,15 +1,18 @@
 """The decora_wifi component."""
 
+from dataclasses import dataclass
 import logging
-from dataclasses import dataclass, field
+
 from decora_wifi import DecoraWiFiSession
-from decora_wifi.models.person import Person
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import HomeAssistant, CALLBACK_TYPE
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 
-from .const import DOMAIN, PLATFORMS
+from .const import DOMAIN
+
+PLATFORMS = [Platform.LIGHT]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -18,61 +21,33 @@ _LOGGER = logging.getLogger(__name__)
 class DecoraComponentData:
     """Decora Component Data Class."""
 
-    clientSession: DecoraWiFiSession
-    entity_ids: set[str | None] = field(default_factory=set)
+    session: DecoraWiFiSession
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up config entry."""
 
-    email = entry.data[CONF_USERNAME]
+    hass.data.setdefault(DOMAIN, {})
+
+    email = entry.data[CONF_EMAIL]
     password = entry.data[CONF_PASSWORD]
     session = DecoraWiFiSession()
+    user = await hass.async_add_executor_job(lambda: session.login(email, password))
+    if not user:
+        raise ConfigEntryAuthFailed("invalid authentication")
 
-    hass.data[DOMAIN] = DecoraComponentData(session)
-    hass.data[DOMAIN] = session
-
-    # PR Need handle some config errors
-    # except ConfigEntryError as ex:
-
-    try:
-        success = await hass.async_add_executor_job(
-            lambda: session.login(email, password)
-        )
-
-        # If login failed, notify user.
-        if success is None:
-            msg = "Failed to log into myLeviton Services. Check credentials."
-            _LOGGER.error(msg)
-            # persistent_notification.create(
-            #     hass, msg, title=NOTIFICATION_TITLE, notification_id=NOTIFICATION_ID
-            # )
-            # return
-
-    except ValueError:
-        _LOGGER.error("Failed to communicate with myLeviton Service")
-
-    # Listen for the stop event and log out.
-    def logout(event):
-        """Log out..."""
-        try:
-            if session is not None:
-                Person.logout(session)
-        except ValueError:
-            _LOGGER.error("Failed to log out of myLeviton Service")
+    hass.data[DOMAIN][entry.entry_id] = DecoraComponentData(session)
 
     # Forward the setup to the sensor platform.
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     )
 
-    hass.bus.listen(EVENT_HOMEASSISTANT_STOP, logout)
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     hass.data.pop(DOMAIN)
     return unload_ok

--- a/homeassistant/components/decora_wifi/__init__.py
+++ b/homeassistant/components/decora_wifi/__init__.py
@@ -4,6 +4,7 @@ import logging
 
 from decora_wifi import DecoraWiFiSession
 from decora_wifi.models.person import Person
+import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
@@ -16,10 +17,15 @@ from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.typing import ConfigType
 
+from .config_flow import BASE_SCHEMA
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 PLATFORMS = [Platform.LIGHT]
+CONFIG_SCHEMA = vol.Schema(
+    {DOMAIN: BASE_SCHEMA},
+    extra=vol.ALLOW_EXTRA,
+)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -51,12 +57,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data[DOMAIN][entry.entry_id] = session
 
-    # Forward the setup to the sensor platform.
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     )
 
-    # Listen for the stop event and log out.
     def logout(event: Event) -> None:
         try:
             if session is not None:

--- a/homeassistant/components/decora_wifi/__init__.py
+++ b/homeassistant/components/decora_wifi/__init__.py
@@ -1,20 +1,17 @@
 """The decora_wifi component."""
 
 from dataclasses import dataclass
-import logging
 
 from decora_wifi import DecoraWiFiSession
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, Platform
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
 from .const import DOMAIN
 
 PLATFORMS = [Platform.LIGHT]
-
-_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
@@ -29,10 +26,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})
 
-    email = entry.data[CONF_EMAIL]
+    username = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]
     session = DecoraWiFiSession()
-    user = await hass.async_add_executor_job(lambda: session.login(email, password))
+    user = await hass.async_add_executor_job(lambda: session.login(username, password))
     if not user:
         raise ConfigEntryAuthFailed("invalid authentication")
 

--- a/homeassistant/components/decora_wifi/__init__.py
+++ b/homeassistant/components/decora_wifi/__init__.py
@@ -48,12 +48,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     def logout(event: Event) -> None:
-        try:
-            if session is not None:
+        if session is not None:
+            try:
                 Person.logout(session)
-        except ValueError:
-            _LOGGER.error("Failed to log out of myLeviton Service")
+            except ValueError as err:
+                _LOGGER.error("Failed to log out of myLeviton Service: %s", err)
 
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, logout)
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, logout)
 
     return True

--- a/homeassistant/components/decora_wifi/__init__.py
+++ b/homeassistant/components/decora_wifi/__init__.py
@@ -10,7 +10,7 @@ from decora_wifi.models.residence import Residence
 from decora_wifi.models.residential_account import ResidentialAccount
 import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_PASSWORD,
     CONF_USERNAME,
@@ -19,7 +19,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import ConfigEntryError
-from homeassistant.helpers.typing import ConfigType
 
 from .config_flow import BASE_SCHEMA
 from .const import DOMAIN
@@ -30,21 +29,6 @@ CONFIG_SCHEMA = vol.Schema(
     {DOMAIN: BASE_SCHEMA},
     extra=vol.ALLOW_EXTRA,
 )
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up decora_wifi component."""
-
-    if DOMAIN not in config:
-        return True
-
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=config[DOMAIN]
-        )
-    )
-
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/decora_wifi/__init__.py
+++ b/homeassistant/components/decora_wifi/__init__.py
@@ -75,14 +75,14 @@ class DecoraWifiAsyncClient:
         self.session = session
         self.hass = hass
 
-    async def get_permissions(self):
+    async def get_permissions(self) -> list[Permission]:
         """Get all permissions for the provided session."""
         assert self.session.user
         return await self.hass.async_add_executor_job(
             self.session.user.get_residential_permissions
         )
 
-    async def get_residences(self, permissions: list[Permission]):
+    async def get_residences(self, permissions: list[Permission]) -> list[Residence]:
         """Get all residences for the provided permissions."""
         residences: list[Residence] = []
         for perm in permissions:
@@ -97,8 +97,9 @@ class DecoraWifiAsyncClient:
 
     async def get_iot_switches(self, residences: list[Residence]) -> list[IotSwitch]:
         """Get all the iot switches for the provided residences."""
-        return [
-            sw
-            for res in residences
-            for sw in (await self.hass.async_add_executor_job(res.get_iot_switches))
-        ]
+        return await self.hass.async_add_executor_job(
+            lambda: self._get_iot_switches(residences)
+        )
+
+    def _get_iot_switches(self, residences: list[Residence]) -> list[IotSwitch]:
+        return [sw for res in residences for sw in (res.get_iot_switches())]

--- a/homeassistant/components/decora_wifi/__init__.py
+++ b/homeassistant/components/decora_wifi/__init__.py
@@ -83,13 +83,17 @@ class DecoraWifiAsyncClient:
 
     async def get_residences(self, permissions: list[Permission]) -> list[Residence]:
         """Get all residences for the provided permissions."""
+        return await self.hass.async_add_executor_job(
+            lambda: self._get_residences(permissions)
+        )
+
+    def _get_residences(self, permissions: list[Permission]) -> list[Residence]:
+        """Get all residences for the provided permissions."""
         residences: list[Residence] = []
         for perm in permissions:
             if perm.residentialAccountId is not None:
                 account = ResidentialAccount(self.session, perm.residentialAccountId)
-                residences.extend(
-                    await self.hass.async_add_executor_job(account.get_residences)
-                )
+                residences.extend(account.get_residences())
             elif perm.residenceId is not None:
                 residences.append(Residence(self.session, perm.residenceId))
         return residences

--- a/homeassistant/components/decora_wifi/config_flow.py
+++ b/homeassistant/components/decora_wifi/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for Decora Wifi integration."""
 
 import logging
+from typing import Any
 
 from decora_wifi import DecoraWiFiSession
 import voluptuous as vol
@@ -47,19 +48,11 @@ class DecoreWifiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             },
         )
 
-        if CONF_USERNAME not in import_data or CONF_PASSWORD not in import_data:
-            _LOGGER.error(
-                "Could not import config data from yaml. Required Fields not found "
-                "in decora_wifi config: %s, %s",
-                CONF_USERNAME,
-                CONF_PASSWORD,
-            )
-            # We don't have enough to auto-import, so skip to new setup
-            return await self.async_step_user(None)
-
         return await self.async_step_user(import_data)
 
-    async def async_step_user(self, user_input=None) -> FlowResult:
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Handle a flow initiated by the user."""
 
         errors: dict[str, str] = {}

--- a/homeassistant/components/decora_wifi/config_flow.py
+++ b/homeassistant/components/decora_wifi/config_flow.py
@@ -91,9 +91,7 @@ async def async_validate_input(
     """Validate user input. Will throw if cannot authenticated with provided credentials."""
     session = DecoraWiFiSession()
     try:
-        user = await hass.async_add_executor_job(
-            lambda: session.login(username, password)
-        )
+        user = await hass.async_add_executor_job(session.login, username, password)
     # As of the current release of the decora wifi lib (1.4), all api errors raise a generic ValueError
     except ValueError as err:
         raise CannotConnect("request failed") from err

--- a/homeassistant/components/decora_wifi/config_flow.py
+++ b/homeassistant/components/decora_wifi/config_flow.py
@@ -16,7 +16,7 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-DATA_SCHEMA = vol.Schema(
+BASE_SCHEMA = vol.Schema(
     {
         vol.Required("username"): str,
         vol.Required("password"): str,
@@ -100,7 +100,7 @@ class DecoreWifiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
 
         return self.async_show_form(
-            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+            step_id="user", data_schema=BASE_SCHEMA, errors=errors
         )
 
 

--- a/homeassistant/components/decora_wifi/config_flow.py
+++ b/homeassistant/components/decora_wifi/config_flow.py
@@ -79,17 +79,8 @@ class DecoreWifiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             else:
                 # No Errors
                 unique_id = username.lower()
-                existing_entry = await self.async_set_unique_id(unique_id)
+                await self.async_set_unique_id(unique_id)
                 self._abort_if_unique_id_configured()
-
-                if existing_entry:
-                    self.hass.config_entries.async_update_entry(
-                        existing_entry, data=user_input
-                    )
-                    # Reload the config entry otherwise devices will remain unavailable
-                    self.hass.async_create_task(
-                        self.hass.config_entries.async_reload(existing_entry.entry_id)
-                    )
 
                 return self.async_create_entry(
                     title=username,

--- a/homeassistant/components/decora_wifi/config_flow.py
+++ b/homeassistant/components/decora_wifi/config_flow.py
@@ -36,7 +36,7 @@ class DecoreWifiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.hass,
             HOMEASSISTANT_DOMAIN,
             f"deprecated_yaml_{DOMAIN}",
-            breaks_in_ha_version="2024.11.0",
+            breaks_in_ha_version="2024.6.0",
             is_fixable=False,
             issue_domain=DOMAIN,
             severity=IssueSeverity.WARNING,
@@ -69,7 +69,6 @@ class DecoreWifiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             try:
                 await async_validate_input(self.hass, username, password)
-                unique_id = username.lower()
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except InvalidAuth:
@@ -79,6 +78,7 @@ class DecoreWifiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "unknown"
             else:
                 # No Errors
+                unique_id = username.lower()
                 existing_entry = await self.async_set_unique_id(unique_id)
                 self._abort_if_unique_id_configured()
 

--- a/homeassistant/components/decora_wifi/config_flow.py
+++ b/homeassistant/components/decora_wifi/config_flow.py
@@ -28,6 +28,48 @@ class DecoreWifiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    async def async_step_import(self, import_data: dict[str, str]) -> FlowResult:
+        """Import decora wifi config from configuration.yaml."""
+
+        if CONF_USERNAME not in import_data or CONF_PASSWORD not in import_data:
+            _LOGGER.error(
+                "Could not import config data from yaml. Required Fields not found: %s, %s",
+                CONF_USERNAME,
+                CONF_PASSWORD,
+            )
+            return await self.async_step_user(None)
+
+        return self.async_create_entry(
+            title=CONF_USERNAME,
+            data={CONF_USERNAME: CONF_USERNAME, CONF_PASSWORD: CONF_PASSWORD},
+        )
+
+    # From components/vera
+    # async def async_step_import(self, config: dict[str, Any]) -> FlowResult:
+    #     """Handle a flow initialized by import."""
+
+    #     # If there are entities with the legacy unique_id, then this imported config
+    #     # should also use the legacy unique_id for entity creation.
+    #     entity_registry = er.async_get(self.hass)
+    #     use_legacy_unique_id = (
+    #         len(
+    #             [
+    #                 entry
+    #                 for entry in entity_registry.entities.values()
+    #                 if entry.platform == DOMAIN and entry.unique_id.isdigit()
+    #             ]
+    #         )
+    #         > 0
+    #     )
+
+    #     return await self.async_step_finish(
+    #         {
+    #             **config,
+    #             **{CONF_SOURCE: config_entries.SOURCE_IMPORT},
+    #             **{CONF_LEGACY_UNIQUE_ID: use_legacy_unique_id},
+    #         }
+    #     )
+
     async def async_step_user(self, user_input=None) -> FlowResult:
         """Handle a flow initiated by the user."""
 

--- a/homeassistant/components/decora_wifi/config_flow.py
+++ b/homeassistant/components/decora_wifi/config_flow.py
@@ -18,8 +18,8 @@ _LOGGER = logging.getLogger(__name__)
 
 BASE_SCHEMA = vol.Schema(
     {
-        vol.Required("username"): str,
-        vol.Required("password"): str,
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
     }
 )
 
@@ -64,8 +64,8 @@ class DecoreWifiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         errors: dict[str, str] = {}
         if user_input is not None:
-            username = user_input["username"]
-            password = user_input["password"]
+            username = user_input[CONF_USERNAME]
+            password = user_input[CONF_PASSWORD]
 
             try:
                 await async_validate_input(self.hass, username, password)

--- a/homeassistant/components/decora_wifi/config_flow.py
+++ b/homeassistant/components/decora_wifi/config_flow.py
@@ -77,10 +77,7 @@ class DecoreWifiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                 return self.async_create_entry(
                     title=username,
-                    data={
-                        CONF_USERNAME: username,
-                        CONF_PASSWORD: password,
-                    },
+                    data=user_input,
                 )
 
         return self.async_show_form(

--- a/homeassistant/components/decora_wifi/config_flow.py
+++ b/homeassistant/components/decora_wifi/config_flow.py
@@ -1,0 +1,59 @@
+"""Will write later."""
+
+import logging
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_DEVICES, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.data_entry_flow import FlowResult
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class DecoreWifiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Will write later."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input=None) -> FlowResult:
+        """Will write later."""
+
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            username = user_input["username"]
+            pwd = user_input["password"]
+
+            await self.async_set_unique_id(username.lower())
+            self._abort_if_unique_id_configured()
+
+            # Abode example
+            # existing_entry = await self.async_set_unique_id(self._username)
+
+            # if existing_entry:
+            #     self.hass.config_entries.async_update_entry(
+            #         existing_entry, data=config_data
+            #     )
+            #     # Reload the Abode config entry otherwise devices will remain unavailable
+            #     self.hass.async_create_task(
+            #         self.hass.config_entries.async_reload(existing_entry.entry_id)
+            #     )
+
+            return self.async_create_entry(
+                title=username,
+                data={
+                    CONF_USERNAME: username,
+                    CONF_PASSWORD: pwd,
+                    CONF_DEVICES: [],
+                },
+            )
+
+        data_schema = {
+            vol.Required("username"): str,
+            vol.Required("password"): str,
+        }
+        return self.async_show_form(
+            step_id="user", data_schema=vol.Schema(data_schema), errors=errors
+        )

--- a/homeassistant/components/decora_wifi/config_flow.py
+++ b/homeassistant/components/decora_wifi/config_flow.py
@@ -1,4 +1,4 @@
-"""Will write later."""
+"""Config flow for Decora Wifi integration."""
 
 import logging
 
@@ -100,7 +100,13 @@ async def async_validate_input(
 ) -> None:
     """Validate user input. Will throw if cannot authenticated with provided credentials."""
     session = DecoraWiFiSession()
-    user = await hass.async_add_executor_job(lambda: session.login(username, password))
+    try:
+        user = await hass.async_add_executor_job(
+            lambda: session.login(username, password)
+        )
+    # As of the current release of the decora wifi lib (1.4), all api errors raise a generic ValueError
+    except ValueError as err:
+        raise CannotConnect("request failed") from err
     if not user:
         raise InvalidAuth("invalid authentication")
 

--- a/homeassistant/components/decora_wifi/config_flow.py
+++ b/homeassistant/components/decora_wifi/config_flow.py
@@ -2,15 +2,25 @@
 
 import logging
 
+from decora_wifi import DecoraWiFiSession
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_DEVICES, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required("email"): str,
+        vol.Required("password"): str,
+    }
+)
 
 
 class DecoreWifiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -23,37 +33,62 @@ class DecoreWifiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         errors: dict[str, str] = {}
         if user_input is not None:
-            username = user_input["username"]
-            pwd = user_input["password"]
+            email = user_input["email"]
+            password = user_input["password"]
 
-            await self.async_set_unique_id(username.lower())
-            self._abort_if_unique_id_configured()
+            try:
+                unique_id, session = await async_validate_input(
+                    self.hass, email, password
+                )
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                # No Errors
+                existing_entry = await self.async_set_unique_id(unique_id)
+                self._abort_if_unique_id_configured()
 
-            # Abode example
-            # existing_entry = await self.async_set_unique_id(self._username)
+                if existing_entry:
+                    self.hass.config_entries.async_update_entry(
+                        existing_entry, data=user_input
+                    )
+                    # Reload the config entry otherwise devices will remain unavailable
+                    self.hass.async_create_task(
+                        self.hass.config_entries.async_reload(existing_entry.entry_id)
+                    )
 
-            # if existing_entry:
-            #     self.hass.config_entries.async_update_entry(
-            #         existing_entry, data=config_data
-            #     )
-            #     # Reload the Abode config entry otherwise devices will remain unavailable
-            #     self.hass.async_create_task(
-            #         self.hass.config_entries.async_reload(existing_entry.entry_id)
-            #     )
+                return self.async_create_entry(
+                    title=email,
+                    data={
+                        CONF_EMAIL: email,
+                        CONF_PASSWORD: password,
+                        # CONF_DEVICES: [],
+                    },
+                )
 
-            return self.async_create_entry(
-                title=username,
-                data={
-                    CONF_USERNAME: username,
-                    CONF_PASSWORD: pwd,
-                    CONF_DEVICES: [],
-                },
-            )
-
-        data_schema = {
-            vol.Required("username"): str,
-            vol.Required("password"): str,
-        }
         return self.async_show_form(
-            step_id="user", data_schema=vol.Schema(data_schema), errors=errors
+            step_id="user", data_schema=DATA_SCHEMA, errors=errors
         )
+
+
+async def async_validate_input(
+    hass: HomeAssistant, email: str, password: str
+) -> tuple[str, DecoraWiFiSession]:
+    """Will add later."""
+    session = DecoraWiFiSession()
+    user = await hass.async_add_executor_job(lambda: session.login(email, password))
+    if not user:
+        raise InvalidAuth("invalid authentication")
+    return email, session
+
+
+class CannotConnect(HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/decora_wifi/const.py
+++ b/homeassistant/components/decora_wifi/const.py
@@ -1,0 +1,6 @@
+"""Constants for the Decore Wifi integration."""
+
+from homeassistant.const import Platform
+
+DOMAIN = "decora_wifi"
+PLATFORMS = [Platform.LIGHT]

--- a/homeassistant/components/decora_wifi/const.py
+++ b/homeassistant/components/decora_wifi/const.py
@@ -1,3 +1,3 @@
-"""Constants for the Decore Wifi integration."""
+"""Constants for the Decora Wifi integration."""
 
 DOMAIN = "decora_wifi"

--- a/homeassistant/components/decora_wifi/const.py
+++ b/homeassistant/components/decora_wifi/const.py
@@ -1,6 +1,3 @@
 """Constants for the Decore Wifi integration."""
 
-from homeassistant.const import Platform
-
 DOMAIN = "decora_wifi"
-PLATFORMS = [Platform.LIGHT]

--- a/homeassistant/components/decora_wifi/light.py
+++ b/homeassistant/components/decora_wifi/light.py
@@ -40,7 +40,7 @@ NOTIFICATION_TITLE = "myLeviton Decora Setup"
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Will write later."""
+    """Set up Decora Wifi Switches."""
 
     component: DecoraComponentData = hass.data[DOMAIN][entry.entry_id]
 

--- a/homeassistant/components/decora_wifi/light.py
+++ b/homeassistant/components/decora_wifi/light.py
@@ -15,12 +15,13 @@ from homeassistant.components.light import (
     LightEntity,
     LightEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import DecoraWifiAsyncClient
 from .const import DOMAIN
@@ -31,6 +32,21 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {vol.Required(CONF_USERNAME): cv.string, vol.Required(CONF_PASSWORD): cv.string}
 )
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up decora_wifi component."""
+
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
+        )
+    )
 
 
 async def async_setup_entry(

--- a/homeassistant/components/decora_wifi/light.py
+++ b/homeassistant/components/decora_wifi/light.py
@@ -10,7 +10,6 @@ from decora_wifi.models.residence import Residence
 from decora_wifi.models.residential_account import ResidentialAccount
 import voluptuous as vol
 
-from homeassistant.components import persistent_notification
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_TRANSITION,
@@ -19,11 +18,14 @@ from homeassistant.components.light import (
     LightEntity,
     LightEntityFeature,
 )
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, EVENT_HOMEASSISTANT_STOP
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,45 +38,45 @@ NOTIFICATION_ID = "leviton_notification"
 NOTIFICATION_TITLE = "myLeviton Decora Setup"
 
 
-def setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Set up the Decora WiFi platform."""
-
-    email = config[CONF_USERNAME]
-    password = config[CONF_PASSWORD]
+    """Will write later."""
+    # data = hass.data[DOMAIN]
+    email = entry.data[CONF_USERNAME]
+    password = entry.data[CONF_PASSWORD]
     session = DecoraWiFiSession()
+    user = await hass.async_add_executor_job(lambda: session.login(email, password))
+    if not user:
+        raise RuntimeError("config error")
+    # Assert logged in
 
     try:
-        success = session.login(email, password)
-
-        # If login failed, notify user.
-        if success is None:
-            msg = "Failed to log into myLeviton Services. Check credentials."
-            _LOGGER.error(msg)
-            persistent_notification.create(
-                hass, msg, title=NOTIFICATION_TITLE, notification_id=NOTIFICATION_ID
-            )
-            return
-
-        # Gather all the available devices...
-        perms = session.user.get_residential_permissions()
         all_switches = []
+        # Gather all the available devices...
+
+        # PENDING better handling for this async stuff
+        perms = await hass.async_add_executor_job(
+            session.user.get_residential_permissions
+        )
         for permission in perms:
             if permission.residentialAccountId is not None:
                 acct = ResidentialAccount(session, permission.residentialAccountId)
-                for residence in acct.get_residences():
-                    for switch in residence.get_iot_switches():
+                residences = await hass.async_add_executor_job(acct.get_residences)
+                for residence in residences:
+                    switches = await hass.async_add_executor_job(
+                        residence.get_iot_switches
+                    )
+                    for switch in switches:
                         all_switches.append(switch)
             elif permission.residenceId is not None:
                 residence = Residence(session, permission.residenceId)
-                for switch in residence.get_iot_switches():
+                switches = await hass.async_add_executor_job(residence.get_iot_switches)
+                for switch in switches:
                     all_switches.append(switch)
 
-        add_entities(DecoraWifiLight(sw) for sw in all_switches)
+        async_add_entities([DecoraWifiLight(sw) for sw in all_switches])
+
     except ValueError:
         _LOGGER.error("Failed to communicate with myLeviton Service")
 
@@ -87,7 +89,7 @@ def setup_platform(
         except ValueError:
             _LOGGER.error("Failed to log out of myLeviton Service")
 
-    hass.bus.listen(EVENT_HOMEASSISTANT_STOP, logout)
+    # hass.bus.listen(EVENT_HOMEASSISTANT_STOP, logout)
 
 
 class DecoraWifiLight(LightEntity):
@@ -171,3 +173,18 @@ class DecoraWifiLight(LightEntity):
             self._switch.refresh()
         except ValueError:
             _LOGGER.error("Failed to update myLeviton switch data")
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={
+                # Serial numbers are unique identifiers within a specific domain
+                (DOMAIN, self.unique_id)
+            },
+            name=self.name,
+            # manufacturer=self.light.manufacturername,
+            # model=self.light.productname,
+            # sw_version=self.light.swversion,
+            # via_device=(hue.DOMAIN, self.api.bridgeid),
+        )

--- a/homeassistant/components/decora_wifi/light.py
+++ b/homeassistant/components/decora_wifi/light.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from decora_wifi import DecoraWiFiSession
 from decora_wifi.models.residence import Residence
 from decora_wifi.models.residential_account import ResidentialAccount
 import voluptuous as vol
@@ -23,7 +24,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DecoraComponentData
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -42,10 +42,9 @@ async def async_setup_entry(
 ) -> None:
     """Set up Decora Wifi Switches."""
 
-    component: DecoraComponentData = hass.data[DOMAIN][entry.entry_id]
+    session: DecoraWiFiSession = hass.data[DOMAIN][entry.entry_id]
 
     try:
-        session = component.session
         assert session.user
 
         perms = await hass.async_add_executor_job(

--- a/homeassistant/components/decora_wifi/light.py
+++ b/homeassistant/components/decora_wifi/light.py
@@ -33,9 +33,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {vol.Required(CONF_USERNAME): cv.string, vol.Required(CONF_PASSWORD): cv.string}
 )
 
-NOTIFICATION_ID = "leviton_notification"
-NOTIFICATION_TITLE = "myLeviton Decora Setup"
-
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback

--- a/homeassistant/components/decora_wifi/light.py
+++ b/homeassistant/components/decora_wifi/light.py
@@ -5,6 +5,8 @@ import logging
 from typing import Any
 
 from decora_wifi import DecoraWiFiSession
+from decora_wifi.models.iot_switch import IotSwitch
+from decora_wifi.models.permission import Permission
 from decora_wifi.models.residence import Residence
 from decora_wifi.models.residential_account import ResidentialAccount
 import voluptuous as vol
@@ -40,31 +42,14 @@ async def async_setup_entry(
     """Set up the Decora WiFi platform."""
 
     session: DecoraWiFiSession = hass.data[DOMAIN][entry.entry_id]
-
+    asyncSession = DecoraWifiAsyncClient(session, hass)
     try:
-        assert session.user
+        permissions = await asyncSession.get_permissions()
+        residences = await asyncSession.get_residences(permissions)
+        iot_switches = await asyncSession.get_iot_switches(residences)
+        async_add_entities([DecoraWifiLight(e) for e in iot_switches])
 
-        perms = await hass.async_add_executor_job(
-            session.user.get_residential_permissions
-        )
-        residences: list[Residence] = []
-        for permission in perms:
-            if permission.residentialAccountId is not None:
-                account = ResidentialAccount(session, permission.residentialAccountId)
-                residences.extend(
-                    await hass.async_add_executor_job(account.get_residences)
-                )
-            elif permission.residenceId is not None:
-                residences.append(Residence(session, permission.residenceId))
-
-        switches = [
-            DecoraWifiLight(sw)
-            for res in residences
-            for sw in (await hass.async_add_executor_job(res.get_iot_switches))
-        ]
-
-        async_add_entities(switches)
-
+    # As of the current release of the decora wifi lib (1.4), all api errors raise a generic ValueError
     except ValueError:
         _LOGGER.error("Failed to communicate with myLeviton Service")
 
@@ -165,3 +150,40 @@ class DecoraWifiLight(LightEntity):
             sw_version=self._switch.version,
             serial_number=self._switch.serial,
         )
+
+
+class DecoraWifiAsyncClient:
+    """A thin wrapper to make async calls more readable."""
+
+    def __init__(self, session: DecoraWiFiSession, hass: HomeAssistant) -> None:
+        """DecoraWifiAsyncClient."""
+        self.session = session
+        self.hass = hass
+
+    async def get_permissions(self):
+        """Get all permissions for the provided session."""
+        assert self.session.user
+        return await self.hass.async_add_executor_job(
+            self.session.user.get_residential_permissions
+        )
+
+    async def get_residences(self, permissions: list[Permission]):
+        """Get all residences for the provided permissions."""
+        residences: list[Residence] = []
+        for perm in permissions:
+            if perm.residentialAccountId is not None:
+                account = ResidentialAccount(self.session, perm.residentialAccountId)
+                residences.extend(
+                    await self.hass.async_add_executor_job(account.get_residences)
+                )
+            elif perm.residenceId is not None:
+                residences.append(Residence(self.session, perm.residenceId))
+        return residences
+
+    async def get_iot_switches(self, residences: list[Residence]) -> list[IotSwitch]:
+        """Get all the iot switches for the provided residences."""
+        return [
+            sw
+            for res in residences
+            for sw in (await self.hass.async_add_executor_job(res.get_iot_switches))
+        ]

--- a/homeassistant/components/decora_wifi/light.py
+++ b/homeassistant/components/decora_wifi/light.py
@@ -37,7 +37,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Set up Decora Wifi Switches."""
+    """Set up the Decora WiFi platform."""
 
     session: DecoraWiFiSession = hass.data[DOMAIN][entry.entry_id]
 
@@ -58,12 +58,12 @@ async def async_setup_entry(
                 residences.append(Residence(session, permission.residenceId))
 
         switches = [
-            sw
+            DecoraWifiLight(sw)
             for res in residences
             for sw in (await hass.async_add_executor_job(res.get_iot_switches))
         ]
 
-        async_add_entities([DecoraWifiLight(sw) for sw in switches])
+        async_add_entities(switches)
 
     except ValueError:
         _LOGGER.error("Failed to communicate with myLeviton Service")

--- a/homeassistant/components/decora_wifi/light.py
+++ b/homeassistant/components/decora_wifi/light.py
@@ -78,7 +78,7 @@ class DecoraWifiLight(LightEntity):
         self._switch = switch
         self._attr_unique_id = switch.serial
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self.unique_id)},
+            identifiers={(DOMAIN, switch.serial)},
             name=switch.name,
             manufacturer=switch.manufacturer,
             model=switch.model,

--- a/homeassistant/components/decora_wifi/light.py
+++ b/homeassistant/components/decora_wifi/light.py
@@ -188,3 +188,13 @@ class DecoraWifiLight(LightEntity):
             # sw_version=self.light.swversion,
             # via_device=(hue.DOMAIN, self.api.bridgeid),
         )
+
+    # async def async_added_to_hass(self) -> None:
+    #     """Subscribe to Abode connection status updates."""
+    #     await self.hass.async_add_executor_job(
+    #         self._data.abode.events.add_connection_status_callback,
+    #         self.unique_id,
+    #         self._update_connection_status,
+    #     )
+
+    #     self.hass.data[DOMAIN].entity_ids.add(self.entity_id)

--- a/homeassistant/components/decora_wifi/light.py
+++ b/homeassistant/components/decora_wifi/light.py
@@ -79,11 +79,11 @@ class DecoraWifiLight(LightEntity):
         self._attr_unique_id = switch.serial
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self.unique_id)},
-            name=self.name,
-            manufacturer=self._switch.manufacturer,
-            model=self._switch.model,
-            sw_version=self._switch.version,
-            serial_number=self._switch.serial,
+            name=switch.name,
+            manufacturer=switch.manufacturer,
+            model=switch.model,
+            sw_version=switch.version,
+            serial_number=switch.serial,
         )
 
     @property

--- a/homeassistant/components/decora_wifi/light.py
+++ b/homeassistant/components/decora_wifi/light.py
@@ -58,6 +58,14 @@ class DecoraWifiLight(LightEntity):
         """Initialize the switch."""
         self._switch = switch
         self._attr_unique_id = switch.serial
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self.unique_id)},
+            name=self.name,
+            manufacturer=self._switch.manufacturer,
+            model=self._switch.model,
+            sw_version=self._switch.version,
+            serial_number=self._switch.serial,
+        )
 
     @property
     def color_mode(self) -> str:
@@ -132,18 +140,3 @@ class DecoraWifiLight(LightEntity):
             self._switch.refresh()
         except ValueError:
             _LOGGER.error("Failed to update myLeviton switch data")
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return the device info."""
-        return DeviceInfo(
-            identifiers={
-                # Serial numbers are unique identifiers within a specific domain
-                (DOMAIN, self.unique_id)
-            },
-            name=self.name,
-            manufacturer=self._switch.manufacturer,
-            model=self._switch.model,
-            sw_version=self._switch.version,
-            serial_number=self._switch.serial,
-        )

--- a/homeassistant/components/decora_wifi/light.py
+++ b/homeassistant/components/decora_wifi/light.py
@@ -18,6 +18,7 @@ from homeassistant.components.light import (
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -60,11 +61,13 @@ async def async_setup_entry(
         permissions = await asyncSession.get_permissions()
         residences = await asyncSession.get_residences(permissions)
         iot_switches = await asyncSession.get_iot_switches(residences)
-        async_add_entities([DecoraWifiLight(e) for e in iot_switches])
 
     # As of the current release of the decora wifi lib (1.4), all api errors raise a generic ValueError
-    except ValueError:
+    except ValueError as err:
         _LOGGER.error("Failed to communicate with myLeviton Service")
+        raise ConfigEntryNotReady from err
+
+    async_add_entities([DecoraWifiLight(e) for e in iot_switches])
 
 
 class DecoraWifiLight(LightEntity):

--- a/homeassistant/components/decora_wifi/light.py
+++ b/homeassistant/components/decora_wifi/light.py
@@ -78,7 +78,7 @@ class DecoraWifiLight(LightEntity):
         self._switch = switch
         self._attr_unique_id = switch.serial
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, switch.serial)},
+            identifiers={(DOMAIN, self.unique_id)},
             name=switch.name,
             manufacturer=switch.manufacturer,
             model=switch.model,

--- a/homeassistant/components/decora_wifi/light.py
+++ b/homeassistant/components/decora_wifi/light.py
@@ -5,10 +5,6 @@ import logging
 from typing import Any
 
 from decora_wifi import DecoraWiFiSession
-from decora_wifi.models.iot_switch import IotSwitch
-from decora_wifi.models.permission import Permission
-from decora_wifi.models.residence import Residence
-from decora_wifi.models.residential_account import ResidentialAccount
 import voluptuous as vol
 
 from homeassistant.components.light import (
@@ -26,6 +22,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import DecoraWifiAsyncClient
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -150,40 +147,3 @@ class DecoraWifiLight(LightEntity):
             sw_version=self._switch.version,
             serial_number=self._switch.serial,
         )
-
-
-class DecoraWifiAsyncClient:
-    """A thin wrapper to make async calls more readable."""
-
-    def __init__(self, session: DecoraWiFiSession, hass: HomeAssistant) -> None:
-        """DecoraWifiAsyncClient."""
-        self.session = session
-        self.hass = hass
-
-    async def get_permissions(self):
-        """Get all permissions for the provided session."""
-        assert self.session.user
-        return await self.hass.async_add_executor_job(
-            self.session.user.get_residential_permissions
-        )
-
-    async def get_residences(self, permissions: list[Permission]):
-        """Get all residences for the provided permissions."""
-        residences: list[Residence] = []
-        for perm in permissions:
-            if perm.residentialAccountId is not None:
-                account = ResidentialAccount(self.session, perm.residentialAccountId)
-                residences.extend(
-                    await self.hass.async_add_executor_job(account.get_residences)
-                )
-            elif perm.residenceId is not None:
-                residences.append(Residence(self.session, perm.residenceId))
-        return residences
-
-    async def get_iot_switches(self, residences: list[Residence]) -> list[IotSwitch]:
-        """Get all the iot switches for the provided residences."""
-        return [
-            sw
-            for res in residences
-            for sw in (await self.hass.async_add_executor_job(res.get_iot_switches))
-        ]

--- a/homeassistant/components/decora_wifi/light.py
+++ b/homeassistant/components/decora_wifi/light.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from decora_wifi import DecoraWiFiSession
-from decora_wifi.models.person import Person
 from decora_wifi.models.residence import Residence
 from decora_wifi.models.residential_account import ResidentialAccount
 import voluptuous as vol
@@ -25,6 +23,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import DecoraComponentData
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -42,60 +41,42 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Will write later."""
-    # data = hass.data[DOMAIN]
-    email = entry.data[CONF_USERNAME]
-    password = entry.data[CONF_PASSWORD]
-    session = DecoraWiFiSession()
-    user = await hass.async_add_executor_job(lambda: session.login(email, password))
-    if not user:
-        raise RuntimeError("config error")
-    # Assert logged in
+
+    component: DecoraComponentData = hass.data[DOMAIN][entry.entry_id]
 
     try:
-        all_switches = []
-        # Gather all the available devices...
+        session = component.session
+        assert session.user
 
-        # PENDING better handling for this async stuff
         perms = await hass.async_add_executor_job(
             session.user.get_residential_permissions
         )
+        residences: list[Residence] = []
         for permission in perms:
             if permission.residentialAccountId is not None:
-                acct = ResidentialAccount(session, permission.residentialAccountId)
-                residences = await hass.async_add_executor_job(acct.get_residences)
-                for residence in residences:
-                    switches = await hass.async_add_executor_job(
-                        residence.get_iot_switches
-                    )
-                    for switch in switches:
-                        all_switches.append(switch)
+                account = ResidentialAccount(session, permission.residentialAccountId)
+                residences.extend(
+                    await hass.async_add_executor_job(account.get_residences)
+                )
             elif permission.residenceId is not None:
-                residence = Residence(session, permission.residenceId)
-                switches = await hass.async_add_executor_job(residence.get_iot_switches)
-                for switch in switches:
-                    all_switches.append(switch)
+                residences.append(Residence(session, permission.residenceId))
 
-        async_add_entities([DecoraWifiLight(sw) for sw in all_switches])
+        switches = [
+            sw
+            for res in residences
+            for sw in (await hass.async_add_executor_job(res.get_iot_switches))
+        ]
+
+        async_add_entities([DecoraWifiLight(sw) for sw in switches])
 
     except ValueError:
         _LOGGER.error("Failed to communicate with myLeviton Service")
-
-    # Listen for the stop event and log out.
-    def logout(event):
-        """Log out..."""
-        try:
-            if session is not None:
-                Person.logout(session)
-        except ValueError:
-            _LOGGER.error("Failed to log out of myLeviton Service")
-
-    # hass.bus.listen(EVENT_HOMEASSISTANT_STOP, logout)
 
 
 class DecoraWifiLight(LightEntity):
     """Representation of a Decora WiFi switch."""
 
-    def __init__(self, switch):
+    def __init__(self, switch) -> None:
         """Initialize the switch."""
         self._switch = switch
         self._attr_unique_id = switch.serial
@@ -120,22 +101,22 @@ class DecoraWifiLight(LightEntity):
         return LightEntityFeature(0)
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the display name of this switch."""
         return self._switch.name
 
     @property
-    def unique_id(self):
+    def unique_id(self) -> str:
         """Return the ID of this light."""
         return self._switch.serial
 
     @property
-    def brightness(self):
+    def brightness(self) -> int:
         """Return the brightness of the dimmer switch."""
         return int(self._switch.brightness * 255 / 100)
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool:
         """Return true if switch is on."""
         return self._switch.power == "ON"
 
@@ -183,18 +164,8 @@ class DecoraWifiLight(LightEntity):
                 (DOMAIN, self.unique_id)
             },
             name=self.name,
-            # manufacturer=self.light.manufacturername,
-            # model=self.light.productname,
-            # sw_version=self.light.swversion,
-            # via_device=(hue.DOMAIN, self.api.bridgeid),
+            manufacturer=self._switch.manufacturer,
+            model=self._switch.model,
+            sw_version=self._switch.version,
+            serial_number=self._switch.serial,
         )
-
-    # async def async_added_to_hass(self) -> None:
-    #     """Subscribe to Abode connection status updates."""
-    #     await self.hass.async_add_executor_job(
-    #         self._data.abode.events.add_connection_status_callback,
-    #         self.unique_id,
-    #         self._update_connection_status,
-    #     )
-
-    #     self.hass.data[DOMAIN].entity_ids.add(self.entity_id)

--- a/homeassistant/components/decora_wifi/manifest.json
+++ b/homeassistant/components/decora_wifi/manifest.json
@@ -2,6 +2,7 @@
   "domain": "decora_wifi",
   "name": "Leviton Decora Wi-Fi",
   "codeowners": [],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/decora_wifi",
   "iot_class": "cloud_polling",
   "loggers": ["decora_wifi"],

--- a/homeassistant/components/decora_wifi/strings.json
+++ b/homeassistant/components/decora_wifi/strings.json
@@ -2,15 +2,21 @@
   "config": {
     "step": {
       "user": {
-        "title": "Add Group",
-        "description": "Some description",
+        "title": "Setup Decora Wifi",
+        "description": "Your my.leviton.com Credentials",
         "data": {
-          "entities": "Entities"
-        },
-        "data_description": {
-          "entities": "The entities to add to the group"
+          "email": "Email",
+          "password": "Password"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   }
 }

--- a/homeassistant/components/decora_wifi/strings.json
+++ b/homeassistant/components/decora_wifi/strings.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Add Group",
+        "description": "Some description",
+        "data": {
+          "entities": "Entities"
+        },
+        "data_description": {
+          "entities": "The entities to add to the group"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/decora_wifi/strings.json
+++ b/homeassistant/components/decora_wifi/strings.json
@@ -3,9 +3,9 @@
     "step": {
       "user": {
         "title": "Setup Decora Wifi",
-        "description": "Your my.leviton.com Credentials",
+        "description": "Your my.leviton.com credentials",
         "data": {
-          "email": "Email",
+          "username": "Username",
           "password": "Password"
         }
       }
@@ -16,7 +16,7 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
     }
   }
 }

--- a/homeassistant/components/decora_wifi/strings.json
+++ b/homeassistant/components/decora_wifi/strings.json
@@ -5,8 +5,8 @@
         "title": "Setup Decora Wifi",
         "description": "Your my.leviton.com credentials",
         "data": {
-          "username": "Username",
-          "password": "Password"
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
         }
       }
     },

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -93,6 +93,7 @@ FLOWS = {
         "crownstone",
         "daikin",
         "deconz",
+        "decora_wifi",
         "deluge",
         "denonavr",
         "devialet",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -1019,7 +1019,7 @@
     "decora_wifi": {
       "name": "Leviton Decora Wi-Fi",
       "integration_type": "hub",
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "cloud_polling"
     },
     "delijn": {

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -541,6 +541,9 @@ dbus-fast==2.14.0
 # homeassistant.components.debugpy
 debugpy==1.8.0
 
+# homeassistant.components.decora_wifi
+# decora-wifi==1.4
+
 # homeassistant.components.ihc
 # homeassistant.components.namecheapdns
 # homeassistant.components.ohmconnect

--- a/tests/components/decora_wifi/__init__.py
+++ b/tests/components/decora_wifi/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Decora Wifi integration."""

--- a/tests/components/decora_wifi/test_config_flow.py
+++ b/tests/components/decora_wifi/test_config_flow.py
@@ -105,7 +105,6 @@ async def test_duplicate_error(hass: HomeAssistant) -> None:
     ):
         await entry.async_setup(hass)
         await hass.async_block_till_done()
-
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data=CONFIG
         )
@@ -133,27 +132,3 @@ async def test_async_step_import_success(hass: HomeAssistant) -> None:
         CONF_USERNAME: "test-email",
         CONF_PASSWORD: "test-password",
     }
-
-
-async def test_async_step_import_incomplete(hass: HomeAssistant) -> None:
-    """Test import step failure."""
-
-    with patch(
-        "homeassistant.components.decora_wifi.config_flow.DecoraWiFiSession.login",
-        return_value=True,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={CONF_USERNAME: "test-email"},
-        )
-
-        assert result["type"] == FlowResultType.FORM
-
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={CONF_USERNAME: "test-email", CONF_PASSWORD: "test-password"},
-        )
-
-        assert result["type"] == FlowResultType.CREATE_ENTRY

--- a/tests/components/decora_wifi/test_config_flow.py
+++ b/tests/components/decora_wifi/test_config_flow.py
@@ -1,0 +1,80 @@
+"""Test the decora_wifi config flow."""
+from unittest.mock import patch
+
+from homeassistant import config_entries
+from homeassistant.components.decora_wifi.config_flow import CannotConnect
+from homeassistant.components.decora_wifi.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+
+async def test_form(hass: HomeAssistant) -> None:
+    """Test we get the form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert not result["errors"]
+    with patch(
+        "homeassistant.components.decora_wifi.config_flow.DecoraWiFiSession.login",
+        return_value=True,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "email": "test-email",
+                "password": "test-password",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "test-email"
+    assert result2["data"] == {
+        "email": "test-email",
+        "password": "test-password",
+    }
+
+
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.decora_wifi.config_flow.DecoraWiFiSession.login",
+        return_value=False,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "email": "test-email",
+                "password": "bad-password",
+            },
+        )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.decora_wifi.config_flow.DecoraWiFiSession.login",
+        side_effect=CannotConnect,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "email": "test-email",
+                "password": "bad-password",
+            },
+        )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "cannot_connect"}

--- a/tests/components/decora_wifi/test_config_flow.py
+++ b/tests/components/decora_wifi/test_config_flow.py
@@ -5,7 +5,10 @@ from homeassistant import config_entries
 from homeassistant.components.decora_wifi.config_flow import CannotConnect
 from homeassistant.components.decora_wifi.const import DOMAIN
 from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
 
 
 async def test_form(hass: HomeAssistant) -> None:
@@ -22,17 +25,17 @@ async def test_form(hass: HomeAssistant) -> None:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                "email": "test-email",
-                "password": "test-password",
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
             },
         )
         await hass.async_block_till_done()
 
     assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "test-email"
+    assert result2["title"] == "test-username"
     assert result2["data"] == {
-        "email": "test-email",
-        "password": "test-password",
+        CONF_USERNAME: "test-username",
+        CONF_PASSWORD: "test-password",
     }
 
 
@@ -49,8 +52,8 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                "email": "test-email",
-                "password": "bad-password",
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "bad-password",
             },
         )
 
@@ -71,10 +74,58 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                "email": "test-email",
-                "password": "bad-password",
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "bad-password",
             },
         )
 
     assert result2["type"] == FlowResultType.FORM
     assert result2["errors"] == {"base": "cannot_connect"}
+
+
+async def test_duplicate_error(hass: HomeAssistant) -> None:
+    """Test that it disallows creating w/ same "username."""
+    CONFIG = {
+        CONF_USERNAME: "test-username",
+        CONF_PASSWORD: "test-password",
+    }
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="test-username", data=CONFIG)
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.decora_wifi.config_flow.DecoraWiFiSession.login",
+        return_value=True,
+    ):
+        await entry.async_setup(hass)
+        await hass.async_block_till_done()
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}, data=CONFIG
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+
+
+# async def test_async_step_import_success(hass: HomeAssistant) -> None:
+#     """Test import step success."""
+#     with patch("pyvera.VeraController") as vera_controller_class_mock:
+#         controller = MagicMock()
+#         controller.refresh_data = MagicMock()
+#         controller.serial_number = "serial_number_1"
+#         vera_controller_class_mock.return_value = controller
+
+#         result = await hass.config_entries.flow.async_init(
+#             DOMAIN,
+#             context={"source": config_entries.SOURCE_IMPORT},
+#             data={CONF_CONTROLLER: "http://127.0.0.1:123/"},
+#         )
+
+#         assert result["type"] == FlowResultType.CREATE_ENTRY
+#         assert result["title"] == "http://127.0.0.1:123"
+#         assert result["data"] == {
+#             CONF_CONTROLLER: "http://127.0.0.1:123",
+#             CONF_SOURCE: config_entries.SOURCE_IMPORT,
+#             CONF_LEGACY_UNIQUE_ID: False,
+#         }
+#         assert result["result"].unique_id == controller.serial_number

--- a/tests/components/decora_wifi/test_light.py
+++ b/tests/components/decora_wifi/test_light.py
@@ -1,0 +1,35 @@
+"""Test Decora Wifi Light Platform."""
+from unittest.mock import patch
+
+from homeassistant.components.decora_wifi import DOMAIN
+from homeassistant.config_entries import ConfigEntryState, ConfigType
+from homeassistant.const import CONF_PASSWORD, CONF_PLATFORM, CONF_USERNAME, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.setup import async_setup_component
+
+LEGACY_CONFIG: ConfigType = {
+    Platform.LIGHT: [
+        {
+            CONF_PLATFORM: DOMAIN,
+            CONF_USERNAME: "test-username",
+            CONF_PASSWORD: "test-password",
+        }
+    ]
+}
+
+
+async def test_legacy_migration(hass: HomeAssistant) -> None:
+    """Test migration from yaml to config flow."""
+
+    with patch(
+        "homeassistant.components.decora_wifi.config_flow.DecoraWiFiSession.login",
+        return_value=True,
+    ):
+        assert await async_setup_component(hass, Platform.LIGHT, LEGACY_CONFIG)
+        await hass.async_block_till_done()
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].state is ConfigEntryState.LOADED
+    issue_registry = ir.async_get(hass)
+    assert len(issue_registry.issues) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Migrate `decora_wifi` from platform config yaml to ConfigFlow via UI.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
[Leviton Decora Wifi](https://www.home-assistant.io/integrations/decora_wifi/) currently requires manual configuration, and only "entities" are added. This PR:
* Add Config Flow for Decora Wifi Integration, including validation of credentials
* Adds `DeviceInfo`, including fields previously not read by integration
* Wrapped Client calls into thin async client wrapper for clarify

If this change is green light, I will prepare a PR for homeassistant.io docs as well. 
We may be able to re-use [this PR](https://github.com/home-assistant/home-assistant.io/pull/22005))

#### Previous PR
Realized after creating this PR that similar PR was created last year, although it was never completed. I think they are similar, however decided to keep mine since the other was 1.5 years old and used some custom pattern vs established ones (e.g. used "trigger_import" vs "step_import" for importing yaml)
https://github.com/home-assistant/core/pull/68093/files

#### Additional Notes
1. MyLeviton uses "email" for authentication, but to improve backwards compatibility, keeping config key  as "USERNAME".

2. I am wondering if the correct entity for this integration should have been `Switch` and not `Light` since it control "Switches". Note even the api call is "get_iot_switches". It's likely they are controlling "lights", but also entirely possible they are controlling "outlets" or other devices. If we were to use the type switch instead, users could map switch to lights using "Switch As X" [integration](https://www.home-assistant.io/integrations/switch_as_x/). 
Obviously this change would be out of scope for this PR but curious if reviewers have any thoughts on this, and if it makes sense to consider or best way to handle type changes like this.

#### Code Owner
According to [adr-0008](https://github.com/home-assistant/architecture/blob/master/adr/0008-code-owners.md), this might be considered a new feature or substantial refactor and therefore call for being added to `CODEOWNERS`.
Please let me know if this is not the case


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: We may be able to re-use this one https://github.com/home-assistant/home-assistant.io/pull/22005/files


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


### Tests

1. Setup account, ensured device was loaded and successfully controlled. Deleted and re-added.
2. Ran with credentials in `configuration.yaml`, ensured config was migrated into new integration
3. Ensure deprecation message was shown for the case above
4. Attempted to add account twice with same email, got expected "already registered error" 

<img width="1165" alt="image" src="https://github.com/home-assistant/core/assets/9513968/8a3003af-502e-46f1-9f46-1fd58ed8f12f">

<img width="1005" alt="image" src="https://github.com/home-assistant/core/assets/9513968/5de9595e-93d0-4377-9261-923965c650b0">
