### PR TITLE
Assign specific error code for HomeAssistantError on websocket_api connection exceptions

### DIFF
--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -271,7 +271,7 @@ class ActiveConnection:
             err_message = "Timeout"
         elif isinstance(err, HomeAssistantError):
             err_message = str(err)
-            code = const.ERR_UNKNOWN_ERROR
+            code = const.ERR_HOME_ASSISTANT_ERROR
             translation_domain = err.translation_domain
             translation_key = err.translation_key
             translation_placeholders = err.translation_placeholders

--- a/tests/components/application_credentials/test_init.py
+++ b/tests/components/application_credentials/test_init.py
@@ -479,7 +479,7 @@ async def test_config_flow(
     resp = await client.cmd("delete", {"application_credentials_id": ID})
     assert not resp.get("success")
     assert "error" in resp
-    assert resp["error"].get("code") == "unknown_error"
+    assert resp["error"].get("code") == "home_assistant_error"
     assert (
         resp["error"].get("message")
         == "Cannot delete credential in use by integration fake_integration"

--- a/tests/components/blueprint/test_websocket_api.py
+++ b/tests/components/blueprint/test_websocket_api.py
@@ -438,7 +438,7 @@ async def test_delete_blueprint_in_use_by_automation(
         assert msg["id"] == 9
         assert not msg["success"]
         assert msg["error"] == {
-            "code": "unknown_error",
+            "code": "home_assistant_error",
             "message": "Blueprint in use",
         }
 
@@ -484,6 +484,6 @@ async def test_delete_blueprint_in_use_by_script(
         assert msg["id"] == 9
         assert not msg["success"]
         assert msg["error"] == {
-            "code": "unknown_error",
+            "code": "home_assistant_error",
             "message": "Blueprint in use",
         }

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -242,7 +242,7 @@ async def test_remove_config_entry_from_device(
     response = await ws_client.receive_json()
 
     assert not response["success"]
-    assert response["error"]["code"] == "unknown_error"
+    assert response["error"]["code"] == "home_assistant_error"
 
     # Make async_remove_config_entry_device return True
     can_remove = True
@@ -365,7 +365,7 @@ async def test_remove_config_entry_from_device_fails(
     response = await ws_client.receive_json()
 
     assert not response["success"]
-    assert response["error"]["code"] == "unknown_error"
+    assert response["error"]["code"] == "home_assistant_error"
     assert response["error"]["message"] == "Unknown config entry"
 
     # Try removing a config entry which does not support removal from the device
@@ -380,7 +380,7 @@ async def test_remove_config_entry_from_device_fails(
     response = await ws_client.receive_json()
 
     assert not response["success"]
-    assert response["error"]["code"] == "unknown_error"
+    assert response["error"]["code"] == "home_assistant_error"
     assert (
         response["error"]["message"] == "Config entry does not support device removal"
     )
@@ -397,7 +397,7 @@ async def test_remove_config_entry_from_device_fails(
     response = await ws_client.receive_json()
 
     assert not response["success"]
-    assert response["error"]["code"] == "unknown_error"
+    assert response["error"]["code"] == "home_assistant_error"
     assert response["error"]["message"] == "Unknown device"
 
     # Try removing a config entry from a device which it's not connected to
@@ -428,7 +428,7 @@ async def test_remove_config_entry_from_device_fails(
     response = await ws_client.receive_json()
 
     assert not response["success"]
-    assert response["error"]["code"] == "unknown_error"
+    assert response["error"]["code"] == "home_assistant_error"
     assert response["error"]["message"] == "Config entry not in device"
 
     # Try removing a config entry which can't be loaded from a device - allowed
@@ -443,5 +443,5 @@ async def test_remove_config_entry_from_device_fails(
     response = await ws_client.receive_json()
 
     assert not response["success"]
-    assert response["error"]["code"] == "unknown_error"
+    assert response["error"]["code"] == "home_assistant_error"
     assert response["error"]["message"] == "Integration not found"

--- a/tests/components/fritzbox/test_init.py
+++ b/tests/components/fritzbox/test_init.py
@@ -296,7 +296,7 @@ async def test_remove_device(
     )
     response = await ws_client.receive_json()
     assert not response["success"]
-    assert response["error"]["code"] == "unknown_error"
+    assert response["error"]["code"] == "home_assistant_error"
     await hass.async_block_till_done()
 
     # try to delete orphan_device

--- a/tests/components/group/test_config_flow.py
+++ b/tests/components/group/test_config_flow.py
@@ -699,4 +699,4 @@ async def test_option_flow_sensor_preview_config_entry_removed(
     )
     msg = await client.receive_json()
     assert not msg["success"]
-    assert msg["error"] == {"code": "unknown_error", "message": "Unknown error"}
+    assert msg["error"] == {"code": "home_assistant_error", "message": "Unknown error"}

--- a/tests/components/input_select/test_init.py
+++ b/tests/components/input_select/test_init.py
@@ -740,7 +740,7 @@ async def test_update_duplicates(
     )
     resp = await client.receive_json()
     assert not resp["success"]
-    assert resp["error"]["code"] == "unknown_error"
+    assert resp["error"]["code"] == "home_assistant_error"
     assert resp["error"]["message"] == "Duplicate options are not allowed"
 
     state = hass.states.get(input_entity_id)
@@ -812,7 +812,7 @@ async def test_ws_create_duplicates(
     )
     resp = await client.receive_json()
     assert not resp["success"]
-    assert resp["error"]["code"] == "unknown_error"
+    assert resp["error"]["code"] == "home_assistant_error"
     assert resp["error"]["message"] == "Duplicate options are not allowed"
 
     assert not hass.states.get(input_entity_id)

--- a/tests/components/tag/test_init.py
+++ b/tests/components/tag/test_init.py
@@ -131,5 +131,5 @@ async def test_tag_id_exists(
     await client.send_json({"id": 2, "type": f"{DOMAIN}/create", "tag_id": "test tag"})
     response = await client.receive_json()
     assert not response["success"]
-    assert response["error"]["code"] == "unknown_error"
+    assert response["error"]["code"] == "home_assistant_error"
     assert len(changes) == 0

--- a/tests/components/template/test_config_flow.py
+++ b/tests/components/template/test_config_flow.py
@@ -845,4 +845,4 @@ async def test_option_flow_sensor_preview_config_entry_removed(
     )
     msg = await client.receive_json()
     assert not msg["success"]
-    assert msg["error"] == {"code": "unknown_error", "message": "Unknown error"}
+    assert msg["error"] == {"code": "home_assistant_error", "message": "Unknown error"}

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -2327,7 +2327,7 @@ async def test_execute_script(
                 translation_key="test_error",
                 translation_placeholders={"option": "bla"},
             ),
-            "unknown_error",
+            "home_assistant_error",
         ),
         (
             ServiceValidationError(

--- a/tests/components/websocket_api/test_connection.py
+++ b/tests/components/websocket_api/test_connection.py
@@ -39,15 +39,15 @@ from tests.common import MockUser
         ),
         (
             exceptions.HomeAssistantError("Failed to do X"),
-            websocket_api.ERR_UNKNOWN_ERROR,
+            websocket_api.ERR_HOME_ASSISTANT_ERROR,
             "Failed to do X",
-            "Error handling message: Failed to do X (unknown_error) Mock User from 127.0.0.42 (Browser)",
+            "Error handling message: Failed to do X (home_assistant_error) Mock User from 127.0.0.42 (Browser)",
         ),
         (
             exceptions.ServiceValidationError("Failed to do X"),
-            websocket_api.ERR_UNKNOWN_ERROR,
+            websocket_api.ERR_HOME_ASSISTANT_ERROR,
             "Failed to do X",
-            "Error handling message: Failed to do X (unknown_error) Mock User from 127.0.0.42 (Browser)",
+            "Error handling message: Failed to do X (home_assistant_error) Mock User from 127.0.0.42 (Browser)",
         ),
         (
             ValueError("Really bad"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Assign specific error code for HomeAssistantError on websocket_api connection exceptions

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
