### PR TITLE
Add Wyoming satellite audio settings

### DIFF
--- a/homeassistant/components/wyoming/__init__.py
+++ b/homeassistant/components/wyoming/__init__.py
@@ -17,7 +17,12 @@ from .satellite import WyomingSatellite
 
 _LOGGER = logging.getLogger(__name__)
 
-SATELLITE_PLATFORMS = [Platform.BINARY_SENSOR, Platform.SELECT, Platform.SWITCH]
+SATELLITE_PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.SELECT,
+    Platform.SWITCH,
+    Platform.NUMBER,
+]
 
 __all__ = [
     "ATTR_SPEAKER",

--- a/homeassistant/components/wyoming/devices.py
+++ b/homeassistant/components/wyoming/devices.py
@@ -20,6 +20,8 @@ class SatelliteDevice:
     is_enabled: bool = True
     pipeline_name: str | None = None
     noise_suppression_level: int = 0
+    auto_gain: int = 0
+    volume_multiplier: float = 1.0
 
     _is_active_listener: Callable[[], None] | None = None
     _is_enabled_listener: Callable[[], None] | None = None
@@ -55,6 +57,22 @@ class SatelliteDevice:
         """Set noise suppression level."""
         if noise_suppression_level != self.noise_suppression_level:
             self.noise_suppression_level = noise_suppression_level
+            if self._audio_settings_listener is not None:
+                self._audio_settings_listener()
+
+    @callback
+    def set_auto_gain(self, auto_gain: int) -> None:
+        """Set auto gain amount."""
+        if auto_gain != self.auto_gain:
+            self.auto_gain = auto_gain
+            if self._audio_settings_listener is not None:
+                self._audio_settings_listener()
+
+    @callback
+    def set_volume_multiplier(self, volume_multiplier: float) -> None:
+        """Set auto gain amount."""
+        if volume_multiplier != self.volume_multiplier:
+            self.volume_multiplier = volume_multiplier
             if self._audio_settings_listener is not None:
                 self._audio_settings_listener()
 
@@ -106,4 +124,18 @@ class SatelliteDevice:
         ent_reg = er.async_get(hass)
         return ent_reg.async_get_entity_id(
             "select", DOMAIN, f"{self.satellite_id}-noise_suppression_level"
+        )
+
+    def get_auto_gain_entity_id(self, hass: HomeAssistant) -> str | None:
+        """Return entity id for auto gain amount."""
+        ent_reg = er.async_get(hass)
+        return ent_reg.async_get_entity_id(
+            "number", DOMAIN, f"{self.satellite_id}-auto_gain"
+        )
+
+    def get_volume_multiplier_entity_id(self, hass: HomeAssistant) -> str | None:
+        """Return entity id for microphone volume multiplier."""
+        ent_reg = er.async_get(hass)
+        return ent_reg.async_get_entity_id(
+            "number", DOMAIN, f"{self.satellite_id}-volume_multiplier"
         )

--- a/homeassistant/components/wyoming/devices.py
+++ b/homeassistant/components/wyoming/devices.py
@@ -19,10 +19,12 @@ class SatelliteDevice:
     is_active: bool = False
     is_enabled: bool = True
     pipeline_name: str | None = None
+    noise_suppression_level: int = 0
 
     _is_active_listener: Callable[[], None] | None = None
     _is_enabled_listener: Callable[[], None] | None = None
     _pipeline_listener: Callable[[], None] | None = None
+    _audio_settings_listener: Callable[[], None] | None = None
 
     @callback
     def set_is_active(self, active: bool) -> None:
@@ -49,6 +51,14 @@ class SatelliteDevice:
                 self._pipeline_listener()
 
     @callback
+    def set_noise_suppression_level(self, noise_suppression_level: int) -> None:
+        """Set noise suppression level."""
+        if noise_suppression_level != self.noise_suppression_level:
+            self.noise_suppression_level = noise_suppression_level
+            if self._audio_settings_listener is not None:
+                self._audio_settings_listener()
+
+    @callback
     def set_is_active_listener(self, is_active_listener: Callable[[], None]) -> None:
         """Listen for updates to is_active."""
         self._is_active_listener = is_active_listener
@@ -62,6 +72,13 @@ class SatelliteDevice:
     def set_pipeline_listener(self, pipeline_listener: Callable[[], None]) -> None:
         """Listen for updates to pipeline."""
         self._pipeline_listener = pipeline_listener
+
+    @callback
+    def set_audio_settings_listener(
+        self, audio_settings_listener: Callable[[], None]
+    ) -> None:
+        """Listen for updates to audio settings."""
+        self._audio_settings_listener = audio_settings_listener
 
     def get_assist_in_progress_entity_id(self, hass: HomeAssistant) -> str | None:
         """Return entity id for assist in progress binary sensor."""
@@ -82,4 +99,11 @@ class SatelliteDevice:
         ent_reg = er.async_get(hass)
         return ent_reg.async_get_entity_id(
             "select", DOMAIN, f"{self.satellite_id}-pipeline"
+        )
+
+    def get_noise_suppression_level_entity_id(self, hass: HomeAssistant) -> str | None:
+        """Return entity id for noise suppression select."""
+        ent_reg = er.async_get(hass)
+        return ent_reg.async_get_entity_id(
+            "select", DOMAIN, f"{self.satellite_id}-noise_suppression_level"
         )

--- a/homeassistant/components/wyoming/number.py
+++ b/homeassistant/components/wyoming/number.py
@@ -1,0 +1,102 @@
+"""Number entities for Wyoming integration."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+from homeassistant.components.number import NumberEntityDescription, RestoreNumber
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .entity import WyomingSatelliteEntity
+
+if TYPE_CHECKING:
+    from .models import DomainDataItem
+
+_MAX_AUTO_GAIN: Final = 31
+_MIN_VOLUME_MULTIPLIER: Final = 0.1
+_MAX_VOLUME_MULTIPLIER: Final = 10.0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Wyoming number entities."""
+    item: DomainDataItem = hass.data[DOMAIN][config_entry.entry_id]
+
+    # Setup is only forwarded for satellites
+    assert item.satellite is not None
+
+    device = item.satellite.device
+    async_add_entities(
+        [
+            WyomingSatelliteAutoGainNumber(device),
+            WyomingSatelliteVolumeMultiplierNumber(device),
+        ]
+    )
+
+
+class WyomingSatelliteAutoGainNumber(WyomingSatelliteEntity, RestoreNumber):
+    """Entity to represent auto gain amount."""
+
+    entity_description = NumberEntityDescription(
+        key="auto_gain",
+        translation_key="auto_gain",
+        entity_category=EntityCategory.CONFIG,
+    )
+    _attr_should_poll = False
+    _attr_native_min_value = 0
+    _attr_native_max_value = _MAX_AUTO_GAIN
+    _attr_native_value = 0
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to Home Assistant."""
+        await super().async_added_to_hass()
+
+        state = await self.async_get_last_state()
+        if state is not None:
+            await self.async_set_native_value(float(state.state))
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set new value."""
+        auto_gain = int(max(0, min(_MAX_AUTO_GAIN, value)))
+        self._attr_native_value = auto_gain
+        self.async_write_ha_state()
+        self._device.set_auto_gain(auto_gain)
+
+
+class WyomingSatelliteVolumeMultiplierNumber(WyomingSatelliteEntity, RestoreNumber):
+    """Entity to represent microphone volume multiplier."""
+
+    entity_description = NumberEntityDescription(
+        key="volume_multiplier",
+        translation_key="volume_multiplier",
+        entity_category=EntityCategory.CONFIG,
+    )
+    _attr_should_poll = False
+    _attr_native_min_value = _MIN_VOLUME_MULTIPLIER
+    _attr_native_max_value = _MAX_VOLUME_MULTIPLIER
+    _attr_native_step = 0.1
+    _attr_native_value = 1.0
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to Home Assistant."""
+        await super().async_added_to_hass()
+        last_number_data = await self.async_get_last_number_data()
+        if (last_number_data is not None) and (
+            last_number_data.native_value is not None
+        ):
+            await self.async_set_native_value(last_number_data.native_value)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set new value."""
+        self._attr_native_value = float(
+            max(_MIN_VOLUME_MULTIPLIER, min(_MAX_VOLUME_MULTIPLIER, value))
+        )
+        self.async_write_ha_state()
+        self._device.set_volume_multiplier(self._attr_native_value)

--- a/homeassistant/components/wyoming/satellite.py
+++ b/homeassistant/components/wyoming/satellite.py
@@ -236,6 +236,8 @@ class WyomingSatellite:
                     pipeline_id=pipeline_id,
                     audio_settings=assist_pipeline.AudioSettings(
                         noise_suppression_level=self.device.noise_suppression_level,
+                        auto_gain_dbfs=self.device.auto_gain,
+                        volume_multiplier=self.device.volume_multiplier,
                     ),
                 )
             )

