### PR TITLE
Partially revert #103807: Remove deprecated aux heat support from ESPHome climate entities

### DIFF
--- a/homeassistant/components/esphome/climate.py
+++ b/homeassistant/components/esphome/climate.py
@@ -173,8 +173,6 @@ class EsphomeClimateEntity(EsphomeEntity[ClimateInfo, ClimateState], ClimateEnti
             features |= ClimateEntityFeature.TARGET_TEMPERATURE
         if self._static_info.supports_target_humidity:
             features |= ClimateEntityFeature.TARGET_HUMIDITY
-        if self._static_info.supports_aux_heat:
-            features |= ClimateEntityFeature.AUX_HEAT
         if self.preset_modes:
             features |= ClimateEntityFeature.PRESET_MODE
         if self.fan_modes:
@@ -272,12 +270,6 @@ class EsphomeClimateEntity(EsphomeEntity[ClimateInfo, ClimateState], ClimateEnti
         """Return the humidity we try to reach."""
         return round(self._state.target_humidity)
 
-    @property
-    @esphome_state_property
-    def is_aux_heat(self) -> bool:
-        """Return the auxiliary heater state."""
-        return self._state.aux_heat
-
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature (and operation mode if set)."""
         data: dict[str, Any] = {"key": self._key}
@@ -326,11 +318,3 @@ class EsphomeClimateEntity(EsphomeEntity[ClimateInfo, ClimateState], ClimateEnti
         await self._client.climate_command(
             key=self._key, swing_mode=_SWING_MODES.from_hass(swing_mode)
         )
-
-    async def async_turn_aux_heat_on(self) -> None:
-        """Turn auxiliary heater on."""
-        await self._client.climate_command(key=self._key, aux_heat=True)
-
-    async def async_turn_aux_heat_off(self) -> None:
-        """Turn auxiliary heater off."""
-        await self._client.climate_command(key=self._key, aux_heat=False)

--- a/tests/components/esphome/test_climate.py
+++ b/tests/components/esphome/test_climate.py
@@ -15,7 +15,6 @@ from aioesphomeapi import (
 )
 
 from homeassistant.components.climate import (
-    ATTR_AUX_HEAT,
     ATTR_CURRENT_HUMIDITY,
     ATTR_FAN_MODE,
     ATTR_HUMIDITY,
@@ -29,7 +28,6 @@ from homeassistant.components.climate import (
     ATTR_TEMPERATURE,
     DOMAIN as CLIMATE_DOMAIN,
     FAN_HIGH,
-    SERVICE_SET_AUX_HEAT,
     SERVICE_SET_FAN_MODE,
     SERVICE_SET_HUMIDITY,
     SERVICE_SET_HVAC_MODE,
@@ -39,7 +37,7 @@ from homeassistant.components.climate import (
     SWING_BOTH,
     HVACMode,
 )
-from homeassistant.const import ATTR_ENTITY_ID, STATE_ON
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 
 
@@ -318,68 +316,6 @@ async def test_climate_entity_with_step_and_target_temp(
     mock_client.climate_command.assert_has_calls(
         [call(key=1, swing_mode=ClimateSwingMode.BOTH)]
     )
-    mock_client.climate_command.reset_mock()
-
-
-async def test_climate_entity_with_aux_heat(
-    hass: HomeAssistant, mock_client: APIClient, mock_generic_device_entry
-) -> None:
-    """Test a generic climate entity with aux heat."""
-    entity_info = [
-        ClimateInfo(
-            object_id="myclimate",
-            key=1,
-            name="my climate",
-            unique_id="my_climate",
-            supports_current_temperature=True,
-            supports_two_point_target_temperature=True,
-            supports_action=True,
-            visual_min_temperature=10.0,
-            visual_max_temperature=30.0,
-            supports_aux_heat=True,
-        )
-    ]
-    states = [
-        ClimateState(
-            key=1,
-            mode=ClimateMode.HEAT,
-            action=ClimateAction.HEATING,
-            current_temperature=30,
-            target_temperature=20,
-            fan_mode=ClimateFanMode.AUTO,
-            swing_mode=ClimateSwingMode.BOTH,
-            aux_heat=True,
-        )
-    ]
-    user_service = []
-    await mock_generic_device_entry(
-        mock_client=mock_client,
-        entity_info=entity_info,
-        user_service=user_service,
-        states=states,
-    )
-    state = hass.states.get("climate.test_myclimate")
-    assert state is not None
-    assert state.state == HVACMode.HEAT
-    attributes = state.attributes
-    assert attributes[ATTR_AUX_HEAT] == STATE_ON
-
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_AUX_HEAT,
-        {ATTR_ENTITY_ID: "climate.test_myclimate", ATTR_AUX_HEAT: False},
-        blocking=True,
-    )
-    mock_client.climate_command.assert_has_calls([call(key=1, aux_heat=False)])
-    mock_client.climate_command.reset_mock()
-
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_AUX_HEAT,
-        {ATTR_ENTITY_ID: "climate.test_myclimate", ATTR_AUX_HEAT: True},
-        blocking=True,
-    )
-    mock_client.climate_command.assert_has_calls([call(key=1, aux_heat=True)])
     mock_client.climate_command.reset_mock()
 
 


### PR DESCRIPTION
## Proposed change

Remove deprecated aux heat support from ESPHome climate entities.

This partially reverts #103807

Deprecation decision: home-assistant/architecture#932


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #103807
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
