### PR TITLE
Migrate homeassistant component tests to use freezegun

### DIFF
--- a/tests/components/homeassistant/triggers/test_time_pattern.py
+++ b/tests/components/homeassistant/triggers/test_time_pattern.py
@@ -1,7 +1,7 @@
 """The tests for the time_pattern automation."""
 from datetime import timedelta
-from unittest.mock import patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 import voluptuous as vol
 
@@ -27,33 +27,33 @@ def setup_comp(hass):
     mock_component(hass, "group")
 
 
-async def test_if_fires_when_hour_matches(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_when_hour_matches(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+) -> None:
     """Test for firing if hour is matching."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
         year=now.year + 1, hour=3
     )
-    with patch(
-        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
-    ):
-        assert await async_setup_component(
-            hass,
-            automation.DOMAIN,
-            {
-                automation.DOMAIN: {
-                    "trigger": {
-                        "platform": "time_pattern",
-                        "hours": 0,
-                        "minutes": "*",
-                        "seconds": "*",
-                    },
-                    "action": {
-                        "service": "test.automation",
-                        "data_template": {"id": "{{ trigger.id}}"},
-                    },
-                }
-            },
-        )
+    freezer.move_to(time_that_will_not_match_right_away)
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "time_pattern",
+                    "hours": 0,
+                    "minutes": "*",
+                    "seconds": "*",
+                },
+                "action": {
+                    "service": "test.automation",
+                    "data_template": {"id": "{{ trigger.id}}"},
+                },
+            }
+        },
+    )
 
     async_fire_time_changed(hass, now.replace(year=now.year + 2, hour=0))
     await hass.async_block_till_done()
@@ -72,30 +72,30 @@ async def test_if_fires_when_hour_matches(hass: HomeAssistant, calls) -> None:
     assert calls[0].data["id"] == 0
 
 
-async def test_if_fires_when_minute_matches(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_when_minute_matches(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+) -> None:
     """Test for firing if minutes are matching."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
         year=now.year + 1, minute=30
     )
-    with patch(
-        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
-    ):
-        assert await async_setup_component(
-            hass,
-            automation.DOMAIN,
-            {
-                automation.DOMAIN: {
-                    "trigger": {
-                        "platform": "time_pattern",
-                        "hours": "*",
-                        "minutes": 0,
-                        "seconds": "*",
-                    },
-                    "action": {"service": "test.automation"},
-                }
-            },
-        )
+    freezer.move_to(time_that_will_not_match_right_away)
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "time_pattern",
+                    "hours": "*",
+                    "minutes": 0,
+                    "seconds": "*",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
 
     async_fire_time_changed(hass, now.replace(year=now.year + 2, minute=0))
 
@@ -103,30 +103,30 @@ async def test_if_fires_when_minute_matches(hass: HomeAssistant, calls) -> None:
     assert len(calls) == 1
 
 
-async def test_if_fires_when_second_matches(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_when_second_matches(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+) -> None:
     """Test for firing if seconds are matching."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
         year=now.year + 1, second=30
     )
-    with patch(
-        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
-    ):
-        assert await async_setup_component(
-            hass,
-            automation.DOMAIN,
-            {
-                automation.DOMAIN: {
-                    "trigger": {
-                        "platform": "time_pattern",
-                        "hours": "*",
-                        "minutes": "*",
-                        "seconds": 0,
-                    },
-                    "action": {"service": "test.automation"},
-                }
-            },
-        )
+    freezer.move_to(time_that_will_not_match_right_away)
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "time_pattern",
+                    "hours": "*",
+                    "minutes": "*",
+                    "seconds": 0,
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
 
     async_fire_time_changed(hass, now.replace(year=now.year + 2, second=0))
 
@@ -135,31 +135,29 @@ async def test_if_fires_when_second_matches(hass: HomeAssistant, calls) -> None:
 
 
 async def test_if_fires_when_second_as_string_matches(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
 ) -> None:
     """Test for firing if seconds are matching."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
         year=now.year + 1, second=15
     )
-    with patch(
-        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
-    ):
-        assert await async_setup_component(
-            hass,
-            automation.DOMAIN,
-            {
-                automation.DOMAIN: {
-                    "trigger": {
-                        "platform": "time_pattern",
-                        "hours": "*",
-                        "minutes": "*",
-                        "seconds": "30",
-                    },
-                    "action": {"service": "test.automation"},
-                }
-            },
-        )
+    freezer.move_to(time_that_will_not_match_right_away)
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "time_pattern",
+                    "hours": "*",
+                    "minutes": "*",
+                    "seconds": "30",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
 
     async_fire_time_changed(
         hass, time_that_will_not_match_right_away + timedelta(seconds=15)
@@ -169,30 +167,30 @@ async def test_if_fires_when_second_as_string_matches(
     assert len(calls) == 1
 
 
-async def test_if_fires_when_all_matches(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_when_all_matches(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+) -> None:
     """Test for firing if everything matches."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
         year=now.year + 1, hour=4
     )
-    with patch(
-        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
-    ):
-        assert await async_setup_component(
-            hass,
-            automation.DOMAIN,
-            {
-                automation.DOMAIN: {
-                    "trigger": {
-                        "platform": "time_pattern",
-                        "hours": 1,
-                        "minutes": 2,
-                        "seconds": 3,
-                    },
-                    "action": {"service": "test.automation"},
-                }
-            },
-        )
+    freezer.move_to(time_that_will_not_match_right_away)
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "time_pattern",
+                    "hours": 1,
+                    "minutes": 2,
+                    "seconds": 3,
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
 
     async_fire_time_changed(
         hass, now.replace(year=now.year + 2, hour=1, minute=2, second=3)
@@ -202,30 +200,30 @@ async def test_if_fires_when_all_matches(hass: HomeAssistant, calls) -> None:
     assert len(calls) == 1
 
 
-async def test_if_fires_periodic_seconds(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_periodic_seconds(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+) -> None:
     """Test for firing periodically every second."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
         year=now.year + 1, second=1
     )
-    with patch(
-        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
-    ):
-        assert await async_setup_component(
-            hass,
-            automation.DOMAIN,
-            {
-                automation.DOMAIN: {
-                    "trigger": {
-                        "platform": "time_pattern",
-                        "hours": "*",
-                        "minutes": "*",
-                        "seconds": "/10",
-                    },
-                    "action": {"service": "test.automation"},
-                }
-            },
-        )
+    freezer.move_to(time_that_will_not_match_right_away)
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "time_pattern",
+                    "hours": "*",
+                    "minutes": "*",
+                    "seconds": "/10",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
 
     async_fire_time_changed(
         hass, now.replace(year=now.year + 2, hour=0, minute=0, second=10)
@@ -235,31 +233,31 @@ async def test_if_fires_periodic_seconds(hass: HomeAssistant, calls) -> None:
     assert len(calls) >= 1
 
 
-async def test_if_fires_periodic_minutes(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_periodic_minutes(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+) -> None:
     """Test for firing periodically every minute."""
 
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
         year=now.year + 1, minute=1
     )
-    with patch(
-        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
-    ):
-        assert await async_setup_component(
-            hass,
-            automation.DOMAIN,
-            {
-                automation.DOMAIN: {
-                    "trigger": {
-                        "platform": "time_pattern",
-                        "hours": "*",
-                        "minutes": "/2",
-                        "seconds": "*",
-                    },
-                    "action": {"service": "test.automation"},
-                }
-            },
-        )
+    freezer.move_to(time_that_will_not_match_right_away)
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "time_pattern",
+                    "hours": "*",
+                    "minutes": "/2",
+                    "seconds": "*",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
 
     async_fire_time_changed(
         hass, now.replace(year=now.year + 2, hour=0, minute=2, second=0)
@@ -269,30 +267,30 @@ async def test_if_fires_periodic_minutes(hass: HomeAssistant, calls) -> None:
     assert len(calls) == 1
 
 
-async def test_if_fires_periodic_hours(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_periodic_hours(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+) -> None:
     """Test for firing periodically every hour."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
         year=now.year + 1, hour=1
     )
-    with patch(
-        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
-    ):
-        assert await async_setup_component(
-            hass,
-            automation.DOMAIN,
-            {
-                automation.DOMAIN: {
-                    "trigger": {
-                        "platform": "time_pattern",
-                        "hours": "/2",
-                        "minutes": "*",
-                        "seconds": "*",
-                    },
-                    "action": {"service": "test.automation"},
-                }
-            },
-        )
+    freezer.move_to(time_that_will_not_match_right_away)
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "time_pattern",
+                    "hours": "/2",
+                    "minutes": "*",
+                    "seconds": "*",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
 
     async_fire_time_changed(
         hass, now.replace(year=now.year + 2, hour=2, minute=0, second=0)
@@ -302,25 +300,25 @@ async def test_if_fires_periodic_hours(hass: HomeAssistant, calls) -> None:
     assert len(calls) == 1
 
 
-async def test_default_values(hass: HomeAssistant, calls) -> None:
+async def test_default_values(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+) -> None:
     """Test for firing at 2 minutes every hour."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
         year=now.year + 1, minute=1
     )
-    with patch(
-        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
-    ):
-        assert await async_setup_component(
-            hass,
-            automation.DOMAIN,
-            {
-                automation.DOMAIN: {
-                    "trigger": {"platform": "time_pattern", "minutes": "2"},
-                    "action": {"service": "test.automation"},
-                }
-            },
-        )
+    freezer.move_to(time_that_will_not_match_right_away)
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {"platform": "time_pattern", "minutes": "2"},
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
 
     async_fire_time_changed(
         hass, now.replace(year=now.year + 2, hour=1, minute=2, second=0)


### PR DESCRIPTION
## Proposed change
Migrate the tests of the `homeassistant` component to use freezegun instead of patching `homeassistant.util.dt.utcnow` directly

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
