### PR TITLE
Add workaround for orjson not handling subclasses of str

### DIFF
--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -35,6 +35,7 @@ class SerializationError(HomeAssistantError):
 
 def json_loads(__obj: bytes | bytearray | memoryview | str) -> JsonValueType:
     """Parse JSON data.
+
     This adds a workaround for orjson not handling subclasses of str,
     https://github.com/ijl/orjson/issues/445.
     """

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -34,7 +34,11 @@ class SerializationError(HomeAssistantError):
 
 
 def json_loads(__obj: bytes | bytearray | memoryview | str) -> JsonValueType:
-    """Parse JSON data."""
+    """Parse JSON data.
+    
+    This adds a workaround for orjson not handling subclasses of str,
+    https://github.com/ijl/orjson/issues/445.
+    """
     if type(__obj) in (bytes, bytearray, memoryview, str):
         return orjson.loads(__obj)  # type:ignore[no-any-return]
     if isinstance(__obj, str):

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -33,9 +33,13 @@ class SerializationError(HomeAssistantError):
     """Error serializing the data to JSON."""
 
 
-json_loads: Callable[[bytes | bytearray | memoryview | str], JsonValueType]
-json_loads = orjson.loads
-"""Parse JSON data."""
+def json_loads(__obj: bytes | bytearray | memoryview | str) -> JsonValueType:
+    """Parse JSON data."""
+    if type(__obj) in (bytes, bytearray, memoryview, str):
+        return orjson.loads(__obj)  # type:ignore[no-any-return]
+    if isinstance(__obj, str):
+        return orjson.loads(str(__obj))  # type:ignore[no-any-return]
+    return orjson.loads(__obj)  # type:ignore[no-any-return]
 
 
 def json_loads_array(__obj: bytes | bytearray | memoryview | str) -> JsonArrayType:

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -35,7 +35,6 @@ class SerializationError(HomeAssistantError):
 
 def json_loads(__obj: bytes | bytearray | memoryview | str) -> JsonValueType:
     """Parse JSON data.
-    
     This adds a workaround for orjson not handling subclasses of str,
     https://github.com/ijl/orjson/issues/445.
     """

--- a/tests/util/test_json.py
+++ b/tests/util/test_json.py
@@ -1,10 +1,12 @@
 """Test Home Assistant json utility functions."""
 from pathlib import Path
 
+import orjson
 import pytest
 
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util.json import (
+    json_loads,
     json_loads_array,
     json_loads_object,
     load_json,
@@ -153,3 +155,20 @@ async def test_deprecated_save_json(
     save_json(fname, TEST_JSON_A)
     assert "uses save_json from homeassistant.util.json" in caplog.text
     assert "should be updated to use homeassistant.helpers.json module" in caplog.text
+
+
+async def test_loading_derived_class():
+    """Test loading data from classes derived from str."""
+
+    class MyStr(str):
+        pass
+
+    class MyBytes(bytes):
+        pass
+
+    assert json_loads('"abc"') == "abc"
+    assert json_loads(MyStr('"abc"')) == "abc"
+
+    assert json_loads(b'"abc"') == "abc"
+    with pytest.raises(orjson.JSONDecodeError):
+        assert json_loads(MyBytes(b'"abc"')) == "abc"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add workaround for `orjson` not handling subclasses of str

Fixes https://github.com/home-assistant/core/issues/105309
Reported on orjson as https://github.com/ijl/orjson/issues/445


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
