### PR TITLE
Add Lyric thermostat room entities

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -751,6 +751,7 @@ omit =
     homeassistant/components/lw12wifi/light.py
     homeassistant/components/lyric/__init__.py
     homeassistant/components/lyric/api.py
+    homeassistant/components/lyric/binary_sensor.py
     homeassistant/components/lyric/climate.py
     homeassistant/components/lyric/sensor.py
     homeassistant/components/mailgun/notify.py

--- a/homeassistant/components/lyric/__init__.py
+++ b/homeassistant/components/lyric/__init__.py
@@ -91,7 +91,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             async with asyncio.timeout(60):
                 await asyncio.gather(*get_thermostat_room_tasks)
 
-            return lyric
         except LyricAuthenticationException as exception:
             # Attempt to refresh the token before failing.
             # Honeywell appear to have issues keeping tokens saved.

--- a/homeassistant/components/lyric/binary_sensor.py
+++ b/homeassistant/components/lyric/binary_sensor.py
@@ -1,4 +1,5 @@
 """Support for Honeywell Lyric binary sensors."""
+
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -54,23 +55,19 @@ async def async_setup_entry(
     """Set up the Honeywell Lyric binary sensor platform based on a config entry."""
     coordinator: DataUpdateCoordinator[Lyric] = hass.data[DOMAIN][entry.entry_id]
 
-    entities = []
-
-    for location in coordinator.data.locations:
-        for device in location.devices:
-            for room in coordinator.data.rooms_dict[device.macID].values():
-                for room_sensor in ROOM_SENSORS:
-                    entities.append(
-                        LyricRoomBinarySensor(
-                            coordinator,
-                            room_sensor,
-                            location,
-                            device,
-                            room,
-                        )
-                    )
-
-    async_add_entities(entities)
+    async_add_entities(
+        LyricRoomBinarySensor(
+            coordinator,
+            room_sensor,
+            location,
+            device,
+            room,
+        )
+        for location in coordinator.data.locations
+        for device in location.devices
+        for room in coordinator.data.rooms_dict[device.macID].values()
+        for room_sensor in ROOM_SENSORS
+    )
 
 
 class LyricRoomBinarySensor(LyricRoomEntity, BinarySensorEntity):

--- a/homeassistant/components/lyric/binary_sensor.py
+++ b/homeassistant/components/lyric/binary_sensor.py
@@ -1,0 +1,104 @@
+"""Support for Honeywell Lyric binary sensors."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from aiolyric import Lyric
+from aiolyric.objects.device import LyricDevice
+from aiolyric.objects.location import LyricLocation
+from aiolyric.objects.priority import LyricRoom
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from . import LyricRoomEntity
+from .const import DOMAIN
+
+
+@dataclass(frozen=True)
+class LyricRoomBinarySensorEntityDescriptionMixin:
+    """Mixin for required keys."""
+
+    value_fn: Callable[[LyricRoom], bool]
+
+
+@dataclass(frozen=True)
+class LyricRoomBinarySensorEntityDescription(
+    BinarySensorEntityDescription, LyricRoomBinarySensorEntityDescriptionMixin
+):
+    """Class describing Honeywell Lyric room binary sensor entities."""
+
+
+ROOM_SENSORS = [
+    LyricRoomBinarySensorEntityDescription(
+        key="overall_motion",
+        translation_key="overall_motion",
+        name="overall motion",
+        device_class=BinarySensorDeviceClass.MOTION,
+        value_fn=lambda room: room.overallMotion,
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the Honeywell Lyric binary sensor platform based on a config entry."""
+    coordinator: DataUpdateCoordinator[Lyric] = hass.data[DOMAIN][entry.entry_id]
+
+    entities = []
+
+    for location in coordinator.data.locations:
+        for device in location.devices:
+            for room in coordinator.data.rooms_dict[device.macID].values():
+                for room_sensor in ROOM_SENSORS:
+                    entities.append(
+                        LyricRoomBinarySensor(
+                            coordinator,
+                            room_sensor,
+                            location,
+                            device,
+                            room,
+                        )
+                    )
+
+    async_add_entities(entities)
+
+
+class LyricRoomBinarySensor(LyricRoomEntity, BinarySensorEntity):
+    """Define a Honeywell Lyric room binary sensor."""
+
+    entity_description: LyricRoomBinarySensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator[Lyric],
+        description: LyricRoomBinarySensorEntityDescription,
+        location: LyricLocation,
+        device: LyricDevice,
+        room: LyricRoom,
+    ) -> None:
+        """Initialize."""
+        super().__init__(
+            coordinator,
+            location,
+            device,
+            room,
+            f"{device.macID}_room_{room.id}_{description.key}",
+        )
+        self.entity_description = description
+        room_name = room.roomName or f"Room {room.id}"
+        self._attr_name = f"{room_name} {description.name}"
+
+    @property
+    def is_on(self) -> bool:
+        """Return the binary state."""
+        return self.entity_description.value_fn(self.room)

