### PR TITLE
Remove duplicate fixture from bsblan

### DIFF
--- a/tests/components/bsblan/conftest.py
+++ b/tests/components/bsblan/conftest.py
@@ -39,24 +39,14 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_bsblan_config_flow() -> Generator[None, MagicMock, None]:
-    """Return a mocked BSBLAN client."""
-    with patch(
-        "homeassistant.components.bsblan.config_flow.BSBLAN", autospec=True
-    ) as bsblan_mock:
-        bsblan = bsblan_mock.return_value
-        bsblan.device.return_value = Device.parse_raw(
-            load_fixture("device.json", DOMAIN)
-        )
-        bsblan.info.return_value = Info.parse_raw(load_fixture("info.json", DOMAIN))
-        yield bsblan
-
-
-@pytest.fixture
 def mock_bsblan(request: pytest.FixtureRequest) -> Generator[None, MagicMock, None]:
     """Return a mocked BSBLAN client."""
 
-    with patch("homeassistant.components.bsblan.BSBLAN", autospec=True) as bsblan_mock:
+    with patch(
+        "homeassistant.components.bsblan.BSBLAN", autospec=True
+    ) as bsblan_mock, patch(
+        "homeassistant.components.bsblan.config_flow.BSBLAN", new=bsblan_mock
+    ):
         bsblan = bsblan_mock.return_value
         bsblan.info.return_value = Info.parse_raw(load_fixture("info.json", DOMAIN))
         bsblan.device.return_value = Device.parse_raw(

--- a/tests/components/bsblan/test_config_flow.py
+++ b/tests/components/bsblan/test_config_flow.py
@@ -16,7 +16,7 @@ from tests.common import MockConfigEntry
 
 async def test_full_user_flow_implementation(
     hass: HomeAssistant,
-    mock_bsblan_config_flow: MagicMock,
+    mock_bsblan: MagicMock,
     mock_setup_entry: AsyncMock,
 ) -> None:
     """Test the full manual user flow from start to finish."""
@@ -52,7 +52,7 @@ async def test_full_user_flow_implementation(
     assert result2["result"].unique_id == format_mac("00:80:41:19:69:90")
 
     assert len(mock_setup_entry.mock_calls) == 1
-    assert len(mock_bsblan_config_flow.device.mock_calls) == 1
+    assert len(mock_bsblan.device.mock_calls) == 1
 
 
 async def test_show_user_form(hass: HomeAssistant) -> None:
@@ -68,10 +68,10 @@ async def test_show_user_form(hass: HomeAssistant) -> None:
 
 async def test_connection_error(
     hass: HomeAssistant,
-    mock_bsblan_config_flow: MagicMock,
+    mock_bsblan: MagicMock,
 ) -> None:
     """Test we show user form on BSBLan connection error."""
-    mock_bsblan_config_flow.device.side_effect = BSBLANConnectionError
+    mock_bsblan.device.side_effect = BSBLANConnectionError
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -92,7 +92,7 @@ async def test_connection_error(
 
 async def test_user_device_exists_abort(
     hass: HomeAssistant,
-    mock_bsblan_config_flow: MagicMock,
+    mock_bsblan: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test we abort flow if BSBLAN device already configured."""


### PR DESCRIPTION
## Proposed change
Remove the almost double fixture for the config flow of bsblan.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
