### PR TITLE
Add Fastdotcom DataUpdateCoordinator

### DIFF
--- a/homeassistant/components/fastdotcom/__init__.py
+++ b/homeassistant/components/fastdotcom/__init__.py
@@ -1,22 +1,18 @@
 """Support for testing internet speed via Fast.com."""
 from __future__ import annotations
 
-from datetime import datetime, timedelta
 import logging
-from typing import Any
 
-from fastdotcom import fast_com
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_SCAN_INTERVAL
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.dispatcher import dispatcher_send
-from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_MANUAL, DATA_UPDATED, DEFAULT_INTERVAL, DOMAIN, PLATFORMS
+from .const import CONF_MANUAL, DEFAULT_INTERVAL, DOMAIN, PLATFORMS
+from .coordinator import FastdotcomDataUpdateCoordindator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,21 +44,10 @@ async def async_setup_platform(hass: HomeAssistant, config: ConfigType) -> bool:
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up the Fast.com component."""
-    data = hass.data[DOMAIN] = SpeedtestData(hass)
-
-    entry.async_on_unload(
-        async_track_time_interval(hass, data.update, timedelta(hours=DEFAULT_INTERVAL))
-    )
-    # Run an initial update to get a starting state
-    await data.update()
-
-    async def update(service_call: ServiceCall | None = None) -> None:
-        """Service call to manually update the data."""
-        await data.update()
-
-    hass.services.async_register(DOMAIN, "speedtest", update)
-
+    """Set up Fast.com from a config entry."""
+    coordinator = FastdotcomDataUpdateCoordindator(hass)
+    await coordinator.async_config_entry_first_refresh()
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
     await hass.config_entries.async_forward_entry_setups(
         entry,
         PLATFORMS,
@@ -73,23 +58,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload Fast.com config entry."""
+    hass.services.async_remove(DOMAIN, "speedtest")
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data.pop(DOMAIN)
+        coordinator: FastdotcomDataUpdateCoordindator = hass.data[DOMAIN].pop(
+            entry.entry_id
+        )
+        await coordinator.async_shutdown()
     return unload_ok
-
-
-class SpeedtestData:
-    """Get the latest data from Fast.com."""
-
-    def __init__(self, hass: HomeAssistant) -> None:
-        """Initialize the data object."""
-        self.data: dict[str, Any] | None = None
-        self._hass = hass
-
-    async def update(self, now: datetime | None = None) -> None:
-        """Get the latest data from fast.com."""
-        _LOGGER.debug("Executing Fast.com speedtest")
-        fast_com_data = await self._hass.async_add_executor_job(fast_com)
-        self.data = {"download": fast_com_data}
-        _LOGGER.debug("Fast.com speedtest finished, with mbit/s: %s", fast_com_data)
-        dispatcher_send(self._hass, DATA_UPDATED)

