### PR TITLE
Migrate octoprint tests to use freezegun

### DIFF
--- a/tests/components/octoprint/test_sensor.py
+++ b/tests/components/octoprint/test_sensor.py
@@ -1,6 +1,7 @@
 """The tests for Octoptint binary sensor module."""
 from datetime import UTC, datetime
-from unittest.mock import patch
+
+from freezegun.api import FrozenDateTimeFactory
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -8,7 +9,7 @@ from homeassistant.helpers import entity_registry as er
 from . import init_integration
 
 
-async def test_sensors(hass: HomeAssistant) -> None:
+async def test_sensors(hass: HomeAssistant, freezer: FrozenDateTimeFactory) -> None:
     """Test the underlying sensors."""
     printer = {
         "state": {
@@ -22,11 +23,8 @@ async def test_sensors(hass: HomeAssistant) -> None:
         "progress": {"completion": 50, "printTime": 600, "printTimeLeft": 6000},
         "state": "Printing",
     }
-    with patch(
-        "homeassistant.util.dt.utcnow",
-        return_value=datetime(2020, 2, 20, 9, 10, 13, 543, tzinfo=UTC),
-    ):
-        await init_integration(hass, "sensor", printer=printer, job=job)
+    freezer.move_to(datetime(2020, 2, 20, 9, 10, 13, 543, tzinfo=UTC))
+    await init_integration(hass, "sensor", printer=printer, job=job)
 
     entity_registry = er.async_get(hass)
 
@@ -80,7 +78,9 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert entry.unique_id == "Estimated Finish Time-uuid"
 
 
-async def test_sensors_no_target_temp(hass: HomeAssistant) -> None:
+async def test_sensors_no_target_temp(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
     """Test the underlying sensors."""
     printer = {
         "state": {
@@ -89,10 +89,8 @@ async def test_sensors_no_target_temp(hass: HomeAssistant) -> None:
         },
         "temperature": {"tool1": {"actual": 18.83136, "target": None}},
     }
-    with patch(
-        "homeassistant.util.dt.utcnow", return_value=datetime(2020, 2, 20, 9, 10, 0)
-    ):
-        await init_integration(hass, "sensor", printer=printer)
+    freezer.move_to(datetime(2020, 2, 20, 9, 10, 0))
+    await init_integration(hass, "sensor", printer=printer)
 
     entity_registry = er.async_get(hass)
 
@@ -111,7 +109,9 @@ async def test_sensors_no_target_temp(hass: HomeAssistant) -> None:
     assert entry.unique_id == "target tool1 temp-uuid"
 
 
-async def test_sensors_paused(hass: HomeAssistant) -> None:
+async def test_sensors_paused(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
     """Test the underlying sensors."""
     printer = {
         "state": {
@@ -125,10 +125,8 @@ async def test_sensors_paused(hass: HomeAssistant) -> None:
         "progress": {"completion": 50, "printTime": 600, "printTimeLeft": 6000},
         "state": "Paused",
     }
-    with patch(
-        "homeassistant.util.dt.utcnow", return_value=datetime(2020, 2, 20, 9, 10, 0)
-    ):
-        await init_integration(hass, "sensor", printer=printer, job=job)
+    freezer.move_to(datetime(2020, 2, 20, 9, 10, 0))
+    await init_integration(hass, "sensor", printer=printer, job=job)
 
     entity_registry = er.async_get(hass)
 
@@ -147,17 +145,17 @@ async def test_sensors_paused(hass: HomeAssistant) -> None:
     assert entry.unique_id == "Estimated Finish Time-uuid"
 
 
-async def test_sensors_printer_disconnected(hass: HomeAssistant) -> None:
+async def test_sensors_printer_disconnected(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
     """Test the underlying sensors."""
     job = {
         "job": {},
         "progress": {"completion": 50, "printTime": 600, "printTimeLeft": 6000},
         "state": "Paused",
     }
-    with patch(
-        "homeassistant.util.dt.utcnow", return_value=datetime(2020, 2, 20, 9, 10, 0)
-    ):
-        await init_integration(hass, "sensor", printer=None, job=job)
+    freezer.move_to(datetime(2020, 2, 20, 9, 10, 0))
+    await init_integration(hass, "sensor", printer=None, job=job)
 
     entity_registry = er.async_get(hass)
 


### PR DESCRIPTION
## Proposed change
Migrate octoprint tests to use freezegun

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
