### PR TITLE
Skip TTS when text is empty

### DIFF
--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -1024,39 +1024,38 @@ class PipelineRun:
             )
         )
 
-        try:
-            # Synthesize audio and get URL
-            tts_media_id = tts_generate_media_source_id(
-                self.hass,
-                tts_input,
-                engine=self.tts_engine,
-                language=self.pipeline.tts_language,
-                options=self.tts_options,
-            )
-            tts_media = await media_source.async_resolve_media(
-                self.hass,
-                tts_media_id,
-                None,
-            )
-        except Exception as src_error:
-            _LOGGER.exception("Unexpected error during text-to-speech")
-            raise TextToSpeechError(
-                code="tts-failed",
-                message="Unexpected error during text-to-speech",
-            ) from src_error
+        if tts_input.strip():
+            try:
+                # Synthesize audio and get URL
+                tts_media_id = tts_generate_media_source_id(
+                    self.hass,
+                    tts_input,
+                    engine=self.tts_engine,
+                    language=self.pipeline.tts_language,
+                    options=self.tts_options,
+                )
+                tts_media = await media_source.async_resolve_media(
+                    self.hass,
+                    tts_media_id,
+                    None,
+                )
+            except Exception as src_error:
+                _LOGGER.exception("Unexpected error during text-to-speech")
+                raise TextToSpeechError(
+                    code="tts-failed",
+                    message="Unexpected error during text-to-speech",
+                ) from src_error
 
-        _LOGGER.debug("TTS result %s", tts_media)
+            _LOGGER.debug("TTS result %s", tts_media)
+            tts_output = {
+                "media_id": tts_media_id,
+                **asdict(tts_media),
+            }
+        else:
+            tts_output = {}
 
         self.process_event(
-            PipelineEvent(
-                PipelineEventType.TTS_END,
-                {
-                    "tts_output": {
-                        "media_id": tts_media_id,
-                        **asdict(tts_media),
-                    }
-                },
-            )
+            PipelineEvent(PipelineEventType.TTS_END, {"tts_output": tts_output})
         )
 
         return tts_media.url

--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -1024,7 +1024,7 @@ class PipelineRun:
             )
         )
 
-        if tts_input.strip():
+        if tts_input := tts_input.strip():
             try:
                 # Synthesize audio and get URL
                 tts_media_id = tts_generate_media_source_id(

--- a/homeassistant/components/voip/voip.py
+++ b/homeassistant/components/voip/voip.py
@@ -389,11 +389,16 @@ class PipelineRtpDatagramProtocol(RtpDatagramProtocol):
             self._conversation_id = event.data["intent_output"]["conversation_id"]
         elif event.type == PipelineEventType.TTS_END:
             # Send TTS audio to caller over RTP
-            media_id = event.data["tts_output"]["media_id"]
-            self.hass.async_create_background_task(
-                self._send_tts(media_id),
-                "voip_pipeline_tts",
-            )
+            tts_output = event.data["tts_output"]
+            if tts_output:
+                media_id = tts_output["media_id"]
+                self.hass.async_create_background_task(
+                    self._send_tts(media_id),
+                    "voip_pipeline_tts",
+                )
+            else:
+                # Empty TTS response
+                self._tts_done.set()
         elif event.type == PipelineEventType.ERROR:
             # Play error tone instead of wait for TTS
             self._pipeline_error = True

--- a/tests/components/assist_pipeline/snapshots/test_websocket.ambr
+++ b/tests/components/assist_pipeline/snapshots/test_websocket.ambr
@@ -650,6 +650,33 @@
     'message': 'Timeout running pipeline',
   })
 # ---
