### PR TITLE
Migrate tag & tts tests to use freezegun

### DIFF
--- a/tests/components/tag/test_event.py
+++ b/tests/components/tag/test_event.py
@@ -1,6 +1,6 @@
 """Tests for the tag component."""
-from unittest.mock import patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.tag import DOMAIN, EVENT_TAG_SCANNED, async_scan_tag
@@ -40,7 +40,10 @@ def storage_setup_named_tag(
 
 
 async def test_named_tag_scanned_event(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup_named_tag
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    freezer: FrozenDateTimeFactory,
+    storage_setup_named_tag,
 ) -> None:
     """Test scanning named tag triggering event."""
     assert await storage_setup_named_tag()
@@ -50,8 +53,8 @@ async def test_named_tag_scanned_event(
     events = async_capture_events(hass, EVENT_TAG_SCANNED)
 
     now = dt_util.utcnow()
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
-        await async_scan_tag(hass, TEST_TAG_ID, TEST_DEVICE_ID)
+    freezer.move_to(now)
+    await async_scan_tag(hass, TEST_TAG_ID, TEST_DEVICE_ID)
 
     assert len(events) == 1
 
@@ -83,7 +86,10 @@ def storage_setup_unnamed_tag(hass, hass_storage):
 
 
 async def test_unnamed_tag_scanned_event(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup_unnamed_tag
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    freezer: FrozenDateTimeFactory,
+    storage_setup_unnamed_tag,
 ) -> None:
     """Test scanning named tag triggering event."""
     assert await storage_setup_unnamed_tag()
@@ -93,8 +99,8 @@ async def test_unnamed_tag_scanned_event(
     events = async_capture_events(hass, EVENT_TAG_SCANNED)
 
     now = dt_util.utcnow()
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
-        await async_scan_tag(hass, TEST_TAG_ID, TEST_DEVICE_ID)
+    freezer.move_to(now)
+    await async_scan_tag(hass, TEST_TAG_ID, TEST_DEVICE_ID)
 
     assert len(events) == 1
 

--- a/tests/components/tag/test_init.py
+++ b/tests/components/tag/test_init.py
@@ -1,6 +1,6 @@
 """Tests for the tag component."""
-from unittest.mock import patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.tag import DOMAIN, TAGS, async_scan_tag
@@ -76,7 +76,10 @@ async def test_ws_update(
 
 
 async def test_tag_scanned(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    freezer: FrozenDateTimeFactory,
+    storage_setup,
 ) -> None:
     """Test scanning tags."""
     assert await storage_setup()
@@ -93,8 +96,8 @@ async def test_tag_scanned(
     assert "test tag" in result
 
     now = dt_util.utcnow()
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
-        await async_scan_tag(hass, "new tag", "some_scanner")
+    freezer.move_to(now)
+    await async_scan_tag(hass, "new tag", "some_scanner")
 
     await client.send_json({"id": 7, "type": f"{DOMAIN}/list"})
     resp = await client.receive_json()


### PR DESCRIPTION
## Proposed change
Migrate tag & tts tests to make use of freezegun instead of directly patching `homeassistant.util.dt.utcnow`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
