### PR TITLE
Add entity type attribute to Deutscher Wetterdienst (DWD)

### DIFF
--- a/homeassistant/components/dwd_weather_warnings/const.py
+++ b/homeassistant/components/dwd_weather_warnings/const.py
@@ -19,6 +19,7 @@ ATTR_REGION_NAME: Final = "region_name"
 ATTR_REGION_ID: Final = "region_id"
 ATTR_LAST_UPDATE: Final = "last_update"
 ATTR_WARNING_COUNT: Final = "warning_count"
+ATTR_TYPE: Final = "type"
 
 API_ATTR_WARNING_NAME: Final = "event"
 API_ATTR_WARNING_TYPE: Final = "event_code"

--- a/homeassistant/components/dwd_weather_warnings/sensor.py
+++ b/homeassistant/components/dwd_weather_warnings/sensor.py
@@ -33,6 +33,7 @@ from .const import (
     ATTR_LAST_UPDATE,
     ATTR_REGION_ID,
     ATTR_REGION_NAME,
+    ATTR_TYPE,
     ATTR_WARNING_COUNT,
     CURRENT_WARNING_SENSOR,
     DEFAULT_NAME,
@@ -116,8 +117,10 @@ class DwdWeatherWarningsSensor(
 
         if self.entity_description.key == CURRENT_WARNING_SENSOR:
             searched_warnings = self.api.current_warnings
+            data[ATTR_TYPE] = "current"
         else:
             searched_warnings = self.api.expected_warnings
+            data[ATTR_TYPE] = "advance"
 
         data[ATTR_WARNING_COUNT] = len(searched_warnings)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds a `type` attribute to DWD entities which can be `current` or `advanced` depending on the sensor type. 

This change is motivated by recent issues in my project - https://github.com/MrBartusek/MeteoalarmCard/issues/214. Currently programaticly differentiating these entities in custom frontend cards is tricky. My approach was to detect entity type by its name or `friendly_name` however, these values can be modified by the user and are translated. The other approach that've considered was to use `unique_id` but it comes with another set of problems. I think this change will greatly help MeteoalarmCard and other similar projects

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30165

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
