### PR TITLE
Update motion_light.yaml: allow the selection of groups

### DIFF
--- a/homeassistant/components/automation/blueprints/motion_light.yaml
+++ b/homeassistant/components/automation/blueprints/motion_light.yaml
@@ -10,47 +10,47 @@ blueprint:
       selector:
         entity:
           filter:
-            device_class: motion
-            domain: binary_sensor
+            domain:
+              - binary_sensor
+              - group
+          multiple: false
     light_target:
       name: Light
       selector:
         target:
           entity:
-            domain: light
+            - domain:
+                - light
     no_motion_wait:
       name: Wait time
       description: Time to leave the light on after last motion is detected.
       default: 120
       selector:
         number:
-          min: 0
-          max: 3600
+          min: 0.0
+          max: 3600.0
           unit_of_measurement: seconds
-
-# If motion is detected within the delay,
-# we restart the script.
+          mode: slider
+          step: 1.0
 mode: restart
 max_exceeded: silent
-
 trigger:
   platform: state
   entity_id: !input motion_entity
   from: "off"
   to: "on"
-
 action:
-  - alias: "Turn on the light"
+  - alias: Turn on the light
     service: light.turn_on
     target: !input light_target
-  - alias: "Wait until there is no motion from device"
+  - alias: Wait until there is no motion from device
     wait_for_trigger:
       platform: state
       entity_id: !input motion_entity
       from: "on"
       to: "off"
-  - alias: "Wait the number of seconds that has been set"
+  - alias: Wait the number of seconds that has been set
     delay: !input no_motion_wait
-  - alias: "Turn off the light"
+  - alias: Turn off the light
     service: light.turn_off
     target: !input light_target


### PR DESCRIPTION
Allow the selection of groups in motion_light.yaml. This allows you to group multiple motion sensors in a group, and turn off the light when the whole group clears.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Not breaking, but it does allow you to select you to any binary sensor, since I couldn't find a way to specify the domain using this approach:

![CleanShot 2023-12-02 at 10 06 59@2x](https://github.com/home-assistant/core/assets/528287/f5fff147-1c70-4bd3-a37c-78c426825bf2)


## Proposed change
I have three sensors in my hallway and adjacent storage room. I want to turn on the lights when any of these sensors trigger, and turn them off when they're all clear. Creating a complex automation seems overkill, since this is a great case for a binary sensor group.

I love the simplicity of `motion_light.yaml`, but it doesn't allow you to select any groups. That's why I made this PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [   Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
