### PR TITLE
Fix incompatible 'measurement' state and 'volume' device class warnings in Overkiz

### DIFF
--- a/homeassistant/components/overkiz/sensor.py
+++ b/homeassistant/components/overkiz/sensor.py
@@ -100,7 +100,7 @@ SENSOR_DESCRIPTIONS: list[OverkizSensorDescription] = [
         name="Water volume estimation at 40 °C",
         icon="mdi:water",
         native_unit_of_measurement=UnitOfVolume.LITERS,
-        device_class=SensorDeviceClass.VOLUME,
+        device_class=SensorDeviceClass.VOLUME_STORAGE,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
     ),
@@ -110,7 +110,7 @@ SENSOR_DESCRIPTIONS: list[OverkizSensorDescription] = [
         icon="mdi:water",
         native_unit_of_measurement=UnitOfVolume.LITERS,
         device_class=SensorDeviceClass.VOLUME,
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=SensorStateClass.TOTAL_INCREASING,
     ),
     OverkizSensorDescription(
         key=OverkizState.IO_OUTLET_ENGINE,


### PR DESCRIPTION
This PR includes fixes to eliminate warning such as:
```
2023-12-02 09:20:39.475 INFO (MainThread) [homeassistant.components.water_heater] Setting up water_heater.overkiz
2023-12-02 09:20:39.482 WARNING (MainThread) [homeassistant.components.sensor] Entity sensor.dhwp_actuator_water_volume_estimation_at_40_degc (<class 'homeassistant.components.overkiz.sensor.OverkizStateSensor'>) is using state class 'measurement' which is impossible considering device class ('volume') it is using; expected None or one of 'total', 'total_increasing'; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+overkiz%22
2023-12-02 09:20:39.483 WARNING (MainThread) [homeassistant.components.sensor] Entity sensor.dhwp_actuator_water_consumption (<class 'homeassistant.components.overkiz.sensor.OverkizStateSensor'>) is using state class 'measurement' which is impossible considering device class ('volume') it is using; expected None or one of 'total', 'total_increasing'; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+overkiz%22
```

Such changes were already mentioned in several PRs, but never made it into `dev`:
* https://github.com/home-assistant/core/pull/87139#pullrequestreview-1348281730
* https://github.com/home-assistant/core/pull/89948