### PR TITLE
Raise exceptions instead of logging for Lyric service failures

### DIFF
--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -353,7 +353,11 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                     mode=mode,
                 )
             except LYRIC_EXCEPTIONS as err:
-                raise HomeAssistantError("Failed to set heat/cool setpoints") from err
+                raise HomeAssistantError(
+                    str(err),
+                    translation_domain=DOMAIN,
+                    translation_key="set_heat_cool_setpoints_failed",
+                ) from err
 
             await self.coordinator.async_refresh()
         else:
@@ -365,14 +369,22 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                         self.location, device, coolSetpoint=temp
                     )
                 except LYRIC_EXCEPTIONS as err:
-                    raise HomeAssistantError("Failed to set cool setpoint") from err
+                    raise HomeAssistantError(
+                        str(err),
+                        translation_domain=DOMAIN,
+                        translation_key="set_cool_setpoint_failed",
+                    ) from err
             else:
                 try:
                     await self._update_thermostat(
                         self.location, device, heatSetpoint=temp
                     )
                 except LYRIC_EXCEPTIONS as err:
-                    raise HomeAssistantError("Failed to set heat setpoint") from err
+                    raise HomeAssistantError(
+                        str(err),
+                        translation_domain=DOMAIN,
+                        translation_key="set_heat_setpoint_failed",
+                    ) from err
 
             await self.coordinator.async_refresh()
 
@@ -407,7 +419,14 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                         autoChangeoverActive=False,
                     )
                 except LYRIC_EXCEPTIONS as err:
-                    raise HomeAssistantError("Failed to set HVAC mode to heat") from err
+                    raise HomeAssistantError(
+                        str(err),
+                        translation_domain=DOMAIN,
+                        translation_key="set_hvac_mode_failed",
+                        translation_placeholders={
+                            "mode": LYRIC_HVAC_MODE_HEAT,
+                        },
+                    ) from err
 
                 # Sleep 3 seconds before proceeding
                 await asyncio.sleep(3)
@@ -425,7 +444,9 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                     )
                 except LYRIC_EXCEPTIONS as err:
                     raise HomeAssistantError(
-                        "Failed to enable autoChangeoverActive"
+                        str(err),
+                        translation_domain=DOMAIN,
+                        translation_key="activate_auto_changeover_failed",
                     ) from err
             else:
                 _LOGGER.debug(
@@ -438,7 +459,9 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                     )
                 except LYRIC_EXCEPTIONS as err:
                     raise HomeAssistantError(
-                        "Failed to enable autoChangeoverActive"
+                        str(err),
+                        translation_domain=DOMAIN,
+                        translation_key="activate_auto_changeover_failed",
                     ) from err
         else:
             _LOGGER.debug("HVAC mode passed to lyric: %s", LYRIC_HVAC_MODES[hvac_mode])
@@ -451,7 +474,12 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                 )
             except LYRIC_EXCEPTIONS as err:
                 raise HomeAssistantError(
-                    f"Failed to set HVAC mode to {LYRIC_HVAC_MODES[hvac_mode]}"
+                    str(err),
+                    translation_domain=DOMAIN,
+                    translation_key="set_hvac_mode_failed",
+                    translation_placeholders={
+                        "mode": LYRIC_HVAC_MODES[hvac_mode],
+                    },
                 ) from err
 
     async def _async_set_hvac_mode_lcc(self, hvac_mode: HVACMode) -> None:
@@ -464,7 +492,12 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
             )
         except LYRIC_EXCEPTIONS as err:
             raise HomeAssistantError(
-                f"Failed to set HVAC mode to {LYRIC_HVAC_MODES[hvac_mode]}"
+                str(err),
+                translation_domain=DOMAIN,
+                translation_key="set_hvac_mode_failed",
+                translation_placeholders={
+                    "mode": LYRIC_HVAC_MODES[hvac_mode],
+                },
             ) from err
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
@@ -476,7 +509,12 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
             )
         except LYRIC_EXCEPTIONS as err:
             raise HomeAssistantError(
-                f"Failed to set thermostatSetpointStatus to {preset_mode}"
+                str(err),
+                translation_domain=DOMAIN,
+                translation_key="set_setpoint_status_failed",
+                translation_placeholders={
+                    "mode": preset_mode,
+                },
             ) from err
 
         await self.coordinator.async_refresh()
@@ -493,7 +531,12 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
             )
         except LYRIC_EXCEPTIONS as err:
             raise HomeAssistantError(
-                f"Failed to set nextPeriodTime to {time_period}"
+                str(err),
+                translation_domain=DOMAIN,
+                translation_key="set_next_period_time_failed",
+                translation_placeholders={
+                    "time": time_period,
+                },
             ) from err
 
         await self.coordinator.async_refresh()
@@ -505,8 +548,11 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
             lyric_fan_mode = LYRIC_FAN_MODES[fan_mode]
         except KeyError:
             raise HomeAssistantError(
-                "The fan mode requested does not have a corresponding mode in lyric: "
-                f"{fan_mode}"
+                translation_domain=DOMAIN,
+                translation_key="invalid_fan_mode",
+                translation_placeholders={
+                    "mode": fan_mode,
+                },
             ) from None
 
         try:
@@ -514,7 +560,12 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
             await self._update_fan(self.location, self.device, mode=lyric_fan_mode)
         except LYRIC_EXCEPTIONS as err:
             raise HomeAssistantError(
-                f"Failed to set fan mode to {lyric_fan_mode}"
+                str(err),
+                translation_domain=DOMAIN,
+                translation_key="set_fan_mode_failed",
+                translation_placeholders={
+                    "mode": lyric_fan_mode,
+                },
             ) from err
 
         await self.coordinator.async_refresh()

--- a/homeassistant/components/lyric/strings.json
+++ b/homeassistant/components/lyric/strings.json
@@ -44,6 +44,35 @@
       }
     }
   },
+  "exceptions": {
+    "set_heat_cool_setpoints_failed": {
+      "message": "Failed to set heat and cool setpoints"
+    },
+    "set_heat_setpoint_failed": {
+      "message": "Failed to set heat setpoint"
+    },
+    "set_cool_setpoint_failed": {
+      "message": "Failed to set cool setpoint"
+    },
+    "set_hvac_mode_failed": {
+      "message": "Failed to set HVAC mode to {mode}"
+    },
+    "activate_auto_changeover_failed": {
+      "message": "Failed to activate auto-changeover"
+    },
+    "set_setpoint_status_failed": {
+      "message": "Failed to set setpoint status to {mode}"
+    },
+    "set_next_period_time_failed": {
+      "message": "Failed to set next period time to {time}"
+    },
+    "invalid_fan_mode": {
+      "message": "The fan mode requested does not have a corresponding mode in Lyric: {mode}"
+    },
+    "set_fan_mode_failed": {
+      "message": "Failed to set fan mode to {mode}"
+    }
+  },
   "services": {
     "set_hold_time": {
       "name": "Set Hold Time",


### PR DESCRIPTION
## Proposed change
Raise `HomeAssistantError` anytime a Lyric API call fails instead of simply logging the error.

This was requested in [this comment](https://github.com/home-assistant/core/pull/104853#discussion_r1421700752) on another PR, but seems more appropriate to apply to the entire file as a standalone change.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Related to https://github.com/home-assistant/core/pull/104853

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
