### PR TITLE
Evohome: add option to disable high-precision temperatures

### DIFF
--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -252,12 +252,17 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         _config[GWS][0][TCS] = loc_config[GWS][0][TCS]
         _LOGGER.debug("Config = %s", _config)
 
-    client_v1 = evohomeasync.EvohomeClient(
-        client_v2.username,
-        client_v2.password,
-        session_id=user_data.get("sessionId") if user_data else None,  # STORAGE_VER 1
-        session=async_get_clientsession(hass),
-    )
+    if config[DOMAIN][CONF_HIGH_PRECISION]:
+        client_v1 = evohomeasync.EvohomeClient(
+            client_v2.username,
+            client_v2.password,
+            session_id=user_data.get("sessionId")
+            if user_data
+            else None,  # STORAGE_VER 1
+            session=async_get_clientsession(hass),
+        )
+    else:
+        client_v1 = None
 
     hass.data[DOMAIN] = {}
     hass.data[DOMAIN]["broker"] = broker = EvoBroker(

--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -46,6 +46,7 @@ ACCESS_TOKEN_EXPIRES = "access_token_expires"
 REFRESH_TOKEN = "refresh_token"
 USER_DATA = "user_data"
 
+CONF_HIGH_PRECISION = "high_precision"
 CONF_LOCATION_IDX = "location_idx"
 
 SCAN_INTERVAL_DEFAULT = timedelta(seconds=300)
@@ -57,6 +58,7 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Required(CONF_USERNAME): cv.string,
                 vol.Required(CONF_PASSWORD): cv.string,
+                vol.Optional(CONF_HIGH_PRECISION, default=True): cv.boolean,
                 vol.Optional(CONF_LOCATION_IDX, default=0): cv.positive_int,
                 vol.Optional(
                     CONF_SCAN_INTERVAL, default=SCAN_INTERVAL_DEFAULT


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


_By default_, this integration calls an two separate vendor APIs:
 - the newer API is used for all features, but it provides measured zone temperatures with a precision of 0.5 'C
 - the older API uses a precision of 0.01 'C, and 'overwrites' the temps from the newer API

> To be clear: higher-precision temps are to 0.01 'C, and not 0.1 'C!

This raises the following issues:
 - the higher-precision temps change much more frequently, causing increased changes to the state machine
 - there is no reasonable use-case for such high-precision data
 - this feature is potentially abusing the vendors API, especially w.r.t. rate limits (and a `SCAN_INTERVAL` of 60 seconds)
 - the increased complexity of the code has caused failures in the past

In any case, it is not clear everyone would prefer the higher-precision temperatures.

I propose to deprecate this feature over time, starting with the ability for the user to choose to disable it (i.e. for now, it remains enabled). A warning will be thrown that high-precision temps are a bad idea, and the user should consider disabling them. 

In future, it would be disabled by default, and need to be enabled by the user.

The documentation will need to be changed - a PR will come for that.

I appreciate that this integration is past due for config flow, and that changes such as this could normally obligate adding that functionality. please bear with me, there are plans for config flow to be added in a future PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
