### PR TITLE
Fix alexa calling not featured cover services

### DIFF
--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -1322,7 +1322,7 @@ async def async_api_set_range(
         range_value = int(range_value)
         if supported & cover.CoverEntityFeature.CLOSE_TILT and range_value == 0:
             service = cover.SERVICE_CLOSE_COVER_TILT
-        elif supported & cover.CoverEntityFeature.CLOSE_TILT and range_value == 100:
+        elif supported & cover.CoverEntityFeature.OPEN_TILT and range_value == 100:
             service = cover.SERVICE_OPEN_COVER_TILT
         else:
             service = cover.SERVICE_SET_COVER_TILT_POSITION
@@ -1333,7 +1333,7 @@ async def async_api_set_range(
         range_value = int(range_value)
         if range_value == 0:
             service = fan.SERVICE_TURN_OFF
-        elif supported and fan.FanEntityFeature.SET_SPEED:
+        elif supported & fan.FanEntityFeature.SET_SPEED:
             service = fan.SERVICE_SET_PERCENTAGE
             data[fan.ATTR_PERCENTAGE] = range_value
         else:

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -1304,13 +1304,14 @@ async def async_api_set_range(
     service = None
     data: dict[str, Any] = {ATTR_ENTITY_ID: entity.entity_id}
     range_value = directive.payload["rangeValue"]
+    supported = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
 
     # Cover Position
     if instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
         range_value = int(range_value)
-        if range_value == 0:
+        if supported & cover.CoverEntityFeature.CLOSE and range_value == 0:
             service = cover.SERVICE_CLOSE_COVER
-        elif range_value == 100:
+        elif supported & cover.CoverEntityFeature.OPEN and range_value == 100:
             service = cover.SERVICE_OPEN_COVER
         else:
             service = cover.SERVICE_SET_COVER_POSITION
@@ -1319,9 +1320,9 @@ async def async_api_set_range(
     # Cover Tilt
     elif instance == f"{cover.DOMAIN}.tilt":
         range_value = int(range_value)
-        if range_value == 0:
+        if supported & cover.CoverEntityFeature.CLOSE_TILT and range_value == 0:
             service = cover.SERVICE_CLOSE_COVER_TILT
-        elif range_value == 100:
+        elif supported & cover.CoverEntityFeature.CLOSE_TILT and range_value == 100:
             service = cover.SERVICE_OPEN_COVER_TILT
         else:
             service = cover.SERVICE_SET_COVER_TILT_POSITION
@@ -1332,13 +1333,11 @@ async def async_api_set_range(
         range_value = int(range_value)
         if range_value == 0:
             service = fan.SERVICE_TURN_OFF
+        elif supported and fan.FanEntityFeature.SET_SPEED:
+            service = fan.SERVICE_SET_PERCENTAGE
+            data[fan.ATTR_PERCENTAGE] = range_value
         else:
-            supported = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
-            if supported and fan.FanEntityFeature.SET_SPEED:
-                service = fan.SERVICE_SET_PERCENTAGE
-                data[fan.ATTR_PERCENTAGE] = range_value
-            else:
-                service = fan.SERVICE_TURN_ON
+            service = fan.SERVICE_TURN_ON
 
     # Humidifier target humidity
     elif instance == f"{humidifier.DOMAIN}.{humidifier.ATTR_HUMIDITY}":

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -1937,6 +1937,18 @@ async def test_group(hass: HomeAssistant) -> None:
             CoverEntityFeature.SET_POSITION,
             "cover.set_cover_position",
         ),
+        (
+            0,
+            0,
+            CoverEntityFeature.SET_POSITION | CoverEntityFeature.OPEN,
+            "cover.set_cover_position",
+        ),
+        (
+            100,
+            100,
+            CoverEntityFeature.SET_POSITION | CoverEntityFeature.CLOSE,
+            "cover.set_cover_position",
+        ),
     ],
     ids=[
         "position_30_open_close",
@@ -1946,6 +1958,8 @@ async def test_group(hass: HomeAssistant) -> None:
         "position_0_no_open_close",
         "position_60_no_open_close",
         "position_100_no_open_close",
+        "position_0_no_close",
+        "position_100_no_open",
     ],
 )
 async def test_cover_position(
@@ -3621,6 +3635,18 @@ async def test_presence_sensor(hass: HomeAssistant) -> None:
             CoverEntityFeature.SET_TILT_POSITION,
             "cover.set_cover_tilt_position",
         ),
+        (
+            0,
+            0,
+            CoverEntityFeature.SET_TILT_POSITION | CoverEntityFeature.OPEN_TILT,
+            "cover.set_cover_tilt_position",
+        ),
+        (
+            100,
+            100,
+            CoverEntityFeature.SET_TILT_POSITION | CoverEntityFeature.CLOSE_TILT,
+            "cover.set_cover_tilt_position",
+        ),
     ],
     ids=[
         "tilt_position_30_open_close",
@@ -3630,6 +3656,8 @@ async def test_presence_sensor(hass: HomeAssistant) -> None:
         "tilt_position_0_no_open_close",
         "tilt_position_60_no_open_close",
         "tilt_position_100_no_open_close",
+        "tilt_position_0_no_close",
+        "tilt_position_100_no_open",
     ],
 )
 async def test_cover_tilt_position(

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -6,7 +6,7 @@ import pytest
 
 from homeassistant.components.alexa import smart_home, state_report
 import homeassistant.components.camera as camera
-from homeassistant.components.cover import CoverDeviceClass
+from homeassistant.components.cover import CoverDeviceClass, CoverEntityFeature
 from homeassistant.components.media_player import MediaPlayerEntityFeature
 from homeassistant.components.vacuum import VacuumEntityFeature
 from homeassistant.config import async_process_ha_core_config
@@ -1884,8 +1884,185 @@ async def test_group(hass: HomeAssistant) -> None:
     )
 
 
