### PR TITLE
Fix ZHA cover state

### DIFF
--- a/homeassistant/components/zha/cover.py
+++ b/homeassistant/components/zha/cover.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 
 import asyncio
 import collections
-import functools
-import logging
 from datetime import timedelta
+import functools
 from typing import TYPE_CHECKING, Any
 
 from zigpy.zcl.foundation import Status
@@ -27,9 +26,9 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
 
 from .core import discovery
 from .core.const import (
@@ -75,9 +74,8 @@ async def async_setup_entry(
 
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_COVER)
 class ZhaCover(ZhaEntity, CoverEntity):
-    """
-    Representation of a ZHA cover.
-    
+    """Representation of a ZHA cover.
+
     Covers doesn't have a way to report movement, they are only reporting changes in lift / tilt.
     That's why we track history of these reports and judge the (lack of) movement + direction based on that.
     """
@@ -113,9 +111,8 @@ class ZhaCover(ZhaEntity, CoverEntity):
 
     @property
     def is_closed(self) -> bool | None:
-        """
-        Return if the cover is closed.
-        
+        """Return if the cover is closed.
+
         Consider cover closed only if both tilt and lift are 0.
         If cover doesn't support tilt, only care about lift.
         """
@@ -125,9 +122,8 @@ class ZhaCover(ZhaEntity, CoverEntity):
 
     @property
     def _is_open(self) -> bool | None:
-        """
-        Return if the cover is open.
-        
+        """Return if the cover is open.
+
         Consider cover closed only if both tilt and lift are 100.
         If cover doesn't support tilt, only care about lift.
 
@@ -185,7 +181,7 @@ class ZhaCover(ZhaEntity, CoverEntity):
         # if movement is in progress, schedule a timer to clear it
         if self._state in (STATE_OPENING, STATE_CLOSING):
             self._cancel_clear_movement_timer = async_call_later(self.hass, MOVEMENT_TIMEOUT, self._clear_movement)
-                
+
 
     def _touch_position(self):
         """Store current position into a history."""

--- a/homeassistant/components/zha/cover.py
+++ b/homeassistant/components/zha/cover.py
@@ -152,7 +152,7 @@ class ZhaCover(ZhaEntity, CoverEntity):
         self.async_write_ha_state()
 
     @callback
-    def async_update_state(self, state):
+    def _async_update_state(self, state):
         """Handle state update from cluster handler."""
         _LOGGER.debug("state=%s", state)
         self._state = state
@@ -163,28 +163,28 @@ class ZhaCover(ZhaEntity, CoverEntity):
         res = await self._cover_cluster_handler.up_open()
         if res[1] is not Status.SUCCESS:
             raise HomeAssistantError(f"Failed to open cover: {res[1]}")
-        self.async_update_state(STATE_OPENING)
+        self._async_update_state(STATE_OPENING)
 
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Open the cover tilt."""
         res = await self._cover_cluster_handler.go_to_tilt_percentage(0)
         if res[1] is not Status.SUCCESS:
             raise HomeAssistantError(f"Failed to open cover tilt: {res[1]}")
-        self.async_update_state(STATE_OPENING)
+        self._async_update_state(STATE_OPENING)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the window cover."""
         res = await self._cover_cluster_handler.down_close()
         if res[1] is not Status.SUCCESS:
             raise HomeAssistantError(f"Failed to close cover: {res[1]}")
-        self.async_update_state(STATE_CLOSING)
+        self._async_update_state(STATE_CLOSING)
 
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Close the cover tilt."""
         res = await self._cover_cluster_handler.go_to_tilt_percentage(100)
         if res[1] is not Status.SUCCESS:
             raise HomeAssistantError(f"Failed to close cover tilt: {res[1]}")
-        self.async_update_state(STATE_CLOSING)
+        self._async_update_state(STATE_CLOSING)
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the roller shutter to a specific position."""
@@ -192,7 +192,7 @@ class ZhaCover(ZhaEntity, CoverEntity):
         res = await self._cover_cluster_handler.go_to_lift_percentage(100 - new_pos)
         if res[1] is not Status.SUCCESS:
             raise HomeAssistantError(f"Failed to set cover position: {res[1]}")
-        self.async_update_state(
+        self._async_update_state(
             STATE_CLOSING if new_pos < self._current_position else STATE_OPENING
         )
 
@@ -202,7 +202,7 @@ class ZhaCover(ZhaEntity, CoverEntity):
         res = await self._cover_cluster_handler.go_to_tilt_percentage(100 - new_pos)
         if res[1] is not Status.SUCCESS:
             raise HomeAssistantError(f"Failed to set cover tilt position: {res[1]}")
-        self.async_update_state(
+        self._async_update_state(
             STATE_CLOSING if new_pos < self._tilt_position else STATE_OPENING
         )
 
@@ -211,8 +211,7 @@ class ZhaCover(ZhaEntity, CoverEntity):
         res = await self._cover_cluster_handler.stop()
         if res[1] is not Status.SUCCESS:
             raise HomeAssistantError(f"Failed to stop cover: {res[1]}")
-        self._state = STATE_OPEN if self._current_position > 0 else STATE_CLOSED
-        self.async_write_ha_state()
+        self._async_update_state(STATE_CLOSED if self.is_closed else STATE_OPEN)
 
     async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
         """Stop the cover tilt."""

--- a/homeassistant/components/zha/cover.py
+++ b/homeassistant/components/zha/cover.py
@@ -103,10 +103,15 @@ class ZhaCover(ZhaEntity, CoverEntity):
 
     @property
     def is_closed(self) -> bool | None:
-        """Return if the cover is closed."""
-        if self.current_cover_position is None:
+        """
+        Return if the cover is closed.
+        
+        Consider cover closed only if both tilt and lift are 0.
+        If cover doesn't support tilt, only care about lift.
+        """
+        if self._current_position is None:
             return None
-        return self.current_cover_position == 0
+        return self._current_position == 0 and getattr(self, "_tilt_position", 0) == 0
 
     @property
     def is_opening(self) -> bool:

--- a/homeassistant/components/zha/cover.py
+++ b/homeassistant/components/zha/cover.py
@@ -131,7 +131,7 @@ class ZhaCover(ZhaEntity, CoverEntity):
         Consider cover closed only if both tilt and lift are 100.
         If cover doesn't support tilt, only care about lift.
 
-        This is not required by the API, but it is only used internally.
+        This is not required by the API, but it is used internally.
         """
         if self._current_position is None:
             return None
@@ -186,7 +186,7 @@ class ZhaCover(ZhaEntity, CoverEntity):
                 elif self._position_history[-1] > self._position_history[0]:
                     self._async_update_state(STATE_OPENING)
                 else:
-                    # tilt-only movement are typically so short that we rather keep the state
+                    # tilt-only movements are typically so short that we rather keep the state
                     self.async_write_ha_state()
                 
 
@@ -203,11 +203,7 @@ class ZhaCover(ZhaEntity, CoverEntity):
 
     @callback
     def _async_update_state(self, state):
-        """
-        Inform HASS of current state.
-        
-        In case of opening/closing states, schedule a timer to clear movement.
-        """
+        """Inform HASS of current state."""
         self.debug("Setting state: %s", state)
         self._state = state
         self.async_write_ha_state()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The PR fixes an issue with ZHA covers, which were stuck in opening/closing state (unless top/bottom position was reached).

There is a limitation that ZCL doesn't present a standard attribute to read if cover is moving or not. The way the PR overcomes this issue is by introducing `MOVEMENT_TIMEOUT` after which the cover falls back to open/closed state. When cover is moving, the timeout is reset on every attribute report.

On top of the bugfix, there is an attempt to capture external start of movement (using wall switch) and convert them to opening/closing state as well. For this purpose, a `position_history` has been introduced.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #98933, fixes https://github.com/zigpy/zha-device-handlers/issues/1397
- This PR is related to issue: alternative solution - #99646
- Link to documentation pull request: -

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
