### PR TITLE
Retry braviatv failed power status query

### DIFF
--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -17,7 +17,7 @@ from pybravia import (
     BraviaNotFound,
     BraviaTurnedOff,
 )
-from tenacity import Retrying, stop_after_attempt
+from tenacity import AsyncRetrying, stop_after_attempt
 
 from homeassistant.components.media_player import MediaType
 from homeassistant.const import CONF_PIN
@@ -143,7 +143,9 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
                     raise ConfigEntryAuthFailed from err
 
             # Retry up to 3 times in case request failed
-            for attempt in Retrying(reraise=True, stop=stop_after_attempt(3)):
+            async for attempt in AsyncRetrying(
+                reraise=True, stop=stop_after_attempt(3)
+            ):
                 with attempt:
                     power_status = await self.client.get_power_status()
 

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -142,7 +142,7 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
                 except BraviaAuthError as err:
                     raise ConfigEntryAuthFailed from err
 
-            # Retry up to 3 times if request failed
+            # Retry up to 3 times in case request failed
             for attempt in Retrying(reraise=True, stop=stop_after_attempt(3)):
                 with attempt:
                     power_status = await self.client.get_power_status()

--- a/homeassistant/components/braviatv/manifest.json
+++ b/homeassistant/components/braviatv/manifest.json
@@ -7,7 +7,10 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["pybravia"],
-  "requirements": ["pybravia==0.3.3"],
+  "requirements": [
+    "pybravia==0.3.3",
+    "tenacity==8.2.3"
+  ],
   "ssdp": [
     {
       "st": "urn:schemas-sony-com:service:ScalarWebAPI:1",

--- a/homeassistant/components/braviatv/manifest.json
+++ b/homeassistant/components/braviatv/manifest.json
@@ -7,10 +7,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["pybravia"],
-  "requirements": [
-    "pybravia==0.3.3",
-    "tenacity==8.2.3"
-  ],
+  "requirements": ["pybravia==0.3.3", "tenacity==8.2.3"],
   "ssdp": [
     {
       "st": "urn:schemas-sony-com:service:ScalarWebAPI:1",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2578,6 +2578,9 @@ temescal==0.5
 # homeassistant.components.temper
 temperusb==1.6.0
 
+# homeassistant.components.braviatv
+tenacity==8.2.3
+
 # homeassistant.components.tensorflow
 # tensorflow==2.5.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1921,6 +1921,9 @@ temescal==0.5
 # homeassistant.components.temper
 temperusb==1.6.0
 
+# homeassistant.components.braviatv
+tenacity==8.2.3
+
 # homeassistant.components.powerwall
 tesla-powerwall==0.3.19
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR retries the power status request up to three times on error. This should fix #98816 in most scenarios, as previously network request timeouts would cause the TV power status to switch to `off` for 10 seconds, even whilst the TV is still on.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #98816

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
