### PR TITLE
Make API init async in Minecraft Server

### DIFF
--- a/homeassistant/components/minecraft_server/api.py
+++ b/homeassistant/components/minecraft_server/api.py
@@ -9,6 +9,8 @@ from dns.resolver import LifetimeTimeout
 from mcstatus import BedrockServer, JavaServer
 from mcstatus.status_response import BedrockStatusResponse, JavaStatusResponse
 
+from homeassistant.core import HomeAssistant
+
 _LOGGER = logging.getLogger(__name__)
 
 LOOKUP_TIMEOUT: float = 10
@@ -52,35 +54,54 @@ class MinecraftServerConnectionError(Exception):
     """Raised when no data can be fechted from the server."""
 
 
+class MinecraftServerNotInitializedError(Exception):
+    """Raised when APIs are used although server instance is not initialized yet."""
+
+
 class MinecraftServer:
     """Minecraft Server wrapper class for 3rd party library mcstatus."""
 
     _server: BedrockServer | JavaServer
 
-    def __init__(self, server_type: MinecraftServerType, address: str) -> None:
+    def __init__(
+        self, hass: HomeAssistant, server_type: MinecraftServerType, address: str
+    ) -> None:
         """Initialize server instance."""
+        self._initialized = False
+        self._hass = hass
+        self._server_type = server_type
+        self._address = address
+
+    async def async_initialize(self) -> None:
+        """Perform async initialization of server instance."""
+        self._initialized = True
+
         try:
-            if server_type == MinecraftServerType.JAVA_EDITION:
-                self._server = JavaServer.lookup(address, timeout=LOOKUP_TIMEOUT)
+            if self._server_type == MinecraftServerType.JAVA_EDITION:
+                self._server = await JavaServer.async_lookup(self._address)
             else:
-                self._server = BedrockServer.lookup(address, timeout=LOOKUP_TIMEOUT)
+                self._server = await self._hass.async_add_executor_job(
+                    BedrockServer.lookup, self._address
+                )
         except (ValueError, LifetimeTimeout) as error:
             raise MinecraftServerAddressError(
-                f"Lookup of '{address}' failed: {self._get_error_message(error)}"
+                f"Lookup of '{self._address}' failed: {self._get_error_message(error)}"
             ) from error
 
         self._server.timeout = DATA_UPDATE_TIMEOUT
-        self._address = address
+        self._address = self._address
 
         _LOGGER.debug(
-            "%s server instance created with address '%s'", server_type, address
+            "%s server instance created with address '%s'",
+            self._server_type,
+            self._address,
         )
 
     async def async_is_online(self) -> bool:
         """Check if the server is online, supporting both Java and Bedrock Edition servers."""
         try:
             await self.async_get_data()
-        except MinecraftServerConnectionError:
+        except (MinecraftServerConnectionError, MinecraftServerNotInitializedError):
             return False
 
         return True
@@ -88,6 +109,9 @@ class MinecraftServer:
     async def async_get_data(self) -> MinecraftServerData:
         """Get updated data from the server, supporting both Java and Bedrock Edition servers."""
         status_response: BedrockStatusResponse | JavaStatusResponse
+
+        if not self._initialized:
+            raise MinecraftServerNotInitializedError()
 
         try:
             status_response = await self._server.async_status(tries=DATA_UPDATE_RETRIES)

--- a/homeassistant/components/minecraft_server/config_flow.py
+++ b/homeassistant/components/minecraft_server/config_flow.py
@@ -35,10 +35,10 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
 
             # Some Bedrock Edition servers mimic a Java Edition server, therefore check for a Bedrock Edition server first.
             for server_type in MinecraftServerType:
+                api = MinecraftServer(self.hass, server_type, address)
+
                 try:
-                    api = await self.hass.async_add_executor_job(
-                        MinecraftServer, server_type, address
-                    )
+                    await api.async_initialize()
                 except MinecraftServerAddressError:
                     pass
                 else:

