### PR TITLE
Improve matrix typing

### DIFF
--- a/homeassistant/components/matrix/__init__.py
+++ b/homeassistant/components/matrix/__init__.py
@@ -7,7 +7,7 @@ import logging
 import mimetypes
 import os
 import re
-from typing import NewType, TypedDict
+from typing import Final, NewType, Required, TypedDict
 
 import aiofiles.os
 from nio import AsyncClient, Event, MatrixRoom
@@ -49,11 +49,11 @@ _LOGGER = logging.getLogger(__name__)
 
 SESSION_FILE = ".matrix.conf"
 
-CONF_HOMESERVER = "homeserver"
-CONF_ROOMS = "rooms"
-CONF_COMMANDS = "commands"
-CONF_WORD = "word"
-CONF_EXPRESSION = "expression"
+CONF_HOMESERVER: Final = "homeserver"
+CONF_ROOMS: Final = "rooms"
+CONF_COMMANDS: Final = "commands"
+CONF_WORD: Final = "word"
+CONF_EXPRESSION: Final = "expression"
 
 CONF_USERNAME_REGEX = "^@[^:]*:.*"
 CONF_ROOMS_REGEX = "^[!|#][^:]*:.*"
@@ -78,10 +78,10 @@ RoomAnyID = RoomID | RoomAlias
 class ConfigCommand(TypedDict, total=False):
     """Corresponds to a single COMMAND_SCHEMA."""
 
-    name: str  # CONF_NAME
-    rooms: list[RoomID] | None  # CONF_ROOMS
-    word: WordCommand | None  # CONF_WORD
-    expression: ExpressionCommand | None  # CONF_EXPRESSION
+    name: Required[str]  # CONF_NAME
+    rooms: list[RoomID]  # CONF_ROOMS
+    word: WordCommand  # CONF_WORD
+    expression: ExpressionCommand  # CONF_EXPRESSION
 
 
 COMMAND_SCHEMA = vol.All(
@@ -223,15 +223,15 @@ class MatrixBot:
     def _load_commands(self, commands: list[ConfigCommand]) -> None:
         for command in commands:
             # Set the command for all listening_rooms, unless otherwise specified.
-            command.setdefault(CONF_ROOMS, list(self._listening_rooms.values()))  # type: ignore[misc]
+            command.setdefault(CONF_ROOMS, list(self._listening_rooms.values()))
 
             # COMMAND_SCHEMA guarantees that exactly one of CONF_WORD and CONF_expression are set.
             if (word_command := command.get(CONF_WORD)) is not None:
-                for room_id in command[CONF_ROOMS]:  # type: ignore[literal-required]
+                for room_id in command[CONF_ROOMS]:
                     self._word_commands.setdefault(room_id, {})
-                    self._word_commands[room_id][word_command] = command  # type: ignore[index]
+                    self._word_commands[room_id][word_command] = command
             else:
-                for room_id in command[CONF_ROOMS]:  # type: ignore[literal-required]
+                for room_id in command[CONF_ROOMS]:
                     self._expression_commands.setdefault(room_id, [])
                     self._expression_commands[room_id].append(command)
 
@@ -263,7 +263,7 @@ class MatrixBot:
 
         # After single-word commands, check all regex commands in the room.
         for command in self._expression_commands.get(room_id, []):
-            match: re.Match = command[CONF_EXPRESSION].match(message.body)  # type: ignore[literal-required]
+            match = command[CONF_EXPRESSION].match(message.body)
             if not match:
                 continue
             message_data = {


### PR DESCRIPTION
## Proposed change
Add a few `Final` annotations to get rid some `type: ignore` comments.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
