### PR TITLE
Fix device sync to Google Assistant if Matter integration is active

### DIFF
--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -59,7 +59,11 @@ LOCAL_SDK_MIN_VERSION = AwesomeVersion("2.1.5")
 @callback
 def _get_registry_entries(
     hass: HomeAssistant, entity_id: str
-) -> tuple[er.RegistryEntry | None, dr.DeviceEntry | None, ar.AreaEntry | None,]:
+) -> tuple[
+    er.RegistryEntry | None,
+    dr.DeviceEntry | None,
+    ar.AreaEntry | None,
+]:
     """Get registry entries."""
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)

--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -59,11 +59,7 @@ LOCAL_SDK_MIN_VERSION = AwesomeVersion("2.1.5")
 @callback
 def _get_registry_entries(
     hass: HomeAssistant, entity_id: str
-) -> tuple[
-    er.RegistryEntry | None,
-    dr.DeviceEntry | None,
-    ar.AreaEntry | None,
-]:
+) -> tuple[er.RegistryEntry | None, dr.DeviceEntry | None, ar.AreaEntry | None,]:
     """Get registry entries."""
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
@@ -686,8 +682,12 @@ class GoogleEntity:
             return device
 
         # Add Matter info
-        if "matter" in self.hass.config.components and (
-            matter_info := matter.get_matter_device_info(self.hass, device_entry.id)
+        if (
+            "matter" in self.hass.config.components
+            and any(x for x in device_entry.identifiers if x[0] == "matter")
+            and (
+                matter_info := matter.get_matter_device_info(self.hass, device_entry.id)
+            )
         ):
             device["matterUniqueId"] = matter_info["unique_id"]
             device["matterOriginalVendorId"] = matter_info["vendor_id"]

--- a/homeassistant/components/matter/helpers.py
+++ b/homeassistant/components/matter/helpers.py
@@ -94,7 +94,7 @@ def get_node_from_device_entry(
     )
 
     if device_id_full is None:
-        raise ValueError(f"Device {device.id} is not a Matter device")
+        return None
 
     device_id = device_id_full.lstrip(device_id_type_prefix)
     matter_client = matter.matter_client

--- a/tests/components/google_assistant/test_helpers.py
+++ b/tests/components/google_assistant/test_helpers.py
@@ -89,6 +89,7 @@ async def test_google_entity_sync_serialize_with_matter(
         manufacturer="Someone",
         model="Some model",
         sw_version="Some Version",
+        identifiers={("matter", "12345678")},
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     entity = entity_registry.async_get_or_create(

--- a/tests/components/matter/test_helpers.py
+++ b/tests/components/matter/test_helpers.py
@@ -60,16 +60,13 @@ async def test_get_node_from_device_entry(
 
     assert node_from_device_entry is node
 
-    with pytest.raises(ValueError) as value_error:
-        await get_node_from_device_entry(hass, other_device_entry)
-
-    assert f"Device {other_device_entry.id} is not a Matter device" in str(
-        value_error.value
-    )
+    # test non-Matter device returns None
+    assert get_node_from_device_entry(hass, other_device_entry) is None
 
     matter_client.server_info = None
 
+    # test non-initialized server raises RuntimeError
     with pytest.raises(RuntimeError) as runtime_error:
-        node_from_device_entry = await get_node_from_device_entry(hass, device_entry)
+        node_from_device_entry = get_node_from_device_entry(hass, device_entry)
 
     assert "Matter server information is not available" in str(runtime_error.value)


### PR DESCRIPTION
## Proposed change
To deduplicate devices on Google Home if both HA and Google Home have the same device in their Matter fabric, some logic was added to Home Assistant to pass Matter specific id's to Google Assistant.

This logic was however called for non-Matter devices as well and instead of returning None if a device was non-existing, the Matter integration was (unexpectedly) raising a ValueError. Result was that non-matter devices would no longer be synced with Google Assistant if a user has the Matter integration installed.

This patches this issue for now, while we think of a more robust callback-like solution in the future;

- Prevent the Google Assistant integration from calling the function inside the Matter integration to get the special id's if a device is not Matter.
- Return None in the matter integration lookup helper if the device doe snot exist instead of raising ValueError.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #104761
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
