### PR TITLE
Add significant Change support for remote

### DIFF
--- a/homeassistant/components/remote/significant_change.py
+++ b/homeassistant/components/remote/significant_change.py
@@ -1,0 +1,27 @@
+"""Helper to test significant Remote state changes."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.core import HomeAssistant, callback
+
+from . import ATTR_CURRENT_ACTIVITY
+
+
+@callback
+def async_check_significant_change(
+    hass: HomeAssistant,
+    old_state: str,
+    old_attrs: dict,
+    new_state: str,
+    new_attrs: dict,
+    **kwargs: Any,
+) -> bool | None:
+    """Test if state significantly changed."""
+    if old_state != new_state:
+        return True
+
+    if old_attrs.get(ATTR_CURRENT_ACTIVITY) != new_attrs.get(ATTR_CURRENT_ACTIVITY):
+        return True
+
+    return False

--- a/tests/components/remote/test_significant_change.py
+++ b/tests/components/remote/test_significant_change.py
@@ -1,0 +1,62 @@
+"""Test the Remote significant change platform."""
+from homeassistant.components.remote import ATTR_ACTIVITY_LIST, ATTR_CURRENT_ACTIVITY
+from homeassistant.components.remote.significant_change import (
+    async_check_significant_change,
+)
+
+
+async def test_significant_change() -> None:
+    """Detect Remote significant changes."""
+    # no change at all
+    attrs = {
+        ATTR_CURRENT_ACTIVITY: "playing",
+        ATTR_ACTIVITY_LIST: ["playing", "paused"],
+    }
+    assert not async_check_significant_change(None, "on", attrs, "on", attrs)
+
+    # change of state is significant
+    assert async_check_significant_change(None, "on", attrs, "off", attrs)
+
+    # change of current activity is significant
+    attrs = {
+        "old": {
+            ATTR_CURRENT_ACTIVITY: "playing",
+            ATTR_ACTIVITY_LIST: ["playing", "paused"],
+        },
+        "new": {
+            ATTR_CURRENT_ACTIVITY: "paused",
+            ATTR_ACTIVITY_LIST: ["playing", "paused"],
+        },
+    }
+    assert async_check_significant_change(None, "on", attrs["old"], "on", attrs["new"])
+
+    # change of list of possible activities is not significant
+    attrs = {
+        "old": {
+            ATTR_CURRENT_ACTIVITY: "playing",
+            ATTR_ACTIVITY_LIST: ["playing", "paused"],
+        },
+        "new": {
+            ATTR_CURRENT_ACTIVITY: "playing",
+            ATTR_ACTIVITY_LIST: ["playing"],
+        },
+    }
+    assert not async_check_significant_change(
+        None, "on", attrs["old"], "on", attrs["new"]
+    )
+
+    # change of any not official attribute is not significant
+    attrs = {
+        "old": {
+            ATTR_CURRENT_ACTIVITY: "playing",
+            ATTR_ACTIVITY_LIST: ["playing", "paused"],
+        },
+        "new": {
+            ATTR_CURRENT_ACTIVITY: "playing",
+            ATTR_ACTIVITY_LIST: ["playing", "paused"],
+            "not_official": "changed",
+        },
+    }
+    assert not async_check_significant_change(
+        None, "on", attrs["old"], "on", attrs["new"]
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #45660
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
