### PR TITLE
Disconnect before reconnecting to satellite

### DIFF
--- a/homeassistant/components/wyoming/satellite.py
+++ b/homeassistant/components/wyoming/satellite.py
@@ -71,11 +71,11 @@ class WyomingSatellite:
             while self.is_running:
                 try:
                     # Check if satellite has been disabled
-                    if not self.device.is_enabled:
+                    while not self.device.is_enabled:
                         await self.on_disabled()
                         if not self.is_running:
                             # Satellite was stopped while waiting to be enabled
-                            break
+                            return
 
                     # Connect and run pipeline loop
                     await self._run_once()
@@ -87,7 +87,7 @@ class WyomingSatellite:
             # Ensure sensor is off
             self.device.set_is_active(False)
 
-        await self.on_stopped()
+            await self.on_stopped()
 
     def stop(self) -> None:
         """Signal satellite task to stop running."""
@@ -130,6 +130,7 @@ class WyomingSatellite:
             self._audio_queue.put_nowait(None)
 
         self._enabled_changed_event.set()
+        self._enabled_changed_event.clear()
 
     def _pipeline_changed(self) -> None:
         """Run when device pipeline changes."""
@@ -255,8 +256,16 @@ class WyomingSatellite:
                     chunk = AudioChunk.from_event(client_event)
                     chunk = self._chunk_converter.convert(chunk)
                     self._audio_queue.put_nowait(chunk.audio)
+                elif AudioStop.is_type(client_event.type):
+                    # Stop pipeline
+                    _LOGGER.debug("Client requested pipeline to stop")
+                    self._audio_queue.put_nowait(b"")
+                    break
                 else:
                     _LOGGER.debug("Unexpected event from satellite: %s", client_event)
+
+            # Ensure task finishes
+            await _pipeline_task
 
             _LOGGER.debug("Pipeline finished")
 
@@ -348,11 +357,22 @@ class WyomingSatellite:
 
     async def _connect(self) -> None:
         """Connect to satellite over TCP."""
+        await self._disconnect()
+
         _LOGGER.debug(
             "Connecting to satellite at %s:%s", self.service.host, self.service.port
         )
         self._client = AsyncTcpClient(self.service.host, self.service.port)
         await self._client.connect()
+
+    async def _disconnect(self) -> None:
+        """Disconnect if satellite is currently connected."""
+        if self._client is None:
+            return
+
+        _LOGGER.debug("Disconnecting from satellite")
+        await self._client.disconnect()
+        self._client = None
 
     async def _stream_tts(self, media_id: str) -> None:
         """Stream TTS WAV audio to satellite in chunks."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a few outstanding fixes to Wyoming satellites:

- When reconnecting, make sure to disconnect the previous connection (instead of letting it time out)
- Keep checking disabled flag instead of just once per run
- Stop a pipeline on the `AudioStop` message
- Make sure pipeline task finishes

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
