### PR TITLE
Rename todo due_date_time parameter to due_datetime

### DIFF
--- a/homeassistant/components/todo/__init__.py
+++ b/homeassistant/components/todo/__init__.py
@@ -35,7 +35,7 @@ from .const import (
     ATTR_DESCRIPTION,
     ATTR_DUE,
     ATTR_DUE_DATE,
-    ATTR_DUE_DATE_TIME,
+    ATTR_DUE_DATETIME,
     DOMAIN,
     TodoItemStatus,
     TodoListEntityFeature,
@@ -73,7 +73,7 @@ TODO_ITEM_FIELDS = [
         required_feature=TodoListEntityFeature.SET_DUE_DATE_ON_ITEM,
     ),
     TodoItemFieldDescription(
-        service_field=ATTR_DUE_DATE_TIME,
+        service_field=ATTR_DUE_DATETIME,
         validation=vol.All(cv.datetime, dt_util.as_local),
         todo_item_field=ATTR_DUE,
         required_feature=TodoListEntityFeature.SET_DUE_DATETIME_ON_ITEM,
@@ -89,9 +89,7 @@ TODO_ITEM_FIELDS = [
 TODO_ITEM_FIELD_SCHEMA = {
     vol.Optional(desc.service_field): desc.validation for desc in TODO_ITEM_FIELDS
 }
-TODO_ITEM_FIELD_VALIDATIONS = [
-    cv.has_at_most_one_key(ATTR_DUE_DATE, ATTR_DUE_DATE_TIME)
-]
+TODO_ITEM_FIELD_VALIDATIONS = [cv.has_at_most_one_key(ATTR_DUE_DATE, ATTR_DUE_DATETIME)]
 
 
 def _validate_supported_features(

--- a/homeassistant/components/todo/const.py
+++ b/homeassistant/components/todo/const.py
@@ -6,7 +6,7 @@ DOMAIN = "todo"
 
 ATTR_DUE = "due"
 ATTR_DUE_DATE = "due_date"
-ATTR_DUE_DATE_TIME = "due_date_time"
+ATTR_DUE_DATETIME = "due_datetime"
 ATTR_DESCRIPTION = "description"
 
 

--- a/homeassistant/components/todo/services.yaml
+++ b/homeassistant/components/todo/services.yaml
@@ -29,7 +29,7 @@ add_item:
       example: "2023-11-17"
       selector:
         date:
-    due_date_time:
+    due_datetime:
       example: "2023-11-17 13:30:00"
       selector:
         datetime:
@@ -65,7 +65,7 @@ update_item:
       example: "2023-11-17"
       selector:
         date:
-    due_date_time:
+    due_datetime:
       example: "2023-11-17 13:30:00"
       selector:
         datetime:

--- a/homeassistant/components/todo/strings.json
+++ b/homeassistant/components/todo/strings.json
@@ -29,7 +29,7 @@
           "description": "The date the to-do item is expected to be completed."
         },
         "due_datetime": {
-          "name": "Due date time",
+          "name": "Due date and time",
           "description": "The date and time the to-do item is expected to be completed."
         },
         "description": {
@@ -59,7 +59,7 @@
           "description": "The date the to-do item is expected to be completed."
         },
         "due_datetime": {
-          "name": "Due date time",
+          "name": "Due date and time",
           "description": "The date and time the to-do item is expected to be completed."
         },
         "description": {

--- a/homeassistant/components/todo/strings.json
+++ b/homeassistant/components/todo/strings.json
@@ -28,7 +28,7 @@
           "name": "Due date",
           "description": "The date the to-do item is expected to be completed."
         },
-        "due_date_time": {
+        "due_datetime": {
           "name": "Due date time",
           "description": "The date and time the to-do item is expected to be completed."
         },
@@ -58,7 +58,7 @@
           "name": "Due date",
           "description": "The date the to-do item is expected to be completed."
         },
-        "due_date_time": {
+        "due_datetime": {
           "name": "Due date time",
           "description": "The date and time the to-do item is expected to be completed."
         },

--- a/tests/components/local_todo/test_todo.py
+++ b/tests/components/local_todo/test_todo.py
@@ -71,7 +71,7 @@ def set_time_zone(hass: HomeAssistant) -> None:
         ({}, {}),
         ({"due_date": "2023-11-17"}, {"due": "2023-11-17"}),
         (
-            {"due_date_time": "2023-11-17T11:30:00+00:00"},
+            {"due_datetime": "2023-11-17T11:30:00+00:00"},
             {"due": "2023-11-17T05:30:00-06:00"},
         ),
         ({"description": "Additional detail"}, {"description": "Additional detail"}),
@@ -118,7 +118,7 @@ async def test_add_item(
         ({}, {}),
         ({"due_date": "2023-11-17"}, {"due": "2023-11-17"}),
         (
-            {"due_date_time": "2023-11-17T11:30:00+00:00"},
+            {"due_datetime": "2023-11-17T11:30:00+00:00"},
             {"due": "2023-11-17T05:30:00-06:00"},
         ),
         ({"description": "Additional detail"}, {"description": "Additional detail"}),
@@ -213,7 +213,7 @@ async def test_bulk_remove(
         ({"status": "completed"}, {"status": "completed"}, "0"),
         ({"due_date": "2023-11-17"}, {"due": "2023-11-17"}, "1"),
         (
-            {"due_date_time": "2023-11-17T11:30:00+00:00"},
+            {"due_datetime": "2023-11-17T11:30:00+00:00"},
             {"due": "2023-11-17T05:30:00-06:00"},
             "1",
         ),

--- a/tests/components/todo/test_init.py
+++ b/tests/components/todo/test_init.py
@@ -354,10 +354,10 @@ async def test_add_item_service_raises(
         (
             {
                 "item": "Submit forms",
-                "due_date_time": f"2023-11-17T17:00:00{TEST_OFFSET}",
+                "due_datetime": f"2023-11-17T17:00:00{TEST_OFFSET}",
             },
             ValueError,
-            "does not support setting field 'due_date_time'",
+            "does not support setting field 'due_datetime'",
         ),
     ],
 )
@@ -396,7 +396,7 @@ async def test_add_item_service_invalid_input(
         ),
         (
             TodoListEntityFeature.SET_DUE_DATETIME_ON_ITEM,
-            {"item": "New item", "due_date_time": f"2023-11-13T17:00:00{TEST_OFFSET}"},
+            {"item": "New item", "due_datetime": f"2023-11-13T17:00:00{TEST_OFFSET}"},
             TodoItem(
                 summary="New item",
                 status=TodoItemStatus.NEEDS_ACTION,
@@ -405,7 +405,7 @@ async def test_add_item_service_invalid_input(
         ),
         (
             TodoListEntityFeature.SET_DUE_DATETIME_ON_ITEM,
-            {"item": "New item", "due_date_time": "2023-11-13T17:00:00+00:00"},
+            {"item": "New item", "due_datetime": "2023-11-13T17:00:00+00:00"},
             TodoItem(
                 summary="New item",
                 status=TodoItemStatus.NEEDS_ACTION,
@@ -414,7 +414,7 @@ async def test_add_item_service_invalid_input(
         ),
         (
             TodoListEntityFeature.SET_DUE_DATETIME_ON_ITEM,
-            {"item": "New item", "due_date_time": "2023-11-13"},
+            {"item": "New item", "due_datetime": "2023-11-13"},
             TodoItem(
                 summary="New item",
                 status=TodoItemStatus.NEEDS_ACTION,
@@ -663,7 +663,7 @@ async def test_update_item_service_invalid_input(
 @pytest.mark.parametrize(
     ("update_data"),
     [
-        ({"due_date_time": f"2023-11-13T17:00:00{TEST_OFFSET}"}),
+        ({"due_datetime": f"2023-11-13T17:00:00{TEST_OFFSET}"}),
         ({"due_date": "2023-11-13"}),
         ({"description": "Submit revised draft"}),
     ],
@@ -697,7 +697,7 @@ async def test_update_todo_item_field_unsupported(
         ),
         (
             TodoListEntityFeature.SET_DUE_DATETIME_ON_ITEM,
-            {"due_date_time": f"2023-11-13T17:00:00{TEST_OFFSET}"},
+            {"due_datetime": f"2023-11-13T17:00:00{TEST_OFFSET}"},
             TodoItem(
                 uid="1",
                 due=datetime.datetime(2023, 11, 13, 17, 0, 0, tzinfo=TEST_TIMEZONE),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- There are more occurences of datetime than date_time in our users docs. Rename the `due_date_time` parameter to `due_datetime` to match that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29900

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
