### PR TITLE
Avoid db hit and executor job for impossible history queries

### DIFF
--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -21,7 +21,7 @@ import homeassistant.util.dt as dt_util
 
 from . import websocket_api
 from .const import DOMAIN
-from .helpers import entities_may_have_state_changes_after
+from .helpers import entities_may_have_state_changes_after, has_recorder_run_after
 
 CONF_ORDER = "use_include_order"
 
@@ -106,7 +106,8 @@ class HistoryPeriodView(HomeAssistantView):
         no_attributes = "no_attributes" in request.query
 
         if (
-            not include_start_time_state
+            (end_time and not has_recorder_run_after(hass, end_time))
+            or not include_start_time_state
             and entity_ids
             and not entities_may_have_state_changes_after(
                 hass, entity_ids, start_time, no_attributes

--- a/homeassistant/components/history/helpers.py
+++ b/homeassistant/components/history/helpers.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from collections.abc import Iterable
 from datetime import datetime as dt
 
+from homeassistant.components.recorder import get_instance
+from homeassistant.components.recorder.models import process_timestamp
 from homeassistant.core import HomeAssistant
 
 
@@ -21,3 +23,10 @@ def entities_may_have_state_changes_after(
             return True
 
     return False
+
+
+def has_recorder_run_after(hass: HomeAssistant, run_time: dt) -> bool:
+    """Check if the recorder has any runs after a specific time."""
+    return run_time >= process_timestamp(
+        get_instance(hass).recorder_runs_manager.first.start
+    )

--- a/homeassistant/components/history/websocket_api.py
+++ b/homeassistant/components/history/websocket_api.py
@@ -39,7 +39,7 @@ from homeassistant.helpers.typing import EventType
 import homeassistant.util.dt as dt_util
 
 from .const import EVENT_COALESCE_TIME, MAX_PENDING_HISTORY_STATES
-from .helpers import entities_may_have_state_changes_after
+from .helpers import entities_may_have_state_changes_after, has_recorder_run_after
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -142,7 +142,8 @@ async def ws_get_history_during_period(
     no_attributes = msg["no_attributes"]
 
     if (
-        not include_start_time_state
+        (end_time and not has_recorder_run_after(hass, end_time))
+        or not include_start_time_state
         and entity_ids
         and not entities_may_have_state_changes_after(
             hass, entity_ids, start_time, no_attributes


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The frontend is much more likely to make an impossible history query now that users can go back in time and see stats on the graphs from the UI. https://github.com/home-assistant/frontend/pull/18213

We already have coverage for via test_history_stream_before_history_starts and test_fetch_period_api_before_history_started, and this PR only makes the check happen sooner to avoid the executor job (and likely the db hit if it was not already suppressed)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