-async def test_cover_position_range(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    ("position", "position_attr_in_service_call", "supported_features", "service_call"),
+    [
+        (
+            30,
+            30,
+            CoverEntityFeature.SET_POSITION
+            | CoverEntityFeature.OPEN
+            | CoverEntityFeature.CLOSE,
+            "cover.set_cover_position",
+        ),
+        (
+            0,
+            None,
+            CoverEntityFeature.SET_POSITION
+            | CoverEntityFeature.OPEN
+            | CoverEntityFeature.CLOSE,
+            "cover.close_cover",
+        ),
+        (
+            99,
+            99,
+            CoverEntityFeature.SET_POSITION
+            | CoverEntityFeature.OPEN
+            | CoverEntityFeature.CLOSE,
+            "cover.set_cover_position",
+        ),
+        (
+            100,
+            None,
+            CoverEntityFeature.SET_POSITION
+            | CoverEntityFeature.OPEN
+            | CoverEntityFeature.CLOSE,
+            "cover.open_cover",
+        ),
+        (
+            0,
+            0,
+            CoverEntityFeature.SET_POSITION,
+            "cover.set_cover_position",
+        ),
+        (
+            60,
+            60,
+            CoverEntityFeature.SET_POSITION,
+            "cover.set_cover_position",
+        ),
+        (
+            100,
+            100,
+            CoverEntityFeature.SET_POSITION,
+            "cover.set_cover_position",
+        ),
+    ],
+    ids=[
+        "position_30_open_close",
+        "position_0_open_close",
+        "position_99_open_close",
+        "position_100_open_close",
+        "position_0_no_open_close",
+        "position_60_no_open_close",
+        "position_100_no_open_close",
+    ],
+)
+async def test_cover_position(
+    hass: HomeAssistant,
+    position: int,
+    position_attr_in_service_call: int | None,
+    supported_features: CoverEntityFeature,
+    service_call: str,
+) -> None:
     """Test cover discovery and position using rangeController."""
