### PR TITLE
Correct SerialException import in dsmr, firmata, landysgyr_heat_meater and rfxtrx integrations

### DIFF
--- a/homeassistant/components/dsmr/config_flow.py
+++ b/homeassistant/components/dsmr/config_flow.py
@@ -116,7 +116,7 @@ class DSMRConnection:
 
         try:
             transport, protocol = await asyncio.create_task(reader_factory())
-        except (serial.serialutil.SerialException, OSError):
+        except (serial.SerialException, OSError):
             LOGGER.exception("Error connecting to DSMR")
             return False
 

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -651,7 +651,7 @@ async def async_setup_entry(
                     entry.data.get(CONF_RECONNECT_INTERVAL, DEFAULT_RECONNECT_INTERVAL)
                 )
 
-            except (serial.serialutil.SerialException, OSError):
+            except (serial.SerialException, OSError):
                 # Log any error while establishing connection and drop to retry
                 # connection wait
                 LOGGER.exception("Error connecting to DSMR")

--- a/homeassistant/components/firmata/board.py
+++ b/homeassistant/components/firmata/board.py
@@ -65,12 +65,12 @@ class FirmataBoard:
         except RuntimeError as err:
             _LOGGER.error("Error connecting to PyMata board %s: %s", self.name, err)
             return False
-        except serial.serialutil.SerialTimeoutException as err:
+        except serial.SerialTimeoutException as err:
             _LOGGER.error(
                 "Timeout writing to serial port for PyMata board %s: %s", self.name, err
             )
             return False
-        except serial.serialutil.SerialException as err:
+        except serial.SerialException as err:
             _LOGGER.error(
                 "Error connecting to serial port for PyMata board %s: %s",
                 self.name,

--- a/homeassistant/components/firmata/config_flow.py
+++ b/homeassistant/components/firmata/config_flow.py
@@ -41,12 +41,12 @@ class FirmataFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         except RuntimeError as err:
             _LOGGER.error("Error connecting to PyMata board %s: %s", name, err)
             return self.async_abort(reason="cannot_connect")
-        except serial.serialutil.SerialTimeoutException as err:
+        except serial.SerialTimeoutException as err:
             _LOGGER.error(
                 "Timeout writing to serial port for PyMata board %s: %s", name, err
             )
             return self.async_abort(reason="cannot_connect")
-        except serial.serialutil.SerialException as err:
+        except serial.SerialException as err:
             _LOGGER.error(
                 "Error connecting to serial port for PyMata board %s: %s", name, err
             )

--- a/homeassistant/components/landisgyr_heat_meter/config_flow.py
+++ b/homeassistant/components/landisgyr_heat_meter/config_flow.py
@@ -108,7 +108,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 # validate and retrieve the model and device number for a unique id
                 data = await self.hass.async_add_executor_job(heat_meter.read)
 
-        except (asyncio.TimeoutError, serial.serialutil.SerialException) as err:
+        except (asyncio.TimeoutError, serial.SerialException) as err:
             _LOGGER.warning("Failed read data from: %s. %s", port, err)
             raise CannotConnect(f"Error communicating with device: {err}") from err
 

--- a/homeassistant/components/landisgyr_heat_meter/coordinator.py
+++ b/homeassistant/components/landisgyr_heat_meter/coordinator.py
@@ -33,5 +33,5 @@ class UltraheatCoordinator(DataUpdateCoordinator[HeatMeterResponse]):
         try:
             async with asyncio.timeout(ULTRAHEAT_TIMEOUT):
                 return await self.hass.async_add_executor_job(self.api.read)
-        except (FileNotFoundError, serial.serialutil.SerialException) as err:
+        except (FileNotFoundError, serial.SerialException) as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -643,7 +643,7 @@ def _test_transport(host: str | None, port: int | None, device: str | None) -> b
     else:
         try:
             conn = rfxtrxmod.PySerialTransport(device)
-        except serial.serialutil.SerialException:
+        except serial.SerialException:
             return False
 
         if conn.serial is None:

--- a/tests/components/dsmr/test_config_flow.py
+++ b/tests/components/dsmr/test_config_flow.py
@@ -335,7 +335,7 @@ async def test_setup_serial_fail(
     # override the mock to have it fail the first time and succeed after
     first_fail_connection_factory = AsyncMock(
         return_value=(transport, protocol),
-        side_effect=chain([serial.serialutil.SerialException], repeat(DEFAULT)),
+        side_effect=chain([serial.SerialException], repeat(DEFAULT)),
     )
 
     assert result["type"] == "form"

--- a/tests/components/firmata/test_config_flow.py
+++ b/tests/components/firmata/test_config_flow.py
@@ -31,7 +31,7 @@ async def test_import_cannot_connect_serial(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.firmata.board.PymataExpress.start_aio",
-        side_effect=serial.serialutil.SerialException,
+        side_effect=serial.SerialException,
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -48,7 +48,7 @@ async def test_import_cannot_connect_serial_timeout(hass: HomeAssistant) -> None
 
     with patch(
         "homeassistant.components.firmata.board.PymataExpress.start_aio",
-        side_effect=serial.serialutil.SerialTimeoutException,
+        side_effect=serial.SerialTimeoutException,
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,

--- a/tests/components/landisgyr_heat_meter/test_config_flow.py
+++ b/tests/components/landisgyr_heat_meter/test_config_flow.py
@@ -104,7 +104,7 @@ async def test_list_entry(mock_port, mock_heat_meter, hass: HomeAssistant) -> No
 async def test_manual_entry_fail(mock_heat_meter, hass: HomeAssistant) -> None:
     """Test manual entry fails."""
 
-    mock_heat_meter().read.side_effect = serial.serialutil.SerialException
+    mock_heat_meter().read.side_effect = serial.SerialException
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -135,7 +135,7 @@ async def test_manual_entry_fail(mock_heat_meter, hass: HomeAssistant) -> None:
 async def test_list_entry_fail(mock_port, mock_heat_meter, hass: HomeAssistant) -> None:
     """Test select from list entry fails."""
 
-    mock_heat_meter().read.side_effect = serial.serialutil.SerialException
+    mock_heat_meter().read.side_effect = serial.SerialException
     port = mock_serial_port()
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/landisgyr_heat_meter/test_sensor.py
+++ b/tests/components/landisgyr_heat_meter/test_sensor.py
@@ -150,7 +150,7 @@ async def test_exception_on_polling(
     assert state.state == "123.0"
 
     # Now 'disable' the connection and wait for polling and see if it fails
-    mock_heat_meter().read.side_effect = serial.serialutil.SerialException
+    mock_heat_meter().read.side_effect = serial.SerialException
     freezer.tick(POLLING_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -216,7 +216,7 @@ async def test_setup_network_fail(transport_mock, hass: HomeAssistant) -> None:
 @patch("serial.tools.list_ports.comports", return_value=[com_port()])
 @patch(
     "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.connect",
-    side_effect=serial.serialutil.SerialException,
+    side_effect=serial.SerialException,
 )
 async def test_setup_serial_fail(com_mock, connect_mock, hass: HomeAssistant) -> None:
     """Test setup serial failed connection."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use direct import of `SerialException` and `SerialTimeoutException`.

See: https://pyserial.readthedocs.io/en/latest/pyserial_api.html#serial.SerialException

Affected integrations:
- dsmr
- firmata
- landysgyr_heat_meter
- rfxtrx


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #104876
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
