### PR TITLE
Add first TypeVarTuple annotations

### DIFF
--- a/homeassistant/helpers/ratelimit.py
+++ b/homeassistant/helpers/ratelimit.py
@@ -5,10 +5,12 @@ import asyncio
 from collections.abc import Callable, Hashable
 from datetime import datetime, timedelta
 import logging
-from typing import Any
+from typing import TypeVarTuple
 
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.util.dt as dt_util
+
+_Ts = TypeVarTuple("_Ts")
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,8 +61,8 @@ class KeyedRateLimit:
         key: Hashable,
         rate_limit: timedelta | None,
         now: datetime,
-        action: Callable,
-        *args: Any,
+        action: Callable[[*_Ts], None],
+        *args: *_Ts,
     ) -> datetime | None:
         """Check rate limits and schedule an action if we hit the limit.
 

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -10,7 +10,7 @@ import functools
 import logging
 import threading
 from traceback import extract_stack
-from typing import Any, ParamSpec, TypeVar
+from typing import Any, ParamSpec, TypeVar, TypeVarTuple
 
 from homeassistant.exceptions import HomeAssistantError
 
@@ -21,6 +21,7 @@ _SHUTDOWN_RUN_CALLBACK_THREADSAFE = "_shutdown_run_callback_threadsafe"
 _T = TypeVar("_T")
 _R = TypeVar("_R")
 _P = ParamSpec("_P")
+_Ts = TypeVarTuple("_Ts")
 
 
 def cancelling(task: Future[Any]) -> bool:
@@ -29,7 +30,7 @@ def cancelling(task: Future[Any]) -> bool:
 
 
 def run_callback_threadsafe(
-    loop: AbstractEventLoop, callback: Callable[..., _T], *args: Any
+    loop: AbstractEventLoop, callback: Callable[[*_Ts], _T], *args: *_Ts
 ) -> concurrent.futures.Future[_T]:
     """Submit a callback object to a given event loop.
 


### PR DESCRIPTION
## Proposed change
Now that both mypy and pyright support TypeVarTuple, we can start to use it to annotate callbacks which only accept `*args`. _Something quite commonly use for asyncio callback functions. See https://github.com/python/typeshed/pull/11015 for a few more examples with `call_soon` and others. These will be included in a future mypy release - probably in January._

One thing to consider: even though the typing is correct, there is an existing bug in pyright when functions with default arguments are passed. It has already been fixed but will only be included in the next Pylance release. So for the time being those emit false-positives.

*Update*: Fixed with pre-release version `v2023.12.100`.

<img width="537" alt="Screenshot 2023-12-09 at 12 23 32" src="https://github.com/home-assistant/core/assets/30130371/25469be0-972c-4bb8-bada-dd86a5d7ae04">

https://github.com/home-assistant/core/blob/d54c36307a839578e086775d1eed1c6be445d7c7/homeassistant/core.py#L1191-L1193

Ref: https://github.com/microsoft/pyright/issues/6613


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