+    device = (
+        "cover.test_range",
+        "open",
+        {
+            "friendly_name": "Test cover range",
+            "device_class": "blind",
+            "supported_features": supported_features,
+            "position": position,
+        },
+    )
+    appliance = await discovery_test(device, hass)
+
+    assert appliance["endpointId"] == "cover#test_range"
+    assert appliance["displayCategories"][0] == "INTERIOR_BLIND"
+    assert appliance["friendlyName"] == "Test cover range"
+
+    capabilities = assert_endpoint_capabilities(
+        appliance,
+        "Alexa.PowerController",
+        "Alexa.RangeController",
+        "Alexa.EndpointHealth",
+        "Alexa",
+    )
+
+    range_capability = get_capability(capabilities, "Alexa.RangeController")
+    assert range_capability is not None
+    assert range_capability["instance"] == "cover.position"
+
+    properties = range_capability["properties"]
+    assert properties["nonControllable"] is False
+    assert {"name": "rangeValue"} in properties["supported"]
+
+    capability_resources = range_capability["capabilityResources"]
+    assert capability_resources is not None
+    assert {
+        "@type": "text",
+        "value": {"text": "Position", "locale": "en-US"},
+    } in capability_resources["friendlyNames"]
+
+    assert {
+        "@type": "asset",
+        "value": {"assetId": "Alexa.Setting.Opening"},
+    } in capability_resources["friendlyNames"]
+
+    configuration = range_capability["configuration"]
+    assert configuration is not None
+    assert configuration["unitOfMeasure"] == "Alexa.Unit.Percent"
+
+    supported_range = configuration["supportedRange"]
+    assert supported_range["minimumValue"] == 0
+    assert supported_range["maximumValue"] == 100
+    assert supported_range["precision"] == 1
+
+    # Assert for Position Semantics
+    position_semantics = range_capability["semantics"]
+    assert position_semantics is not None
+
+    position_action_mappings = position_semantics["actionMappings"]
+    assert position_action_mappings is not None
+    assert {
+        "@type": "ActionsToDirective",
+        "actions": ["Alexa.Actions.Lower", "Alexa.Actions.Close"],
+        "directive": {"name": "SetRangeValue", "payload": {"rangeValue": 0}},
+    } in position_action_mappings
+    assert {
+        "@type": "ActionsToDirective",
+        "actions": ["Alexa.Actions.Raise", "Alexa.Actions.Open"],
+        "directive": {"name": "SetRangeValue", "payload": {"rangeValue": 100}},
+    } in position_action_mappings
+
+    position_state_mappings = position_semantics["stateMappings"]
+    assert position_state_mappings is not None
+    assert {
+        "@type": "StatesToValue",
+        "states": ["Alexa.States.Closed"],
+        "value": 0,
+    } in position_state_mappings
+    assert {
+        "@type": "StatesToRange",
+        "states": ["Alexa.States.Open"],
+        "range": {"minimumValue": 1, "maximumValue": 100},
+    } in position_state_mappings
+
+    call, msg = await assert_request_calls_service(
+        "Alexa.RangeController",
+        "SetRangeValue",
+        "cover#test_range",
+        service_call,
+        hass,
+        payload={"rangeValue": position},
+        instance="cover.position",
+    )
+    assert call.data.get("position") == position_attr_in_service_call
+    properties = msg["context"]["properties"][0]
+    assert properties["name"] == "rangeValue"
+    assert properties["namespace"] == "Alexa.RangeController"
+    assert properties["value"] == position
+
+
+async def test_cover_position_range(
+    hass: HomeAssistant,
+) -> None:
+    """Test cover discovery and position range using rangeController.
+
+    Also tests an invalid cover position being handled correctly.
+    """
+
     device = (
         "cover.test_range",
         "open",
@@ -1968,59 +2145,6 @@ async def test_cover_position_range(hass: HomeAssistant) -> None:
         "states": ["Alexa.States.Open"],
         "range": {"minimumValue": 1, "maximumValue": 100},
     } in position_state_mappings