--- a/homeassistant/components/minecraft_server/coordinator.py
+++ b/homeassistant/components/minecraft_server/coordinator.py
@@ -7,7 +7,12 @@ import logging
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .api import MinecraftServer, MinecraftServerConnectionError, MinecraftServerData
+from .api import (
+    MinecraftServer,
+    MinecraftServerConnectionError,
+    MinecraftServerData,
+    MinecraftServerNotInitializedError,
+)
 
 SCAN_INTERVAL = timedelta(seconds=60)
 
@@ -32,5 +37,8 @@ class MinecraftServerCoordinator(DataUpdateCoordinator[MinecraftServerData]):
         """Get updated data from the server."""
         try:
             return await self._api.async_get_data()
-        except MinecraftServerConnectionError as error:
+        except (
+            MinecraftServerConnectionError,
+            MinecraftServerNotInitializedError,
+        ) as error:
             raise UpdateFailed(error) from error

--- a/tests/components/minecraft_server/snapshots/test_binary_sensor.ambr
+++ b/tests/components/minecraft_server/snapshots/test_binary_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_binary_sensor[bedrock_mock_config_entry-BedrockServer-status_response1]
+# name: test_binary_sensor[bedrock_mock_config_entry-BedrockServer-lookup-status_response1]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'connectivity',
@@ -13,7 +13,7 @@
     'state': 'on',
   })
 # ---
-# name: test_binary_sensor[java_mock_config_entry-JavaServer-status_response0]
+# name: test_binary_sensor[java_mock_config_entry-JavaServer-async_lookup-status_response0]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'connectivity',
@@ -27,7 +27,7 @@
     'state': 'on',
   })
 # ---
-# name: test_binary_sensor_update[bedrock_mock_config_entry-BedrockServer-status_response1]
+# name: test_binary_sensor_update[bedrock_mock_config_entry-BedrockServer-lookup-status_response1]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'connectivity',
@@ -41,7 +41,7 @@
     'state': 'on',
   })
 # ---
-# name: test_binary_sensor_update[java_mock_config_entry-JavaServer-status_response0]
+# name: test_binary_sensor_update[java_mock_config_entry-JavaServer-async_lookup-status_response0]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'connectivity',

--- a/tests/components/minecraft_server/snapshots/test_sensor.ambr
+++ b/tests/components/minecraft_server/snapshots/test_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_sensor[bedrock_mock_config_entry-BedrockServer-status_response1-entity_ids1]
+# name: test_sensor[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Latency',
@@ -13,7 +13,7 @@
     'state': '5',
   })
 # ---
-# name: test_sensor[bedrock_mock_config_entry-BedrockServer-status_response1-entity_ids1].1
+# name: test_sensor[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].1
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Players online',
@@ -27,7 +27,7 @@
     'state': '3',
   })
 # ---
-# name: test_sensor[bedrock_mock_config_entry-BedrockServer-status_response1-entity_ids1].2
+# name: test_sensor[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].2
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Players max',
@@ -41,7 +41,7 @@
     'state': '10',
   })
 # ---
-# name: test_sensor[bedrock_mock_config_entry-BedrockServer-status_response1-entity_ids1].3
+# name: test_sensor[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].3
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server World message',
@@ -54,7 +54,7 @@
     'state': 'Dummy MOTD',
   })
 # ---
-# name: test_sensor[bedrock_mock_config_entry-BedrockServer-status_response1-entity_ids1].4
+# name: test_sensor[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].4
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Version',
@@ -67,7 +67,7 @@
     'state': 'Dummy Version',
   })
 # ---
-# name: test_sensor[bedrock_mock_config_entry-BedrockServer-status_response1-entity_ids1].5
+# name: test_sensor[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].5
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Protocol version',
@@ -80,7 +80,7 @@
     'state': '123',
   })
 # ---
-# name: test_sensor[bedrock_mock_config_entry-BedrockServer-status_response1-entity_ids1].6
+# name: test_sensor[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].6
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Map name',
@@ -93,7 +93,7 @@
     'state': 'Dummy Map Name',
   })
 # ---
-# name: test_sensor[bedrock_mock_config_entry-BedrockServer-status_response1-entity_ids1].7
+# name: test_sensor[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].7
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Game mode',
@@ -106,7 +106,7 @@
     'state': 'Dummy Game Mode',
   })
 # ---
