### PR TITLE
Add minimum state duration variable to `history_stats` sensor config

### DIFF
--- a/homeassistant/components/history_stats/data.py
+++ b/homeassistant/components/history_stats/data.py
@@ -202,7 +202,7 @@ class HistoryStats:
                 history_state_duration = (
                     state_change_timestamp - last_state_change_timestamp
                 )
-                if history_state_duration >= min_state_timestamp:
+                if abs(history_state_duration) >= min_state_timestamp:
                     elapsed += history_state_duration
                 else:
                     match_count -= 1
@@ -216,7 +216,7 @@ class HistoryStats:
         if previous_state_matches:
             measure_end = min(end_timestamp, now_timestamp)
             last_state_duration = measure_end - last_state_change_timestamp
-            if last_state_duration >= min_state_timestamp:
+            if abs(last_state_duration) >= min_state_timestamp:
                 elapsed += last_state_duration
             else:
                 match_count -= 1

--- a/homeassistant/components/history_stats/data.py
+++ b/homeassistant/components/history_stats/data.py
@@ -202,7 +202,7 @@ class HistoryStats:
                 history_state_duration = (
                     state_change_timestamp - last_state_change_timestamp
                 )
-                if history_state_duration > min_state_timestamp:
+                if history_state_duration >= min_state_timestamp:
                     elapsed += history_state_duration
                 else:
                     match_count -= 1
@@ -216,7 +216,7 @@ class HistoryStats:
         if previous_state_matches:
             measure_end = min(end_timestamp, now_timestamp)
             last_state_duration = measure_end - last_state_change_timestamp
-            if last_state_duration > min_state_timestamp:
+            if last_state_duration >= min_state_timestamp:
                 elapsed += last_state_duration
             else:
                 match_count -= 1

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -877,6 +877,16 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
                         "min_state_duration": {"minutes": 5},
                         "type": "time",
                     },
+                    {
+                        "platform": "history_stats",
+                        "entity_id": "binary_sensor.state",
+                        "name": "sensor5",
+                        "state": "off",
+                        "start": "{{ utcnow().replace(hour=0, minute=0, second=0) }}",
+                        "duration": {"hours": 2},
+                        "min_state_duration": {"minutes": 20},
+                        "type": "time",
+                    },
                 ]
             },
         )
@@ -891,6 +901,7 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
     assert hass.states.get("sensor.sensor3").state == "1"
     assert hass.states.get("sensor.sensor4").state == "0.0"
     assert hass.states.get("sensor.sensor5").state == "0.0"
+    assert hass.states.get("sensor.sensor6").state == "0.0"
 
     one_hour_in = start_time + timedelta(minutes=60)
     with freeze_time(one_hour_in):
@@ -902,6 +913,7 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
     assert hass.states.get("sensor.sensor3").state == "1"
     assert hass.states.get("sensor.sensor4").state == "50.0"
     assert hass.states.get("sensor.sensor5").state == "1.0"
+    assert hass.states.get("sensor.sensor6").state == "0.0"
 
     turn_off_time = start_time + timedelta(minutes=90)
     with freeze_time(turn_off_time):
@@ -915,6 +927,7 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
     assert hass.states.get("sensor.sensor3").state == "1"
     assert hass.states.get("sensor.sensor4").state == "75.0"
     assert hass.states.get("sensor.sensor5").state == "1.5"
+    assert hass.states.get("sensor.sensor6").state == "0.0"
 
     turn_back_on_time = start_time + timedelta(minutes=105)
     with freeze_time(turn_back_on_time):
@@ -926,6 +939,7 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
     assert hass.states.get("sensor.sensor3").state == "1"
     assert hass.states.get("sensor.sensor4").state == "75.0"
     assert hass.states.get("sensor.sensor5").state == "1.5"
+    assert hass.states.get("sensor.sensor6").state == "0.0"
 
     with freeze_time(turn_back_on_time):
         hass.states.async_set("binary_sensor.state", "on")
@@ -936,6 +950,7 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
     assert hass.states.get("sensor.sensor3").state == "2"
     assert hass.states.get("sensor.sensor4").state == "75.0"
     assert hass.states.get("sensor.sensor5").state == "1.5"