--- a/homeassistant/components/wyoming/satellite.py
+++ b/homeassistant/components/wyoming/satellite.py
@@ -60,6 +60,7 @@ class WyomingSatellite:
 
         self.device.set_is_enabled_listener(self._enabled_changed)
         self.device.set_pipeline_listener(self._pipeline_changed)
+        self.device.set_audio_settings_listener(self._audio_settings_changed)
 
     async def run(self) -> None:
         """Run and maintain a connection to satellite."""
@@ -131,6 +132,12 @@ class WyomingSatellite:
 
     def _pipeline_changed(self) -> None:
         """Run when device pipeline changes."""
+
+        # Cancel any running pipeline
+        self._audio_queue.put_nowait(None)
+
+    def _audio_settings_changed(self) -> None:
+        """Run when device audio settings."""
 
         # Cancel any running pipeline
         self._audio_queue.put_nowait(None)
@@ -227,6 +234,9 @@ class WyomingSatellite:
                     end_stage=end_stage,
                     tts_audio_output="wav",
                     pipeline_id=pipeline_id,
+                    audio_settings=assist_pipeline.AudioSettings(
+                        noise_suppression_level=self.device.noise_suppression_level,
+                    ),
                 )
             )
 

--- a/homeassistant/components/wyoming/select.py
+++ b/homeassistant/components/wyoming/select.py
@@ -1,12 +1,15 @@
-"""Select entities for VoIP integration."""
+"""Select entities for Wyoming integration."""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
 from homeassistant.components.assist_pipeline.select import AssistPipelineSelect
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import restore_state
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -16,19 +19,34 @@ from .entity import WyomingSatelliteEntity
 if TYPE_CHECKING:
     from .models import DomainDataItem
 
