### PR TITLE
Remove workaround for default lock code in Matter

### DIFF
--- a/homeassistant/components/matter/lock.py
+++ b/homeassistant/components/matter/lock.py
@@ -1,7 +1,7 @@
 """Matter lock."""
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 from chip.clusters import Objects as clusters
 
@@ -89,7 +89,7 @@ class MatterLock(MatterEntity, LockEntity):
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the lock with pin if needed."""
-        code: Optional[str] = kwargs.get(ATTR_CODE)
+        code: str | None = kwargs.get(ATTR_CODE)
         code_bytes = code.encode() if code else None
         await self.send_device_command(
             command=clusters.DoorLock.Commands.LockDoor(code_bytes)
@@ -97,7 +97,7 @@ class MatterLock(MatterEntity, LockEntity):
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the lock with pin if needed."""
-        code: Optional[str] = kwargs.get(ATTR_CODE)
+        code: str | None = kwargs.get(ATTR_CODE)
         code_bytes = code.encode() if code else None
         if self.supports_unbolt:
             # if the lock reports it has separate unbolt support,
@@ -113,7 +113,7 @@ class MatterLock(MatterEntity, LockEntity):
 
     async def async_open(self, **kwargs: Any) -> None:
         """Open the door latch."""
-        code: Optional[str] = kwargs.get(ATTR_CODE)
+        code: str | None = kwargs.get(ATTR_CODE)
         code_bytes = code.encode() if code else None
         await self.send_device_command(
             command=clusters.DoorLock.Commands.UnlockDoor(code_bytes)

--- a/homeassistant/components/matter/lock.py
+++ b/homeassistant/components/matter/lock.py
@@ -1,7 +1,7 @@
 """Matter lock."""
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 from chip.clusters import Objects as clusters
 
@@ -89,7 +89,7 @@ class MatterLock(MatterEntity, LockEntity):
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the lock with pin if needed."""
-        code: str = kwargs.get(ATTR_CODE, None)
+        code: Optional[str] = kwargs.get(ATTR_CODE)
         code_bytes = code.encode() if code else None
         await self.send_device_command(
             command=clusters.DoorLock.Commands.LockDoor(code_bytes)
@@ -97,7 +97,7 @@ class MatterLock(MatterEntity, LockEntity):
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the lock with pin if needed."""
-        code: str = kwargs.get(ATTR_CODE, None)
+        code: Optional[str] = kwargs.get(ATTR_CODE)
         code_bytes = code.encode() if code else None
         if self.supports_unbolt:
             # if the lock reports it has separate unbolt support,
@@ -113,7 +113,7 @@ class MatterLock(MatterEntity, LockEntity):
 
     async def async_open(self, **kwargs: Any) -> None:
         """Open the door latch."""
-        code: str = kwargs.get(ATTR_CODE, None)
+        code: Optional[str] = kwargs.get(ATTR_CODE)
         code_bytes = code.encode() if code else None
         await self.send_device_command(
             command=clusters.DoorLock.Commands.UnlockDoor(code_bytes)

--- a/homeassistant/components/matter/lock.py
+++ b/homeassistant/components/matter/lock.py
@@ -89,10 +89,7 @@ class MatterLock(MatterEntity, LockEntity):
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the lock with pin if needed."""
-        code: str = kwargs.get(
-            ATTR_CODE,
-            self._lock_option_default_code,
-        )
+        code: str = kwargs.get(ATTR_CODE, None)
         code_bytes = code.encode() if code else None
         await self.send_device_command(
             command=clusters.DoorLock.Commands.LockDoor(code_bytes)
@@ -100,10 +97,7 @@ class MatterLock(MatterEntity, LockEntity):
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the lock with pin if needed."""
-        code: str = kwargs.get(
-            ATTR_CODE,
-            self._lock_option_default_code,
-        )
+        code: str = kwargs.get(ATTR_CODE, None)
         code_bytes = code.encode() if code else None
         if self.supports_unbolt:
             # if the lock reports it has separate unbolt support,
@@ -119,10 +113,7 @@ class MatterLock(MatterEntity, LockEntity):
 
     async def async_open(self, **kwargs: Any) -> None:
         """Open the door latch."""
-        code: str = kwargs.get(
-            ATTR_CODE,
-            self._lock_option_default_code,
-        )
+        code: str = kwargs.get(ATTR_CODE, None)
         code_bytes = code.encode() if code else None
         await self.send_device_command(
             command=clusters.DoorLock.Commands.UnlockDoor(code_bytes)

--- a/tests/components/matter/test_door_lock.py
+++ b/tests/components/matter/test_door_lock.py
@@ -14,6 +14,7 @@ from homeassistant.components.lock import (
 )
 from homeassistant.const import ATTR_CODE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
+import homeassistant.helpers.entity_registry as er
 
 from .common import set_node_attribute, trigger_subscription_callback
 
@@ -101,6 +102,7 @@ async def test_lock_requires_pin(
     hass: HomeAssistant,
     matter_client: MagicMock,
     door_lock: MatterNode,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test door lock with PINCode."""
 
@@ -134,6 +136,26 @@ async def test_lock_requires_pin(
         node_id=door_lock.node_id,
         endpoint_id=1,
         command=clusters.DoorLock.Commands.LockDoor(code.encode()),
+        timed_request_timeout_ms=1000,
+    )
+
+    # Lock door using default code
+    default_code = "7654321"
+    entity_registry.async_update_entity_options(
+        "lock.mock_door_lock", "lock", {"default_code": default_code}
+    )
+    await trigger_subscription_callback(hass, matter_client)
+    await hass.services.async_call(
+        "lock",
+        "lock",
+        {"entity_id": "lock.mock_door_lock"},
+        blocking=True,
+    )
+    assert matter_client.send_device_command.call_count == 2
+    assert matter_client.send_device_command.call_args == call(
+        node_id=door_lock.node_id,
+        endpoint_id=1,
+        command=clusters.DoorLock.Commands.LockDoor(default_code.encode()),
         timed_request_timeout_ms=1000,
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Removes the workaround for retrieving the default code in Matter locks, as it is no longer necessary after PR #103463

Note: I don't have any Matter locks, but I added a case for default code to the Matter lock unit test.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
