### PR TITLE
Fix feedreader date comparison to allow RSS entries with identical timestamps

### DIFF
--- a/homeassistant/components/feedreader/__init__.py
+++ b/homeassistant/components/feedreader/__init__.py
@@ -197,35 +197,40 @@ class FeedManager:
             )
         entry.update({"feed_url": self._url})
         self._hass.bus.fire(self._event_type, entry)
+        _LOGGER.debug("New event fired for entry %s", entry.get("link"))
 
     def _publish_new_entries(self) -> None:
         """Publish new entries to the event bus."""
         assert self._feed is not None
-        new_entries = False
+        new_entry_count = 0
         self._last_entry_timestamp = self._storage.get_timestamp(self._feed_id)
         if self._last_entry_timestamp:
             self._firstrun = False
         else:
             # Set last entry timestamp as epoch time if not available
             self._last_entry_timestamp = dt_util.utc_from_timestamp(0).timetuple()
+        # locally cache self._last_entry_timestamp so that entries published at identical times can be processed
+        last_entry_timestamp = self._last_entry_timestamp
         for entry in self._feed.entries:
             if (
                 self._firstrun
                 or (
                     "published_parsed" in entry
-                    and entry.published_parsed > self._last_entry_timestamp
+                    and entry.published_parsed > last_entry_timestamp
                 )
                 or (
                     "updated_parsed" in entry
-                    and entry.updated_parsed > self._last_entry_timestamp
+                    and entry.updated_parsed > last_entry_timestamp
                 )
             ):
                 self._update_and_fire_entry(entry)
-                new_entries = True
+                new_entry_count += 1
             else:
-                _LOGGER.debug("Entry %s already processed", entry)
-        if not new_entries:
+                _LOGGER.debug("Already processed entry %s", entry.get("link"))
+        if new_entry_count == 0:
             self._log_no_entries()
+        else:
+            _LOGGER.debug("%d entries published in feed %s", new_entry_count, self._url)
         self._firstrun = False
 
 

--- a/tests/fixtures/feedreader6.xml
+++ b/tests/fixtures/feedreader6.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+    <channel>
+        <title>RSS Sample</title>
+        <description>This is an example of an RSS feed</description>
+        <link>http://www.example.com/main.html</link>
+        <lastBuildDate>Mon, 30 Apr 2018 12:00:00 +0000 </lastBuildDate>
+        <pubDate>Mon, 30 Apr 2018 15:00:00 +0000</pubDate>
+        <ttl>1800</ttl>
+
+        <item>
+            <title>Title 1</title>
+            <description>Description 1</description>
+            <link>http://www.example.com/link/1</link>
+            <guid isPermaLink="false">GUID 1</guid>
+            <pubDate>Mon, 30 Apr 2018 15:10:00 +0000</pubDate>
+        </item>
+        <item>
+            <title>Title 2</title>
+            <description>Description 2</description>
+            <link>http://www.example.com/link/2</link>
+            <guid isPermaLink="false">GUID 2</guid>
+            <pubDate>Mon, 30 Apr 2018 15:10:00 +0000</pubDate>
+        </item>
+
+    </channel>
+</rss>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This subtly changes how entries' publish dates are compared in the feedreader component. 

The old comparison logic inadvertently resulted in unique RSS feed entries that were published at the exact same time to be ignored. While the first of e.g. five entries with the same publish date would fire a `feedreader` event, the remaining four entries would be treated as "already processed" despite also being new.

The new comparison logic ensures that even entries with same publish dates get sent to the event bus. 

A new pytest catches the old behavior and passes for the new logic.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
