### PR TITLE
Use freezegun in cert_expiry tests

### DIFF
--- a/tests/components/cert_expiry/test_init.py
+++ b/tests/components/cert_expiry/test_init.py
@@ -2,6 +2,8 @@
 from datetime import timedelta
 from unittest.mock import patch
 
+from freezegun import freeze_time
+
 from homeassistant.components.cert_expiry.const import DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -73,8 +75,8 @@ async def test_update_unique_id(hass: HomeAssistant) -> None:
     assert entry.unique_id == f"{HOST}:{PORT}"
 
 
-@patch("homeassistant.util.dt.utcnow", return_value=static_datetime())
-async def test_unload_config_entry(mock_now, hass: HomeAssistant) -> None:
+@freeze_time(static_datetime())
+async def test_unload_config_entry(hass: HomeAssistant) -> None:
     """Test unloading a config entry."""
     assert hass.state is CoreState.running
 

--- a/tests/components/cert_expiry/test_sensors.py
+++ b/tests/components/cert_expiry/test_sensors.py
@@ -4,6 +4,8 @@ import socket
 import ssl
 from unittest.mock import patch
 
+from freezegun import freeze_time
+
 from homeassistant.components.cert_expiry.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PORT, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import CoreState, HomeAssistant
@@ -15,8 +17,8 @@ from .helpers import future_timestamp, static_datetime
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-@patch("homeassistant.util.dt.utcnow", return_value=static_datetime())
-async def test_async_setup_entry(mock_now, hass: HomeAssistant) -> None:
+@freeze_time(static_datetime())
+async def test_async_setup_entry(hass: HomeAssistant) -> None:
     """Test async_setup_entry."""
     assert hass.state is CoreState.running
 
@@ -82,7 +84,7 @@ async def test_update_sensor(hass: HomeAssistant) -> None:
     starting_time = static_datetime()
     timestamp = future_timestamp(100)
 
-    with patch("homeassistant.util.dt.utcnow", return_value=starting_time), patch(
+    with freeze_time(starting_time), patch(
         "homeassistant.components.cert_expiry.coordinator.get_cert_expiry_timestamp",
         return_value=timestamp,
     ):
@@ -98,7 +100,7 @@ async def test_update_sensor(hass: HomeAssistant) -> None:
     assert state.attributes.get("is_valid")
 
     next_update = starting_time + timedelta(hours=24)
-    with patch("homeassistant.util.dt.utcnow", return_value=next_update), patch(
+    with freeze_time(next_update), patch(
         "homeassistant.components.cert_expiry.coordinator.get_cert_expiry_timestamp",
         return_value=timestamp,
     ):
@@ -126,7 +128,7 @@ async def test_update_sensor_network_errors(hass: HomeAssistant) -> None:
     starting_time = static_datetime()
     timestamp = future_timestamp(100)
 
-    with patch("homeassistant.util.dt.utcnow", return_value=starting_time), patch(
+    with freeze_time(starting_time), patch(
         "homeassistant.components.cert_expiry.coordinator.get_cert_expiry_timestamp",
         return_value=timestamp,
     ):
@@ -143,7 +145,7 @@ async def test_update_sensor_network_errors(hass: HomeAssistant) -> None:
 
     next_update = starting_time + timedelta(hours=24)
 
-    with patch("homeassistant.util.dt.utcnow", return_value=next_update), patch(
+    with freeze_time(next_update), patch(
         "homeassistant.components.cert_expiry.helper.get_cert",
         side_effect=socket.gaierror,
     ):
@@ -155,7 +157,7 @@ async def test_update_sensor_network_errors(hass: HomeAssistant) -> None:
     state = hass.states.get("sensor.example_com_cert_expiry")
     assert state.state == STATE_UNAVAILABLE
 
-    with patch("homeassistant.util.dt.utcnow", return_value=next_update), patch(
+    with freeze_time(next_update), patch(
         "homeassistant.components.cert_expiry.coordinator.get_cert_expiry_timestamp",
         return_value=timestamp,
     ):
@@ -171,7 +173,7 @@ async def test_update_sensor_network_errors(hass: HomeAssistant) -> None:
 
     next_update = starting_time + timedelta(hours=72)
 
-    with patch("homeassistant.util.dt.utcnow", return_value=next_update), patch(
+    with freeze_time(next_update), patch(
         "homeassistant.components.cert_expiry.helper.get_cert",
         side_effect=ssl.SSLError("something bad"),
     ):
@@ -186,7 +188,7 @@ async def test_update_sensor_network_errors(hass: HomeAssistant) -> None:
 
     next_update = starting_time + timedelta(hours=96)
 
-    with patch("homeassistant.util.dt.utcnow", return_value=next_update), patch(
+    with freeze_time(next_update), patch(
         "homeassistant.components.cert_expiry.helper.get_cert", side_effect=Exception()
     ):
         async_fire_time_changed(hass, utcnow() + timedelta(hours=96))


### PR DESCRIPTION
## Proposed change
Make use of freezegun instead of patching `utcnow` directly in cert_expiry tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
