### PR TITLE
Prevent duplicate default SSLContext instances

### DIFF
--- a/tests/util/test_ssl.py
+++ b/tests/util/test_ssl.py
@@ -51,3 +51,12 @@ def test_no_verify_ssl_context(mock_sslcontext) -> None:
         mock_sslcontext.set_ciphers.assert_called_with(
             SSL_CIPHER_LISTS[SSLCipherList.INTERMEDIATE]
         )
+
+
+def test_ssl_context_caching() -> None:
+    """Test that SSLContext instances are cached correctly."""
+
+    assert client_context() is client_context(SSLCipherList.PYTHON_DEFAULT)
+    assert create_no_verify_ssl_context() is create_no_verify_ssl_context(
+        SSLCipherList.PYTHON_DEFAULT
+    )


### PR DESCRIPTION
needs https://github.com/home-assistant/core/pull/105362
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR fixes the unintentional duplication of default `SSLContext` instances created in `util/ssl.py` (#105115), when the factory methods are called both with and without explicitly passing the default cipher list. The root cause of this behavior is that the `@functools.cache` decorator does not play nicely with default arguments. While the performance/efficiency impact of these duplicate contexts is quite small, so is the fix. 😄 

The approach taken was to move the implementation and caching into private functions that do not have a default argument value. There are no changes to the actual implementation. The existing public functions now call those private functions, always passing in the argument explicitly to ensure reliable cache behavior. The public functions maintain their existing signatures (including the defaulted argument value), so there is no change to the public API.

A new test was added to verify the caching behavior.

The change in `imap/coordinator.py` is to resolve a `mypy` warning that cropped up. I suspect the `@cache` decorator was obscuring some of the type information previously. Now that it is removed from the public functions, `mypy` correctly caught that a `str` was incorrectly being passed where an enumeration value is required.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #105115
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
