### PR TITLE
Add Keenetic NDMS2 network interfaces as switches

### DIFF
--- a/homeassistant/components/keenetic_ndms2/__init__.py
+++ b/homeassistant/components/keenetic_ndms2/__init__.py
@@ -23,7 +23,7 @@ from .const import (
 )
 from .router import KeeneticRouter
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.DEVICE_TRACKER]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.DEVICE_TRACKER, Platform.SWITCH]
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/homeassistant/components/keenetic_ndms2/manifest.json
+++ b/homeassistant/components/keenetic_ndms2/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/keenetic_ndms2",
   "iot_class": "local_polling",
   "loggers": ["ndms2_client"],
-  "requirements": ["ndms2-client==0.1.2"],
+  "requirements": ["ndms2-client==0.1.3"],
   "ssdp": [
     {
       "deviceType": "urn:schemas-upnp-org:device:InternetGatewayDevice:1",

--- a/homeassistant/components/keenetic_ndms2/router.py
+++ b/homeassistant/components/keenetic_ndms2/router.py
@@ -35,7 +35,7 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 IGNORED_INTERFACE_TYPES = {'Port', 'WifiMaster'}
-
+UPDATE_DELAY_SECONDS = 2
 
 class KeeneticRouter:
     """Keenetic client Object."""
@@ -125,8 +125,17 @@ class KeeneticRouter:
         """Event specific per router entry to signal updates."""
         return f"keenetic-update-{self.config_entry.entry_id}"
 
-    def set_interface_state(self, interface_id: str, is_on: bool):
+    async def set_interface_state(self, interface_id: str, is_on: bool):
         self._client.set_interface_state(interface_id, is_on)
+
+        async def deferred_update(_now):
+            await self.request_update()
+
+        async_call_later(
+            self.hass,
+            UPDATE_DELAY_SECONDS,
+            deferred_update
+        )
 
     async def request_update(self):
         """Request an update."""

--- a/homeassistant/components/keenetic_ndms2/switch.py
+++ b/homeassistant/components/keenetic_ndms2/switch.py
@@ -79,11 +79,11 @@ class KeeneticInterface(SwitchEntity):
     def is_on(self) -> bool | None:
         return self._interface_info.state == "up"
 
-    def turn_on(self, **kwargs: Any) -> None:
-        return self._router.set_interface_state(self._interface_info.name, True)
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        await self._router.set_interface_state(self._interface_info.name, True)
 
-    def turn_off(self, **kwargs: Any) -> None:
-        return self._router.set_interface_state(self._interface_info.name, False)
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self._router.set_interface_state(self._interface_info.name, False)
 
     @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:

--- a/homeassistant/components/keenetic_ndms2/switch.py
+++ b/homeassistant/components/keenetic_ndms2/switch.py
@@ -1,0 +1,131 @@
+import logging
+from typing import Any, Mapping
+
+from ndms2_client import InterfaceInfo
+
+from homeassistant.components.switch import SwitchEntity, SwitchDeviceClass
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from .const import DOMAIN, ROUTER
+from .router import KeeneticRouter
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up interfaces for Keenetic NDMS2 component."""
+    router: KeeneticRouter = hass.data[DOMAIN][config_entry.entry_id][ROUTER]
+
+    tracked: set[str] = set()
+
+    @callback
+    def update_from_router():
+        """Update the status of devices."""
+        update_items(router, async_add_entities, tracked)
+
+    async_dispatcher_connect(hass, router.signal_update, update_from_router)
+
+    update_from_router()
+
+
+@callback
+def update_items(router: KeeneticRouter, async_add_entities, tracked: set[str]):
+    """Update tracked interface state from the hub."""
+    new_tracked: list[KeeneticInterface] = []
+    for name, interface in router.last_interfaces.items():
+        if name not in tracked:
+            tracked.add(name)
+            new_tracked.append(KeeneticInterface(router, interface))
+
+    async_add_entities(new_tracked)
+
+
+class KeeneticInterface(SwitchEntity):
+    """Representation of network interface."""
+    _is_available: bool
+    _router: KeeneticRouter
+    _interface_info: InterfaceInfo
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _entity_component_unrecorded_attributes: frozenset[str] = {'description', 'mac', 'mask', 'mtu', 'security_level',
+                                                               'type', 'uptime', 'ssid', 'plugged'}
+
+    def __init__(self, router: KeeneticRouter, interface_info: InterfaceInfo) -> None:
+        self._router = router
+        self._interface_info = interface_info
+        self._attr_unique_id = f"interface_{interface_info.name}_{router.config_entry.entry_id}"
+        self._is_available = True
+
+    @property
+    def device_class(self) -> SwitchDeviceClass:
+        return SwitchDeviceClass.SWITCH
+
+    @property
+    def name(self) -> str:
+        return self._interface_info.description or self._interface_info.name
+
+    @property
+    def available(self) -> bool:
+        return self._is_available
+
+    @property
+    def is_on(self) -> bool | None:
+        return self._interface_info.state == "up"
+
+    def turn_on(self, **kwargs: Any) -> None:
+        return self._router.set_interface_state(self._interface_info.name, True)
+
+    def turn_off(self, **kwargs: Any) -> None:
+        return self._router.set_interface_state(self._interface_info.name, False)
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        return {
+            'link': self._interface_info.link,
+            'state': self._interface_info.state,
+            'address': self._interface_info.address,
+            'description': self._interface_info.description,
+            'connected': self._interface_info.connected,
+            'mac': self._interface_info.mac,
+            'mask': self._interface_info.mask,
+            'mtu': self._interface_info.mtu,
+            'security_level': self._interface_info.security_level,
+            'type': self._interface_info.type,
+            'uptime': self._interface_info.uptime,
+            'ssid': self._interface_info.ssid,
+            'plugged': self._interface_info.plugged
+        }
+
+    async def async_added_to_hass(self) -> None:
+        """Interface entity created."""
+        _LOGGER.debug("New interface %s (%s)", self.name, self.unique_id)
+
+        @callback
+        async def update_device() -> None:
+            _LOGGER.debug(
+                "Updating Keenetic interface %s (%s)",
+                self.entity_id,
+                self.unique_id,
+            )
+            new_interface_info = self._router.last_interfaces.get(self._interface_info.name)
+            if new_interface_info:
+                self._interface_info = new_interface_info
+                self._is_available = True
+            else:
+                self._is_available = False
+                await self.async_remove()
+
+            self.async_write_ha_state()
+
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, self._router.signal_update, update_device
+            )
+        )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1292,7 +1292,7 @@ mypermobil==0.1.6
 nad-receiver==0.3.0
 
 # homeassistant.components.keenetic_ndms2
-ndms2-client==0.1.2
+ndms2-client==0.1.3
 
 # homeassistant.components.ness_alarm
 nessclient==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1013,7 +1013,7 @@ mutesync==0.0.1
 mypermobil==0.1.6
 
 # homeassistant.components.keenetic_ndms2
-ndms2-client==0.1.2
+ndms2-client==0.1.3
 
 # homeassistant.components.ness_alarm
 nessclient==1.0.0
@@ -2058,7 +2058,7 @@ wallbox==0.4.14
 watchdog==2.3.1
 
 # homeassistant.components.assist_pipeline
-webrtc-noise-gain==1.2.3
+#webrtc-noise-gain==1.2.3
 
 # homeassistant.components.whirlpool
 whirlpool-sixth-sense==0.18.4


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This PR adds support for turning on and off network interfaces as switches.
For this purpose the `ndms2-client` dependency was updated from version 0.1.2 to 0.1.3. [Related PR](https://github.com/foxel/python_ndms2_client/pull/9)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
