### PR TITLE
Add volume intents for media_player

### DIFF
--- a/homeassistant/components/media_player/intent.py
+++ b/homeassistant/components/media_player/intent.py
@@ -1,0 +1,22 @@
+"""Intents for the media_player integration."""
+from __future__ import annotations
+
+from homeassistant.const import SERVICE_VOLUME_DOWN, SERVICE_VOLUME_UP
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
+
+from . import DOMAIN
+
+INTENT_VOLUME_UP = "HassVolumeUp"
+INTENT_VOLUME_DOWN = "HassVolumeDown"
+
+
+async def async_setup_intents(hass: HomeAssistant) -> None:
+    """Set up the media_player intents."""
+    intent.async_register(
+        hass, intent.ServiceIntentHandler(INTENT_VOLUME_UP, DOMAIN, SERVICE_VOLUME_UP)
+    )
+    intent.async_register(
+        hass,
+        intent.ServiceIntentHandler(INTENT_VOLUME_DOWN, DOMAIN, SERVICE_VOLUME_DOWN),
+    )

--- a/tests/components/media_player/test_intent.py
+++ b/tests/components/media_player/test_intent.py
@@ -1,0 +1,61 @@
+"""Tests for the media_player intents."""
+from homeassistant.components import media_player
+from homeassistant.components.media_player import intent
+from homeassistant.const import STATE_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.intent import async_handle
+
+from tests.common import async_mock_service
+
+
+async def test_intent_volume_up(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the volume up intent."""
+
+    entry = entity_registry.async_get_or_create(media_player.DOMAIN, "test", "5678")
+
+    hass.states.async_set(entry.entity_id, STATE_ON)
+    calls = async_mock_service(
+        hass, media_player.DOMAIN, media_player.SERVICE_VOLUME_UP
+    )
+
+    await intent.async_setup_intents(hass)
+
+    response = await async_handle(
+        hass,
+        "test",
+        intent.INTENT_VOLUME_UP,
+    )
+
+    # Response should contain one target
+    assert len(response.success_results) == 1
+    assert len(calls) == 1
+
+
+async def test_intent_volume_down(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the volume up intent."""
+
+    entry = entity_registry.async_get_or_create(media_player.DOMAIN, "test", "5678")
+
+    hass.states.async_set(entry.entity_id, STATE_ON)
+    calls = async_mock_service(
+        hass, media_player.DOMAIN, media_player.SERVICE_VOLUME_DOWN
+    )
+
+    await intent.async_setup_intents(hass)
+
+    response = await async_handle(
+        hass,
+        "test",
+        intent.INTENT_VOLUME_DOWN,
+    )
+
+    # Response should contain one target
+    assert len(response.success_results) == 1
+    assert len(calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Adds the intents HassVolumeUp and HassVolumeDown to media_player. Registers them using ServiceIntentHandler.

Most voice assistants support some way to interact with music / other media players. By initially adding volume change options this lays the foundation for future expansions on assist for other intents.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: home-assistant/intents#1623
- As the documentation for built-in intents is generated automatically, I will create a PR against `intents.yaml` in the intents repository if you consider the names appropriately - at least I assume that these intents should be considered built-in.
- I am very new to home-assistant, so there are surely a lot of pitfalls I stepped in. I would greatly appreciate if you could point them out for me. Take this as an initial draft that I can iterate on until you think this PR is done correctly.
- While I have added tests, my knowledge is not sophisticated enough to be sure they are working as intended - please also take a look at them.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally. (I do not know how to properly test this manually as long as the intents are not added to assist)
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist] (I can rebase to newest dev before merge)
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
- See above regarding the missing change in the documentation - PR for intents repository will be created if this looks good otherwise

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
- I'll have a look at some!

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
