### PR TITLE
Fix ZHA quirk ID custom entities matching all devices

### DIFF
--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -253,7 +253,7 @@ class MatchRule:
             else:
                 matches.append(model in self.models)
 
-        if self.quirk_ids and quirk_id:
+        if self.quirk_ids:
             if callable(self.quirk_ids):
                 matches.append(self.quirk_ids(quirk_id))
             else:


### PR DESCRIPTION
## Proposed change
This PR fixes an issue where all custom entities that use quirk IDs match all devices.

This is done by removing the part to check if `bool(quirk_id)` evaluates to `True` on a device (so `None` and not empty). This is not needed anyway.

#102482 initially added it, because `quirk_id` (on a device) can be `None` (unlike model/manufacturer) and it shouldn't be matched successfully in that case.
I must have been under the assumption that the relevant code was only used when the match evaluates to `True` already. *Obviously*, it's also used to add `False` to the `matches` list and not match the entity later.

To clarify, `self.quirk_ids` is from the `MatchRule`, so the quirk IDs from a "custom entity".
`quirk_id` is the quirk id from the device and can be `None`. That doesn't matter though.

This is now also inline with how the "matches" work for the other attributes.

### Background:

At the moment, `TuyaPowerOnStateSelectEntity`, `TuyaBacklightModeSelectEntity`, and `TuyaChildLockSwitch` use quirk IDs. Those entities were always matched (falsely).

In reality, this isn't a big issue, as `ZHASwitchConfigurationEntity` checks that the attribute actually exists and is supported on the specified cluster.
However, for Aqara EU plugs (and possibly other devices?), the custom `power_outage_memory` entity wasn't created, because there seems to be another issue in entity creation logic that where only the first defined "custom entity" for a device is created, because of this (tracked down by @dmulcahey):
https://github.com/home-assistant/core/blob/05e122e22b32113e39ae8f8e2b3e405ba796b7e2/homeassistant/components/zha/core/discovery.py#L250-L258
with:
https://github.com/home-assistant/core/blob/05e122e22b32113e39ae8f8e2b3e405ba796b7e2/homeassistant/components/zha/core/discovery.py#L222

It'll abort after the first config entity is added then.

That whole block shouldn't be run when the method is run with `config_diagnostic_entities = True`. 
While this needs to be fixed in a future PR, it shouldn't go into a patch release, as it'll be a breaking change for some devices due to the unique ID changing.

### Summary

To summarize, there are two issues that combined together cause some config entities to not appear.
This PR fixes one of the issues (the easier one). This fix also causes the missing config entities to re-appear.

There is a second issue where only one config entity is added depending on the device type though. This is not fixed in this PR, as the fix will likely be a breaking change and shouldn't go into a patch release.

### Milestone

This should target the next 2023.12.x patch release.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
