### PR TITLE
Migrate non-component tests to use freezegun/freezer

### DIFF
--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
+from freezegun import freeze_time
 import pytest
 import voluptuous as vol
 
@@ -1137,7 +1138,7 @@ async def test_state_for(hass: HomeAssistant) -> None:
     assert not test(hass)
 
     now = dt_util.utcnow() + timedelta(seconds=5)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         assert test(hass)
 
 
@@ -1163,7 +1164,7 @@ async def test_state_for_template(hass: HomeAssistant) -> None:
     assert not test(hass)
 
     now = dt_util.utcnow() + timedelta(seconds=5)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         assert test(hass)
 
 
@@ -2235,7 +2236,7 @@ async def test_if_action_before_sunrise_no_offset(
     # sunrise: 2015-09-16 13:33:18 UTC,   sunset: 2015-09-17 01:53:45 UTC
     # now = sunrise + 1s -> 'before sunrise' not true
     now = datetime(2015, 9, 16, 13, 33, 19, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 0
@@ -2247,7 +2248,7 @@ async def test_if_action_before_sunrise_no_offset(
 
     # now = sunrise -> 'before sunrise' true
     now = datetime(2015, 9, 16, 13, 33, 18, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 1
@@ -2259,7 +2260,7 @@ async def test_if_action_before_sunrise_no_offset(
 
     # now = local midnight -> 'before sunrise' true
     now = datetime(2015, 9, 16, 7, 0, 0, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 2
@@ -2271,7 +2272,7 @@ async def test_if_action_before_sunrise_no_offset(
 
     # now = local midnight - 1s -> 'before sunrise' not true
     now = datetime(2015, 9, 17, 6, 59, 59, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 2
@@ -2306,7 +2307,7 @@ async def test_if_action_after_sunrise_no_offset(
     # sunrise: 2015-09-16 13:33:18 UTC,   sunset: 2015-09-17 01:53:45 UTC
     # now = sunrise - 1s -> 'after sunrise' not true
     now = datetime(2015, 9, 16, 13, 33, 17, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 0
@@ -2318,7 +2319,7 @@ async def test_if_action_after_sunrise_no_offset(
 
     # now = sunrise + 1s -> 'after sunrise' true
     now = datetime(2015, 9, 16, 13, 33, 19, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 1
@@ -2330,7 +2331,7 @@ async def test_if_action_after_sunrise_no_offset(
 
     # now = local midnight -> 'after sunrise' not true
     now = datetime(2015, 9, 16, 7, 0, 0, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 1
@@ -2342,7 +2343,7 @@ async def test_if_action_after_sunrise_no_offset(
 
     # now = local midnight - 1s -> 'after sunrise' true
     now = datetime(2015, 9, 17, 6, 59, 59, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 2
@@ -2381,7 +2382,7 @@ async def test_if_action_before_sunrise_with_offset(
     # sunrise: 2015-09-16 13:33:18 UTC,   sunset: 2015-09-17 01:53:45 UTC
     # now = sunrise + 1s + 1h -> 'before sunrise' with offset +1h not true
     now = datetime(2015, 9, 16, 14, 33, 19, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 0
@@ -2393,7 +2394,7 @@ async def test_if_action_before_sunrise_with_offset(
 
     # now = sunrise + 1h -> 'before sunrise' with offset +1h true
     now = datetime(2015, 9, 16, 14, 33, 18, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 1
@@ -2405,7 +2406,7 @@ async def test_if_action_before_sunrise_with_offset(
 
     # now = UTC midnight -> 'before sunrise' with offset +1h not true
     now = datetime(2015, 9, 17, 0, 0, 0, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 1
@@ -2417,7 +2418,7 @@ async def test_if_action_before_sunrise_with_offset(
 
     # now = UTC midnight - 1s -> 'before sunrise' with offset +1h not true
     now = datetime(2015, 9, 16, 23, 59, 59, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 1
@@ -2429,7 +2430,7 @@ async def test_if_action_before_sunrise_with_offset(
 
     # now = local midnight -> 'before sunrise' with offset +1h true
     now = datetime(2015, 9, 16, 7, 0, 0, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 2
@@ -2441,7 +2442,7 @@ async def test_if_action_before_sunrise_with_offset(
 
     # now = local midnight - 1s -> 'before sunrise' with offset +1h not true
     now = datetime(2015, 9, 17, 6, 59, 59, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 2
@@ -2453,7 +2454,7 @@ async def test_if_action_before_sunrise_with_offset(
 
     # now = sunset -> 'before sunrise' with offset +1h not true
     now = datetime(2015, 9, 17, 1, 53, 45, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 2
@@ -2465,7 +2466,7 @@ async def test_if_action_before_sunrise_with_offset(
 
     # now = sunset -1s -> 'before sunrise' with offset +1h not true
     now = datetime(2015, 9, 17, 1, 53, 44, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 2
@@ -2504,7 +2505,7 @@ async def test_if_action_before_sunset_with_offset(
     # sunrise: 2015-09-16 13:33:18 UTC,   sunset: 2015-09-17 01:53:45 UTC
     # now = local midnight -> 'before sunset' with offset +1h true
     now = datetime(2015, 9, 16, 7, 0, 0, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 1
@@ -2516,7 +2517,7 @@ async def test_if_action_before_sunset_with_offset(
 
     # now = sunset + 1s + 1h -> 'before sunset' with offset +1h not true
     now = datetime(2015, 9, 17, 2, 53, 46, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 1
@@ -2528,7 +2529,7 @@ async def test_if_action_before_sunset_with_offset(
 
     # now = sunset + 1h -> 'before sunset' with offset +1h true
     now = datetime(2015, 9, 17, 2, 53, 44, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 2
@@ -2540,7 +2541,7 @@ async def test_if_action_before_sunset_with_offset(
 
     # now = UTC midnight -> 'before sunset' with offset +1h true
     now = datetime(2015, 9, 17, 0, 0, 0, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 3
@@ -2552,7 +2553,7 @@ async def test_if_action_before_sunset_with_offset(
 
     # now = UTC midnight - 1s -> 'before sunset' with offset +1h true
     now = datetime(2015, 9, 16, 23, 59, 59, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 4
@@ -2564,7 +2565,7 @@ async def test_if_action_before_sunset_with_offset(
 
     # now = sunrise -> 'before sunset' with offset +1h true
     now = datetime(2015, 9, 16, 13, 33, 18, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 5
@@ -2576,7 +2577,7 @@ async def test_if_action_before_sunset_with_offset(
 
     # now = sunrise -1s -> 'before sunset' with offset +1h true
     now = datetime(2015, 9, 16, 13, 33, 17, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 6
@@ -2588,7 +2589,7 @@ async def test_if_action_before_sunset_with_offset(
 
     # now = local midnight-1s -> 'after sunrise' with offset +1h not true
     now = datetime(2015, 9, 17, 6, 59, 59, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 6
@@ -2627,7 +2628,7 @@ async def test_if_action_after_sunrise_with_offset(
     # sunrise: 2015-09-16 13:33:18 UTC,   sunset: 2015-09-17 01:53:45 UTC
     # now = sunrise - 1s + 1h -> 'after sunrise' with offset +1h not true
     now = datetime(2015, 9, 16, 14, 33, 17, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 0
@@ -2639,7 +2640,7 @@ async def test_if_action_after_sunrise_with_offset(
 
     # now = sunrise + 1h -> 'after sunrise' with offset +1h true
     now = datetime(2015, 9, 16, 14, 33, 58, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 1
@@ -2651,7 +2652,7 @@ async def test_if_action_after_sunrise_with_offset(
 
     # now = UTC noon -> 'after sunrise' with offset +1h not true
     now = datetime(2015, 9, 16, 12, 0, 0, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 1
@@ -2663,7 +2664,7 @@ async def test_if_action_after_sunrise_with_offset(
 
     # now = UTC noon - 1s -> 'after sunrise' with offset +1h not true
     now = datetime(2015, 9, 16, 11, 59, 59, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 1
@@ -2675,7 +2676,7 @@ async def test_if_action_after_sunrise_with_offset(
 
     # now = local noon -> 'after sunrise' with offset +1h true
     now = datetime(2015, 9, 16, 19, 1, 0, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 2
@@ -2687,7 +2688,7 @@ async def test_if_action_after_sunrise_with_offset(
 
     # now = local noon - 1s -> 'after sunrise' with offset +1h true
     now = datetime(2015, 9, 16, 18, 59, 59, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 3
@@ -2699,7 +2700,7 @@ async def test_if_action_after_sunrise_with_offset(
 
     # now = sunset -> 'after sunrise' with offset +1h true
     now = datetime(2015, 9, 17, 1, 53, 45, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 4
@@ -2711,7 +2712,7 @@ async def test_if_action_after_sunrise_with_offset(
 
     # now = sunset + 1s -> 'after sunrise' with offset +1h true
     now = datetime(2015, 9, 17, 1, 53, 45, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 5
@@ -2723,7 +2724,7 @@ async def test_if_action_after_sunrise_with_offset(
 
     # now = local midnight-1s -> 'after sunrise' with offset +1h true
     now = datetime(2015, 9, 17, 6, 59, 59, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 6
@@ -2735,7 +2736,7 @@ async def test_if_action_after_sunrise_with_offset(
 
     # now = local midnight -> 'after sunrise' with offset +1h not true
     now = datetime(2015, 9, 17, 7, 0, 0, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 6
@@ -2774,7 +2775,7 @@ async def test_if_action_after_sunset_with_offset(
     # sunrise: 2015-09-16 13:33:18 UTC,   sunset: 2015-09-17 01:53:45 UTC
     # now = sunset - 1s + 1h -> 'after sunset' with offset +1h not true
     now = datetime(2015, 9, 17, 2, 53, 44, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 0
@@ -2786,7 +2787,7 @@ async def test_if_action_after_sunset_with_offset(
 
     # now = sunset + 1h -> 'after sunset' with offset +1h true
     now = datetime(2015, 9, 17, 2, 53, 45, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 1
@@ -2798,7 +2799,7 @@ async def test_if_action_after_sunset_with_offset(
 
     # now = midnight-1s -> 'after sunset' with offset +1h true
     now = datetime(2015, 9, 16, 6, 59, 59, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 2
@@ -2810,7 +2811,7 @@ async def test_if_action_after_sunset_with_offset(
 
     # now = midnight -> 'after sunset' with offset +1h not true
     now = datetime(2015, 9, 16, 7, 0, 0, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 2
@@ -2849,7 +2850,7 @@ async def test_if_action_after_and_before_during(
     # sunrise: 2015-09-16 13:33:18 UTC,   sunset: 2015-09-17 01:53:45 UTC
     # now = sunrise - 1s -> 'after sunrise' + 'before sunset' not true
     now = datetime(2015, 9, 16, 13, 33, 17, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 0
@@ -2865,7 +2866,7 @@ async def test_if_action_after_and_before_during(
 
     # now = sunset + 1s -> 'after sunrise' + 'before sunset' not true
     now = datetime(2015, 9, 17, 1, 53, 46, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 0
@@ -2877,7 +2878,7 @@ async def test_if_action_after_and_before_during(
 
     # now = sunrise + 1s -> 'after sunrise' + 'before sunset' true
     now = datetime(2015, 9, 16, 13, 33, 19, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 1
@@ -2893,7 +2894,7 @@ async def test_if_action_after_and_before_during(
 
     # now = sunset - 1s -> 'after sunrise' + 'before sunset' true
     now = datetime(2015, 9, 17, 1, 53, 44, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 2
@@ -2909,7 +2910,7 @@ async def test_if_action_after_and_before_during(
 
     # now = 9AM local  -> 'after sunrise' + 'before sunset' true
     now = datetime(2015, 9, 16, 16, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 3
@@ -2952,7 +2953,7 @@ async def test_if_action_before_or_after_during(
     # sunrise: 2015-09-16 13:33:18 UTC,   sunset: 2015-09-17 01:53:45 UTC
     # now = sunrise - 1s -> 'before sunrise' | 'after sunset' true
     now = datetime(2015, 9, 16, 13, 33, 17, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 1
@@ -2968,7 +2969,7 @@ async def test_if_action_before_or_after_during(
 
     # now = sunset + 1s -> 'before sunrise' | 'after sunset' true
     now = datetime(2015, 9, 17, 1, 53, 46, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 2
@@ -2984,7 +2985,7 @@ async def test_if_action_before_or_after_during(
 
     # now = sunrise + 1s -> 'before sunrise' | 'after sunset' false
     now = datetime(2015, 9, 16, 13, 33, 19, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 2
@@ -3000,7 +3001,7 @@ async def test_if_action_before_or_after_during(
 
     # now = sunset - 1s -> 'before sunrise' | 'after sunset' false
     now = datetime(2015, 9, 17, 1, 53, 44, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 2
@@ -3016,7 +3017,7 @@ async def test_if_action_before_or_after_during(
 
     # now = midnight + 1s local  -> 'before sunrise' | 'after sunset' true
     now = datetime(2015, 9, 16, 7, 0, 1, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 3
@@ -3032,7 +3033,7 @@ async def test_if_action_before_or_after_during(
 
     # now = midnight - 1s local  -> 'before sunrise' | 'after sunset' true
     now = datetime(2015, 9, 17, 6, 59, 59, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 4
@@ -3077,7 +3078,7 @@ async def test_if_action_before_sunrise_no_offset_kotzebue(
     # sunrise: 2015-07-24 15:21:12 UTC,   sunset: 2015-07-25 11:13:33 UTC
     # now = sunrise + 1s -> 'before sunrise' not true
     now = datetime(2015, 7, 24, 15, 21, 13, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 0
@@ -3089,7 +3090,7 @@ async def test_if_action_before_sunrise_no_offset_kotzebue(
 
     # now = sunrise - 1h -> 'before sunrise' true
     now = datetime(2015, 7, 24, 14, 21, 12, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 1
@@ -3101,7 +3102,7 @@ async def test_if_action_before_sunrise_no_offset_kotzebue(
 
     # now = local midnight -> 'before sunrise' true
     now = datetime(2015, 7, 24, 8, 0, 0, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 2
@@ -3113,7 +3114,7 @@ async def test_if_action_before_sunrise_no_offset_kotzebue(
 
     # now = local midnight - 1s -> 'before sunrise' not true
     now = datetime(2015, 7, 24, 7, 59, 59, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 2
@@ -3154,7 +3155,7 @@ async def test_if_action_after_sunrise_no_offset_kotzebue(
     # sunrise: 2015-07-24 15:21:12 UTC,   sunset: 2015-07-25 11:13:33 UTC
     # now = sunrise -> 'after sunrise' true
     now = datetime(2015, 7, 24, 15, 21, 12, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 1
@@ -3166,7 +3167,7 @@ async def test_if_action_after_sunrise_no_offset_kotzebue(
 
     # now = sunrise - 1h -> 'after sunrise' not true
     now = datetime(2015, 7, 24, 14, 21, 12, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 1
@@ -3178,7 +3179,7 @@ async def test_if_action_after_sunrise_no_offset_kotzebue(
 
     # now = local midnight -> 'after sunrise' not true
     now = datetime(2015, 7, 24, 8, 0, 1, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 1
@@ -3190,7 +3191,7 @@ async def test_if_action_after_sunrise_no_offset_kotzebue(
 
     # now = local midnight - 1s -> 'after sunrise' true
     now = datetime(2015, 7, 24, 7, 59, 59, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 2
@@ -3231,7 +3232,7 @@ async def test_if_action_before_sunset_no_offset_kotzebue(
     # sunrise: 2015-07-24 15:21:12 UTC,   sunset: 2015-07-25 11:13:33 UTC
     # now = sunset + 1s -> 'before sunset' not true
     now = datetime(2015, 7, 25, 11, 13, 34, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 0
@@ -3243,7 +3244,7 @@ async def test_if_action_before_sunset_no_offset_kotzebue(
 
     # now = sunset - 1h-> 'before sunset' true
     now = datetime(2015, 7, 25, 10, 13, 33, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 1
@@ -3255,7 +3256,7 @@ async def test_if_action_before_sunset_no_offset_kotzebue(
 
     # now = local midnight -> 'before sunrise' true
     now = datetime(2015, 7, 24, 8, 0, 0, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 2
@@ -3267,7 +3268,7 @@ async def test_if_action_before_sunset_no_offset_kotzebue(
 
     # now = local midnight - 1s -> 'before sunrise' not true
     now = datetime(2015, 7, 24, 7, 59, 59, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 2
@@ -3308,7 +3309,7 @@ async def test_if_action_after_sunset_no_offset_kotzebue(
     # sunrise: 2015-07-24 15:21:12 UTC,   sunset: 2015-07-25 11:13:33 UTC
     # now = sunset -> 'after sunset' true
     now = datetime(2015, 7, 25, 11, 13, 33, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 1
@@ -3320,7 +3321,7 @@ async def test_if_action_after_sunset_no_offset_kotzebue(
 
     # now = sunset - 1s -> 'after sunset' not true
     now = datetime(2015, 7, 25, 11, 13, 32, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 1
@@ -3332,7 +3333,7 @@ async def test_if_action_after_sunset_no_offset_kotzebue(
 
     # now = local midnight -> 'after sunset' not true
     now = datetime(2015, 7, 24, 8, 0, 1, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 1
@@ -3344,7 +3345,7 @@ async def test_if_action_after_sunset_no_offset_kotzebue(
 
     # now = local midnight - 1s -> 'after sunset' true
     now = datetime(2015, 7, 24, 7, 59, 59, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+    with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert len(calls) == 2

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -923,7 +923,9 @@ async def test_track_template_error_can_recover(
 
 
 async def test_track_template_time_change(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test tracking template with time change."""
     template_error = Template("{{ utcnow().minute % 2 == 0 }}", hass)
@@ -935,17 +937,15 @@ async def test_track_template_time_change(
 
     start_time = dt_util.utcnow() + timedelta(hours=24)
     time_that_will_not_match_right_away = start_time.replace(minute=1, second=0)
-    with patch(
-        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
-    ):
-        unsub = async_track_template(hass, template_error, error_callback)
-        await hass.async_block_till_done()
-        assert not calls
+    freezer.move_to(time_that_will_not_match_right_away)
+    unsub = async_track_template(hass, template_error, error_callback)
+    await hass.async_block_till_done()
+    assert not calls
 
     first_time = start_time.replace(minute=2, second=0)
-    with patch("homeassistant.util.dt.utcnow", return_value=first_time):
-        async_fire_time_changed(hass, first_time)
-        await hass.async_block_till_done()
+    freezer.move_to(first_time)
+    async_fire_time_changed(hass, first_time)
+    await hass.async_block_till_done()
 
     assert len(calls) == 1
     assert calls[0] == (None, None, None)
@@ -3312,84 +3312,89 @@ async def test_track_template_with_time_default(hass: HomeAssistant) -> None:
     info.async_remove()
 
 
-async def test_track_template_with_time_that_leaves_scope(hass: HomeAssistant) -> None:
+async def test_track_template_with_time_that_leaves_scope(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
     """Test tracking template with time."""
     now = dt_util.utcnow()
     test_time = datetime(now.year + 1, 5, 24, 11, 59, 1, 500000, tzinfo=dt_util.UTC)
+    freezer.move_to(test_time)
 
-    with patch("homeassistant.util.dt.utcnow", return_value=test_time):
-        hass.states.async_set("binary_sensor.washing_machine", "on")
-        specific_runs = []
-        template_complex = Template(
-            """
-            {% if states.binary_sensor.washing_machine.state == "on" %}
-                {{ now() }}
-            {% else %}
-                {{ states.binary_sensor.washing_machine.last_updated }}
-            {% endif %}
-        """,
-            hass,
-        )
+    hass.states.async_set("binary_sensor.washing_machine", "on")
+    specific_runs = []
+    template_complex = Template(
+        """
+        {% if states.binary_sensor.washing_machine.state == "on" %}
+            {{ now() }}
+        {% else %}
+            {{ states.binary_sensor.washing_machine.last_updated }}
+        {% endif %}
+    """,
+        hass,
+    )
 
-        def specific_run_callback(
-            event: EventType[EventStateChangedData] | None,
-            updates: list[TrackTemplateResult],
-        ) -> None:
-            specific_runs.append(updates.pop().result)
+    def specific_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
+        specific_runs.append(updates.pop().result)
 
-        info = async_track_template_result(
-            hass, [TrackTemplate(template_complex, None)], specific_run_callback
-        )
-        await hass.async_block_till_done()
+    info = async_track_template_result(
+        hass, [TrackTemplate(template_complex, None)], specific_run_callback
+    )
+    await hass.async_block_till_done()
 
-        assert info.listeners == {
-            "all": False,
-            "domains": set(),
-            "entities": {"binary_sensor.washing_machine"},
-            "time": True,
-        }
+    assert info.listeners == {
+        "all": False,
+        "domains": set(),
+        "entities": {"binary_sensor.washing_machine"},
+        "time": True,
+    }
 
-        hass.states.async_set("binary_sensor.washing_machine", "off")
-        await hass.async_block_till_done()
+    hass.states.async_set("binary_sensor.washing_machine", "off")
+    await hass.async_block_till_done()
 
-        assert info.listeners == {
-            "all": False,
-            "domains": set(),
-            "entities": {"binary_sensor.washing_machine"},
-            "time": False,
-        }
+    assert info.listeners == {
+        "all": False,
+        "domains": set(),
+        "entities": {"binary_sensor.washing_machine"},
+        "time": False,
+    }
 
-        hass.states.async_set("binary_sensor.washing_machine", "on")
-        await hass.async_block_till_done()
+    hass.states.async_set("binary_sensor.washing_machine", "on")
+    await hass.async_block_till_done()
 
-        assert info.listeners == {
-            "all": False,
-            "domains": set(),
-            "entities": {"binary_sensor.washing_machine"},
-            "time": True,
-        }
+    assert info.listeners == {
+        "all": False,
+        "domains": set(),
+        "entities": {"binary_sensor.washing_machine"},
+        "time": True,
+    }
 
-        # Verify we do not update before the minute rolls over
-        callback_count_before_time_change = len(specific_runs)
-        async_fire_time_changed(hass, test_time)
-        await hass.async_block_till_done()
-        assert len(specific_runs) == callback_count_before_time_change
+    # Verify we do not update before the minute rolls over
+    callback_count_before_time_change = len(specific_runs)
+    async_fire_time_changed(hass, test_time)
+    await hass.async_block_till_done()
+    assert len(specific_runs) == callback_count_before_time_change
 
-        async_fire_time_changed(hass, test_time + timedelta(seconds=58))
-        await hass.async_block_till_done()
-        assert len(specific_runs) == callback_count_before_time_change
+    new_time = test_time + timedelta(seconds=58)
+    freezer.move_to(new_time)
+    async_fire_time_changed(hass, new_time)
+    await hass.async_block_till_done()
+    assert len(specific_runs) == callback_count_before_time_change
 
-        # Verify we do update on the next change of minute
-        async_fire_time_changed(hass, test_time + timedelta(seconds=59))
-
-        await hass.async_block_till_done()
-        assert len(specific_runs) == callback_count_before_time_change + 1
+    # Verify we do update on the next change of minute
+    new_time = test_time + timedelta(seconds=59)
+    freezer.move_to(new_time)
+    async_fire_time_changed(hass, new_time)
+    await hass.async_block_till_done()
+    assert len(specific_runs) == callback_count_before_time_change + 1
 
     info.async_remove()
 
 
 async def test_async_track_template_result_multiple_templates_mixing_listeners(
-    hass: HomeAssistant,
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
     """Test tracking multiple templates with mixing listener types."""
 
@@ -3410,18 +3415,16 @@ async def test_async_track_template_result_multiple_templates_mixing_listeners(
     time_that_will_not_match_right_away = datetime(
         now.year + 1, 5, 24, 11, 59, 55, tzinfo=dt_util.UTC
     )
+    freezer.move_to(time_that_will_not_match_right_away)
 
-    with patch(
-        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
-    ):
-        info = async_track_template_result(
-            hass,
-            [
-                TrackTemplate(template_1, None),
-                TrackTemplate(template_2, None),
-            ],
-            refresh_listener,
-        )
+    info = async_track_template_result(
+        hass,
+        [
+            TrackTemplate(template_1, None),
+            TrackTemplate(template_2, None),
+        ],
+        refresh_listener,
+    )
 
     assert info.listeners == {
         "all": False,
@@ -3450,9 +3453,9 @@ async def test_async_track_template_result_multiple_templates_mixing_listeners(
 
     refresh_runs = []
     next_time = time_that_will_not_match_right_away + timedelta(hours=25)
-    with patch("homeassistant.util.dt.utcnow", return_value=next_time):
-        async_fire_time_changed(hass, next_time)
-        await hass.async_block_till_done()
+    freezer.move_to(next_time)
+    async_fire_time_changed(hass, next_time)
+    await hass.async_block_till_done()
 
     assert refresh_runs == [
         [
@@ -3787,7 +3790,10 @@ async def test_track_sunset(hass: HomeAssistant) -> None:
         assert len(offset_runs) == 1
 
 
-async def test_async_track_time_change(hass: HomeAssistant) -> None:
+async def test_async_track_time_change(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
     """Test tracking time change."""
     none_runs = []
     wildcard_runs = []
@@ -3798,21 +3804,19 @@ async def test_async_track_time_change(hass: HomeAssistant) -> None:
     time_that_will_not_match_right_away = datetime(
         now.year + 1, 5, 24, 11, 59, 55, tzinfo=dt_util.UTC
     )
+    freezer.move_to(time_that_will_not_match_right_away)
 
-    with patch(
-        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
-    ):
-        unsub = async_track_time_change(hass, callback(lambda x: none_runs.append(x)))
-        unsub_utc = async_track_utc_time_change(
-            hass, callback(lambda x: specific_runs.append(x)), second=[0, 30]
-        )
-        unsub_wildcard = async_track_time_change(
-            hass,
-            callback(lambda x: wildcard_runs.append(x)),
-            second="*",
-            minute="*",
-            hour="*",
-        )
+    unsub = async_track_time_change(hass, callback(lambda x: none_runs.append(x)))
+    unsub_utc = async_track_utc_time_change(
+        hass, callback(lambda x: specific_runs.append(x)), second=[0, 30]
+    )
+    unsub_wildcard = async_track_time_change(
+        hass,
+        callback(lambda x: wildcard_runs.append(x)),
+        second="*",
+        minute="*",
+        hour="*",
+    )
 
     async_fire_time_changed(
         hass, datetime(now.year + 1, 5, 24, 12, 0, 0, 999999, tzinfo=dt_util.UTC)
@@ -3851,7 +3855,10 @@ async def test_async_track_time_change(hass: HomeAssistant) -> None:
     assert len(none_runs) == 3
 
 
-async def test_periodic_task_minute(hass: HomeAssistant) -> None:
+async def test_periodic_task_minute(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
     """Test periodic tasks per minute."""
     specific_runs = []
 
@@ -3860,13 +3867,11 @@ async def test_periodic_task_minute(hass: HomeAssistant) -> None:
     time_that_will_not_match_right_away = datetime(
         now.year + 1, 5, 24, 11, 59, 55, tzinfo=dt_util.UTC
     )
+    freezer.move_to(time_that_will_not_match_right_away)
 
-    with patch(
-        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
-    ):
-        unsub = async_track_utc_time_change(
-            hass, callback(lambda x: specific_runs.append(x)), minute="/5", second=0
-        )
+    unsub = async_track_utc_time_change(
+        hass, callback(lambda x: specific_runs.append(x)), minute="/5", second=0
+    )
 
     async_fire_time_changed(
         hass, datetime(now.year + 1, 5, 24, 12, 0, 0, 999999, tzinfo=dt_util.UTC)
@@ -3895,7 +3900,10 @@ async def test_periodic_task_minute(hass: HomeAssistant) -> None:
     assert len(specific_runs) == 2
 
 
-async def test_periodic_task_hour(hass: HomeAssistant) -> None:
+async def test_periodic_task_hour(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
     """Test periodic tasks per hour."""
     specific_runs = []
 
@@ -3904,17 +3912,15 @@ async def test_periodic_task_hour(hass: HomeAssistant) -> None:
     time_that_will_not_match_right_away = datetime(
         now.year + 1, 5, 24, 21, 59, 55, tzinfo=dt_util.UTC
     )
+    freezer.move_to(time_that_will_not_match_right_away)
 
-    with patch(
-        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
-    ):
-        unsub = async_track_utc_time_change(
-            hass,
-            callback(lambda x: specific_runs.append(x)),
-            hour="/2",
-            minute=0,
-            second=0,
-        )
+    unsub = async_track_utc_time_change(
+        hass,
+        callback(lambda x: specific_runs.append(x)),
+        hour="/2",
+        minute=0,
+        second=0,
+    )
 
     async_fire_time_changed(
         hass, datetime(now.year + 1, 5, 24, 22, 0, 0, 999999, tzinfo=dt_util.UTC)
@@ -3973,71 +3979,77 @@ async def test_periodic_task_wrong_input(hass: HomeAssistant) -> None:
     assert len(specific_runs) == 0
 
 
-async def test_periodic_task_clock_rollback(hass: HomeAssistant) -> None:
+async def test_periodic_task_clock_rollback(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
     """Test periodic tasks with the time rolling backwards."""
     specific_runs = []
 
     now = dt_util.utcnow()
-
     time_that_will_not_match_right_away = datetime(
         now.year + 1, 5, 24, 21, 59, 55, tzinfo=dt_util.UTC
     )
+    freezer.move_to(time_that_will_not_match_right_away)
 
-    with patch(
-        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
-    ):
-        unsub = async_track_utc_time_change(
-            hass,
-            callback(lambda x: specific_runs.append(x)),
-            hour="/2",
-            minute=0,
-            second=0,
-        )
-
-    async_fire_time_changed(
-        hass, datetime(now.year + 1, 5, 24, 22, 0, 0, 999999, tzinfo=dt_util.UTC)
+    unsub = async_track_utc_time_change(
+        hass,
+        callback(lambda x: specific_runs.append(x)),
+        hour="/2",
+        minute=0,
+        second=0,
     )
+
+    new_time = datetime(now.year + 1, 5, 24, 22, 0, 0, 999999, tzinfo=dt_util.UTC)
+    freezer.move_to(new_time)
+    async_fire_time_changed(hass, new_time)
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
-    async_fire_time_changed(
-        hass, datetime(now.year + 1, 5, 24, 23, 0, 0, 999999, tzinfo=dt_util.UTC)
-    )
+    new_time = datetime(now.year + 1, 5, 24, 23, 0, 0, 999999, tzinfo=dt_util.UTC)
+    freezer.move_to(new_time)
+    async_fire_time_changed(hass, new_time)
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
+    new_time = datetime(now.year + 1, 5, 24, 22, 0, 0, 999999, tzinfo=dt_util.UTC)
+    freezer.move_to(new_time)
     async_fire_time_changed(
         hass,
-        datetime(now.year + 1, 5, 24, 22, 0, 0, 999999, tzinfo=dt_util.UTC),
+        new_time,
         fire_all=True,
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
+    new_time = datetime(now.year + 1, 5, 24, 0, 0, 0, 999999, tzinfo=dt_util.UTC)
+    freezer.move_to(new_time)
     async_fire_time_changed(
         hass,
-        datetime(now.year + 1, 5, 24, 0, 0, 0, 999999, tzinfo=dt_util.UTC),
+        new_time,
         fire_all=True,
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
-    async_fire_time_changed(
-        hass, datetime(now.year + 1, 5, 25, 2, 0, 0, 999999, tzinfo=dt_util.UTC)
-    )
+    new_time = datetime(now.year + 1, 5, 25, 2, 0, 0, 999999, tzinfo=dt_util.UTC)
+    freezer.move_to(new_time)
+    async_fire_time_changed(hass, new_time)
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
     unsub()
 
-    async_fire_time_changed(
-        hass, datetime(now.year + 1, 5, 25, 2, 0, 0, 999999, tzinfo=dt_util.UTC)
-    )
+    new_time = datetime(now.year + 1, 5, 25, 2, 0, 0, 999999, tzinfo=dt_util.UTC)
+    freezer.move_to(new_time)
+    async_fire_time_changed(hass, new_time)
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
 
-async def test_periodic_task_duplicate_time(hass: HomeAssistant) -> None:
+async def test_periodic_task_duplicate_time(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
     """Test periodic tasks not triggering on duplicate time."""
     specific_runs = []
 
@@ -4046,17 +4058,15 @@ async def test_periodic_task_duplicate_time(hass: HomeAssistant) -> None:
     time_that_will_not_match_right_away = datetime(
         now.year + 1, 5, 24, 21, 59, 55, tzinfo=dt_util.UTC
     )
+    freezer.move_to(time_that_will_not_match_right_away)
 
-    with patch(
-        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
-    ):
-        unsub = async_track_utc_time_change(
-            hass,
-            callback(lambda x: specific_runs.append(x)),
-            hour="/2",
-            minute=0,
-            second=0,
-        )
+    unsub = async_track_utc_time_change(
+        hass,
+        callback(lambda x: specific_runs.append(x)),
+        hour="/2",
+        minute=0,
+        second=0,
+    )
 
     async_fire_time_changed(
         hass, datetime(now.year + 1, 5, 24, 22, 0, 0, 999999, tzinfo=dt_util.UTC)

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -9,6 +9,7 @@ from types import MappingProxyType
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from freezegun import freeze_time
 import pytest
 import voluptuous as vol
 
@@ -1346,13 +1347,13 @@ async def test_wait_template_with_utcnow(hass: HomeAssistant) -> None:
 
     try:
         non_matching_time = start_time.replace(hour=3)
-        with patch("homeassistant.util.dt.utcnow", return_value=non_matching_time):
+        with freeze_time(non_matching_time):
             hass.async_create_task(script_obj.async_run(context=Context()))
             await asyncio.wait_for(wait_started_flag.wait(), 1)
             assert script_obj.is_running
 
         match_time = start_time.replace(hour=12)
-        with patch("homeassistant.util.dt.utcnow", return_value=match_time):
+        with freeze_time(match_time):
             async_fire_time_changed(hass, match_time)
     except (AssertionError, asyncio.TimeoutError):
         await script_obj.async_stop()
@@ -1378,15 +1379,13 @@ async def test_wait_template_with_utcnow_no_match(hass: HomeAssistant) -> None:
 
     try:
         non_matching_time = start_time.replace(hour=3)
-        with patch("homeassistant.util.dt.utcnow", return_value=non_matching_time):
+        with freeze_time(non_matching_time):
             hass.async_create_task(script_obj.async_run(context=Context()))
             await asyncio.wait_for(wait_started_flag.wait(), 1)
             assert script_obj.is_running
 
         second_non_matching_time = start_time.replace(hour=4)
-        with patch(
-            "homeassistant.util.dt.utcnow", return_value=second_non_matching_time
-        ):
+        with freeze_time(second_non_matching_time):
             async_fire_time_changed(hass, second_non_matching_time)
 
         async with asyncio.timeout(0.1):

--- a/tests/helpers/test_sun.py
+++ b/tests/helpers/test_sun.py
@@ -1,8 +1,8 @@
 """The tests for the Sun helpers."""
 
 from datetime import datetime, timedelta
-from unittest.mock import patch
 
+from freezegun import freeze_time
 import pytest
 
 from homeassistant.const import SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET
@@ -77,7 +77,7 @@ def test_next_events(hass: HomeAssistant) -> None:
             break
         mod += 1
 
-    with patch("homeassistant.helpers.condition.dt_util.utcnow", return_value=utc_now):
+    with freeze_time(utc_now):
         assert next_dawn == sun.get_astral_event_next(hass, "dawn")
         assert next_dusk == sun.get_astral_event_next(hass, "dusk")
         assert next_midnight == sun.get_astral_event_next(hass, "midnight")
@@ -132,7 +132,7 @@ def test_date_events_default_date(hass: HomeAssistant) -> None:
     sunrise = astral.sun.sunrise(location.observer, date=utc_today)
     sunset = astral.sun.sunset(location.observer, date=utc_today)
 
-    with patch("homeassistant.util.dt.now", return_value=utc_now):
+    with freeze_time(utc_now):
         assert dawn == sun.get_astral_event_date(hass, "dawn", utc_today)
         assert dusk == sun.get_astral_event_date(hass, "dusk", utc_today)
         assert midnight == sun.get_astral_event_date(hass, "midnight", utc_today)
@@ -171,11 +171,11 @@ def test_date_events_accepts_datetime(hass: HomeAssistant) -> None:
 def test_is_up(hass: HomeAssistant) -> None:
     """Test retrieving next sun events."""
     utc_now = datetime(2016, 11, 1, 12, 0, 0, tzinfo=dt_util.UTC)
-    with patch("homeassistant.helpers.condition.dt_util.utcnow", return_value=utc_now):
+    with freeze_time(utc_now):
         assert not sun.is_up(hass)
 
     utc_now = datetime(2016, 11, 1, 18, 0, 0, tzinfo=dt_util.UTC)
-    with patch("homeassistant.helpers.condition.dt_util.utcnow", return_value=utc_now):
+    with freeze_time(utc_now):
         assert sun.is_up(hass)
 
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1853,7 +1853,7 @@ def test_has_value(hass: HomeAssistant) -> None:
 def test_now(mock_is_safe, hass: HomeAssistant) -> None:
     """Test now method."""
     now = dt_util.now()
-    with patch("homeassistant.util.dt.now", return_value=now):
+    with freeze_time(now):
         info = template.Template("{{ now().isoformat() }}", hass).async_render_to_info()
         assert now.isoformat() == info.result()
 
@@ -1867,7 +1867,7 @@ def test_now(mock_is_safe, hass: HomeAssistant) -> None:
 def test_utcnow(mock_is_safe, hass: HomeAssistant) -> None:
     """Test now method."""
     utcnow = dt_util.utcnow()
-    with patch("homeassistant.util.dt.utcnow", return_value=utcnow):
+    with freeze_time(utcnow):
         info = template.Template(
             "{{ utcnow().isoformat() }}", hass
         ).async_render_to_info()
@@ -1954,7 +1954,7 @@ def test_relative_time(mock_is_safe, hass: HomeAssistant) -> None:
     relative_time_template = (
         '{{relative_time(strptime("2000-01-01 09:00:00", "%Y-%m-%d %H:%M:%S"))}}'
     )
-    with patch("homeassistant.util.dt.now", return_value=now):
+    with freeze_time(now):
         result = template.Template(
             relative_time_template,
             hass,
@@ -2026,7 +2026,7 @@ def test_relative_time(mock_is_safe, hass: HomeAssistant) -> None:
 def test_timedelta(mock_is_safe, hass: HomeAssistant) -> None:
     """Test relative_time method."""
     now = datetime.strptime("2000-01-01 10:00:00 +00:00", "%Y-%m-%d %H:%M:%S %z")
-    with patch("homeassistant.util.dt.now", return_value=now):
+    with freeze_time(now):
         result = template.Template(
             "{{timedelta(seconds=120)}}",
             hass,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -14,6 +14,7 @@ import time
 from typing import Any
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
+from freezegun import freeze_time
 import pytest
 from pytest_unordered import unordered
 import voluptuous as vol
@@ -1129,7 +1130,7 @@ async def test_statemachine_last_changed_not_updated_on_same_state(
 
     future = dt_util.utcnow() + timedelta(hours=10)
 
-    with patch("homeassistant.util.dt.utcnow", return_value=future):
+    with freeze_time(future):
         hass.states.async_set("light.Bowl", "on", {"attr": "triggers_change"})
         await hass.async_block_till_done()
 


### PR DESCRIPTION
## Proposed change
Migrate the non-component to make use of freezegun/freezer instead of patching `homeassistant.util.dt.*` directly.
Should I better split this into multiple PRs?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