+# name: test_pipeline_empty_tts_output
+  dict({
+    'language': 'en',
+    'pipeline': <ANY>,
+    'runner_data': dict({
+      'stt_binary_handler_id': None,
+      'timeout': 300,
+    }),
+  })
+# ---
+# name: test_pipeline_empty_tts_output.1
+  dict({
+    'engine': 'test',
+    'language': 'en-US',
+    'tts_input': '',
+    'voice': 'james_earl_jones',
+  })
+# ---
+# name: test_pipeline_empty_tts_output.2
+  dict({
+    'tts_output': dict({
+    }),
+  })
+# ---
+# name: test_pipeline_empty_tts_output.3
+  None
+# ---
 # name: test_stt_provider_missing
   dict({
     'language': 'en',

--- a/tests/components/assist_pipeline/test_websocket.py
+++ b/tests/components/assist_pipeline/test_websocket.py
@@ -2452,3 +2452,54 @@ async def test_device_capture_queue_full(
         assert msg["event"] == snapshot
         assert msg["event"]["type"] == "end"
         assert msg["event"]["overflow"]
+
+
+async def test_pipeline_empty_tts_output(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    init_components,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test events from a pipeline run with a empty text-to-speech text."""
+    events = []
+    client = await hass_ws_client(hass)
+
+    await client.send_json_auto_id(
+        {
+            "type": "assist_pipeline/run",
+            "start_stage": "tts",
+            "end_stage": "tts",
+            "input": {
+                "text": "",
+            },
+        }
+    )
+
+    # result
+    msg = await client.receive_json()
+    assert msg["success"]
+
+    # run start
+    msg = await client.receive_json()
+    assert msg["event"]["type"] == "run-start"
+    msg["event"]["data"]["pipeline"] = ANY
+    assert msg["event"]["data"] == snapshot
+    events.append(msg["event"])
+
+    # text-to-speech
+    msg = await client.receive_json()
+    assert msg["event"]["type"] == "tts-start"
+    assert msg["event"]["data"] == snapshot
+    events.append(msg["event"])
+
+    msg = await client.receive_json()
+    assert msg["event"]["type"] == "tts-end"
+    assert msg["event"]["data"] == snapshot
+    assert not msg["event"]["data"]["tts_output"]
+    events.append(msg["event"])
+
+    # run end
+    msg = await client.receive_json()
+    assert msg["event"]["type"] == "run-end"
+    assert msg["event"]["data"] == snapshot
+    events.append(msg["event"])

--- a/tests/components/esphome/test_voice_assistant.py
+++ b/tests/components/esphome/test_voice_assistant.py
@@ -337,6 +337,28 @@ async def test_send_tts_called(
         mock_send_tts.assert_called_with(_TEST_MEDIA_ID)
 
 
+async def test_send_tts_not_called_when_empty(
+    hass: HomeAssistant,
+    voice_assistant_udp_server_v1: VoiceAssistantUDPServer,
+    voice_assistant_udp_server_v2: VoiceAssistantUDPServer,
+) -> None:
+    """Test the UDP server with a v1/v2 device doesn't call _send_tts when the output is empty."""
+    with patch(
+        "homeassistant.components.esphome.voice_assistant.VoiceAssistantUDPServer._send_tts"
+    ) as mock_send_tts:
+        voice_assistant_udp_server_v1._event_callback(
+            PipelineEvent(type=PipelineEventType.TTS_END, data={"tts_output": {}})
+        )
+
+        mock_send_tts.assert_not_called()
+
+        voice_assistant_udp_server_v2._event_callback(
+            PipelineEvent(type=PipelineEventType.TTS_END, data={"tts_output": {}})
+        )
+
+        mock_send_tts.assert_not_called()
+
+
 async def test_send_tts(
     hass: HomeAssistant,
     voice_assistant_udp_server_v2: VoiceAssistantUDPServer,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When running a pipeline, some intents (such as `HassNevermind`) produce an empty text-to-speech response by design. This causes issues for some TTS systems, so this PR skips running the actual synthesis when the response is empty. Instead, an empty `tts_output` dict is sent in the pipeline event which mirrors `wake_word_output` (empty when no detection happened).

Additionally, ESPHome and VoIP have been updated to handle the empty TTS output.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
