### PR TITLE
Fix Lyric LCC thermostats auto mode

### DIFF
--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import enum
 import logging
 from time import localtime, strftime, time
 from typing import Any
@@ -151,6 +152,13 @@ async def async_setup_entry(
     )
 
 
+class LyricThermostatType(enum.Enum):
+    """Lyric thermostats are classified as TCC or LCC devices."""
+
+    TCC = enum.auto()
+    LCC = enum.auto()
+
+
 class LyricClimate(LyricDeviceEntity, ClimateEntity):
     """Defines a Honeywell Lyric climate entity."""
 
@@ -201,8 +209,10 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         # Setup supported features
         if device.changeableValues.thermostatSetpointStatus:
             self._attr_supported_features = SUPPORT_FLAGS_LCC
+            self._attr_thermostat_type = LyricThermostatType.LCC
         else:
             self._attr_supported_features = SUPPORT_FLAGS_TCC
+            self._attr_thermostat_type = LyricThermostatType.TCC
 
         # Setup supported fan modes
         if device_fan_modes := device.settings.attributes.get("fan", {}).get(
@@ -356,56 +366,69 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         """Set hvac mode."""
         _LOGGER.debug("HVAC mode: %s", hvac_mode)
         try:
-            if LYRIC_HVAC_MODES[hvac_mode] == LYRIC_HVAC_MODE_HEAT_COOL:
-                # If the system is off, turn it to Heat first then to Auto,
-                # otherwise it turns to.
-                # Auto briefly and then reverts to Off (perhaps related to
-                # heatCoolMode). This is the behavior that happens with the
-                # native app as well, so likely a bug in the api itself
-                if HVAC_MODES[self.device.changeableValues.mode] == HVACMode.OFF:
-                    _LOGGER.debug(
-                        "HVAC mode passed to lyric: %s",
-                        HVAC_MODES[LYRIC_HVAC_MODE_COOL],
-                    )
-                    await self._update_thermostat(
-                        self.location,
-                        self.device,
-                        mode=HVAC_MODES[LYRIC_HVAC_MODE_HEAT],
-                        autoChangeoverActive=False,
-                    )
-                    # Sleep 3 seconds before proceeding
-                    await asyncio.sleep(3)
-                    _LOGGER.debug(
-                        "HVAC mode passed to lyric: %s",
-                        HVAC_MODES[LYRIC_HVAC_MODE_HEAT],
-                    )
-                    await self._update_thermostat(
-                        self.location,
-                        self.device,
-                        mode=HVAC_MODES[LYRIC_HVAC_MODE_HEAT],
-                        autoChangeoverActive=True,
-                    )
-                else:
-                    _LOGGER.debug(
-                        "HVAC mode passed to lyric: %s",
-                        HVAC_MODES[self.device.changeableValues.mode],
-                    )
-                    await self._update_thermostat(
-                        self.location, self.device, autoChangeoverActive=True
-                    )
-            else:
+            match self._attr_thermostat_type:
+                case LyricThermostatType.TCC:
+                    await self._async_set_hvac_mode_tcc(hvac_mode)
+                case LyricThermostatType.LCC:
+                    await self._async_set_hvac_mode_lcc(hvac_mode)
+        except LYRIC_EXCEPTIONS as exception:
+            _LOGGER.error(exception)
+        await self.coordinator.async_refresh()
+
+    async def _async_set_hvac_mode_tcc(self, hvac_mode: HVACMode) -> None:
+        if LYRIC_HVAC_MODES[hvac_mode] == LYRIC_HVAC_MODE_HEAT_COOL:
+            # If the system is off, turn it to Heat first then to Auto,
+            # otherwise it turns to.
+            # Auto briefly and then reverts to Off (perhaps related to
+            # heatCoolMode). This is the behavior that happens with the
+            # native app as well, so likely a bug in the api itself
+            if HVAC_MODES[self.device.changeableValues.mode] == HVACMode.OFF:
                 _LOGGER.debug(
-                    "HVAC mode passed to lyric: %s", LYRIC_HVAC_MODES[hvac_mode]
+                    "HVAC mode passed to lyric: %s",
+                    HVAC_MODES[LYRIC_HVAC_MODE_COOL],
                 )
                 await self._update_thermostat(
                     self.location,
                     self.device,
-                    mode=LYRIC_HVAC_MODES[hvac_mode],
+                    mode=HVAC_MODES[LYRIC_HVAC_MODE_HEAT],
                     autoChangeoverActive=False,
                 )
-        except LYRIC_EXCEPTIONS as exception:
-            _LOGGER.error(exception)
-        await self.coordinator.async_refresh()
+                # Sleep 3 seconds before proceeding
+                await asyncio.sleep(3)
+                _LOGGER.debug(
+                    "HVAC mode passed to lyric: %s",
+                    HVAC_MODES[LYRIC_HVAC_MODE_HEAT],
+                )
+                await self._update_thermostat(
+                    self.location,
+                    self.device,
+                    mode=HVAC_MODES[LYRIC_HVAC_MODE_HEAT],
+                    autoChangeoverActive=True,
+                )
+            else:
+                _LOGGER.debug(
+                    "HVAC mode passed to lyric: %s",
+                    HVAC_MODES[self.device.changeableValues.mode],
+                )
+                await self._update_thermostat(
+                    self.location, self.device, autoChangeoverActive=True
+                )
+        else:
+            _LOGGER.debug("HVAC mode passed to lyric: %s", LYRIC_HVAC_MODES[hvac_mode])
+            await self._update_thermostat(
+                self.location,
+                self.device,
+                mode=LYRIC_HVAC_MODES[hvac_mode],
+                autoChangeoverActive=False,
+            )
+
+    async def _async_set_hvac_mode_lcc(self, hvac_mode: HVACMode) -> None:
+        _LOGGER.debug("HVAC mode passed to lyric: %s", LYRIC_HVAC_MODES[hvac_mode])
+        await self._update_thermostat(
+            self.location,
+            self.device,
+            mode=LYRIC_HVAC_MODES[hvac_mode],
+        )
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set preset (PermanentHold, HoldUntil, NoHold, VacationHold) mode."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Honeywell Lyric thermostats may either be "LCC" or "TCC" devices, as described [here](https://developer.honeywellhome.com/content/t-series-thermostat-guide). TCC devices use the `autoChangeoverActive` field to configure whether the thermostat is in "auto" (heat/cool) mode, while LCC devices ignore that field and use a value of `"Auto"` for the `mode` field.

This component currently only supports the TCC method of setting the mode, so this PR adds support for the LCC method. The latter is actually extremely simple: pass only the mode to the update call.
* The `autoChangeoverActive` parameter can be omitted since [the underlying library will just reset it to what it already was](https://github.com/timmo001/aiolyric/blob/8dbe9ebb55f600ca56534f1ef40b7983a4d0a11e/aiolyric/__init__.py#L138).
* The `thermostatSetpointStatus` parameter can be omitted since [the underlying library will ensure it gets set to a sane value](https://github.com/timmo001/aiolyric/blob/8dbe9ebb55f600ca56534f1ef40b7983a4d0a11e/aiolyric/__init__.py#L145)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