-# name: test_sensor[bedrock_mock_config_entry-BedrockServer-status_response1-entity_ids1].8
+# name: test_sensor[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].8
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Edition',
@@ -119,7 +119,7 @@
     'state': 'MCPE',
   })
 # ---
-# name: test_sensor[java_mock_config_entry-JavaServer-status_response0-entity_ids0]
+# name: test_sensor[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Latency',
@@ -133,7 +133,7 @@
     'state': '5',
   })
 # ---
-# name: test_sensor[java_mock_config_entry-JavaServer-status_response0-entity_ids0].1
+# name: test_sensor[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0].1
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Players online',
@@ -152,7 +152,7 @@
     'state': '3',
   })
 # ---
-# name: test_sensor[java_mock_config_entry-JavaServer-status_response0-entity_ids0].2
+# name: test_sensor[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0].2
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Players max',
@@ -166,7 +166,7 @@
     'state': '10',
   })
 # ---
-# name: test_sensor[java_mock_config_entry-JavaServer-status_response0-entity_ids0].3
+# name: test_sensor[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0].3
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server World message',
@@ -179,7 +179,7 @@
     'state': 'Dummy MOTD',
   })
 # ---
-# name: test_sensor[java_mock_config_entry-JavaServer-status_response0-entity_ids0].4
+# name: test_sensor[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0].4
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Version',
@@ -192,7 +192,7 @@
     'state': 'Dummy Version',
   })
 # ---
-# name: test_sensor[java_mock_config_entry-JavaServer-status_response0-entity_ids0].5
+# name: test_sensor[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0].5
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Protocol version',
@@ -205,7 +205,7 @@
     'state': '123',
   })
 # ---
-# name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-status_response1-entity_ids1]
+# name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Latency',
@@ -219,7 +219,7 @@
     'state': '5',
   })
 # ---
-# name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-status_response1-entity_ids1].1
+# name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].1
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Players online',
@@ -233,7 +233,7 @@
     'state': '3',
   })
 # ---
-# name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-status_response1-entity_ids1].2
+# name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].2
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Players max',
@@ -247,7 +247,7 @@
     'state': '10',
   })
 # ---
-# name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-status_response1-entity_ids1].3
+# name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].3
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server World message',
@@ -260,7 +260,7 @@
     'state': 'Dummy MOTD',
   })
 # ---
-# name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-status_response1-entity_ids1].4
+# name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].4
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Version',
@@ -273,7 +273,7 @@
     'state': 'Dummy Version',
   })
 # ---
-# name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-status_response1-entity_ids1].5
+# name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].5
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Protocol version',
@@ -286,7 +286,7 @@
     'state': '123',
   })
 # ---
-# name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-status_response1-entity_ids1].6
+# name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].6
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Map name',
@@ -299,7 +299,7 @@
     'state': 'Dummy Map Name',
   })
 # ---
-# name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-status_response1-entity_ids1].7
+# name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].7
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Game mode',
@@ -312,7 +312,7 @@
     'state': 'Dummy Game Mode',
   })
 # ---
-# name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-status_response1-entity_ids1].8
+# name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].8
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Edition',
@@ -325,7 +325,7 @@
     'state': 'MCPE',
   })
 # ---
-# name: test_sensor_update[java_mock_config_entry-JavaServer-status_response0-entity_ids0]
+# name: test_sensor_update[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Latency',
@@ -339,7 +339,7 @@
     'state': '5',
   })
 # ---
-# name: test_sensor_update[java_mock_config_entry-JavaServer-status_response0-entity_ids0].1
+# name: test_sensor_update[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0].1
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Players online',
@@ -358,7 +358,7 @@
     'state': '3',
   })
 # ---
-# name: test_sensor_update[java_mock_config_entry-JavaServer-status_response0-entity_ids0].2
+# name: test_sensor_update[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0].2
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Players max',
@@ -372,7 +372,7 @@
     'state': '10',
   })
 # ---
