### PR TITLE
Make Shelly Wall Display thermostat implementation compatible with firmware 1.2.5

### DIFF
--- a/homeassistant/components/shelly/climate.py
+++ b/homeassistant/components/shelly/climate.py
@@ -128,7 +128,7 @@ def async_setup_rpc_entry(
 
         # Wall Display relay is used as the thermostat actuator,
         # we need to remove a switch entity
-        if coordinator.device.shelly["relay_in_thermostat"]:
+        if coordinator.device.shelly.get("relay_in_thermostat", False):
             unique_id = f"{coordinator.mac}-switch:{id_}"
             async_remove_shelly_entity(hass, "switch", unique_id)
 

--- a/homeassistant/components/shelly/climate.py
+++ b/homeassistant/components/shelly/climate.py
@@ -126,9 +126,9 @@ def async_setup_rpc_entry(
     for id_ in climate_key_ids:
         climate_ids.append(id_)
 
-        # Wall Display relay is used as the thermostat actuator,
-        # we need to remove a switch entity
         if coordinator.device.shelly.get("relay_in_thermostat", False):
+            # Wall Display relay is used as the thermostat actuator,
+            # we need to remove a switch entity
             unique_id = f"{coordinator.mac}-switch:{id_}"
             async_remove_shelly_entity(hass, "switch", unique_id)
 

--- a/homeassistant/components/shelly/climate.py
+++ b/homeassistant/components/shelly/climate.py
@@ -42,12 +42,7 @@ from .const import (
 )
 from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator, get_entry_data
 from .entity import ShellyRpcEntity
-from .utils import (
-    async_remove_shelly_entity,
-    get_device_entry_gen,
-    get_rpc_key_ids,
-    is_relay_used_as_actuator,
-)
+from .utils import async_remove_shelly_entity, get_device_entry_gen, get_rpc_key_ids
 
 
 async def async_setup_entry(
@@ -131,7 +126,9 @@ def async_setup_rpc_entry(
     for id_ in climate_key_ids:
         climate_ids.append(id_)
 
-        if is_relay_used_as_actuator(id_, coordinator.mac, coordinator.device.config):
+        # Wall Display relay is used as the thermostat actuator,
+        # we need to remove a switch entity
+        if coordinator.device.shelly["relay_in_thermostat"]:
             unique_id = f"{coordinator.mac}-switch:{id_}"
             async_remove_shelly_entity(hass, "switch", unique_id)
 

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -120,7 +120,7 @@ def async_setup_rpc_entry(
         if coordinator.model == MODEL_WALL_DISPLAY:
             if not coordinator.device.shelly.get("relay_in_thermostat", False):
                 # Wall Display relay is not used as the thermostat actuator,
-                #  we need to remove a climate entity
+                # we need to remove a climate entity
                 unique_id = f"{coordinator.mac}-thermostat:{id_}"
                 async_remove_shelly_entity(hass, "climate", unique_id)
             else:

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -118,7 +118,7 @@ def async_setup_rpc_entry(
             continue
 
         if coordinator.model == MODEL_WALL_DISPLAY:
-            if not coordinator.device.shelly["relay_in_thermostat"]:
+            if not coordinator.device.shelly.get("relay_in_thermostat", False):
                 # Wall Display relay is not used as the thermostat actuator,
                 #  we need to remove a climate entity
                 unique_id = f"{coordinator.mac}-thermostat:{id_}"

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -118,8 +118,9 @@ def async_setup_rpc_entry(
             continue
 
         if coordinator.model == MODEL_WALL_DISPLAY:
-            if coordinator.device.shelly["relay_operational"]:
-                # Wall Display in relay mode, we need to remove a climate entity
+            if not coordinator.device.shelly["relay_in_thermostat"]:
+                # Wall Display relay is not used as the thermostat actuator,
+                #  we need to remove a climate entity
                 unique_id = f"{coordinator.mac}-thermostat:{id_}"
                 async_remove_shelly_entity(hass, "climate", unique_id)
             else:

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -430,10 +430,3 @@ def get_release_url(gen: int, model: str, beta: bool) -> str | None:
         return None
 
     return GEN1_RELEASE_URL if gen == 1 else GEN2_RELEASE_URL
-
-
-def is_relay_used_as_actuator(relay_id: int, mac: str, config: dict[str, Any]) -> bool:
-    """Return True if an internal relay is used as the thermostat actuator."""
-    return f"{mac}/c/switch:{relay_id}".lower() in config[f"thermostat:{relay_id}"].get(
-        "actuator", ""
-    )

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -153,7 +153,6 @@ MOCK_CONFIG = {
         "id": 0,
         "enable": True,
         "type": "heating",
-        "actuator": f"shelly://shellywalldisplay-{MOCK_MAC.lower()}/c/switch:0",
     },
     "sys": {
         "ui_data": {},
@@ -181,7 +180,7 @@ MOCK_SHELLY_RPC = {
     "auth_en": False,
     "auth_domain": None,
     "profile": "cover",
-    "relay_operational": False,
+    "relay_in_thermostat": False,
 }
 
 MOCK_STATUS_COAP = {

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -180,7 +180,7 @@ MOCK_SHELLY_RPC = {
     "auth_en": False,
     "auth_domain": None,
     "profile": "cover",
-    "relay_in_thermostat": False,
+    "relay_in_thermostat": True,
 }
 
 MOCK_STATUS_COAP = {

--- a/tests/components/shelly/test_climate.py
+++ b/tests/components/shelly/test_climate.py
@@ -549,10 +549,6 @@ async def test_rpc_climate_hvac_mode(
     monkeypatch,
 ) -> None:
     """Test climate hvac mode service."""
-    new_shelly = deepcopy(mock_rpc_device.shelly)
-    new_shelly["relay_in_thermostat"] = True
-    monkeypatch.setattr(mock_rpc_device, "shelly", new_shelly)
-
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
 
     state = hass.states.get(ENTITY_ID)
@@ -591,10 +587,6 @@ async def test_rpc_climate_set_temperature(
     hass: HomeAssistant, mock_rpc_device, monkeypatch
 ) -> None:
     """Test climate set target temperature."""
-    new_shelly = deepcopy(mock_rpc_device.shelly)
-    new_shelly["relay_in_thermostat"] = True
-    monkeypatch.setattr(mock_rpc_device, "shelly", new_shelly)
-
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
 
     state = hass.states.get(ENTITY_ID)
@@ -636,10 +628,6 @@ async def test_rpc_climate_hvac_mode_cool(
     new_config = deepcopy(mock_rpc_device.config)
     new_config["thermostat:0"]["type"] = "cooling"
     monkeypatch.setattr(mock_rpc_device, "config", new_config)
-
-    new_shelly = deepcopy(mock_rpc_device.shelly)
-    new_shelly["relay_in_thermostat"] = True
-    monkeypatch.setattr(mock_rpc_device, "shelly", new_shelly)
 
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
 

--- a/tests/components/shelly/test_climate.py
+++ b/tests/components/shelly/test_climate.py
@@ -549,6 +549,10 @@ async def test_rpc_climate_hvac_mode(
     monkeypatch,
 ) -> None:
     """Test climate hvac mode service."""
+    new_shelly = deepcopy(mock_rpc_device.shelly)
+    new_shelly["relay_in_thermostat"] = True
+    monkeypatch.setattr(mock_rpc_device, "shelly", new_shelly)
+
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
 
     state = hass.states.get(ENTITY_ID)
@@ -587,6 +591,10 @@ async def test_rpc_climate_set_temperature(
     hass: HomeAssistant, mock_rpc_device, monkeypatch
 ) -> None:
     """Test climate set target temperature."""
+    new_shelly = deepcopy(mock_rpc_device.shelly)
+    new_shelly["relay_in_thermostat"] = True
+    monkeypatch.setattr(mock_rpc_device, "shelly", new_shelly)
+
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
 
     state = hass.states.get(ENTITY_ID)
@@ -628,6 +636,10 @@ async def test_rpc_climate_hvac_mode_cool(
     new_config = deepcopy(mock_rpc_device.config)
     new_config["thermostat:0"]["type"] = "cooling"
     monkeypatch.setattr(mock_rpc_device, "config", new_config)
+
+    new_shelly = deepcopy(mock_rpc_device.shelly)
+    new_shelly["relay_in_thermostat"] = True
+    monkeypatch.setattr(mock_rpc_device, "shelly", new_shelly)
 
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
 

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -283,9 +283,15 @@ async def test_block_device_gas_valve(
 
 
 async def test_wall_display_thermostat_mode(
-    hass: HomeAssistant, mock_rpc_device, monkeypatch
+    hass: HomeAssistant,
+    mock_rpc_device,
+    monkeypatch,
 ) -> None:
     """Test Wall Display in thermostat mode."""
+    new_shelly = deepcopy(mock_rpc_device.shelly)
+    new_shelly["relay_in_thermostat"] = True
+    monkeypatch.setattr(mock_rpc_device, "shelly", new_shelly)
+
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
 
     # the switch entity should not be created, only the climate entity
@@ -294,7 +300,9 @@ async def test_wall_display_thermostat_mode(
 
 
 async def test_wall_display_relay_mode(
-    hass: HomeAssistant, entity_registry, mock_rpc_device, monkeypatch
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_rpc_device,
 ) -> None:
     """Test Wall Display in thermostat mode."""
     entity_id = register_entity(
@@ -303,11 +311,6 @@ async def test_wall_display_relay_mode(
         "test_name",
         "thermostat:0",
     )
-
-    new_shelly = deepcopy(mock_rpc_device.shelly)
-    new_shelly["relay_operational"] = True
-
-    monkeypatch.setattr(mock_rpc_device, "shelly", new_shelly)
 
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
 

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -285,13 +285,8 @@ async def test_block_device_gas_valve(
 async def test_wall_display_thermostat_mode(
     hass: HomeAssistant,
     mock_rpc_device,
-    monkeypatch,
 ) -> None:
     """Test Wall Display in thermostat mode."""
-    new_shelly = deepcopy(mock_rpc_device.shelly)
-    new_shelly["relay_in_thermostat"] = True
-    monkeypatch.setattr(mock_rpc_device, "shelly", new_shelly)
-
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
 
     # the switch entity should not be created, only the climate entity
@@ -303,6 +298,7 @@ async def test_wall_display_relay_mode(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_rpc_device,
+    monkeypatch,
 ) -> None:
     """Test Wall Display in thermostat mode."""
     entity_id = register_entity(
@@ -311,6 +307,10 @@ async def test_wall_display_relay_mode(
         "test_name",
         "thermostat:0",
     )
+
+    new_shelly = deepcopy(mock_rpc_device.shelly)
+    new_shelly["relay_in_thermostat"] = False
+    monkeypatch.setattr(mock_rpc_device, "shelly", new_shelly)
 
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In the stable firmware release 1.2.5 for Shelly Wall Display, the `relay_operational` value has been replaced with `relay_in_thermostat` which causes a `KeyError` for the switch platform.

This PR adapts the Wall Display thermostat implementation to the stable firmware and simplifies the way to check whether the device's built-in relay is used as a thermostat actuator.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
