### PR TITLE
Disable config flow progress in peco config flow

### DIFF
--- a/homeassistant/components/peco/config_flow.py
+++ b/homeassistant/components/peco/config_flow.py
@@ -33,7 +33,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    meter_verification: bool = False
     meter_data: dict[str, str] = {}
     meter_error: dict[str, str] = {}
 
@@ -53,17 +52,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except HttpError:
             self.meter_error = {"phone_number": "http_error", "type": "error"}
 
-        self.hass.async_create_task(
-            self.hass.config_entries.flow.async_configure(flow_id=self.flow_id)
-        )
-
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the initial step."""
-        if self.meter_verification is True:
-            return self.async_show_progress_done(next_step_id="finish_smart_meter")
-
         if user_input is None:
             return self.async_show_form(
                 step_id="user",
@@ -86,20 +78,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(f"{county}-{phone_number}")
         self._abort_if_unique_id_configured()
 
-        self.meter_verification = True
-
         if self.meter_error is not None:
             # Clear any previous errors, since the user may have corrected them
             self.meter_error = {}
 
-        self.hass.async_create_task(self._verify_meter(phone_number))
+        await self._verify_meter(phone_number)
 
         self.meter_data = user_input
 
-        return self.async_show_progress(
-            step_id="user",
-            progress_action="verifying_meter",
-        )
+        return await self.async_step_finish_smart_meter()
 
     async def async_step_finish_smart_meter(
         self, user_input: dict[str, Any] | None = None
@@ -107,7 +94,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the finish smart meter step."""
         if "phone_number" in self.meter_error:
             if self.meter_error["type"] == "error":
-                self.meter_verification = False
                 return self.async_show_form(
                     step_id="user",
                     data_schema=STEP_USER_DATA_SCHEMA,

--- a/tests/components/peco/test_config_flow.py
+++ b/tests/components/peco/test_config_flow.py
@@ -78,12 +78,6 @@ async def test_meter_value_error(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
-    assert result["step_id"] == "user"
-    assert result["progress_action"] == "verifying_meter"
-
-    result = await hass.config_entries.flow.async_configure(result["flow_id"])
-
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"phone_number": "invalid_phone_number"}
@@ -107,12 +101,6 @@ async def test_incompatible_meter_error(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result["type"] == FlowResultType.SHOW_PROGRESS
-        assert result["step_id"] == "user"
-        assert result["progress_action"] == "verifying_meter"
-
-        result = await hass.config_entries.flow.async_configure(result["flow_id"])
-
         assert result["type"] == FlowResultType.ABORT
         assert result["reason"] == "incompatible_meter"
 
@@ -134,12 +122,6 @@ async def test_unresponsive_meter_error(hass: HomeAssistant) -> None:
             },
         )
         await hass.async_block_till_done()
-
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
-    assert result["step_id"] == "user"
-    assert result["progress_action"] == "verifying_meter"
-
-    result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
@@ -164,12 +146,6 @@ async def test_meter_http_error(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
-    assert result["step_id"] == "user"
-    assert result["progress_action"] == "verifying_meter"
-
-    result = await hass.config_entries.flow.async_configure(result["flow_id"])
-
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"phone_number": "http_error"}
@@ -192,12 +168,6 @@ async def test_smart_meter(hass: HomeAssistant) -> None:
             },
         )
         await hass.async_block_till_done()
-
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
-    assert result["step_id"] == "user"
-    assert result["progress_action"] == "verifying_meter"
-
-    result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "Philadelphia - 1234567890"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Disable config flow progress in peco config flow

The peco config flow shows progress for a task which often finish in a very short time.

This exposed a race condition which was fixed by https://github.com/home-assistant/frontend/pull/18775
However, that PR has to be temporarily reverted because it exposed bugs in other config flows: https://github.com/home-assistant/frontend/pull/18939

Therefore, we need to remove the progress from the `peco` config flow until the frontend race condition is permanently fixed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
