### PR TITLE
Fix Mikrotik rename from wifiwave2 to wifi for upcoming RouterOS 7.13

### DIFF
--- a/homeassistant/components/mikrotik/const.py
+++ b/homeassistant/components/mikrotik/const.py
@@ -25,9 +25,11 @@ CAPSMAN: Final = "capsman"
 DHCP: Final = "dhcp"
 WIRELESS: Final = "wireless"
 WIFIWAVE2: Final = "wifiwave2"
+WIFI: Final = "wifi"
 IS_WIRELESS: Final = "is_wireless"
 IS_CAPSMAN: Final = "is_capsman"
 IS_WIFIWAVE2: Final = "is_wifiwave2"
+IS_WIFI: Final = "is_wifi"
 
 
 MIKROTIK_SERVICES: Final = {
@@ -38,9 +40,11 @@ MIKROTIK_SERVICES: Final = {
     INFO: "/system/routerboard/getall",
     WIRELESS: "/interface/wireless/registration-table/getall",
     WIFIWAVE2: "/interface/wifiwave2/registration-table/print",
+    WIFI: "/interface/wifi/registration-table/print",
     IS_WIRELESS: "/interface/wireless/print",
     IS_CAPSMAN: "/caps-man/interface/print",
     IS_WIFIWAVE2: "/interface/wifiwave2/print",
+    IS_WIFI: "/interface/wifi/print",
 }
 
 

--- a/homeassistant/components/mikrotik/hub.py
+++ b/homeassistant/components/mikrotik/hub.py
@@ -31,10 +31,12 @@ from .const import (
     IDENTITY,
     INFO,
     IS_CAPSMAN,
+    IS_WIFI,
     IS_WIFIWAVE2,
     IS_WIRELESS,
     MIKROTIK_SERVICES,
     NAME,
+    WIFI,
     WIFIWAVE2,
     WIRELESS,
 )
@@ -60,6 +62,7 @@ class MikrotikData:
         self.support_capsman: bool = False
         self.support_wireless: bool = False
         self.support_wifiwave2: bool = False
+        self.support_wifi: bool = False
         self.hostname: str = ""
         self.model: str = ""
         self.firmware: str = ""
@@ -101,6 +104,7 @@ class MikrotikData:
         self.support_capsman = bool(self.command(MIKROTIK_SERVICES[IS_CAPSMAN]))
         self.support_wireless = bool(self.command(MIKROTIK_SERVICES[IS_WIRELESS]))
         self.support_wifiwave2 = bool(self.command(MIKROTIK_SERVICES[IS_WIFIWAVE2]))
+        self.support_wifi = bool(self.command(MIKROTIK_SERVICES[IS_WIFI]))
 
     def get_list_from_interface(self, interface: str) -> dict[str, dict[str, Any]]:
         """Get devices from interface."""
@@ -128,6 +132,9 @@ class MikrotikData:
             elif self.support_wifiwave2:
                 _LOGGER.debug("Hub supports wifiwave2 Interface")
                 device_list = wireless_devices = self.get_list_from_interface(WIFIWAVE2)
+            elif self.support_wifi:
+                _LOGGER.debug("Hub supports wifi Interface")
+                device_list = wireless_devices = self.get_list_from_interface(WIFI)
 
             if not device_list or self.force_dhcp:
                 device_list = self.all_devices


### PR DESCRIPTION
## Proposed change
This Component will break due to a upcoming API change in the next 2-6 weeks. 

Mikrotik will soon release the RouterOS 7.13 update which renames the api command `/interface/wifiwave2/registration-table/print` to `/interface/wifi/registration-table/print`
Calling the old command wont be accepted after the update and the integration breaks.
I've patched this by falling back to "wifi" when "wifiwave2" fails.
This patch was tested with a release candidate 2 of RouterOS 7.13. 


- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [X] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.


To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure