### PR TITLE
Expose the "middleware" parameter of Volkszaehler to platform config

### DIFF
--- a/homeassistant/components/volkszaehler/sensor.py
+++ b/homeassistant/components/volkszaehler/sensor.py
@@ -33,6 +33,9 @@ from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_USE_MIDDLEWARE = "middleware"
+
+DEFAULT_USE_MIDDLEWARE = True
 DEFAULT_HOST = "localhost"
 DEFAULT_NAME = "Volkszaehler"
 DEFAULT_PORT = 80
@@ -75,6 +78,7 @@ SENSOR_KEYS: list[str] = [desc.key for desc in SENSOR_TYPES]
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_UUID): cv.string,
+        vol.Optional(CONF_USE_MIDDLEWARE, default=DEFAULT_USE_MIDDLEWARE): cv.boolean,
         vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
@@ -93,6 +97,8 @@ async def async_setup_platform(
 ) -> None:
     """Set up the Volkszaehler sensors."""
 
+    use_middleware: bool = config[CONF_USE_MIDDLEWARE]
+    host: str = config[CONF_HOST]
     host: str = config[CONF_HOST]
     name: str = config[CONF_NAME]
     port: int = config[CONF_PORT]
@@ -100,7 +106,9 @@ async def async_setup_platform(
     conditions: list[str] = config[CONF_MONITORED_CONDITIONS]
 
     session = async_get_clientsession(hass)
-    vz_api = VolkszaehlerData(Volkszaehler(session, uuid, host=host, port=port))
+    vz_api = VolkszaehlerData(
+        Volkszaehler(session, uuid, host=host, port=port, middleware=use_middleware)
+    )
 
     await vz_api.async_update()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change adds the `middleware` parameter from the Volkszaehler module initialization to the platform configuration in `configuration.yaml`.

Before:
```
  - platform: volkszaehler
    name: "volkszähler"
    host: "127.0.0.1"
    port: "8080"
    uuid: ""
    monitored_conditions:
      - average
      - consumption
      - min
      - max
```

After:
```
  - platform: volkszaehler
    name: "volkszähler"
    host: "127.0.0.1"
    port: "8080"
    uuid: ""
    middleware: true|false
    monitored_conditions:
      - average
      - consumption
      - min
      - max
```
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

This PR fixes issue: fixes #95670
This change fixes the issue where fetching data from a local Volkszaehler server via `http://server-ip/middleware.php/data/00000000-0000-00000-0000-0000000000000.json` returned an error. (Unknown context: 'middleware.php')

In that case, the data needs to be fetched via `http://server-ip/data/00000000-0000-00000-0000-0000000000000.json`.

The Volkszaehler Python module already provides a parameter to remove `middleware.php` from the url which can now be configured by the user.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository] (PR: https://github.com/home-assistant/home-assistant.io/pull/30231)

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [X] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
