### PR TITLE
Move config_per_platform and extract_domain_configs to config.py

### DIFF
--- a/homeassistant/components/automation/config.py
+++ b/homeassistant/components/automation/config.py
@@ -11,7 +11,7 @@ from voluptuous.humanize import humanize_error
 
 from homeassistant.components import blueprint
 from homeassistant.components.trace import TRACE_CONFIG_SCHEMA
-from homeassistant.config import config_without_domain
+from homeassistant.config import config_per_platform, config_without_domain
 from homeassistant.const import (
     CONF_ALIAS,
     CONF_CONDITION,
@@ -21,7 +21,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_per_platform, config_validation as cv, script
+from homeassistant.helpers import config_validation as cv, script
 from homeassistant.helpers.condition import async_validate_conditions_config
 from homeassistant.helpers.trigger import async_validate_trigger_config
 from homeassistant.helpers.typing import ConfigType

--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -14,7 +14,11 @@ import voluptuous as vol
 from homeassistant import util
 from homeassistant.backports.functools import cached_property
 from homeassistant.components import zone
-from homeassistant.config import async_log_schema_error, load_yaml_config_file
+from homeassistant.config import (
+    async_log_schema_error,
+    config_per_platform,
+    load_yaml_config_file,
+)
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_GPS_ACCURACY,
@@ -33,7 +37,6 @@ from homeassistant.const import (
 from homeassistant.core import Event, HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
-    config_per_platform,
     config_validation as cv,
     discovery,
     entity_registry as er,

--- a/homeassistant/components/homeassistant/scene.py
+++ b/homeassistant/components/homeassistant/scene.py
@@ -30,11 +30,7 @@ from homeassistant.core import (
     callback,
 )
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
-from homeassistant.helpers import (
-    config_per_platform,
-    config_validation as cv,
-    entity_platform,
-)
+from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback, EntityPlatform
 from homeassistant.helpers.service import (
     async_extract_entity_ids,
@@ -208,7 +204,7 @@ async def async_setup_platform(
         await platform.async_reset()
 
         # Extract only the config for the Home Assistant platform, ignore the rest.
-        for p_type, p_config in config_per_platform(conf, SCENE_DOMAIN):
+        for p_type, p_config in conf_util.config_per_platform(conf, SCENE_DOMAIN):
             if p_type != HA_DOMAIN:
                 continue
 

--- a/homeassistant/components/mailbox/__init__.py
+++ b/homeassistant/components/mailbox/__init__.py
@@ -13,13 +13,10 @@ from aiohttp.web_exceptions import HTTPNotFound
 
 from homeassistant.components import frontend
 from homeassistant.components.http import HomeAssistantView
+from homeassistant.config import config_per_platform
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import (
-    config_per_platform,
-    config_validation as cv,
-    discovery,
-)
+from homeassistant.helpers import config_validation as cv, discovery
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType

--- a/homeassistant/components/notify/legacy.py
+++ b/homeassistant/components/notify/legacy.py
@@ -6,10 +6,11 @@ from collections.abc import Callable, Coroutine, Mapping
 from functools import partial
 from typing import Any, Protocol, cast
 
+from homeassistant.config import config_per_platform
 from homeassistant.const import CONF_DESCRIPTION, CONF_NAME
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_per_platform, discovery
+from homeassistant.helpers import discovery
 from homeassistant.helpers.service import async_set_service_schema
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType

--- a/homeassistant/components/script/config.py
+++ b/homeassistant/components/script/config.py
@@ -13,7 +13,7 @@ from homeassistant.components.blueprint import (
     is_blueprint_instance_config,
 )
 from homeassistant.components.trace import TRACE_CONFIG_SCHEMA
-from homeassistant.config import config_without_domain
+from homeassistant.config import config_per_platform, config_without_domain
 from homeassistant.const import (
     CONF_ALIAS,
     CONF_DEFAULT,
@@ -30,7 +30,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_per_platform, config_validation as cv
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.script import (
     SCRIPT_MODE_SINGLE,
     async_validate_actions_config,

--- a/homeassistant/components/stt/legacy.py
+++ b/homeassistant/components/stt/legacy.py
@@ -6,8 +6,9 @@ from collections.abc import AsyncIterable, Coroutine
 import logging
 from typing import Any
 
+from homeassistant.config import config_per_platform
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import config_per_platform, discovery
+from homeassistant.helpers import discovery
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.setup import async_prepare_setup_platform
 

--- a/homeassistant/components/tts/legacy.py
+++ b/homeassistant/components/tts/legacy.py
@@ -18,6 +18,7 @@ from homeassistant.components.media_player import (
     SERVICE_PLAY_MEDIA,
     MediaType,
 )
+from homeassistant.config import config_per_platform
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_DESCRIPTION,
@@ -25,7 +26,7 @@ from homeassistant.const import (
     CONF_PLATFORM,
 )
 from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.helpers import config_per_platform, discovery
+from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.service import async_set_service_schema
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType

--- a/homeassistant/helpers/__init__.py
+++ b/homeassistant/helpers/__init__.py
@@ -2,10 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
-import re
 from typing import TYPE_CHECKING
-
-from homeassistant.const import CONF_PLATFORM
 
 if TYPE_CHECKING:
     from .typing import ConfigType
@@ -19,22 +16,23 @@ def config_per_platform(
     For example, will find 'switch', 'switch 2', 'switch 3', .. etc
     Async friendly.
     """
-    for config_key in extract_domain_configs(config, domain):
-        if not (platform_config := config[config_key]):
-            continue
+    # pylint: disable-next=import-outside-toplevel
+    from homeassistant import config as ha_config
 
-        if not isinstance(platform_config, list):
-            platform_config = [platform_config]
+    # pylint: disable-next=import-outside-toplevel
+    from .deprecation import _print_deprecation_warning
 
-        item: ConfigType
-        platform: str | None
-        for item in platform_config:
-            try:
-                platform = item.get(CONF_PLATFORM)
-            except AttributeError:
-                platform = None
+    _print_deprecation_warning(
+        config_per_platform,
+        "config.config_per_platform",
+        "function",
+        "called",
+        "2024.6",
+    )
+    return ha_config.config_per_platform(config, domain)
 
-            yield platform, item
+
+config_per_platform.__name__ = "helpers.config_per_platform"
 
 
 def extract_domain_configs(config: ConfigType, domain: str) -> Sequence[str]:
@@ -42,5 +40,20 @@ def extract_domain_configs(config: ConfigType, domain: str) -> Sequence[str]:
 
     Async friendly.
     """
-    pattern = re.compile(rf"^{domain}(| .+)$")
-    return [key for key in config if pattern.match(key)]
+    # pylint: disable-next=import-outside-toplevel
+    from homeassistant import config as ha_config
+
+    # pylint: disable-next=import-outside-toplevel
+    from .deprecation import _print_deprecation_warning
+
+    _print_deprecation_warning(
+        extract_domain_configs,
+        "config.extract_domain_configs",
+        "function",
+        "called",
+        "2024.6",
+    )
+    return ha_config.extract_domain_configs(config, domain)
+
+
+extract_domain_configs.__name__ = "helpers.extract_domain_configs"

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -32,7 +32,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.loader import async_get_integration, bind_hass
 from homeassistant.setup import async_prepare_setup_platform
 
-from . import config_per_platform, config_validation as cv, discovery, entity, service
+from . import config_validation as cv, discovery, entity, service
 from .entity_platform import EntityPlatform
 from .typing import ConfigType, DiscoveryInfoType
 
@@ -148,7 +148,7 @@ class EntityComponent(Generic[_EntityT]):
         self.config = config
 
         # Look in config for Domain, Domain 2, Domain 3 etc and load them
-        for p_type, p_config in config_per_platform(config, self.domain):
+        for p_type, p_config in conf_util.config_per_platform(config, self.domain):
             if p_type is not None:
                 self.hass.async_create_task(
                     self.async_setup_platform(p_type, p_config),

--- a/homeassistant/helpers/reload.py
+++ b/homeassistant/helpers/reload.py
@@ -13,7 +13,6 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.loader import async_get_integration
 from homeassistant.setup import async_setup_component
 
-from . import config_per_platform
 from .entity import Entity
 from .entity_component import EntityComponent
 from .entity_platform import EntityPlatform, async_get_platforms
@@ -69,7 +68,7 @@ async def _resetup_platform(
 
     root_config: dict[str, list[ConfigType]] = {platform_domain: []}
     # Extract only the config for template, ignore the rest.
-    for p_type, p_config in config_per_platform(conf, platform_domain):
+    for p_type, p_config in conf_util.config_per_platform(conf, platform_domain):
         if p_type != integration_domain:
             continue
 

--- a/tests/helpers/test_init.py
+++ b/tests/helpers/test_init.py
@@ -2,10 +2,12 @@
 
 from collections import OrderedDict
 
+import pytest
+
 from homeassistant import helpers
 
 
-def test_extract_domain_configs() -> None:
+def test_extract_domain_configs(caplog: pytest.LogCaptureFixture) -> None:
     """Test the extraction of domain configuration."""
     config = {
         "zone": None,
@@ -19,8 +21,13 @@ def test_extract_domain_configs() -> None:
         helpers.extract_domain_configs(config, "zone")
     )
 
+    assert (
+        "helpers.extract_domain_configs is a deprecated function which will be removed "
+        "in HA Core 2024.6. Use config.extract_domain_configs instead" in caplog.text
+    )
 
-def test_config_per_platform() -> None:
+
+def test_config_per_platform(caplog: pytest.LogCaptureFixture) -> None:
     """Test config per platform method."""
     config = OrderedDict(
         [
@@ -36,3 +43,8 @@ def test_config_per_platform() -> None:
         (None, 1),
         ("hello 2", config["zone Hallo"][1]),
     ] == list(helpers.config_per_platform(config, "zone"))
+
+    assert (
+        "helpers.config_per_platform is a deprecated function which will be removed "
+        "in HA Core 2024.6. Use config.config_per_platform instead" in caplog.text
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2207,3 +2207,36 @@ async def test_yaml_error(
         if record.levelno == logging.ERROR
     ]
     assert error_records == snapshot
+
+
+def test_extract_domain_configs() -> None:
+    """Test the extraction of domain configuration."""
+    config = {
+        "zone": None,
+        "zoner": None,
+        "zone ": None,
+        "zone Hallo": None,
+        "zone 100": None,
+    }
+
+    assert {"zone", "zone Hallo", "zone 100"} == set(
+        config_util.extract_domain_configs(config, "zone")
+    )
+
+
+def test_config_per_platform() -> None:
+    """Test config per platform method."""
+    config = OrderedDict(
+        [
+            ("zone", {"platform": "hello"}),
+            ("zoner", None),
+            ("zone Hallo", [1, {"platform": "hello 2"}]),
+            ("zone 100", None),
+        ]
+    )
+
+    assert [
+        ("hello", config["zone"]),
+        (None, 1),
+        ("hello 2", config["zone Hallo"][1]),
+    ] == list(config_util.config_per_platform(config, "zone"))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move config_per_platform and extract_domain_configs to config.py

Rationale: All other helper functions for parsing configuration is already in config.py

No integrations published in HACS seem to be using this, but the old functions will still be working for 6 months but print a warning if called.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