--- a/homeassistant/components/lyric/manifest.json
+++ b/homeassistant/components/lyric/manifest.json
@@ -22,5 +22,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["aiolyric"],
   "quality_scale": "silver",
-  "requirements": ["aiolyric==1.1.0"]
+  "requirements": ["aiolyric==1.1.1"]
 }

--- a/homeassistant/components/lyric/sensor.py
+++ b/homeassistant/components/lyric/sensor.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 from aiolyric import Lyric
 from aiolyric.objects.device import LyricDevice
 from aiolyric.objects.location import LyricLocation
+from aiolyric.objects.priority import LyricRoom
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -24,7 +25,7 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
-from . import LyricDeviceEntity
+from . import LyricDeviceEntity, LyricRoomEntity
 from .const import (
     DOMAIN,
     PRESET_HOLD_UNTIL,
@@ -110,6 +111,44 @@ DEVICE_SENSORS: list[LyricSensorEntityDescription] = [
 ]
 
 
+@dataclass(frozen=True)
+class LyricRoomSensorEntityDescriptionMixin:
+    """Mixin for required keys."""
+
+    value_fn: Callable[[LyricRoom], StateType]
+    suitable_fn: Callable[[LyricRoom], bool]
+
+
+@dataclass(frozen=True)
+class LyricRoomSensorEntityDescription(
+    SensorEntityDescription, LyricRoomSensorEntityDescriptionMixin
+):
+    """Class describing Honeywell Lyric room sensor entities."""
+
+
+ROOM_SENSORS = [
+    LyricRoomSensorEntityDescription(
+        key="avg_temperature",
+        translation_key="avg_temperature",
+        name="average temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda room: round(room.roomAvgTemp, 1),
+        suitable_fn=lambda room: room.roomAvgTemp is not None,
+    ),
+    LyricRoomSensorEntityDescription(
+        key="avg_humidity",
+        translation_key="avg_humidity",
+        name="average humidity",
+        device_class=SensorDeviceClass.HUMIDITY,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=PERCENTAGE,
+        value_fn=lambda room: round(room.roomAvgHumidity, 1),
+        suitable_fn=lambda room: room.roomAvgHumidity is not None,
+    ),
+]
+
+
 def get_setpoint_status(status: str, time: str) -> str | None:
     """Get status of the setpoint."""
     if status == PRESET_HOLD_UNTIL:
@@ -147,6 +186,21 @@ async def async_setup_entry(
         if device_sensor.suitable_fn(device)
     )
 
+    async_add_entities(
+        LyricRoomSensor(
+            coordinator,
+            room_sensor,
+            location,
+            device,
+            room,
+        )
+        for location in coordinator.data.locations
+        for device in location.devices
+        for room in coordinator.data.rooms_dict[device.macID].values()
+        for room_sensor in ROOM_SENSORS
+        if room_sensor.suitable_fn(room)
+    )
+
 
 class LyricSensor(LyricDeviceEntity, SensorEntity):
     """Define a Honeywell Lyric sensor."""
@@ -169,12 +223,54 @@ class LyricSensor(LyricDeviceEntity, SensorEntity):
         )
         self.entity_description = description
         if description.device_class == SensorDeviceClass.TEMPERATURE:
-            if device.units == "Fahrenheit":
-                self._attr_native_unit_of_measurement = UnitOfTemperature.FAHRENHEIT
-            else:
-                self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+            self._attr_native_unit_of_measurement = _get_lyric_device_temperature_units(
+                device
+            )
 
     @property
     def native_value(self) -> StateType | datetime:
         """Return the state."""
         return self.entity_description.value_fn(self.device)
+
+
+def _get_lyric_device_temperature_units(device: LyricDevice) -> UnitOfTemperature:
+    return (
+        UnitOfTemperature.FAHRENHEIT
+        if device.units == "Fahrenheit"
+        else UnitOfTemperature.CELSIUS
+    )
+
+
+class LyricRoomSensor(LyricRoomEntity, SensorEntity):
+    """Define a Honeywell Lyric room sensor."""
+
+    entity_description: LyricRoomSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator[Lyric],
+        description: LyricRoomSensorEntityDescription,
+        location: LyricLocation,
+        device: LyricDevice,
+        room: LyricRoom,
+    ) -> None:
+        """Initialize."""
+        super().__init__(
+            coordinator,
+            location,
+            device,
+            room,
+            f"{device.macID}_room_{room.id}_{description.key}",
+        )
+        self.entity_description = description
+        room_name = room.roomName or f"Room {room.id}"
+        self._attr_name = f"{room_name} {description.name}"
+        if description.device_class == SensorDeviceClass.TEMPERATURE:
+            self._attr_native_unit_of_measurement = _get_lyric_device_temperature_units(
+                device
+            )
+
+    @property
+    def native_value(self) -> StateType:
+        """Return the state."""
+        return self.entity_description.value_fn(self.room)

--- a/homeassistant/components/lyric/strings.json
+++ b/homeassistant/components/lyric/strings.json
@@ -41,6 +41,17 @@
       },
       "setpoint_status": {
         "name": "Setpoint status"
+      },
+      "avg_temperature": {
+        "name": "Average temperature"
+      },
+      "avg_humidity": {
+        "name": "Average humidity"
+      }
+    },
+    "binary_sensor": {
+      "overall_motion": {
+        "name": "Overall motion"
       }
     }
   },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -300,7 +300,7 @@ aiolivisi==0.0.19
 aiolookin==1.0.0
 
 # homeassistant.components.lyric
-aiolyric==1.1.0
+aiolyric==1.1.1
 
 # homeassistant.components.modern_forms
 aiomodernforms==0.1.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -273,7 +273,7 @@ aiolivisi==0.0.19
 aiolookin==1.0.0
 
 # homeassistant.components.lyric
-aiolyric==1.1.0
+aiolyric==1.1.1
 
 # homeassistant.components.modern_forms
 aiomodernforms==0.1.8


### PR DESCRIPTION
## Proposed change
Honeywell thermostats can be paired with accessories like [room sensors](https://www.honeywellstore.com/store/products/honeywell-smart-room-sensor-for-t9t10-thermostats-rchtsensor-1pk.htm) in order to set certain rooms as "priorities" for the target temperature. Each sensor is added to a room within the thermostat configuration, and all sensors belonging to the same room produce aggregate measurements of average temperature, average humidity, and overall motion detection for that room. [This API](https://developer.honeywellhome.com/lyric/apis/get/devices/thermostats/%7BdeviceId%7D/priority) is used to get the rooms associated with a thermostat device.

While this room data is used by the thermostat to control its heating and cooling behavior, it would also make for useful sensor data within Home Assistant. For example, the average humidity of an individual room could be used as a trigger for an automation that turns on a humidifier.

This PR adds 3 entities for every room associated with every discovered device:
1. Average temperature (sensor)
2. Average humidity (sensor)
3. Overall motion (binary sensor)

### Example
![Screenshot 2023-12-03 at 2 58 45 PM](https://github.com/home-assistant/core/assets/3101089/01c5d578-b11f-4611-adda-667e54bc4e60)

### Dependency changes
* Updates `aiolyric` to 1.1.1 to include a [typing fix for rooms](https://github.com/timmo001/aiolyric/pull/66)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30127

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