-
-    call, _ = await assert_request_calls_service(
-        "Alexa.RangeController",
-        "SetRangeValue",
-        "cover#test_range",
-        "cover.set_cover_position",
-        hass,
-        payload={"rangeValue": 50},
-        instance="cover.position",
-    )
-    assert call.data["position"] == 50
-
-    call, msg = await assert_request_calls_service(
-        "Alexa.RangeController",
-        "SetRangeValue",
-        "cover#test_range",
-        "cover.close_cover",
-        hass,
-        payload={"rangeValue": 0},
-        instance="cover.position",
-    )
-    properties = msg["context"]["properties"][0]
-    assert properties["name"] == "rangeValue"
-    assert properties["namespace"] == "Alexa.RangeController"
-    assert properties["value"] == 0
-
-    call, msg = await assert_request_calls_service(
-        "Alexa.RangeController",
-        "SetRangeValue",
-        "cover#test_range",
-        "cover.open_cover",
-        hass,
-        payload={"rangeValue": 100},
-        instance="cover.position",
-    )
-    properties = msg["context"]["properties"][0]
-    assert properties["name"] == "rangeValue"
-    assert properties["namespace"] == "Alexa.RangeController"
-    assert properties["value"] == 100
-
-    call, msg = await assert_request_calls_service(
-        "Alexa.RangeController",
-        "AdjustRangeValue",
-        "cover#test_range",
-        "cover.open_cover",
-        hass,
-        payload={"rangeValueDelta": 99, "rangeValueDeltaDefault": False},
-        instance="cover.position",
-    )
-    properties = msg["context"]["properties"][0]
-    assert properties["name"] == "rangeValue"
-    assert properties["namespace"] == "Alexa.RangeController"
-    assert properties["value"] == 100
 
     call, msg = await assert_request_calls_service(
         "Alexa.RangeController",
@@ -3435,8 +3559,145 @@ async def test_presence_sensor(hass: HomeAssistant) -> None:
     assert {"name": "humanPresenceDetectionState"} in properties["supported"]
 
 
-async def test_cover_tilt_position_range(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    (
+        "tilt_position",
+        "tilt_position_attr_in_service_call",
+        "supported_features",
+        "service_call",
+    ),
+    [
+        (
+            30,
+            30,
+            CoverEntityFeature.SET_TILT_POSITION
+            | CoverEntityFeature.OPEN_TILT
+            | CoverEntityFeature.CLOSE_TILT
+            | CoverEntityFeature.STOP_TILT,
+            "cover.set_cover_tilt_position",
+        ),
+        (
+            0,
+            None,
+            CoverEntityFeature.SET_TILT_POSITION
+            | CoverEntityFeature.OPEN_TILT
+            | CoverEntityFeature.CLOSE_TILT
+            | CoverEntityFeature.STOP_TILT,
+            "cover.close_cover_tilt",
+        ),
+        (
+            99,
+            99,
+            CoverEntityFeature.SET_TILT_POSITION
+            | CoverEntityFeature.OPEN_TILT
+            | CoverEntityFeature.CLOSE_TILT
+            | CoverEntityFeature.STOP_TILT,
+            "cover.set_cover_tilt_position",
+        ),
+        (
+            100,
+            None,
+            CoverEntityFeature.SET_TILT_POSITION
+            | CoverEntityFeature.OPEN_TILT
+            | CoverEntityFeature.CLOSE_TILT
+            | CoverEntityFeature.STOP_TILT,
+            "cover.open_cover_tilt",
+        ),
+        (
+            0,
+            0,
+            CoverEntityFeature.SET_TILT_POSITION,
+            "cover.set_cover_tilt_position",
+        ),
+        (
+            60,
+            60,
+            CoverEntityFeature.SET_TILT_POSITION,
+            "cover.set_cover_tilt_position",
+        ),
+        (
+            100,
+            100,
+            CoverEntityFeature.SET_TILT_POSITION,
+            "cover.set_cover_tilt_position",
+        ),
+    ],
+    ids=[
+        "tilt_position_30_open_close",
+        "tilt_position_0_open_close",
+        "tilt_position_99_open_close",
+        "tilt_position_100_open_close",
+        "tilt_position_0_no_open_close",
+        "tilt_position_60_no_open_close",
+        "tilt_position_100_no_open_close",
+    ],
+)
+async def test_cover_tilt_position(
+    hass: HomeAssistant,
+    tilt_position: int,
+    tilt_position_attr_in_service_call: int | None,
+    supported_features: CoverEntityFeature,
+    service_call: str,
+) -> None:
     """Test cover discovery and tilt position using rangeController."""
+    device = (
+        "cover.test_tilt_range",
+        "open",
+        {
+            "friendly_name": "Test cover tilt range",
+            "device_class": "blind",
+            "supported_features": supported_features,
+            "tilt_position": tilt_position,
+        },
+    )
+    appliance = await discovery_test(device, hass)
+
+    assert appliance["endpointId"] == "cover#test_tilt_range"
+    assert appliance["displayCategories"][0] == "INTERIOR_BLIND"
+    assert appliance["friendlyName"] == "Test cover tilt range"
+
+    capabilities = assert_endpoint_capabilities(
+        appliance,
+        "Alexa.PowerController",
+        "Alexa.RangeController",
+        "Alexa.EndpointHealth",
+        "Alexa",
+    )
+
+    range_capability = get_capability(capabilities, "Alexa.RangeController")
+    assert range_capability is not None
+    assert range_capability["instance"] == "cover.tilt"
+
+    semantics = range_capability["semantics"]
+    assert semantics is not None
+
+    action_mappings = semantics["actionMappings"]
+    assert action_mappings is not None
+
+    state_mappings = semantics["stateMappings"]
+    assert state_mappings is not None
+
+    call, msg = await assert_request_calls_service(
+        "Alexa.RangeController",
+        "SetRangeValue",
+        "cover#test_tilt_range",
+        service_call,
+        hass,
+        payload={"rangeValue": tilt_position},
+        instance="cover.tilt",
+    )
+    assert call.data.get("tilt_position") == tilt_position_attr_in_service_call
+    properties = msg["context"]["properties"][0]
+    assert properties["name"] == "rangeValue"
+    assert properties["namespace"] == "Alexa.RangeController"
+    assert properties["value"] == tilt_position
+
+
+async def test_cover_tilt_position_range(hass: HomeAssistant) -> None:
+    """Test cover discovery and tilt position range using rangeController.
+
+    Also tests and invalid tilt position being handled correctly.
+    """
     device = (
         "cover.test_tilt_range",
         "open",
@@ -3484,48 +3745,6 @@ async def test_cover_tilt_position_range(hass: HomeAssistant) -> None:
         instance="cover.tilt",
     )
     assert call.data["tilt_position"] == 50
-
-    call, msg = await assert_request_calls_service(
-        "Alexa.RangeController",
-        "SetRangeValue",
-        "cover#test_tilt_range",
-        "cover.close_cover_tilt",
-        hass,
-        payload={"rangeValue": 0},
-        instance="cover.tilt",
-    )
-    properties = msg["context"]["properties"][0]
-    assert properties["name"] == "rangeValue"
-    assert properties["namespace"] == "Alexa.RangeController"
-    assert properties["value"] == 0
-
-    call, msg = await assert_request_calls_service(
-        "Alexa.RangeController",
-        "SetRangeValue",
-        "cover#test_tilt_range",
-        "cover.open_cover_tilt",
-        hass,
-        payload={"rangeValue": 100},
-        instance="cover.tilt",
-    )
-    properties = msg["context"]["properties"][0]
-    assert properties["name"] == "rangeValue"
-    assert properties["namespace"] == "Alexa.RangeController"
-    assert properties["value"] == 100
-
-    call, msg = await assert_request_calls_service(
-        "Alexa.RangeController",
-        "AdjustRangeValue",
-        "cover#test_tilt_range",
-        "cover.open_cover_tilt",
-        hass,
-        payload={"rangeValueDelta": 99, "rangeValueDeltaDefault": False},
-        instance="cover.tilt",
-    )
-    properties = msg["context"]["properties"][0]
-    assert properties["name"] == "rangeValue"
-    assert properties["namespace"] == "Alexa.RangeController"
-    assert properties["value"] == 100
 
     call, msg = await assert_request_calls_service(
         "Alexa.RangeController",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix alexa calling `cover.open_cover` and `cover.cover_close` if not supported but `cover.set_cover_position` is supported. In that case `cover.set_cover_position` should be called instead.

Fix alexa calling `cover.open_cover_tilt` and `cover.close_cover_tilt` if not supported but `cover.set_cover_tilt_position` is supported. In that case `cover.set_cover_tilt_position` should be called instead.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #105372
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