--- a/homeassistant/components/fastdotcom/__init__.py
+++ b/homeassistant/components/fastdotcom/__init__.py
@@ -70,8 +70,5 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload Fast.com config entry."""
     hass.services.async_remove(DOMAIN, "speedtest")
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        coordinator: FastdotcomDataUpdateCoordindator = hass.data[DOMAIN].pop(
-            entry.entry_id
-        )
-        await coordinator.async_shutdown()
+        hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok

--- a/homeassistant/components/fastdotcom/coordinator.py
+++ b/homeassistant/components/fastdotcom/coordinator.py
@@ -15,7 +15,7 @@ class FastdotcomDataUpdateCoordindator(DataUpdateCoordinator):
     """Class to manage fetching Fast.com data API."""
 
     def __init__(self, hass: HomeAssistant) -> None:
-        """Initialize the coordintor for Fast.com."""
+        """Initialize the coordinator for Fast.com."""
         super().__init__(
             hass,
             LOGGER,

--- a/homeassistant/components/fastdotcom/coordinator.py
+++ b/homeassistant/components/fastdotcom/coordinator.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from typing import Any
 
 from fastdotcom import fast_com
 
@@ -11,7 +12,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import DEFAULT_INTERVAL, DOMAIN, LOGGER
 
 
-class FastdotcomDataUpdateCoordindator(DataUpdateCoordinator):
+class FastdotcomDataUpdateCoordindator(DataUpdateCoordinator[dict[str, Any]]):
     """Class to manage fetching Fast.com data API."""
 
     def __init__(self, hass: HomeAssistant) -> None:

--- a/homeassistant/components/fastdotcom/coordinator.py
+++ b/homeassistant/components/fastdotcom/coordinator.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import Any
 
 from fastdotcom import fast_com
 
@@ -12,7 +11,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import DEFAULT_INTERVAL, DOMAIN, LOGGER
 
 
-class FastdotcomDataUpdateCoordindator(DataUpdateCoordinator[dict[str, Any]]):
+class FastdotcomDataUpdateCoordindator(DataUpdateCoordinator[float]):
     """Class to manage fetching Fast.com data API."""
 
     def __init__(self, hass: HomeAssistant) -> None:
@@ -24,7 +23,7 @@ class FastdotcomDataUpdateCoordindator(DataUpdateCoordinator[dict[str, Any]]):
             update_interval=timedelta(hours=DEFAULT_INTERVAL),
         )
 
-    async def _async_update_data(self) -> dict[str, str]:
+    async def _async_update_data(self) -> float:
         """Run an executor job to retrieve Fast.com data."""
         try:
             return await self.hass.async_add_executor_job(fast_com)

--- a/homeassistant/components/fastdotcom/coordinator.py
+++ b/homeassistant/components/fastdotcom/coordinator.py
@@ -1,0 +1,31 @@
+"""DataUpdateCoordinator for the Fast.com integration."""
+from __future__ import annotations
+
+from datetime import timedelta
+
+from fastdotcom import fast_com
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DEFAULT_INTERVAL, DOMAIN, LOGGER
+
+
+class FastdotcomDataUpdateCoordindator(DataUpdateCoordinator):
+    """Class to manage fetching Fast.com data API."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the coordintor for Fast.com."""
+        super().__init__(
+            hass,
+            LOGGER,
+            name=DOMAIN,
+            update_interval=timedelta(hours=DEFAULT_INTERVAL),
+        )
+
+    async def _async_update_data(self) -> dict[str, str]:
+        """Run an executor job to retrieve Fast.com data."""
+        try:
+            return await self.hass.async_add_executor_job(fast_com)
+        except Exception as exc:
+            raise UpdateFailed(f"Error communicating with Fast.com: {exc}") from exc

--- a/homeassistant/components/fastdotcom/coordinator.py
+++ b/homeassistant/components/fastdotcom/coordinator.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import Any
 
 from fastdotcom import fast_com
 
@@ -12,7 +11,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import DEFAULT_INTERVAL, DOMAIN, LOGGER
 
 
-class FastdotcomDataUpdateCoordindator(DataUpdateCoordinator[dict[str, Any]]):
+class FastdotcomDataUpdateCoordindator(DataUpdateCoordinator):
     """Class to manage fetching Fast.com data API."""
 
     def __init__(self, hass: HomeAssistant) -> None:

--- a/homeassistant/components/fastdotcom/sensor.py
+++ b/homeassistant/components/fastdotcom/sensor.py
@@ -1,8 +1,6 @@
 """Support for Fast.com internet speed testing sensor."""
 from __future__ import annotations
 
-from typing import cast
-
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -12,7 +10,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfDataRate
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
@@ -51,6 +48,6 @@ class SpeedtestSensor(
     @property
     def native_value(
         self,
-    ) -> StateType:
+    ) -> float:
         """Return the state of the sensor."""
-        return cast(StateType, self.coordinator.data)
+        return self.coordinator.data

