### PR TITLE
Fix Lyric HVAC mode reset on temperature change

### DIFF
--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -330,7 +330,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
             mode = (
                 None
                 if device.changeableValues.mode == LYRIC_HVAC_MODE_HEAT_COOL
-                else device.changeableValues.heatCoolMode
+                else HVAC_MODES[device.changeableValues.heatCoolMode]
             )
 
             _LOGGER.debug("Set temperature: %s - %s", target_temp_low, target_temp_high)

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -318,7 +318,28 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         target_temp_low = kwargs.get(ATTR_TARGET_TEMP_LOW)
         target_temp_high = kwargs.get(ATTR_TARGET_TEMP_HIGH)
 
-        if device.changeableValues.autoChangeoverActive:
+        if device.changeableValues.mode == LYRIC_HVAC_MODE_HEAT_COOL:
+            # If the device supports "Auto" mode, don't pass the mode when setting the
+            # temperature
+            if target_temp_low is None or target_temp_high is None:
+                raise HomeAssistantError(
+                    "Could not find target_temp_low and/or target_temp_high in"
+                    " arguments"
+                )
+            _LOGGER.debug("Set temperature: %s - %s", target_temp_low, target_temp_high)
+            try:
+                await self._update_thermostat(
+                    self.location,
+                    device,
+                    coolSetpoint=target_temp_high,
+                    heatSetpoint=target_temp_low,
+                )
+            except LYRIC_EXCEPTIONS as exception:
+                _LOGGER.error(exception)
+            await self.coordinator.async_refresh()
+        elif device.changeableValues.autoChangeoverActive:
+            # If the device uses "autoChangeoverActive", pass the "heatCoolMode" as the
+            # mode
             if target_temp_low is None or target_temp_high is None:
                 raise HomeAssistantError(
                     "Could not find target_temp_low and/or target_temp_high in"


### PR DESCRIPTION
## Proposed change
When my T10 thermostat is in "Auto" mode, changing the temperature causes it to be reset back to it's previous mode (e.g. "Heat").

This is because the `async_set_temperature` method passes the `mode=HVAC_MODES[device.changeableValues.heatCoolMode]` option to the `_update_thermostat` call. When the thermostat is in "Auto" mode, the `heatCoolMode` shows either "Heat" or "Cool" depending on the actual heating or cooling state. E.g.
```
"changeableValues": {
  "mode": "Auto",
  "autoChangeoverActive": true,
  ...
  "heatCoolMode": "Heat"
},
```
Passing this back in as the mode causes the device to be reset back to "Heat" mode.

This checks if the device is in "Auto" mode first, and if so, omits the `mode` parameter when updating the thermostat.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