+_NOISE_SUPPRESSION_LEVEL = {
+    "off": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+    "max": 4,
+}
+_DEFAULT_NOISE_SUPPRESSION_LEVEL = "off"
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up VoIP switch entities."""
+    """Set up Wyoming switch entities."""
     item: DomainDataItem = hass.data[DOMAIN][config_entry.entry_id]
 
     # Setup is only forwarded for satellites
     assert item.satellite is not None
 
-    async_add_entities([WyomingSatellitePipelineSelect(hass, item.satellite.device)])
+    device = item.satellite.device
+    async_add_entities(
+        [
+            WyomingSatellitePipelineSelect(hass, device),
+            WyomingSatelliteNoiseSuppressionLevelSelect(device),
+        ]
+    )
 
 
 class WyomingSatellitePipelineSelect(WyomingSatelliteEntity, AssistPipelineSelect):
@@ -45,3 +63,32 @@ class WyomingSatellitePipelineSelect(WyomingSatelliteEntity, AssistPipelineSelec
         """Select an option."""
         await super().async_select_option(option)
         self.device.set_pipeline_name(option)
+
+
+class WyomingSatelliteNoiseSuppressionLevelSelect(
+    WyomingSatelliteEntity, SelectEntity, restore_state.RestoreEntity
+):
+    """Entity to represent noise suppression level setting."""
+
+    entity_description = SelectEntityDescription(
+        key="noise_suppression_level",
+        translation_key="noise_suppression_level",
+        entity_category=EntityCategory.CONFIG,
+    )
+    _attr_should_poll = False
+    _attr_current_option = _DEFAULT_NOISE_SUPPRESSION_LEVEL
+    _attr_options = list(_NOISE_SUPPRESSION_LEVEL.keys())
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to Home Assistant."""
+        await super().async_added_to_hass()
+
+        state = await self.async_get_last_state()
+        if state is not None and state.state in self.options:
+            self._attr_current_option = state.state
+
+    async def async_select_option(self, option: str) -> None:
+        """Select an option."""
+        self._attr_current_option = option
+        self.async_write_ha_state()
+        self._device.set_noise_suppression_level(_NOISE_SUPPRESSION_LEVEL[option])

--- a/homeassistant/components/wyoming/select.py
+++ b/homeassistant/components/wyoming/select.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 from homeassistant.components.assist_pipeline.select import AssistPipelineSelect
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
@@ -19,14 +19,14 @@ from .entity import WyomingSatelliteEntity
 if TYPE_CHECKING:
     from .models import DomainDataItem
 