--- a/homeassistant/components/fastdotcom/sensor.py
+++ b/homeassistant/components/fastdotcom/sensor.py
@@ -48,12 +48,10 @@ class SpeedtestSensor(
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._attr_unique_id = entry_id
-        self._state: StateType = None
 
     @property
     def native_value(
         self,
     ) -> StateType:
         """Return the state of the sensor."""
-        self._state = cast(StateType, self.coordinator.data)
-        return self._state
+        return cast(StateType, self.coordinator.data)

--- a/homeassistant/components/fastdotcom/sensor.py
+++ b/homeassistant/components/fastdotcom/sensor.py
@@ -1,7 +1,7 @@
 """Support for Fast.com internet speed testing sensor."""
 from __future__ import annotations
 
-from typing import Any
+from typing import cast
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -12,6 +12,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfDataRate
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
@@ -47,13 +48,12 @@ class SpeedtestSensor(
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._attr_unique_id = entry_id
+        self._state: StateType = None
 
     @property
-    # Disabling the pylint, since it's an old function of fastdotcom that's being used
-    # which isn't giving a proper type back
-    # pylint: disable=hass-return-type
     def native_value(
         self,
-    ) -> Any:
+    ) -> StateType:
         """Return the state of the sensor."""
-        return self.coordinator.data
+        self._state = cast(StateType, self.coordinator.data)
+        return self._state

--- a/homeassistant/components/fastdotcom/sensor.py
+++ b/homeassistant/components/fastdotcom/sensor.py
@@ -29,7 +29,6 @@ async def async_setup_entry(
     async_add_entities([SpeedtestSensor(entry.entry_id, coordinator)])
 
 
-# pylint: disable-next=hass-invalid-inheritance # needs fixing
 class SpeedtestSensor(
     CoordinatorEntity[FastdotcomDataUpdateCoordindator], SensorEntity
 ):

--- a/tests/components/fastdotcom/test_config_flow.py
+++ b/tests/components/fastdotcom/test_config_flow.py
@@ -57,10 +57,7 @@ async def test_single_instance_allowed(
 
 async def test_import_flow_success(hass: HomeAssistant) -> None:
     """Test import flow."""
-    with patch(
-        "homeassistant.components.fastdotcom.__init__.async_setup_entry",
-        return_value={"download": "50"},
-    ), patch("homeassistant.components.fastdotcom.sensor.SpeedtestSensor"):
+    with patch("homeassistant.components.fastdotcom.sensor.SpeedtestSensor"):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
@@ -70,5 +67,3 @@ async def test_import_flow_success(hass: HomeAssistant) -> None:
 
         assert result["type"] == FlowResultType.CREATE_ENTRY
         assert result["title"] == "Fast.com"
-        assert result["data"] == {}
-        assert result["options"] == {}

--- a/tests/components/fastdotcom/test_config_flow.py
+++ b/tests/components/fastdotcom/test_config_flow.py
@@ -58,7 +58,7 @@ async def test_single_instance_allowed(
 async def test_import_flow_success(hass: HomeAssistant) -> None:
     """Test import flow."""
     with patch(
-        "homeassistant.components.fastdotcom.__init__.SpeedtestData",
+        "homeassistant.components.fastdotcom.__init__.async_setup_entry",
         return_value={"download": "50"},
     ), patch("homeassistant.components.fastdotcom.sensor.SpeedtestSensor"):
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/fastdotcom/test_config_flow.py
+++ b/tests/components/fastdotcom/test_config_flow.py
@@ -67,3 +67,5 @@ async def test_import_flow_success(hass: HomeAssistant) -> None:
 
         assert result["type"] == FlowResultType.CREATE_ENTRY
         assert result["title"] == "Fast.com"
+        assert result["data"] == {}
+        assert result["options"] == {}

--- a/tests/components/fastdotcom/test_config_flow.py
+++ b/tests/components/fastdotcom/test_config_flow.py
@@ -57,7 +57,7 @@ async def test_single_instance_allowed(
 
 async def test_import_flow_success(hass: HomeAssistant) -> None:
     """Test import flow."""
-    with patch("homeassistant.components.fastdotcom.sensor.SpeedtestSensor"):
+    with patch("homeassistant.components.fastdotcom.coordinator.fast_com"):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},

--- a/tests/components/fastdotcom/test_coordinator.py
+++ b/tests/components/fastdotcom/test_coordinator.py
@@ -1,0 +1,28 @@
+"""Test the FastdotcomDataUpdateCoordindator."""
+from unittest.mock import patch
+
+from homeassistant.components.fastdotcom.coordinator import (
+    FastdotcomDataUpdateCoordindator,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+
+async def test_fastdotcom_data_update_coordinator(hass: HomeAssistant) -> None:
+    """Test the FastdotcomDataUpdateCoordindator."""
+    coordinator = FastdotcomDataUpdateCoordindator(hass)
+
+    with patch(
+        "homeassistant.components.fastdotcom.coordinator.fast_com",
+        return_value={"download": "50"},
+    ):
+        await coordinator.async_refresh()
+        assert coordinator.data == {"download": "50"}
+
+    with patch(
+        "homeassistant.components.fastdotcom.coordinator.fast_com",
+        side_effect=Exception("Test error"),
+    ):
+        await coordinator.async_refresh()
+        assert coordinator.data == {"download": "50"}
+        assert isinstance(coordinator.last_exception, UpdateFailed)

--- a/tests/components/fastdotcom/test_coordinator.py
+++ b/tests/components/fastdotcom/test_coordinator.py
@@ -21,10 +21,10 @@ async def test_fastdotcom_data_update_coordinator(
     )
     config_entry.add_to_hass(hass)
 
+    await hass.config_entries.async_setup(config_entry.entry_id)
     with patch(
         "homeassistant.components.fastdotcom.coordinator.fast_com",
     ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
     state = hass.states.get("sensor.fast_com_download")
@@ -34,7 +34,7 @@ async def test_fastdotcom_data_update_coordinator(
     with patch(
         "homeassistant.components.fastdotcom.coordinator.fast_com", return_value=10.0
     ):
-        freezer.tick(timedelta(hours=1))
+        freezer.tick(timedelta(minutes=59))
         async_fire_time_changed(hass)
         await coordinator.async_refresh()
 
@@ -45,7 +45,7 @@ async def test_fastdotcom_data_update_coordinator(
         "homeassistant.components.fastdotcom.coordinator.fast_com",
         side_effect=Exception("Test error"),
     ):
-        freezer.tick(timedelta(hours=1))
+        freezer.tick(timedelta(minutes=59))
         async_fire_time_changed(hass)
         await coordinator.async_refresh()
 

--- a/tests/components/fastdotcom/test_coordinator.py
+++ b/tests/components/fastdotcom/test_coordinator.py
@@ -30,12 +30,13 @@ async def test_fastdotcom_data_update_coordinator(
     state = hass.states.get("sensor.fast_com_download")
     assert state is not None
 
-
+    coordinator = hass.data[config_entry.domain][config_entry.entry_id]
     with patch(
         "homeassistant.components.fastdotcom.coordinator.fast_com", return_value=10.0
     ):
-        freezer.tick(timedelta(minutes=5, seconds=1))
+        freezer.tick(timedelta(hours=1))
         async_fire_time_changed(hass)
+        await coordinator.async_refresh()
 
     state = hass.states.get("sensor.fast_com_download")
     assert state.state == "10.0"
@@ -44,8 +45,9 @@ async def test_fastdotcom_data_update_coordinator(
         "homeassistant.components.fastdotcom.coordinator.fast_com",
         side_effect=Exception("Test error"),
     ):
-        freezer.tick(timedelta(minutes=5, seconds=1))
+        freezer.tick(timedelta(hours=1))
         async_fire_time_changed(hass)
+        await coordinator.async_refresh()
 
     state = hass.states.get("sensor.fast_com_download")
     assert state.state is STATE_UNAVAILABLE

--- a/tests/components/fastdotcom/test_coordinator.py
+++ b/tests/components/fastdotcom/test_coordinator.py
@@ -36,7 +36,6 @@ async def test_fastdotcom_data_update_coordinator(
     ):
         freezer.tick(timedelta(minutes=5, seconds=1))
         async_fire_time_changed(hass)
-        await coordinator.async_refresh()
 
     state = hass.states.get("sensor.fast_com_download")
     assert state.state == "10.0"

--- a/tests/components/fastdotcom/test_coordinator.py
+++ b/tests/components/fastdotcom/test_coordinator.py
@@ -46,7 +46,6 @@ async def test_fastdotcom_data_update_coordinator(
     ):
         freezer.tick(timedelta(minutes=5, seconds=1))
         async_fire_time_changed(hass)
-        await coordinator.async_refresh()
 
     state = hass.states.get("sensor.fast_com_download")
     assert state.state is STATE_UNAVAILABLE

--- a/tests/components/fastdotcom/test_coordinator.py
+++ b/tests/components/fastdotcom/test_coordinator.py
@@ -21,10 +21,10 @@ async def test_fastdotcom_data_update_coordinator(
     )
     config_entry.add_to_hass(hass)
 
-    await hass.config_entries.async_setup(config_entry.entry_id)
     with patch(
         "homeassistant.components.fastdotcom.coordinator.fast_com",
     ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
     state = hass.states.get("sensor.fast_com_download")

--- a/tests/components/fastdotcom/test_coordinator.py
+++ b/tests/components/fastdotcom/test_coordinator.py
@@ -30,8 +30,6 @@ async def test_fastdotcom_data_update_coordinator(
     state = hass.states.get("sensor.fast_com_download")
     assert state is not None
 
-    coordinator = hass.data[config_entry.domain][config_entry.entry_id]
-    assert coordinator.last_update_success is True
 
     with patch(
         "homeassistant.components.fastdotcom.coordinator.fast_com", return_value=10.0

--- a/tests/components/fastdotcom/test_coordinator.py
+++ b/tests/components/fastdotcom/test_coordinator.py
@@ -29,9 +29,6 @@ async def test_fastdotcom_data_update_coordinator(
     ):
         await hass.async_block_till_done()
 
-    coordinator = hass.data[config_entry.domain][config_entry.entry_id]
-
-    assert coordinator.last_update_success is True
     state = hass.states.get("sensor.fast_com_download")
     assert state is not None
 

--- a/tests/components/fastdotcom/test_coordinator.py
+++ b/tests/components/fastdotcom/test_coordinator.py
@@ -31,6 +31,7 @@ async def test_fastdotcom_data_update_coordinator(
 
     state = hass.states.get("sensor.fast_com_download")
     assert state is not None
+    assert state.state == "10"
 
     with patch(
         "homeassistant.components.fastdotcom.coordinator.fast_com",

--- a/tests/components/fastdotcom/test_coordinator.py
+++ b/tests/components/fastdotcom/test_coordinator.py
@@ -30,8 +30,6 @@ async def test_fastdotcom_data_update_coordinator(
     state = hass.states.get("sensor.fast_com_download")
     assert state is not None
 
-    coordinator = hass.data[config_entry.domain][config_entry.entry_id]
-    assert coordinator.last_update_success is True
 
     with patch(
         "homeassistant.components.fastdotcom.coordinator.fast_com",

--- a/tests/components/fastdotcom/test_coordinator.py
+++ b/tests/components/fastdotcom/test_coordinator.py
@@ -40,8 +40,6 @@ async def test_fastdotcom_data_update_coordinator(
         async_fire_time_changed(hass)
         await hass.async_block_until_done()
 
-    assert coordinator.last_update_success is False
-    assert isinstance(coordinator.last_exception, UpdateFailed) is True
 
     state = hass.states.get("sensor.fast_com_download")
     assert state.state is STATE_UNAVAILABLE

--- a/tests/components/fastdotcom/test_coordinator.py
+++ b/tests/components/fastdotcom/test_coordinator.py
@@ -30,6 +30,18 @@ async def test_fastdotcom_data_update_coordinator(
     state = hass.states.get("sensor.fast_com_download")
     assert state is not None
 
+    coordinator = hass.data[config_entry.domain][config_entry.entry_id]
+    assert coordinator.last_update_success is True
+
+    with patch(
+        "homeassistant.components.fastdotcom.coordinator.fast_com", return_value=10.0
+    ):
+        freezer.tick(timedelta(minutes=5, seconds=1))
+        async_fire_time_changed(hass)
+        await coordinator.async_refresh()
+
+    state = hass.states.get("sensor.fast_com_download")
+    assert state.state == "10.0"
 
     with patch(
         "homeassistant.components.fastdotcom.coordinator.fast_com",

--- a/tests/components/fastdotcom/test_coordinator.py
+++ b/tests/components/fastdotcom/test_coordinator.py
@@ -36,7 +36,9 @@ async def test_fastdotcom_data_update_coordinator(
         "homeassistant.components.fastdotcom.coordinator.fast_com",
         side_effect=Exception("Test error"),
     ):
-        await coordinator.async_refresh()
+        freezer.tick(timedelta(minutes=5, seconds=1))
+        async_fire_time_changed(hass)
+        await hass.async_block_until_done()
 
     assert coordinator.last_update_success is False
     assert isinstance(coordinator.last_exception, UpdateFailed) is True

--- a/tests/components/fastdotcom/test_coordinator.py
+++ b/tests/components/fastdotcom/test_coordinator.py
@@ -14,7 +14,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 async def test_fastdotcom_data_update_coordinator(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
-    """Test the reauth form."""
+    """Test the update coordinator."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="UNIQUE_TEST_ID",

--- a/tests/components/fastdotcom/test_coordinator.py
+++ b/tests/components/fastdotcom/test_coordinator.py
@@ -35,8 +35,6 @@ async def test_fastdotcom_data_update_coordinator(
     state = hass.states.get("sensor.fast_com_download")
     assert state is not None
 
-    freezer.tick(timedelta(minutes=5, seconds=1))
-    async_fire_time_changed(hass)
     with patch(
         "homeassistant.components.fastdotcom.coordinator.fast_com",
         side_effect=Exception("Test error"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As proposed earlier with @gjohansson-ST to split PR's and dedicate a PR to include the DateUpdateCoordinator. This will also fix a `ValueError` upon a clean installation, which is fully mitigated by utilizing the `DataUpdateCoordinator` method.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
