### PR TITLE
Ensure platform setup for all AVM FRITZ!SmartHome devices 

### DIFF
--- a/homeassistant/components/fritzbox/binary_sensor.py
+++ b/homeassistant/components/fritzbox/binary_sensor.py
@@ -72,10 +72,10 @@ async def async_setup_entry(
     @callback
     def _add_entities(devices: set[str] | None = None) -> None:
         """Add devices."""
-        if not devices and not coordinator.new_devices:
-            return
-        if not devices:
+        if devices is None:
             devices = coordinator.new_devices
+        if not devices:
+            return
         async_add_entities(
             FritzboxBinarySensor(coordinator, ain, description)
             for ain in devices

--- a/homeassistant/components/fritzbox/binary_sensor.py
+++ b/homeassistant/components/fritzbox/binary_sensor.py
@@ -70,20 +70,22 @@ async def async_setup_entry(
     coordinator = get_coordinator(hass, entry.entry_id)
 
     @callback
-    def _add_entities() -> None:
+    def _add_entities(devices: set[str] | None = None) -> None:
         """Add devices."""
-        if not coordinator.new_devices:
+        if not devices and not coordinator.new_devices:
             return
+        if not devices:
+            devices = coordinator.new_devices
         async_add_entities(
             FritzboxBinarySensor(coordinator, ain, description)
-            for ain in coordinator.new_devices
+            for ain in devices
             for description in BINARY_SENSOR_TYPES
             if description.suitable(coordinator.data.devices[ain])
         )
 
     entry.async_on_unload(coordinator.async_add_listener(_add_entities))
 
-    _add_entities()
+    _add_entities(set(coordinator.data.devices.keys()))
 
 
 class FritzboxBinarySensor(FritzBoxDeviceEntity, BinarySensorEntity):

--- a/homeassistant/components/fritzbox/button.py
+++ b/homeassistant/components/fritzbox/button.py
@@ -21,10 +21,10 @@ async def async_setup_entry(
     @callback
     def _add_entities(templates: set[str] | None = None) -> None:
         """Add templates."""
-        if not templates and not coordinator.new_templates:
-            return
-        if not templates:
+        if templates is None:
             templates = coordinator.new_templates
+        if not templates:
+            return
         async_add_entities(FritzBoxTemplate(coordinator, ain) for ain in templates)
 
     entry.async_on_unload(coordinator.async_add_listener(_add_entities))

--- a/homeassistant/components/fritzbox/button.py
+++ b/homeassistant/components/fritzbox/button.py
@@ -19,17 +19,17 @@ async def async_setup_entry(
     coordinator = get_coordinator(hass, entry.entry_id)
 
     @callback
-    def _add_entities() -> None:
+    def _add_entities(templates: set[str] | None = None) -> None:
         """Add templates."""
-        if not coordinator.new_templates:
+        if not templates and not coordinator.new_templates:
             return
-        async_add_entities(
-            FritzBoxTemplate(coordinator, ain) for ain in coordinator.new_templates
-        )
+        if not templates:
+            templates = coordinator.new_templates
+        async_add_entities(FritzBoxTemplate(coordinator, ain) for ain in templates)
 
     entry.async_on_unload(coordinator.async_add_listener(_add_entities))
 
-    _add_entities()
+    _add_entities(set(coordinator.data.templates.keys()))
 
 
 class FritzBoxTemplate(FritzBoxEntity, ButtonEntity):

--- a/homeassistant/components/fritzbox/climate.py
+++ b/homeassistant/components/fritzbox/climate.py
@@ -52,19 +52,21 @@ async def async_setup_entry(
     coordinator = get_coordinator(hass, entry.entry_id)
 
     @callback
-    def _add_entities() -> None:
+    def _add_entities(devices: set[str] | None = None) -> None:
         """Add devices."""
-        if not coordinator.new_devices:
+        if not devices and not coordinator.new_devices:
             return
+        if not devices:
+            devices = coordinator.new_devices
         async_add_entities(
             FritzboxThermostat(coordinator, ain)
-            for ain in coordinator.new_devices
+            for ain in devices
             if coordinator.data.devices[ain].has_thermostat
         )
 
     entry.async_on_unload(coordinator.async_add_listener(_add_entities))
 
-    _add_entities()
+    _add_entities(set(coordinator.data.devices.keys()))
 
 
 class FritzboxThermostat(FritzBoxDeviceEntity, ClimateEntity):

--- a/homeassistant/components/fritzbox/climate.py
+++ b/homeassistant/components/fritzbox/climate.py
@@ -54,10 +54,10 @@ async def async_setup_entry(
     @callback
     def _add_entities(devices: set[str] | None = None) -> None:
         """Add devices."""
-        if not devices and not coordinator.new_devices:
-            return
-        if not devices:
+        if devices is None:
             devices = coordinator.new_devices
+        if not devices:
+            return
         async_add_entities(
             FritzboxThermostat(coordinator, ain)
             for ain in devices

--- a/homeassistant/components/fritzbox/cover.py
+++ b/homeassistant/components/fritzbox/cover.py
@@ -26,10 +26,10 @@ async def async_setup_entry(
     @callback
     def _add_entities(devices: set[str] | None = None) -> None:
         """Add devices."""
-        if not devices and not coordinator.new_devices:
-            return
-        if not devices:
+        if devices is None:
             devices = coordinator.new_devices
+        if not devices:
+            return
         async_add_entities(
             FritzboxCover(coordinator, ain)
             for ain in devices

--- a/homeassistant/components/fritzbox/cover.py
+++ b/homeassistant/components/fritzbox/cover.py
@@ -24,19 +24,21 @@ async def async_setup_entry(
     coordinator = get_coordinator(hass, entry.entry_id)
 
     @callback
-    def _add_entities() -> None:
+    def _add_entities(devices: set[str] | None = None) -> None:
         """Add devices."""
-        if not coordinator.new_devices:
+        if not devices and not coordinator.new_devices:
             return
+        if not devices:
+            devices = coordinator.new_devices
         async_add_entities(
             FritzboxCover(coordinator, ain)
-            for ain in coordinator.new_devices
+            for ain in devices
             if coordinator.data.devices[ain].has_blind
         )
 
     entry.async_on_unload(coordinator.async_add_listener(_add_entities))
 
-    _add_entities()
+    _add_entities(set(coordinator.data.devices.keys()))
 
 
 class FritzboxCover(FritzBoxDeviceEntity, CoverEntity):

--- a/homeassistant/components/fritzbox/light.py
+++ b/homeassistant/components/fritzbox/light.py
@@ -32,10 +32,10 @@ async def async_setup_entry(
     @callback
     def _add_entities(devices: set[str] | None = None) -> None:
         """Add devices."""
-        if not devices and not coordinator.new_devices:
-            return
-        if not devices:
+        if devices is None:
             devices = coordinator.new_devices
+        if not devices:
+            return
         async_add_entities(
             FritzboxLight(coordinator, ain)
             for ain in devices

--- a/homeassistant/components/fritzbox/light.py
+++ b/homeassistant/components/fritzbox/light.py
@@ -30,22 +30,21 @@ async def async_setup_entry(
     coordinator = get_coordinator(hass, entry.entry_id)
 
     @callback
-    def _add_entities() -> None:
+    def _add_entities(devices: set[str] | None = None) -> None:
         """Add devices."""
-        if not coordinator.new_devices:
+        if not devices and not coordinator.new_devices:
             return
+        if not devices:
+            devices = coordinator.new_devices
         async_add_entities(
-            FritzboxLight(
-                coordinator,
-                ain,
-            )
-            for ain in coordinator.new_devices
-            if (coordinator.data.devices[ain]).has_lightbulb
+            FritzboxLight(coordinator, ain)
+            for ain in devices
+            if coordinator.data.devices[ain].has_lightbulb
         )
 
     entry.async_on_unload(coordinator.async_add_listener(_add_entities))
 
-    _add_entities()
+    _add_entities(set(coordinator.data.devices.keys()))
 
 
 class FritzboxLight(FritzBoxDeviceEntity, LightEntity):

--- a/homeassistant/components/fritzbox/sensor.py
+++ b/homeassistant/components/fritzbox/sensor.py
@@ -217,10 +217,10 @@ async def async_setup_entry(
     @callback
     def _add_entities(devices: set[str] | None = None) -> None:
         """Add devices."""
-        if not devices and not coordinator.new_devices:
-            return
-        if not devices:
+        if devices is None:
             devices = coordinator.new_devices
+        if not devices:
+            return
         async_add_entities(
             FritzBoxSensor(coordinator, ain, description)
             for ain in devices

--- a/homeassistant/components/fritzbox/sensor.py
+++ b/homeassistant/components/fritzbox/sensor.py
@@ -215,20 +215,22 @@ async def async_setup_entry(
     coordinator = get_coordinator(hass, entry.entry_id)
 
     @callback
-    def _add_entities() -> None:
+    def _add_entities(devices: set[str] | None = None) -> None:
         """Add devices."""
-        if not coordinator.new_devices:
+        if not devices and not coordinator.new_devices:
             return
+        if not devices:
+            devices = coordinator.new_devices
         async_add_entities(
             FritzBoxSensor(coordinator, ain, description)
-            for ain in coordinator.new_devices
+            for ain in devices
             for description in SENSOR_TYPES
             if description.suitable(coordinator.data.devices[ain])
         )
 
     entry.async_on_unload(coordinator.async_add_listener(_add_entities))
 
-    _add_entities()
+    _add_entities(set(coordinator.data.devices.keys()))
 
 
 class FritzBoxSensor(FritzBoxDeviceEntity, SensorEntity):

--- a/homeassistant/components/fritzbox/switch.py
+++ b/homeassistant/components/fritzbox/switch.py
@@ -21,10 +21,10 @@ async def async_setup_entry(
     @callback
     def _add_entities(devices: set[str] | None = None) -> None:
         """Add devices."""
-        if not devices and not coordinator.new_devices:
-            return
-        if not devices:
+        if devices is None:
             devices = coordinator.new_devices
+        if not devices:
+            return
         async_add_entities(
             FritzboxSwitch(coordinator, ain)
             for ain in devices

--- a/homeassistant/components/fritzbox/switch.py
+++ b/homeassistant/components/fritzbox/switch.py
@@ -19,19 +19,21 @@ async def async_setup_entry(
     coordinator = get_coordinator(hass, entry.entry_id)
 
     @callback
-    def _add_entities() -> None:
+    def _add_entities(devices: set[str] | None = None) -> None:
         """Add devices."""
-        if not coordinator.new_devices:
+        if not devices and not coordinator.new_devices:
             return
+        if not devices:
+            devices = coordinator.new_devices
         async_add_entities(
             FritzboxSwitch(coordinator, ain)
-            for ain in coordinator.new_devices
+            for ain in devices
             if coordinator.data.devices[ain].has_switch
         )
 
     entry.async_on_unload(coordinator.async_add_listener(_add_entities))
 
-    _add_entities()
+    _add_entities(set(coordinator.data.devices.keys()))
 
 
 class FritzboxSwitch(FritzBoxDeviceEntity, SwitchEntity):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In case when one platform setup is delayed (_example https://github.com/home-assistant/core/issues/105346#issuecomment-1848942175_) the `coordinator.new_devices` might already be cleared by a meanwhile further coordinator data update run.
To ensure each platform is at proper set up, we statically run `_add_entities` with the whole bunch of devices during setup, but during coordinator update listener, we only consider the `coordinator.new_devices` property.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #105346
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