-_NOISE_SUPPRESSION_LEVEL = {
+_NOISE_SUPPRESSION_LEVEL: Final = {
     "off": 0,
     "low": 1,
     "medium": 2,
     "high": 3,
     "max": 4,
 }
-_DEFAULT_NOISE_SUPPRESSION_LEVEL = "off"
+_DEFAULT_NOISE_SUPPRESSION_LEVEL: Final = "off"
 
 
 async def async_setup_entry(
@@ -34,7 +34,7 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Wyoming switch entities."""
+    """Set up Wyoming select entities."""
     item: DomainDataItem = hass.data[DOMAIN][config_entry.entry_id]
 
     # Setup is only forwarded for satellites

--- a/homeassistant/components/wyoming/strings.json
+++ b/homeassistant/components/wyoming/strings.json
@@ -52,6 +52,14 @@
       "satellite_enabled": {
         "name": "Satellite enabled"
       }
+    },
+    "number": {
+      "auto_gain": {
+        "name": "Auto gain"
+      },
+      "volume_multiplier": {
+        "name": "Mic volume"
+      }
     }
   }
 }

--- a/homeassistant/components/wyoming/strings.json
+++ b/homeassistant/components/wyoming/strings.json
@@ -37,8 +37,15 @@
           "preferred": "[%key:component::assist_pipeline::entity::select::pipeline::state::preferred%]"
         }
       },
-      "noise_suppression": {
-        "name": "Noise suppression"
+      "noise_suppression_level": {
+        "name": "Noise suppression level",
+        "state": {
+          "off": "Off",
+          "low": "Low",
+          "medium": "Medium",
+          "high": "High",
+          "max": "Max"
+        }
       }
     },
     "switch": {

--- a/tests/components/wyoming/conftest.py
+++ b/tests/components/wyoming/conftest.py
@@ -17,6 +17,12 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture(autouse=True)
+def mock_tts_cache_dir_autouse(mock_tts_cache_dir):
+    """Mock the TTS cache dir with empty dir."""
+    return mock_tts_cache_dir
+
+
+@pytest.fixture(autouse=True)
 async def init_components(hass: HomeAssistant):
     """Set up required components."""
     assert await async_setup_component(hass, "homeassistant", {})

--- a/tests/components/wyoming/test_binary_sensor.py
+++ b/tests/components/wyoming/test_binary_sensor.py
@@ -4,6 +4,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
+from . import reload_satellite
+
 
 async def test_assist_in_progress(
     hass: HomeAssistant,
@@ -26,7 +28,8 @@ async def test_assist_in_progress(
     assert state.state == STATE_ON
     assert satellite_device.is_active
 
-    satellite_device.set_is_active(False)
+    # test restore does *not* happen
+    satellite_device = await reload_satellite(hass, satellite_config_entry.entry_id)
 
     state = hass.states.get(assist_in_progress_id)
     assert state is not None

--- a/tests/components/wyoming/test_number.py
+++ b/tests/components/wyoming/test_number.py
@@ -5,6 +5,8 @@ from homeassistant.components.wyoming.devices import SatelliteDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+from . import reload_satellite
+
 
 async def test_auto_gain_number(
     hass: HomeAssistant,
@@ -35,6 +37,13 @@ async def test_auto_gain_number(
 
         # set function should have been called
         mock_agc_changed.assert_called_once_with(31)
+
+    # test restore
+    satellite_device = await reload_satellite(hass, satellite_config_entry.entry_id)
+
+    state = hass.states.get(agc_entity_id)
+    assert state is not None
+    assert int(state.state) == 31
 
     await hass.services.async_call(
         "number",
@@ -75,6 +84,13 @@ async def test_volume_multiplier_number(
 
         # set function should have been called
         mock_vm_changed.assert_called_once_with(2.0)
+
+    # test restore
+    satellite_device = await reload_satellite(hass, satellite_config_entry.entry_id)
+
+    state = hass.states.get(vm_entity_id)
+    assert state is not None
+    assert float(state.state) == 2.0
 
     await hass.services.async_call(
         "number",

--- a/tests/components/wyoming/test_number.py
+++ b/tests/components/wyoming/test_number.py
@@ -1,0 +1,86 @@
+"""Test Wyoming number."""
+from unittest.mock import patch
+
+from homeassistant.components.wyoming.devices import SatelliteDevice
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+
+async def test_auto_gain_number(
+    hass: HomeAssistant,
+    satellite_config_entry: ConfigEntry,
+    satellite_device: SatelliteDevice,
+) -> None:
+    """Test automatic gain control number."""
+    agc_entity_id = satellite_device.get_auto_gain_entity_id(hass)
+    assert agc_entity_id
+
+    state = hass.states.get(agc_entity_id)
+    assert state is not None
+    assert int(state.state) == 0
+    assert satellite_device.auto_gain == 0
+
+    # Change setting
+    with patch.object(satellite_device, "set_auto_gain") as mock_agc_changed:
+        await hass.services.async_call(
+            "number",
+            "set_value",
+            {"entity_id": agc_entity_id, "value": 31},
+            blocking=True,
+        )
+
+        state = hass.states.get(agc_entity_id)
+        assert state is not None
+        assert int(state.state) == 31
+
+        # set function should have been called
+        mock_agc_changed.assert_called_once_with(31)
+
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {"entity_id": agc_entity_id, "value": 15},
+        blocking=True,
+    )
+
+    assert satellite_device.auto_gain == 15
+
+
+async def test_volume_multiplier_number(
+    hass: HomeAssistant,
+    satellite_config_entry: ConfigEntry,
+    satellite_device: SatelliteDevice,
+) -> None:
+    """Test volume multiplier number."""
+    vm_entity_id = satellite_device.get_volume_multiplier_entity_id(hass)
+    assert vm_entity_id
+
+    state = hass.states.get(vm_entity_id)
+    assert state is not None
+    assert float(state.state) == 1.0
+    assert satellite_device.volume_multiplier == 1.0
+
+    # Change setting
+    with patch.object(satellite_device, "set_volume_multiplier") as mock_vm_changed:
+        await hass.services.async_call(
+            "number",
+            "set_value",
+            {"entity_id": vm_entity_id, "value": 2.0},
+            blocking=True,
+        )
+
+        state = hass.states.get(vm_entity_id)
+        assert state is not None
+        assert float(state.state) == 2.0
+
+        # set function should have been called
+        mock_vm_changed.assert_called_once_with(2.0)
+
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {"entity_id": vm_entity_id, "value": 0.5},
+        blocking=True,
+    )
+
+    assert float(satellite_device.volume_multiplier) == 0.5

--- a/tests/components/wyoming/test_select.py
+++ b/tests/components/wyoming/test_select.py
@@ -9,6 +9,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
+from . import reload_satellite
+
 
 async def test_pipeline_select(
     hass: HomeAssistant,
@@ -64,6 +66,13 @@ async def test_pipeline_select(
         # set function should have been called
         mock_pipeline_changed.assert_called_once_with("Test 1")
 
+    # test restore
+    satellite_device = await reload_satellite(hass, satellite_config_entry.entry_id)
+
+    state = hass.states.get(pipeline_entity_id)
+    assert state is not None
+    assert state.state == "Test 1"
+
     # Change back and check update listener
     pipeline_listener = Mock()
     satellite_device.set_pipeline_listener(pipeline_listener)
@@ -114,6 +123,13 @@ async def test_noise_suppression_level_select(
 
         # set function should have been called
         mock_nsl_changed.assert_called_once_with(4)
+
+    # test restore
+    satellite_device = await reload_satellite(hass, satellite_config_entry.entry_id)
+
+    state = hass.states.get(nsl_entity_id)
+    assert state is not None
+    assert state.state == "max"
 
     await hass.services.async_call(
         "select",

--- a/tests/components/wyoming/test_switch.py
+++ b/tests/components/wyoming/test_switch.py
@@ -4,6 +4,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
+from . import reload_satellite
+
 
 async def test_satellite_enabled(
     hass: HomeAssistant,
@@ -30,3 +32,10 @@ async def test_satellite_enabled(
     assert state is not None
     assert state.state == STATE_OFF
     assert not satellite_device.is_enabled
+
+    # test restore
+    satellite_device = await reload_satellite(hass, satellite_config_entry.entry_id)
+
+    state = hass.states.get(satellite_enabled_id)
+    assert state is not None
+    assert state.state == STATE_OFF

--- a/tests/components/wyoming/test_tts.py
+++ b/tests/components/wyoming/test_tts.py
@@ -16,12 +16,6 @@ from homeassistant.helpers.entity_component import DATA_INSTANCES
 from . import MockAsyncTcpClient
 
 
-@pytest.fixture(autouse=True)
-def mock_tts_cache_dir_autouse(mock_tts_cache_dir):
-    """Mock the TTS cache dir with empty dir."""
-    return mock_tts_cache_dir
-
-
 async def test_support(hass: HomeAssistant, init_wyoming_tts) -> None:
     """Test supported properties."""
     state = hass.states.get("tts.test_tts")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds entities for controlling audio settings for Wyoming satellites:

* Noise suppression level (select)
* Automatic gain control (number)
* Microphone volume multiplier (number)

This allows satellites to take full advantage of audio enhancements in Home Assistant. Changes to audio settings will automatically restart a satellite's running pipeline with the updated settings.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30211

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
