### PR TITLE
Remove device from known_devices upon import in ping device tracker

### DIFF
--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -1036,6 +1036,19 @@ def update_config(path: str, dev_id: str, device: Device) -> None:
         out.write(dump(device_config))
 
 
+def remove_device_from_config(hass: HomeAssistant, device_id: str) -> None:
+    """Remove device from YAML configuration file."""
+    path = hass.config.path(YAML_DEVICES)
+    devices = load_yaml_config_file(path)
+    devices.pop(device_id, None)
+    dumped = dump(devices)
+
+    with open(path, "r+", encoding="utf8") as out:
+        out.seek(0)
+        out.truncate()
+        out.write(dumped)
+
+
 def get_gravatar_for_email(email: str) -> str:
     """Return an 80px Gravatar for the given email address.
 

--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -1040,7 +1040,7 @@ def remove_device_from_config(hass: HomeAssistant, device_id: str) -> None:
     """Remove device from YAML configuration file."""
     path = hass.config.path(YAML_DEVICES)
     devices = load_yaml_config_file(path)
-    devices.pop(device_id, None)
+    devices.pop(device_id)
     dumped = dump(devices)
 
     with open(path, "r+", encoding="utf8") as out:

--- a/homeassistant/components/ping/device_tracker.py
+++ b/homeassistant/components/ping/device_tracker.py
@@ -113,7 +113,7 @@ async def async_setup_scanner(
     # delay the import until after Home Assistant has started and everything has been initialized,
     # as the legacy device tracker entities will be restored after the legacy device tracker platforms
     # have been set up, so we can only remove the entities from the state machine then
-    hass.bus.async_listen(EVENT_HOMEASSISTANT_STARTED, _run_import)
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _run_import)
 
     return True
 

--- a/homeassistant/components/ping/device_tracker.py
+++ b/homeassistant/components/ping/device_tracker.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 import voluptuous as vol
 
@@ -57,9 +58,17 @@ async def async_setup_scanner(
         _LOGGER.debug(
             "Home Assistant successfully started, importing ping device tracker config entries now"
         )
-        devices = await hass.async_add_executor_job(
-            load_yaml_config_file, hass.config.path(YAML_DEVICES)
-        )
+
+        devices: dict[Any, Any] = {}
+        try:
+            devices = await hass.async_add_executor_job(
+                load_yaml_config_file, hass.config.path(YAML_DEVICES)
+            )
+        except FileNotFoundError:
+            _LOGGER.debug(
+                "No known_devices.yaml found, skip removal of devices from known_devices.yaml"
+            )
+
         for dev_name, dev_host in config[CONF_HOSTS].items():
             # remove device from known_devices.yaml and the state machine before importing it
             if (

--- a/homeassistant/components/ping/device_tracker.py
+++ b/homeassistant/components/ping/device_tracker.py
@@ -11,9 +11,19 @@ from homeassistant.components.device_tracker import (
     ScannerEntity,
     SourceType,
 )
+from homeassistant.components.device_tracker.legacy import (
+    YAML_DEVICES,
+    remove_device_from_config,
+)
+from homeassistant.config import load_yaml_config_file
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_HOSTS, CONF_NAME
-from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_HOSTS,
+    CONF_NAME,
+    EVENT_HOMEASSISTANT_STARTED,
+)
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, Event, HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
@@ -42,34 +52,61 @@ async def async_setup_scanner(
 ) -> bool:
     """Legacy init: import via config flow."""
 
-    for dev_name, dev_host in config[CONF_HOSTS].items():
-        hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                DOMAIN,
-                context={"source": SOURCE_IMPORT},
-                data={
-                    CONF_IMPORTED_BY: "device_tracker",
-                    CONF_NAME: dev_name,
-                    CONF_HOST: dev_host,
-                    CONF_PING_COUNT: config[CONF_PING_COUNT],
+    async def _run_import(_: Event) -> None:
+        """Delete devices from known_device.yaml and import them via config flow."""
+        _LOGGER.debug(
+            "Home Assistant successfully started, importing ping device tracker config entries now"
+        )
+        devices = await hass.async_add_executor_job(
+            load_yaml_config_file, hass.config.path(YAML_DEVICES)
+        )
+        for dev_name, dev_host in config[CONF_HOSTS].items():
+            # remove device from known_devices.yaml and the state machine before importing it
+            if (
+                not hass.states.async_available(f"device_tracker.{dev_name}")
+                and dev_name in devices
+            ):
+                await hass.async_add_executor_job(
+                    remove_device_from_config, hass, dev_name
+                )
+                hass.states.async_remove(f"device_tracker.{dev_name}")
+                _LOGGER.debug(
+                    "Removed device_tracker.%s from known_devices.yaml and state machine",
+                    dev_name,
+                )
+
+            # run import after everything has been cleaned up
+            hass.async_create_task(
+                hass.config_entries.flow.async_init(
+                    DOMAIN,
+                    context={"source": SOURCE_IMPORT},
+                    data={
+                        CONF_IMPORTED_BY: "device_tracker",
+                        CONF_NAME: dev_name,
+                        CONF_HOST: dev_host,
+                        CONF_PING_COUNT: config[CONF_PING_COUNT],
+                    },
+                )
+            )
+
+            async_create_issue(
+                hass,
+                HOMEASSISTANT_DOMAIN,
+                f"deprecated_yaml_{DOMAIN}",
+                breaks_in_ha_version="2024.6.0",
+                is_fixable=False,
+                issue_domain=DOMAIN,
+                severity=IssueSeverity.WARNING,
+                translation_key="deprecated_yaml",
+                translation_placeholders={
+                    "domain": DOMAIN,
+                    "integration_title": "Ping",
                 },
             )
-        )
 
-    async_create_issue(
-        hass,
-        HOMEASSISTANT_DOMAIN,
-        f"deprecated_yaml_{DOMAIN}",
-        breaks_in_ha_version="2024.6.0",
-        is_fixable=False,
-        issue_domain=DOMAIN,
-        severity=IssueSeverity.WARNING,
-        translation_key="deprecated_yaml",
-        translation_placeholders={
-            "domain": DOMAIN,
-            "integration_title": "Ping",
-        },
-    )
+    # delay the import after Home Assistant has started and everything has been initialized
+    # this way we can remove the restored device_tracker entities from known_devices.yaml
+    hass.bus.async_listen(EVENT_HOMEASSISTANT_STARTED, _run_import)
 
     return True
 

--- a/tests/components/device_tracker/test_legacy.py
+++ b/tests/components/device_tracker/test_legacy.py
@@ -1,0 +1,44 @@
+"""Tests for the legacy device tracker component."""
+from unittest.mock import mock_open, patch
+
+from homeassistant.components.device_tracker import legacy
+from homeassistant.core import HomeAssistant
+from homeassistant.util.yaml import dump
+
+from tests.common import patch_yaml_files
+
+
+def test_remove_device_from_config(hass: HomeAssistant):
+    """Test the removal of a device from a config."""
+    yaml_devices = {
+        "test": {
+            "hide_if_away": True,
+            "mac": "00:11:22:33:44:55",
+            "name": "Test name",
+            "picture": "/local/test.png",
+            "track": True,
+        },
+        "test2": {
+            "hide_if_away": True,
+            "mac": "00:ab:cd:33:44:55",
+            "name": "Test2",
+            "picture": "/local/test2.png",
+            "track": True,
+        },
+    }
+    mopen = mock_open()
+
+    files = {legacy.YAML_DEVICES: dump(yaml_devices)}
+    with patch_yaml_files(files, True), patch(
+        "homeassistant.components.device_tracker.legacy.open", mopen
+    ):
+        legacy.remove_device_from_config(hass, "test")
+
+    mopen().write.assert_called_once_with(
+        "test2:\n"
+        "  hide_if_away: true\n"
+        "  mac: 00:ab:cd:33:44:55\n"
+        "  name: Test2\n"
+        "  picture: /local/test2.png\n"
+        "  track: true\n"
+    )

--- a/tests/components/ping/test_device_tracker.py
+++ b/tests/components/ping/test_device_tracker.py
@@ -3,6 +3,7 @@
 import pytest
 
 from homeassistant.components.ping.const import DOMAIN
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
 from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.setup import async_setup_component
@@ -54,6 +55,9 @@ async def test_import_issue_creation(
         "device_tracker",
         {"device_tracker": {"platform": "ping", "hosts": {"test": "10.10.10.10"}}},
     )
+    await hass.async_block_till_done()
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     await hass.async_block_till_done()
 
     issue = issue_registry.async_get_issue(


### PR DESCRIPTION
## Proposed change
If the YAML is imported via the config flow and the device still exists in `known_devices.yaml`, the config entry will suffix the new entity with `_2` as the entity is already used by the `device_tracker` platform which restores the entities from `known_devices.yaml` on restart.

This PR solves this problem by delaying the import of the device tracker after the start of the HA and then checking if there is already a state with this entity ID and if the device exists in `known_devices.yaml` before the import is triggered. If this is the case, the device is deleted from `known_devices.yaml` and the state machine and the import is triggered. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: #104915 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