-# name: test_sensor_update[java_mock_config_entry-JavaServer-status_response0-entity_ids0].3
+# name: test_sensor_update[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0].3
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server World message',
@@ -385,7 +385,7 @@
     'state': 'Dummy MOTD',
   })
 # ---
-# name: test_sensor_update[java_mock_config_entry-JavaServer-status_response0-entity_ids0].4
+# name: test_sensor_update[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0].4
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Version',
@@ -398,7 +398,7 @@
     'state': 'Dummy Version',
   })
 # ---
-# name: test_sensor_update[java_mock_config_entry-JavaServer-status_response0-entity_ids0].5
+# name: test_sensor_update[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0].5
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Minecraft Server Protocol version',

--- a/tests/components/minecraft_server/test_binary_sensor.py
+++ b/tests/components/minecraft_server/test_binary_sensor.py
@@ -22,16 +22,27 @@ from tests.common import async_fire_time_changed
 
 
 @pytest.mark.parametrize(
-    ("mock_config_entry", "server", "status_response"),
+    ("mock_config_entry", "server", "lookup_function_name", "status_response"),
     [
-        ("java_mock_config_entry", JavaServer, TEST_JAVA_STATUS_RESPONSE),
-        ("bedrock_mock_config_entry", BedrockServer, TEST_BEDROCK_STATUS_RESPONSE),
+        (
+            "java_mock_config_entry",
+            JavaServer,
+            "async_lookup",
+            TEST_JAVA_STATUS_RESPONSE,
+        ),
+        (
+            "bedrock_mock_config_entry",
+            BedrockServer,
+            "lookup",
+            TEST_BEDROCK_STATUS_RESPONSE,
+        ),
     ],
 )
 async def test_binary_sensor(
     hass: HomeAssistant,
     mock_config_entry: str,
     server: JavaServer | BedrockServer,
+    lookup_function_name: str,
     status_response: JavaStatusResponse | BedrockStatusResponse,
     request: pytest.FixtureRequest,
     snapshot: SnapshotAssertion,
@@ -41,7 +52,7 @@ async def test_binary_sensor(
     mock_config_entry.add_to_hass(hass)
 
     with patch(
-        f"homeassistant.components.minecraft_server.api.{server.__name__}.lookup",
+        f"homeassistant.components.minecraft_server.api.{server.__name__}.{lookup_function_name}",
         return_value=server(host=TEST_HOST, port=TEST_PORT),
     ), patch(
         f"homeassistant.components.minecraft_server.api.{server.__name__}.async_status",
@@ -53,16 +64,27 @@ async def test_binary_sensor(
 
 
 @pytest.mark.parametrize(
-    ("mock_config_entry", "server", "status_response"),
+    ("mock_config_entry", "server", "lookup_function_name", "status_response"),
     [
-        ("java_mock_config_entry", JavaServer, TEST_JAVA_STATUS_RESPONSE),
-        ("bedrock_mock_config_entry", BedrockServer, TEST_BEDROCK_STATUS_RESPONSE),
+        (
+            "java_mock_config_entry",
+            JavaServer,
+            "async_lookup",
+            TEST_JAVA_STATUS_RESPONSE,
+        ),
+        (
+            "bedrock_mock_config_entry",
+            BedrockServer,
+            "lookup",
+            TEST_BEDROCK_STATUS_RESPONSE,
+        ),
     ],
 )
 async def test_binary_sensor_update(
     hass: HomeAssistant,
     mock_config_entry: str,
     server: JavaServer | BedrockServer,
+    lookup_function_name: str,
     status_response: JavaStatusResponse | BedrockStatusResponse,
     request: pytest.FixtureRequest,
     snapshot: SnapshotAssertion,
@@ -73,7 +95,7 @@ async def test_binary_sensor_update(
     mock_config_entry.add_to_hass(hass)
 
     with patch(
-        f"homeassistant.components.minecraft_server.api.{server.__name__}.lookup",
+        f"homeassistant.components.minecraft_server.api.{server.__name__}.{lookup_function_name}",
         return_value=server(host=TEST_HOST, port=TEST_PORT),
     ), patch(
         f"homeassistant.components.minecraft_server.api.{server.__name__}.async_status",
@@ -88,16 +110,27 @@ async def test_binary_sensor_update(
 
 
 @pytest.mark.parametrize(
-    ("mock_config_entry", "server", "status_response"),
+    ("mock_config_entry", "server", "lookup_function_name", "status_response"),
     [
-        ("java_mock_config_entry", JavaServer, TEST_JAVA_STATUS_RESPONSE),
-        ("bedrock_mock_config_entry", BedrockServer, TEST_BEDROCK_STATUS_RESPONSE),
+        (
+            "java_mock_config_entry",
+            JavaServer,
+            "async_lookup",
+            TEST_JAVA_STATUS_RESPONSE,
+        ),
+        (
+            "bedrock_mock_config_entry",
+            BedrockServer,
+            "lookup",
+            TEST_BEDROCK_STATUS_RESPONSE,
+        ),
     ],
 )
 async def test_binary_sensor_update_failure(
     hass: HomeAssistant,
     mock_config_entry: str,
     server: JavaServer | BedrockServer,
+    lookup_function_name: str,
     status_response: JavaStatusResponse | BedrockStatusResponse,
     request: pytest.FixtureRequest,
     freezer: FrozenDateTimeFactory,
@@ -107,7 +140,7 @@ async def test_binary_sensor_update_failure(
     mock_config_entry.add_to_hass(hass)
 
     with patch(
-        f"homeassistant.components.minecraft_server.api.{server.__name__}.lookup",
+        f"homeassistant.components.minecraft_server.api.{server.__name__}.{lookup_function_name}",
         return_value=server(host=TEST_HOST, port=TEST_PORT),
     ), patch(
         f"homeassistant.components.minecraft_server.api.{server.__name__}.async_status",

--- a/tests/components/minecraft_server/test_config_flow.py
+++ b/tests/components/minecraft_server/test_config_flow.py
@@ -41,7 +41,7 @@ async def test_address_validation_failure(hass: HomeAssistant) -> None:
         "homeassistant.components.minecraft_server.api.BedrockServer.lookup",
         side_effect=ValueError,
     ), patch(
-        "homeassistant.components.minecraft_server.api.JavaServer.lookup",
+        "homeassistant.components.minecraft_server.api.JavaServer.async_lookup",
         side_effect=ValueError,
     ):
         result = await hass.config_entries.flow.async_init(
@@ -58,7 +58,7 @@ async def test_java_connection_failure(hass: HomeAssistant) -> None:
         "homeassistant.components.minecraft_server.api.BedrockServer.lookup",
         side_effect=ValueError,
     ), patch(
-        "homeassistant.components.minecraft_server.api.JavaServer.lookup",
+        "homeassistant.components.minecraft_server.api.JavaServer.async_lookup",
         return_value=JavaServer(host=TEST_HOST, port=TEST_PORT),
     ), patch(
         "homeassistant.components.minecraft_server.api.JavaServer.async_status",
@@ -95,7 +95,7 @@ async def test_java_connection(hass: HomeAssistant) -> None:
         "homeassistant.components.minecraft_server.api.BedrockServer.lookup",
         side_effect=ValueError,
     ), patch(
-        "homeassistant.components.minecraft_server.api.JavaServer.lookup",
+        "homeassistant.components.minecraft_server.api.JavaServer.async_lookup",
         return_value=JavaServer(host=TEST_HOST, port=TEST_PORT),
     ), patch(
         "homeassistant.components.minecraft_server.api.JavaServer.async_status",
@@ -138,7 +138,7 @@ async def test_recovery(hass: HomeAssistant) -> None:
         "homeassistant.components.minecraft_server.api.BedrockServer.lookup",
         side_effect=ValueError,
     ), patch(
-        "homeassistant.components.minecraft_server.api.JavaServer.lookup",
+        "homeassistant.components.minecraft_server.api.JavaServer.async_lookup",
         side_effect=ValueError,
     ):
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/minecraft_server/test_diagnostics.py
+++ b/tests/components/minecraft_server/test_diagnostics.py
@@ -42,9 +42,14 @@ async def test_config_entry_diagnostics(
     mock_config_entry = request.getfixturevalue(mock_config_entry)
     mock_config_entry.add_to_hass(hass)
 
+    if server.__name__ == "JavaServer":
+        lookup_function_name = "async_lookup"
+    else:
+        lookup_function_name = "lookup"
+
     # Setup mock entry.
     with patch(
-        f"mcstatus.server.{server.__name__}.lookup",
+        f"mcstatus.server.{server.__name__}.{lookup_function_name}",
         return_value=server(host=TEST_HOST, port=TEST_PORT),
     ), patch(
         f"mcstatus.server.{server.__name__}.async_status",

--- a/tests/components/minecraft_server/test_sensor.py
+++ b/tests/components/minecraft_server/test_sensor.py
@@ -55,17 +55,25 @@ BEDROCK_SENSOR_ENTITIES_DISABLED_BY_DEFAULT: list[str] = [
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 @pytest.mark.parametrize(
-    ("mock_config_entry", "server", "status_response", "entity_ids"),
+    (
+        "mock_config_entry",
+        "server",
+        "lookup_function_name",
+        "status_response",
+        "entity_ids",
+    ),
     [
         (
             "java_mock_config_entry",
             JavaServer,
+            "async_lookup",
             TEST_JAVA_STATUS_RESPONSE,
             JAVA_SENSOR_ENTITIES,
         ),
         (
             "bedrock_mock_config_entry",
             BedrockServer,
+            "lookup",
             TEST_BEDROCK_STATUS_RESPONSE,
             BEDROCK_SENSOR_ENTITIES,
         ),
@@ -75,6 +83,7 @@ async def test_sensor(
     hass: HomeAssistant,
     mock_config_entry: str,
     server: JavaServer | BedrockServer,
+    lookup_function_name: str,
     status_response: JavaStatusResponse | BedrockStatusResponse,
     entity_ids: list[str],
     request: pytest.FixtureRequest,
@@ -85,7 +94,7 @@ async def test_sensor(
     mock_config_entry.add_to_hass(hass)
 
     with patch(
-        f"homeassistant.components.minecraft_server.api.{server.__name__}.lookup",
+        f"homeassistant.components.minecraft_server.api.{server.__name__}.{lookup_function_name}",
         return_value=server(host=TEST_HOST, port=TEST_PORT),
     ), patch(
         f"homeassistant.components.minecraft_server.api.{server.__name__}.async_status",
@@ -98,17 +107,25 @@ async def test_sensor(
 
 
 @pytest.mark.parametrize(
-    ("mock_config_entry", "server", "status_response", "entity_ids"),
+    (
+        "mock_config_entry",
+        "server",
+        "lookup_function_name",
+        "status_response",
+        "entity_ids",
+    ),
     [
         (
             "java_mock_config_entry",
             JavaServer,
+            "async_lookup",
             TEST_JAVA_STATUS_RESPONSE,
             JAVA_SENSOR_ENTITIES_DISABLED_BY_DEFAULT,
         ),
         (
             "bedrock_mock_config_entry",
             BedrockServer,
+            "lookup",
             TEST_BEDROCK_STATUS_RESPONSE,
             BEDROCK_SENSOR_ENTITIES_DISABLED_BY_DEFAULT,
         ),
@@ -118,6 +135,7 @@ async def test_sensor_disabled_by_default(
     hass: HomeAssistant,
     mock_config_entry: str,
     server: JavaServer | BedrockServer,
+    lookup_function_name: str,
     status_response: JavaStatusResponse | BedrockStatusResponse,
     entity_ids: list[str],
     request: pytest.FixtureRequest,
@@ -127,7 +145,7 @@ async def test_sensor_disabled_by_default(
     mock_config_entry.add_to_hass(hass)
 
     with patch(
-        f"homeassistant.components.minecraft_server.api.{server.__name__}.lookup",
+        f"homeassistant.components.minecraft_server.api.{server.__name__}.{lookup_function_name}",
         return_value=server(host=TEST_HOST, port=TEST_PORT),
     ), patch(
         f"homeassistant.components.minecraft_server.api.{server.__name__}.async_status",
@@ -141,17 +159,25 @@ async def test_sensor_disabled_by_default(
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 @pytest.mark.parametrize(
-    ("mock_config_entry", "server", "status_response", "entity_ids"),
+    (
+        "mock_config_entry",
+        "server",
+        "lookup_function_name",
+        "status_response",
+        "entity_ids",
+    ),
     [
         (
             "java_mock_config_entry",
             JavaServer,
+            "async_lookup",
             TEST_JAVA_STATUS_RESPONSE,
             JAVA_SENSOR_ENTITIES,
         ),
         (
             "bedrock_mock_config_entry",
             BedrockServer,
+            "lookup",
             TEST_BEDROCK_STATUS_RESPONSE,
             BEDROCK_SENSOR_ENTITIES,
         ),
@@ -161,6 +187,7 @@ async def test_sensor_update(
     hass: HomeAssistant,
     mock_config_entry: str,
     server: JavaServer | BedrockServer,
+    lookup_function_name: str,
     status_response: JavaStatusResponse | BedrockStatusResponse,
     entity_ids: list[str],
     request: pytest.FixtureRequest,
@@ -172,7 +199,7 @@ async def test_sensor_update(
     mock_config_entry.add_to_hass(hass)
 
     with patch(
-        f"homeassistant.components.minecraft_server.api.{server.__name__}.lookup",
+        f"homeassistant.components.minecraft_server.api.{server.__name__}.{lookup_function_name}",
         return_value=server(host=TEST_HOST, port=TEST_PORT),
     ), patch(
         f"homeassistant.components.minecraft_server.api.{server.__name__}.async_status",
@@ -189,17 +216,25 @@ async def test_sensor_update(
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 @pytest.mark.parametrize(
-    ("mock_config_entry", "server", "status_response", "entity_ids"),
+    (
+        "mock_config_entry",
+        "server",
+        "lookup_function_name",
+        "status_response",
+        "entity_ids",
+    ),
     [
         (
             "java_mock_config_entry",
             JavaServer,
+            "async_lookup",
             TEST_JAVA_STATUS_RESPONSE,
             JAVA_SENSOR_ENTITIES,
         ),
         (
             "bedrock_mock_config_entry",
             BedrockServer,
+            "lookup",
             TEST_BEDROCK_STATUS_RESPONSE,
             BEDROCK_SENSOR_ENTITIES,
         ),
@@ -209,6 +244,7 @@ async def test_sensor_update_failure(
     hass: HomeAssistant,
     mock_config_entry: str,
     server: JavaServer | BedrockServer,
+    lookup_function_name: str,
     status_response: JavaStatusResponse | BedrockStatusResponse,
     entity_ids: list[str],
     request: pytest.FixtureRequest,
@@ -219,7 +255,7 @@ async def test_sensor_update_failure(
     mock_config_entry.add_to_hass(hass)
 
     with patch(
-        f"homeassistant.components.minecraft_server.api.{server.__name__}.lookup",
+        f"homeassistant.components.minecraft_server.api.{server.__name__}.{lookup_function_name}",
         return_value=server(host=TEST_HOST, port=TEST_PORT),
     ), patch(
         f"homeassistant.components.minecraft_server.api.{server.__name__}.async_status",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The only part of the integration which was not fully async is the initialization of the api module. This PR makes this last part also async. The lookup of the server address is now moved out of the constructor to an own async function. 

Notes:
- Although `BedrockServer.lookup` is not an async function, it is non-blocking (see info below) and therefor OK to be called.
- This should be the last open point for reaching platinum level.

Background info:
One of the core developers of the dependency `mcstatus` [reached out to us via Discord](https://discord.com/channels/330944238910963714/672220541343760384/1179897915590848643) and informed us about the Bedrock lookup function being non-blocking: [Why doesn’t BedrockServer have an async lookup() method?](https://mcstatus.readthedocs.io/en/stable/pages/faq/#why-doesn-t-bedrockserver-have-an-async-lookup-method)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: n.a.
- This PR is related to issue: n.a.
- Link to documentation pull request: n.a.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
