### PR TITLE
Use shorthand attributes in HVV departures

### DIFF
--- a/homeassistant/components/hvv_departures/binary_sensor.py
+++ b/homeassistant/components/hvv_departures/binary_sensor.py
@@ -125,6 +125,7 @@ class HvvDepartureBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
     _attr_attribution = ATTRIBUTION
     _attr_has_entity_name = True
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
 
     def __init__(self, coordinator, idx, config_entry):
         """Initialize."""
@@ -132,6 +133,22 @@ class HvvDepartureBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self.coordinator = coordinator
         self.idx = idx
         self.config_entry = config_entry
+
+        self._attr_name = coordinator.data[self.idx]["name"]
+        self._attr_unique_id = idx
+        self._attr_device_info = DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={
+                (
+                    DOMAIN,
+                    config_entry.entry_id,
+                    config_entry.data[CONF_STATION]["id"],
+                    config_entry.data[CONF_STATION]["type"],
+                )
+            },
+            manufacturer=MANUFACTURER,
+            name=f"Departures at {config_entry.data[CONF_STATION]['name']}",
+        )
 
     @property
     def is_on(self):
@@ -145,38 +162,6 @@ class HvvDepartureBinarySensor(CoordinatorEntity, BinarySensorEntity):
             self.coordinator.last_update_success
             and self.coordinator.data[self.idx]["available"]
         )
-
-    @property
-    def device_info(self):
-        """Return the device info for this sensor."""
-        return DeviceInfo(
-            entry_type=DeviceEntryType.SERVICE,
-            identifiers={
-                (
-                    DOMAIN,
-                    self.config_entry.entry_id,
-                    self.config_entry.data[CONF_STATION]["id"],
-                    self.config_entry.data[CONF_STATION]["type"],
-                )
-            },
-            manufacturer=MANUFACTURER,
-            name=f"Departures at {self.config_entry.data[CONF_STATION]['name']}",
-        )
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return self.coordinator.data[self.idx]["name"]
-
-    @property
-    def unique_id(self):
-        """Return a unique ID to use for this sensor."""
-        return self.idx
-
-    @property
-    def device_class(self):
-        """Return the class of this device, from component DEVICE_CLASSES."""
-        return BinarySensorDeviceClass.PROBLEM
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:

--- a/homeassistant/components/hvv_departures/binary_sensor.py
+++ b/homeassistant/components/hvv_departures/binary_sensor.py
@@ -134,7 +134,7 @@ class HvvDepartureBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self.idx = idx
         self.config_entry = config_entry
 
-        self._attr_name = coordinator.data[self.idx]["name"]
+        self._attr_name = coordinator.data[idx]["name"]
         self._attr_unique_id = idx
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,

--- a/homeassistant/components/hvv_departures/binary_sensor.py
+++ b/homeassistant/components/hvv_departures/binary_sensor.py
@@ -132,7 +132,6 @@ class HvvDepartureBinarySensor(CoordinatorEntity, BinarySensorEntity):
         super().__init__(coordinator)
         self.coordinator = coordinator
         self.idx = idx
-        self.config_entry = config_entry
 
         self._attr_name = coordinator.data[idx]["name"]
         self._attr_unique_id = idx

--- a/homeassistant/components/hvv_departures/sensor.py
+++ b/homeassistant/components/hvv_departures/sensor.py
@@ -73,6 +73,19 @@ class HVVDepartureSensor(SensorEntity):
         station_id = config_entry.data[CONF_STATION]["id"]
         station_type = config_entry.data[CONF_STATION]["type"]
         self._attr_unique_id = f"{config_entry.entry_id}-{station_id}-{station_type}"
+        self._attr_device_info = DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={
+                (
+                    DOMAIN,
+                    config_entry.entry_id,
+                    config_entry.data[CONF_STATION]["id"],
+                    config_entry.data[CONF_STATION]["type"],
+                )
+            },
+            manufacturer=MANUFACTURER,
+            name=config_entry.data[CONF_STATION]["name"],
+        )
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     async def async_update(self, **kwargs: Any) -> None:
@@ -165,20 +178,3 @@ class HVVDepartureSensor(SensorEntity):
                 }
             )
         self._attr_extra_state_attributes[ATTR_NEXT] = departures
-
-    @property
-    def device_info(self):
-        """Return the device info for this sensor."""
-        return DeviceInfo(
-            entry_type=DeviceEntryType.SERVICE,
-            identifiers={
-                (
-                    DOMAIN,
-                    self.config_entry.entry_id,
-                    self.config_entry.data[CONF_STATION]["id"],
-                    self.config_entry.data[CONF_STATION]["type"],
-                )
-            },
-            manufacturer=MANUFACTURER,
-            name=self.config_entry.data[CONF_STATION]["name"],
-        )


### PR DESCRIPTION
## Proposed change
SSIA
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/61778
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
