### PR TITLE
Bump bimmer-connected to 0.14.5

### DIFF
--- a/homeassistant/components/bmw_connected_drive/manifest.json
+++ b/homeassistant/components/bmw_connected_drive/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/bmw_connected_drive",
   "iot_class": "cloud_polling",
   "loggers": ["bimmer_connected"],
-  "requirements": ["bimmer-connected==0.14.3"]
+  "requirements": ["bimmer-connected[china]==0.14.5"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -526,7 +526,7 @@ beautifulsoup4==4.12.2
 bellows==0.37.1
 
 # homeassistant.components.bmw_connected_drive
-bimmer-connected==0.14.3
+bimmer-connected[china]==0.14.5
 
 # homeassistant.components.bizkaibus
 bizkaibus==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -448,7 +448,7 @@ beautifulsoup4==4.12.2
 bellows==0.37.1
 
 # homeassistant.components.bmw_connected_drive
-bimmer-connected==0.14.3
+bimmer-connected[china]==0.14.5
 
 # homeassistant.components.bluetooth
 bleak-retry-connector==3.3.0

--- a/tests/components/bmw_connected_drive/snapshots/test_diagnostics.ambr
+++ b/tests/components/bmw_connected_drive/snapshots/test_diagnostics.ambr
@@ -413,7 +413,6 @@
             'servicePack': 'WAVE_01',
           }),
           'fetched_at': '2022-07-10T11:00:00+00:00',
-          'is_metric': True,
           'mappingInfo': dict({
             'isAssociated': False,
             'isLmmEnabled': False,
@@ -1288,7 +1287,6 @@
             'servicePack': 'WAVE_01',
           }),
           'fetched_at': '2022-07-10T11:00:00+00:00',
-          'is_metric': True,
           'mappingInfo': dict({
             'isAssociated': False,
             'isLmmEnabled': False,
@@ -1979,7 +1977,6 @@
           'charging_settings': dict({
           }),
           'fetched_at': '2022-07-10T11:00:00+00:00',
-          'is_metric': True,
           'mappingInfo': dict({
             'isAssociated': False,
             'isLmmEnabled': False,
@@ -2734,7 +2731,6 @@
             'servicePack': 'TCB1',
           }),
           'fetched_at': '2022-07-10T11:00:00+00:00',
-          'is_metric': True,
           'mappingInfo': dict({
             'isPrimaryUser': True,
             'mappingStatus': 'CONFIRMED',
@@ -5070,7 +5066,6 @@
           'servicePack': 'TCB1',
         }),
         'fetched_at': '2022-07-10T11:00:00+00:00',
-        'is_metric': True,
         'mappingInfo': dict({
           'isPrimaryUser': True,
           'mappingStatus': 'CONFIRMED',


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump bimmer-connected to 0.14.5. If there still is a bugfix release before 2023.12, including this would be great.

0.14.5 fixes an error where reauthentication flows were triggered although this was not required. This only happened after a 429 Too Many Requests error which for some reason have started coming up this week.

0.14.4 adds a `[china]` extra so we do not require `Pillow` by default. We have multiple users still using Raspbian 32bit where no wheels are available and compiling proves to be difficult.

Diff: https://github.com/bimmerconnected/bimmer_connected/compare/0.14.3...0.14.5
Release notes:
- https://github.com/bimmerconnected/bimmer_connected/releases/tag/0.14.5
- https://github.com/bimmerconnected/bimmer_connected/releases/tag/0.14.4

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #104555
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
