### PR TITLE
Workaround `to_json` template filter in parsing dict key 

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -2133,20 +2133,11 @@ def to_json(
         | (orjson.OPT_SORT_KEYS if sort_keys else 0)
     )
 
-    # Test subclasses os str are not handled correctly
-    try:
-        return orjson.dumps(
-            value,
-            option=option,
-            default=_to_json_default,
-        ).decode("utf-8")
-    except TypeError:
-        return json.dumps(
-            value,
-            ensure_ascii=ensure_ascii,
-            indent=2 if pretty_print else None,
-            sort_keys=sort_keys,
-        )
+    return orjson.dumps(
+        value,
+        option=option,
+        default=_to_json_default,
+    ).decode("utf-8")
 
 
 @pass_context

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -2125,12 +2125,15 @@ def to_json(
 
     option = (
         ORJSON_PASSTHROUGH_OPTIONS
+        # OPT_NON_STR_KEYS is added as a work-a-round to
+        # ensure subclasses os str are not handled correctly
+        # See: https://github.com/ijl/orjson/issues/445
+        | orjson.OPT_NON_STR_KEYS
         | (orjson.OPT_INDENT_2 if pretty_print else 0)
         | (orjson.OPT_SORT_KEYS if sort_keys else 0)
     )
 
-    # Fall back on json.dumps in subclasses os str are not handled correctly
-    # See: https://github.com/ijl/orjson/issues/445
+    # Test subclasses os str are not handled correctly
     try:
         return orjson.dumps(
             value,

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -2125,8 +2125,8 @@ def to_json(
 
     option = (
         ORJSON_PASSTHROUGH_OPTIONS
-        # OPT_NON_STR_KEYS is added as a work-a-round to
-        # ensure subclasses os str are not handled correctly
+        # OPT_NON_STR_KEYS is added as a workaround to
+        # ensure subclasses of str are allowed as dict keys
         # See: https://github.com/ijl/orjson/issues/445
         | orjson.OPT_NON_STR_KEYS
         | (orjson.OPT_INDENT_2 if pretty_print else 0)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -2129,11 +2129,21 @@ def to_json(
         | (orjson.OPT_SORT_KEYS if sort_keys else 0)
     )
 
-    return orjson.dumps(
-        value,
-        option=option,
-        default=_to_json_default,
-    ).decode("utf-8")
+    # Fall back on json.dumps in subclasses os str are not handled correctly
+    # See: https://github.com/ijl/orjson/issues/445
+    try:
+        return orjson.dumps(
+            value,
+            option=option,
+            default=_to_json_default,
+        ).decode("utf-8")
+    except TypeError:
+        return json.dumps(
+            value,
+            ensure_ascii=ensure_ascii,
+            indent=2 if pretty_print else None,
+            sort_keys=sort_keys,
+        )
 
 
 @pass_context

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1233,6 +1233,24 @@ def test_to_json(hass: HomeAssistant) -> None:
     with pytest.raises(TemplateError):
         template.Template("{{ {'Foo': now()} | to_json }}", hass).async_render()
 
+    # Test special case where substring class cannot be rendered
+    # See: https://github.com/ijl/orjson/issues/445
+    class MyStr(str):
+        pass
+
+    expected_result = (
+        '{"mykey1": 11.0, "mykey2": "myvalue2", "mykey3": ["opt3b", "opt3a"]}'
+    )
+    test_dict = {
+        MyStr("mykey2"): "myvalue2",
+        MyStr("mykey1"): 11.0,
+        MyStr("mykey3"): ["opt3b", "opt3a"],
+    }
+    actual_result = template.Template(
+        "{{ test_dict | to_json(sort_keys=True) }}", hass
+    ).async_render(parse_result=False, variables={"test_dict": test_dict})
+    assert actual_result == expected_result
+
 
 def test_to_json_ensure_ascii(hass: HomeAssistant) -> None:
     """Test the object to JSON string filter."""

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1238,9 +1238,7 @@ def test_to_json(hass: HomeAssistant) -> None:
     class MyStr(str):
         pass
 
-    expected_result = (
-        '{"mykey1": 11.0, "mykey2": "myvalue2", "mykey3": ["opt3b", "opt3a"]}'
-    )
+    expected_result = '{"mykey1":11.0,"mykey2":"myvalue2","mykey3":["opt3b","opt3a"]}'
     test_dict = {
         MyStr("mykey2"): "myvalue2",
         MyStr("mykey1"): 11.0,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implement a work-around for `orjson.dumps` that failing parsing a dict that has keys that are a subclass or `str`.
In the work-a-round we allow non string dict key. This workaround need to be reverted once the this issue in orjson has been resolved:

See: https://github.com/ijl/orjson/issues/445

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #105315
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
