### PR TITLE
Preserve both translated/untranslated state in assist response

### DIFF
--- a/homeassistant/components/conversation/const.py
+++ b/homeassistant/components/conversation/const.py
@@ -3,3 +3,6 @@
 DOMAIN = "conversation"
 DEFAULT_EXPOSED_ATTRIBUTES = {"device_class"}
 HOME_ASSISTANT_AGENT = "homeassistant"
+
+ATTR_TRANSLATED_STATE = "translated_state"
+ATTR_UNTRANSLATED_STATE = "untranslated_state"

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -346,7 +346,7 @@ class DefaultAgent(AbstractConversationAgent):
                 }
             )
             state.attributes = attributes
-            state.state = str(state.attributes.get(ATTR_TRANSLATED_STATE))
+            state.state = str(state.attributes[ATTR_TRANSLATED_STATE])
 
         # Get first matched or unmatched state.
         # This is available in the response template as "state".

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -247,7 +247,10 @@ async def test_state_translations(
 
     with patch(
         "homeassistant.components.conversation.default_agent.template.Template.async_render"
-    ) as render_response:
+    ) as render_response, patch(
+        "homeassistant.helpers.translation.async_get_translations",
+        return_value={"component.light.entity_component._.state.off": "translated_off"},
+    ):
         result = await conversation.async_converse(
             hass, "is the demo light off", None, Context()
         )
@@ -255,7 +258,7 @@ async def test_state_translations(
         state_attributes = (
             render_response.call_args[0][0].get("query").get("matched")[0].attributes
         )
-        assert state_attributes.get(ATTR_TRANSLATED_STATE) == "Off"
+        assert state_attributes.get(ATTR_TRANSLATED_STATE) == "translated_off"
         assert state_attributes.get(ATTR_UNTRANSLATED_STATE) == "off"
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add 2 new attributes to voice assistant default conversation agent response states: `translated_state` and `untranslated_state`. At the moment, the default conversation agent overwrites the state with a translated version of itself, but that causes problems since state matching now depends on translations.

As a solution, we can add the original, untranslated state among the state attributes, which can be used in responses like [`HassGetWeather`](https://github.com/home-assistant/intents/blob/8ba1a10bcd21ebf2baee7efbb3bb87b1794fd0e3/responses/en/HassGetWeather.yaml#L5) or [`person_HassGetState`](https://github.com/home-assistant/intents/blob/8ba1a10bcd21ebf2baee7efbb3bb87b1794fd0e3/responses/en/HassGetState.yaml#L69), which now don't work properly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
