### PR TITLE
Accept HTTP 200 through 206 as success for RESTful Switch

### DIFF
--- a/homeassistant/components/rest/switch.py
+++ b/homeassistant/components/rest/switch.py
@@ -171,7 +171,7 @@ class RestSwitch(ManualTriggerEntity, SwitchEntity):
         try:
             req = await self.set_device_state(body_on_t)
 
-            if req.status_code == HTTPStatus.OK:
+            if HTTPStatus.OK <= req.status_code < HTTPStatus.MULTIPLE_CHOICES:
                 self._attr_is_on = True
             else:
                 _LOGGER.error(
@@ -186,7 +186,7 @@ class RestSwitch(ManualTriggerEntity, SwitchEntity):
 
         try:
             req = await self.set_device_state(body_off_t)
-            if req.status_code == HTTPStatus.OK:
+            if HTTPStatus.OK <= req.status_code < HTTPStatus.MULTIPLE_CHOICES:
                 self._attr_is_on = False
             else:
                 _LOGGER.error(

--- a/tests/components/rest/test_switch.py
+++ b/tests/components/rest/test_switch.py
@@ -53,6 +53,22 @@ RESOURCE = "http://localhost/"
 STATE_RESOURCE = RESOURCE
 
 
+@pytest.fixture(
+    params=(
+        HTTPStatus.OK,
+        HTTPStatus.CREATED,
+        HTTPStatus.ACCEPTED,
+        HTTPStatus.NON_AUTHORITATIVE_INFORMATION,
+        HTTPStatus.NO_CONTENT,
+        HTTPStatus.RESET_CONTENT,
+        HTTPStatus.PARTIAL_CONTENT,
+    )
+)
+def http_success_code(request: pytest.FixtureRequest) -> HTTPStatus:
+    """Fixture providing different successful HTTP response code."""
+    return request.param
+
+
 async def test_setup_missing_config(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -262,11 +278,14 @@ async def test_is_on_before_update(hass: HomeAssistant) -> None:
 
 
 @respx.mock
-async def test_turn_on_success(hass: HomeAssistant) -> None:
+async def test_turn_on_success(
+    hass: HomeAssistant,
+    http_success_code: HTTPStatus,
+) -> None:
     """Test turn_on."""
     await _async_setup_test_switch(hass)
 
-    route = respx.post(RESOURCE) % HTTPStatus.OK
+    route = respx.post(RESOURCE) % http_success_code
     respx.get(RESOURCE).mock(side_effect=httpx.RequestError)
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -320,11 +339,14 @@ async def test_turn_on_timeout(hass: HomeAssistant) -> None:
 
 
 @respx.mock
-async def test_turn_off_success(hass: HomeAssistant) -> None:
+async def test_turn_off_success(
+    hass: HomeAssistant,
+    http_success_code: HTTPStatus,
+) -> None:
     """Test turn_off."""
     await _async_setup_test_switch(hass)
 
-    route = respx.post(RESOURCE) % HTTPStatus.OK
+    route = respx.post(RESOURCE) % http_success_code
     respx.get(RESOURCE).mock(side_effect=httpx.RequestError)
     await hass.services.async_call(
         SWITCH_DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The RESTful Switch integration currently considers only HTTP 200 OK to indicate success when turning on/off (#105355). Many REST endpoints return other success codes, such as 204 No Content. This causes the RESTful switch to not update its state until the next poll, as it considers the on/off request a failure.

This PR expands the HTTP status codes considered as successful to 200 through 206. This was chosen to match [the range currently used by `rest/notify.py`](https://github.com/home-assistant/core/blob/e1df1f9ffe46953edc2fefe8b1b78b9ebb5a35f1/homeassistant/components/rest/notify.py#L229).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #105355
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