+    assert hass.states.get("sensor.sensor6").state == "0.0"
 
     end_time = start_time + timedelta(minutes=120)
     with freeze_time(end_time):
@@ -947,6 +962,7 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
     assert hass.states.get("sensor.sensor3").state == "2"
     assert hass.states.get("sensor.sensor4").state == "87.5"
     assert hass.states.get("sensor.sensor5").state == "1.75"
+    assert hass.states.get("sensor.sensor6").state == "0.0"
 
 
 async def test_does_not_work_into_the_future(

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -880,7 +880,7 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
                     {
                         "platform": "history_stats",
                         "entity_id": "binary_sensor.state",
-                        "name": "sensor5",
+                        "name": "sensor6",
                         "state": "off",
                         "start": "{{ utcnow().replace(hour=0, minute=0, second=0) }}",
                         "duration": {"hours": 2},

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -867,6 +867,16 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
                         "duration": {"hours": 2},
                         "type": "ratio",
                     },
+                    {
+                        "platform": "history_stats",
+                        "entity_id": "binary_sensor.state",
+                        "name": "sensor5",
+                        "state": "on",
+                        "start": "{{ utcnow().replace(hour=0, minute=0, second=0) }}",
+                        "duration": {"hours": 2},
+                        "min_state_duration": {"minutes": 5},
+                        "type": "time",
+                    },
                 ]
             },
         )
@@ -880,6 +890,7 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
     assert hass.states.get("sensor.sensor2").state == "0.0"
     assert hass.states.get("sensor.sensor3").state == "1"
     assert hass.states.get("sensor.sensor4").state == "0.0"
+    assert hass.states.get("sensor.sensor5").state == "0.0"
 
     one_hour_in = start_time + timedelta(minutes=60)
     with freeze_time(one_hour_in):
@@ -890,6 +901,7 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
     assert hass.states.get("sensor.sensor2").state == "1.0"
     assert hass.states.get("sensor.sensor3").state == "1"
     assert hass.states.get("sensor.sensor4").state == "50.0"
+    assert hass.states.get("sensor.sensor5").state == "1.0"
 
     turn_off_time = start_time + timedelta(minutes=90)
     with freeze_time(turn_off_time):
@@ -902,6 +914,7 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
     assert hass.states.get("sensor.sensor2").state == "1.5"
     assert hass.states.get("sensor.sensor3").state == "1"
     assert hass.states.get("sensor.sensor4").state == "75.0"
+    assert hass.states.get("sensor.sensor5").state == "1.5"
 
     turn_back_on_time = start_time + timedelta(minutes=105)
     with freeze_time(turn_back_on_time):
@@ -912,6 +925,7 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
     assert hass.states.get("sensor.sensor2").state == "1.5"
     assert hass.states.get("sensor.sensor3").state == "1"
     assert hass.states.get("sensor.sensor4").state == "75.0"
+    assert hass.states.get("sensor.sensor5").state == "1.5"
 
     with freeze_time(turn_back_on_time):
         hass.states.async_set("binary_sensor.state", "on")
@@ -921,6 +935,7 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
     assert hass.states.get("sensor.sensor2").state == "1.5"
     assert hass.states.get("sensor.sensor3").state == "2"
     assert hass.states.get("sensor.sensor4").state == "75.0"
+    assert hass.states.get("sensor.sensor5").state == "1.5"
 
     end_time = start_time + timedelta(minutes=120)
     with freeze_time(end_time):
@@ -931,6 +946,7 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
     assert hass.states.get("sensor.sensor2").state == "1.75"
     assert hass.states.get("sensor.sensor3").state == "2"
     assert hass.states.get("sensor.sensor4").state == "87.5"
+    assert hass.states.get("sensor.sensor5").state == "1.75"
 
 
 async def test_does_not_work_into_the_future(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add optional minimum state duration `min_state_duration` variable to `history_stats` sensor config. It's setting the minimum duration for a state change to be considered in the statistical calculations. Defaults to 0.

Eg:

```
sensor:
  - platform: history_stats
    name: BLE device
    entity_id: binary_sensor.my_ble
    min_state_duration:
      minutes: 2
    state: "off"
    type: time
    start: "{{ now().replace(hour=0, minute=0, second=0) }}"
    end: "{{ now() }}"
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30118

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
