### PR TITLE
Add iBeacon UUID allowlist

### DIFF
--- a/homeassistant/components/ibeacon/config_flow.py
+++ b/homeassistant/components/ibeacon/config_flow.py
@@ -2,12 +2,17 @@
 from __future__ import annotations
 
 from typing import Any
+from uuid import UUID
+
+import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components import bluetooth
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
+import homeassistant.helpers.config_validation as cv
 
-from .const import DOMAIN
+from .const import CONF_ALLOW_NAMELESS_UUIDS, DOMAIN
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -29,3 +34,61 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_create_entry(title="iBeacon Tracker", data={})
 
         return self.async_show_form(step_id="user")
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> OptionsFlow:
+        """Get the options flow for this handler."""
+        return OptionsFlow(config_entry)
+
+
+class OptionsFlow(config_entries.OptionsFlow):
+    """Handle options."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input: dict | None = None) -> FlowResult:
+        """Manage the options."""
+        errors = {}
+
+        current_uuids = self.config_entry.options.get(CONF_ALLOW_NAMELESS_UUIDS, [])
+        new_uuid = None
+
+        if user_input is not None:
+            if new_uuid := user_input.get("new_uuid", "").lower():
+                try:
+                    # accept non-standard formats that can be fixed by UUID
+                    new_uuid = str(UUID(new_uuid))
+                except ValueError:
+                    errors["new_uuid"] = "invalid_uuid_format"
+
+            if not errors:
+                # don't modify current_uuids in memory, cause HA will think that the new
+                # data is equal to the old, and will refuse to write them to disk.
+                updated_uuids = user_input.get("allow_nameless_uuids", [])
+                if new_uuid:
+                    updated_uuids.append(new_uuid)
+
+                data = {CONF_ALLOW_NAMELESS_UUIDS: list(updated_uuids)}
+                return self.async_create_entry(title="", data=data)
+
+        schema = {
+            vol.Optional(
+                "new_uuid",
+                description={"suggested_value": new_uuid},
+            ): str,
+        }
+        if current_uuids:
+            schema |= {
+                vol.Optional(
+                    "allow_nameless_uuids",
+                    default=current_uuids,
+                ): cv.multi_select(sorted(current_uuids))
+            }
+        return self.async_show_form(
+            step_id="init", errors=errors, data_schema=vol.Schema(schema)
+        )

--- a/homeassistant/components/ibeacon/config_flow.py
+++ b/homeassistant/components/ibeacon/config_flow.py
@@ -70,7 +70,7 @@ class OptionsFlow(config_entries.OptionsFlow):
                 # don't modify current_uuids in memory, cause HA will think that the new
                 # data is equal to the old, and will refuse to write them to disk.
                 updated_uuids = user_input.get("allow_nameless_uuids", [])
-                if new_uuid:
+                if new_uuid and new_uuid not in updated_uuids:
                     updated_uuids.append(new_uuid)
 
                 data = {CONF_ALLOW_NAMELESS_UUIDS: list(updated_uuids)}

--- a/homeassistant/components/ibeacon/const.py
+++ b/homeassistant/components/ibeacon/const.py
@@ -46,3 +46,4 @@ MIN_SEEN_TRANSIENT_NEW = (
 
 CONF_IGNORE_ADDRESSES = "ignore_addresses"
 CONF_IGNORE_UUIDS = "ignore_uuids"
+CONF_ALLOW_NAMELESS_UUIDS = "allow_nameless_uuids"

--- a/homeassistant/components/ibeacon/coordinator.py
+++ b/homeassistant/components/ibeacon/coordinator.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+import logging
 import time
 
 from ibeacon_ble import (
@@ -21,6 +22,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 
 from .const import (
+    CONF_ALLOW_NAMELESS_UUIDS,
     CONF_IGNORE_ADDRESSES,
     CONF_IGNORE_UUIDS,
     DOMAIN,
@@ -33,6 +35,8 @@ from .const import (
     UNAVAILABLE_TIMEOUT,
     UPDATE_INTERVAL,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 MONOTONIC_TIME = time.monotonic
 
@@ -141,6 +145,11 @@ class IBeaconCoordinator:
         # iBeacons with random MAC addresses, fixed UUID, random major/minor
         self._major_minor_by_uuid: dict[str, set[tuple[int, int]]] = {}
 
+        # iBeacons from devices with no name
+        self._ignored_nameless_by_uuid: dict[str, set[str]] = {}
+
+        self._entry.add_update_listener(self.async_config_entry_updated)
+
     @callback
     def async_device_id_seen(self, device_id: str) -> bool:
         """Return True if the device_id has been seen since boot."""
@@ -248,6 +257,8 @@ class IBeaconCoordinator:
         if uuid_str in self._ignore_uuids:
             return
 
+        _LOGGER.debug("update beacon %s", uuid_str)
+
         major = ibeacon_advertisement.major
         minor = ibeacon_advertisement.minor
         major_minor_by_uuid = self._major_minor_by_uuid.setdefault(uuid_str, set())
@@ -296,12 +307,24 @@ class IBeaconCoordinator:
         address = service_info.address
         unique_id = f"{group_id}_{address}"
         new = unique_id not in self._last_ibeacon_advertisement_by_unique_id
-        # Reject creating new trackers if the name is not set
-        if new and (
-            service_info.device.name is None
-            or service_info.device.name.replace("-", ":") == service_info.device.address
+        uuid = str(ibeacon_advertisement.uuid)
+
+        # Reject creating new trackers if the name is not set (unless the uuid is allowlisted).
+        if (
+            new
+            and uuid not in self._entry.options.get(CONF_ALLOW_NAMELESS_UUIDS, [])
+            and (
+                service_info.device.name is None
+                or service_info.device.name.replace("-", ":")
+                == service_info.device.address
+            )
         ):
+            # Store the ignored addresses, cause the uuid might be allowlisted later
+            self._ignored_nameless_by_uuid.setdefault(uuid, set()).add(address)
+
+            _LOGGER.debug("ignoring new beacon %s due to empty device name", unique_id)
             return
+
         previously_tracked = address in self._unique_ids_by_address
         self._last_ibeacon_advertisement_by_unique_id[unique_id] = ibeacon_advertisement
         self._async_track_ibeacon_with_unique_address(address, group_id, unique_id)
@@ -426,6 +449,28 @@ class IBeaconCoordinator:
                     self.hass,
                     signal_seen(unique_id),
                     ibeacon_advertisement,
+                )
+
+    async def async_config_entry_updated(
+        self, hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> None:
+        """Restore ignored nameless beacons when the allowlist is updated."""
+
+        for uuid in self._entry.options.get(CONF_ALLOW_NAMELESS_UUIDS, []):
+            for address in self._ignored_nameless_by_uuid.pop(uuid, set()):
+                _LOGGER.debug(
+                    "restoring nameless iBeacon %s from address %s", uuid, address
+                )
+
+                service_info = bluetooth.async_last_service_info(
+                    self.hass, address, connectable=False
+                )
+                if not service_info:
+                    continue  # no longer available
+
+                # the beacon was ignored, we need to re-process it from scratch
+                self._async_update_ibeacon(
+                    service_info, bluetooth.BluetoothChange.ADVERTISEMENT
                 )
 
     @callback

--- a/homeassistant/components/ibeacon/coordinator.py
+++ b/homeassistant/components/ibeacon/coordinator.py
@@ -151,7 +151,9 @@ class IBeaconCoordinator:
         )
         self._ignored_nameless_by_uuid: dict[str, set[str]] = {}
 
-        self._entry.add_update_listener(self.async_config_entry_updated)
+        self._entry.async_on_unload(
+            self._entry.add_update_listener(self.async_config_entry_updated)
+        )
 
     @callback
     def async_device_id_seen(self, device_id: str) -> bool:

--- a/homeassistant/components/ibeacon/coordinator.py
+++ b/homeassistant/components/ibeacon/coordinator.py
@@ -469,10 +469,11 @@ class IBeaconCoordinator:
                     "restoring nameless iBeacon %s from address %s", uuid, address
                 )
 
-                service_info = bluetooth.async_last_service_info(
-                    self.hass, address, connectable=False
-                )
-                if not service_info:
+                if not (
+                    service_info := bluetooth.async_last_service_info(
+                        self.hass, address, connectable=False
+                    )
+                ):
                     continue  # no longer available
 
                 # the beacon was ignored, we need to re-process it from scratch

--- a/homeassistant/components/ibeacon/strings.json
+++ b/homeassistant/components/ibeacon/strings.json
@@ -13,11 +13,15 @@
   "options": {
     "step": {
       "init": {
-        "description": "iBeacons with an RSSI value lower than the Minimum RSSI will be ignored. If the integration is seeing neighboring iBeacons, increasing this value may help.",
+        "description": "iBeacons with an empty device name are ignored by default, unless their UUID is explicitly allowed in the list below.",
         "data": {
-          "min_rssi": "Minimum RSSI"
+          "new_uuid": "Enter a new allowed UUID",
+          "allow_nameless_uuids": "Currently allowed UUIDs. Uncheck to remove"
         }
       }
+    },
+    "error": {
+      "invalid_uuid_format": "UUIDs should contain 32 hex characters grouped as XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
     }
   },
   "entity": {

--- a/tests/components/ibeacon/test_config_flow.py
+++ b/tests/components/ibeacon/test_config_flow.py
@@ -2,7 +2,7 @@
 from unittest.mock import patch
 
 from homeassistant import config_entries
-from homeassistant.components.ibeacon.const import DOMAIN
+from homeassistant.components.ibeacon.const import CONF_ALLOW_NAMELESS_UUIDS, DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -49,3 +49,55 @@ async def test_setup_user_already_setup(
     )
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
+
+
+async def test_options_flow(hass: HomeAssistant, enable_bluetooth: None) -> None:
+    """Test config flow options."""
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    # test save invalid uuid
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "new_uuid": "invalid",
+        },
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "init"
+    assert result["errors"] == {"new_uuid": "invalid_uuid_format"}
+
+    # test save new uuid
+    uuid = "daa4b6bb-b77a-4662-aeb8-b3ed56454091"
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "new_uuid": uuid,
+        },
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"] == {CONF_ALLOW_NAMELESS_UUIDS: [uuid]}
+
+    # restart
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    # delete
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_ALLOW_NAMELESS_UUIDS: [],
+        },
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"] == {CONF_ALLOW_NAMELESS_UUIDS: []}

--- a/tests/components/ibeacon/test_config_flow.py
+++ b/tests/components/ibeacon/test_config_flow.py
@@ -86,13 +86,28 @@ async def test_options_flow(hass: HomeAssistant, enable_bluetooth: None) -> None
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["data"] == {CONF_ALLOW_NAMELESS_UUIDS: [uuid]}
 
-    # restart
+    # test save duplicate uuid
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "init"
 
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_ALLOW_NAMELESS_UUIDS: [uuid],
+            "new_uuid": uuid,
+        },
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"] == {CONF_ALLOW_NAMELESS_UUIDS: [uuid]}
+
     # delete
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "init"
+
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is a followup to #104419 (opening a new PR to keep it clean), which aims to workaround #80357.

The ibeacon integration ignores beacons with empty/default name, to avoid some users getting lots of "garbage" devices.
This PR adds two independent UUID allowlists to accept iBeacons with empty names:
1. An explicit allowlist configurable via option flow.

2. An automatic allowlist of companion app beacons. We search for `mobile_app` entities with unique_id `*_ble_emitter` (note that the entity_id is `*_ble_transmitter`), and allow the UUID listed in the `id` attribute. This allowlist is kept separate from the explicit one, so it's never visible to the user.

Technical notes:
- Since the allowlist entry might be added after first seeing the beacon we need to store the ignored ones and re-process them later.
- Removing an allowlist entry does not remove any entities, the user will need to deleted them manually. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #80357
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30063

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
