### PR TITLE
Migrate device_sun_light_trigger tests to use freezegun

### DIFF
--- a/tests/components/device_sun_light_trigger/test_init.py
+++ b/tests/components/device_sun_light_trigger/test_init.py
@@ -2,6 +2,7 @@
 from datetime import datetime
 from unittest.mock import patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components import (
@@ -72,13 +73,15 @@ async def scanner(hass, enable_custom_integrations):
     return scanner
 
 
-async def test_lights_on_when_sun_sets(hass: HomeAssistant, scanner) -> None:
+async def test_lights_on_when_sun_sets(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, scanner
+) -> None:
     """Test lights go on when there is someone home and the sun sets."""
     test_time = datetime(2017, 4, 5, 1, 2, 3, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=test_time):
-        assert await async_setup_component(
-            hass, device_sun_light_trigger.DOMAIN, {device_sun_light_trigger.DOMAIN: {}}
-        )
+    freezer.move_to(test_time)
+    assert await async_setup_component(
+        hass, device_sun_light_trigger.DOMAIN, {device_sun_light_trigger.DOMAIN: {}}
+    )
 
     await hass.services.async_call(
         light.DOMAIN,
@@ -88,9 +91,9 @@ async def test_lights_on_when_sun_sets(hass: HomeAssistant, scanner) -> None:
     )
 
     test_time = test_time.replace(hour=3)
-    with patch("homeassistant.util.dt.utcnow", return_value=test_time):
-        async_fire_time_changed(hass, test_time)
-        await hass.async_block_till_done()
+    freezer.move_to(test_time)
+    async_fire_time_changed(hass, test_time)
+    await hass.async_block_till_done()
 
     assert all(
         hass.states.get(ent_id).state == STATE_ON
@@ -128,22 +131,22 @@ async def test_lights_turn_off_when_everyone_leaves(
 
 
 async def test_lights_turn_on_when_coming_home_after_sun_set(
-    hass: HomeAssistant, scanner
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, scanner
 ) -> None:
     """Test lights turn on when coming home after sun set."""
     test_time = datetime(2017, 4, 5, 3, 2, 3, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=test_time):
-        await hass.services.async_call(
-            light.DOMAIN, light.SERVICE_TURN_OFF, {ATTR_ENTITY_ID: "all"}, blocking=True
-        )
+    freezer.move_to(test_time)
+    await hass.services.async_call(
+        light.DOMAIN, light.SERVICE_TURN_OFF, {ATTR_ENTITY_ID: "all"}, blocking=True
+    )
 
-        assert await async_setup_component(
-            hass, device_sun_light_trigger.DOMAIN, {device_sun_light_trigger.DOMAIN: {}}
-        )
+    assert await async_setup_component(
+        hass, device_sun_light_trigger.DOMAIN, {device_sun_light_trigger.DOMAIN: {}}
+    )
 
-        hass.states.async_set(f"{DOMAIN}.device_2", STATE_HOME)
+    hass.states.async_set(f"{DOMAIN}.device_2", STATE_HOME)
 
-        await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert all(
         hass.states.get(ent_id).state == light.STATE_ON
@@ -152,85 +155,85 @@ async def test_lights_turn_on_when_coming_home_after_sun_set(
 
 
 async def test_lights_turn_on_when_coming_home_after_sun_set_person(
-    hass: HomeAssistant, scanner
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, scanner
 ) -> None:
     """Test lights turn on when coming home after sun set."""
     device_1 = f"{DOMAIN}.device_1"
     device_2 = f"{DOMAIN}.device_2"
 
     test_time = datetime(2017, 4, 5, 3, 2, 3, tzinfo=dt_util.UTC)
-    with patch("homeassistant.util.dt.utcnow", return_value=test_time):
-        await hass.services.async_call(
-            light.DOMAIN, light.SERVICE_TURN_OFF, {ATTR_ENTITY_ID: "all"}, blocking=True
-        )
-        hass.states.async_set(device_1, STATE_NOT_HOME)
-        hass.states.async_set(device_2, STATE_NOT_HOME)
-        await hass.async_block_till_done()
+    freezer.move_to(test_time)
+    await hass.services.async_call(
+        light.DOMAIN, light.SERVICE_TURN_OFF, {ATTR_ENTITY_ID: "all"}, blocking=True
+    )
+    hass.states.async_set(device_1, STATE_NOT_HOME)
+    hass.states.async_set(device_2, STATE_NOT_HOME)
+    await hass.async_block_till_done()
 
-        assert all(
-            not light.is_on(hass, ent_id)
-            for ent_id in hass.states.async_entity_ids("light")
-        )
-        assert hass.states.get(device_1).state == "not_home"
-        assert hass.states.get(device_2).state == "not_home"
+    assert all(
+        not light.is_on(hass, ent_id)
+        for ent_id in hass.states.async_entity_ids("light")
+    )
+    assert hass.states.get(device_1).state == "not_home"
+    assert hass.states.get(device_2).state == "not_home"
 
-        assert await async_setup_component(
-            hass,
-            "person",
-            {"person": [{"id": "me", "name": "Me", "device_trackers": [device_1]}]},
-        )
+    assert await async_setup_component(
+        hass,
+        "person",
+        {"person": [{"id": "me", "name": "Me", "device_trackers": [device_1]}]},
+    )
 
-        assert await async_setup_component(hass, "group", {})
-        await hass.async_block_till_done()
-        await group.Group.async_create_group(
-            hass,
-            "person_me",
-            created_by_service=False,
-            entity_ids=["person.me"],
-            icon=None,
-            mode=None,
-            object_id=None,
-            order=None,
-        )
+    assert await async_setup_component(hass, "group", {})
+    await hass.async_block_till_done()
+    await group.Group.async_create_group(
+        hass,
+        "person_me",
+        created_by_service=False,
+        entity_ids=["person.me"],
+        icon=None,
+        mode=None,
+        object_id=None,
+        order=None,
+    )
 
-        assert await async_setup_component(
-            hass,
-            device_sun_light_trigger.DOMAIN,
-            {device_sun_light_trigger.DOMAIN: {"device_group": "group.person_me"}},
-        )
+    assert await async_setup_component(
+        hass,
+        device_sun_light_trigger.DOMAIN,
+        {device_sun_light_trigger.DOMAIN: {"device_group": "group.person_me"}},
+    )
 
-        assert all(
-            hass.states.get(ent_id).state == STATE_OFF
-            for ent_id in hass.states.async_entity_ids("light")
-        )
-        assert hass.states.get(device_1).state == "not_home"
-        assert hass.states.get(device_2).state == "not_home"
-        assert hass.states.get("person.me").state == "not_home"
+    assert all(
+        hass.states.get(ent_id).state == STATE_OFF
+        for ent_id in hass.states.async_entity_ids("light")
+    )
+    assert hass.states.get(device_1).state == "not_home"
+    assert hass.states.get(device_2).state == "not_home"
+    assert hass.states.get("person.me").state == "not_home"
 
-        # Unrelated device has no impact
-        hass.states.async_set(device_2, STATE_HOME)
-        await hass.async_block_till_done()
+    # Unrelated device has no impact
+    hass.states.async_set(device_2, STATE_HOME)
+    await hass.async_block_till_done()
 
-        assert all(
-            hass.states.get(ent_id).state == STATE_OFF
-            for ent_id in hass.states.async_entity_ids("light")
-        )
-        assert hass.states.get(device_1).state == "not_home"
-        assert hass.states.get(device_2).state == "home"
-        assert hass.states.get("person.me").state == "not_home"
+    assert all(
+        hass.states.get(ent_id).state == STATE_OFF
+        for ent_id in hass.states.async_entity_ids("light")
+    )
+    assert hass.states.get(device_1).state == "not_home"
+    assert hass.states.get(device_2).state == "home"
+    assert hass.states.get("person.me").state == "not_home"
 
-        # person home switches on
-        hass.states.async_set(device_1, STATE_HOME)
-        await hass.async_block_till_done()
-        await hass.async_block_till_done()
+    # person home switches on
+    hass.states.async_set(device_1, STATE_HOME)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
-        assert all(
-            hass.states.get(ent_id).state == light.STATE_ON
-            for ent_id in hass.states.async_entity_ids("light")
-        )
-        assert hass.states.get(device_1).state == "home"
-        assert hass.states.get(device_2).state == "home"
-        assert hass.states.get("person.me").state == "home"
+    assert all(
+        hass.states.get(ent_id).state == light.STATE_ON
+        for ent_id in hass.states.async_entity_ids("light")
+    )
+    assert hass.states.get(device_1).state == "home"
+    assert hass.states.get(device_2).state == "home"
+    assert hass.states.get("person.me").state == "home"
 
 
 async def test_initialize_start(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change
Move the device_sun_light_trigger tests to use freezegun

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
