### PR TITLE
Add 4 more entities in V2C Trydan EVSE

### DIFF
--- a/homeassistant/components/v2c/strings.json
+++ b/homeassistant/components/v2c/strings.json
@@ -57,13 +57,13 @@
         "name": "Lock EVSE"
       },
       "timer": {
-        "name": "Charge Point Timer"
+        "name": "Charge point timer"
       },
       "dynamic": {
-        "name": "Dynamic Intensity Modulation"
+        "name": "Dynamic intensity modulation"
       },
       "pause_dynamic": {
-        "name": "Pause Dynamic Control Modulation"
+        "name": "Pause dynamic control modulation"
       }
     }
   }

--- a/homeassistant/components/v2c/strings.json
+++ b/homeassistant/components/v2c/strings.json
@@ -52,6 +52,18 @@
     "switch": {
       "paused": {
         "name": "Pause session"
+      },
+      "locked": {
+        "name": "Lock EVSE"
+      },
+      "timer": {
+        "name": "Charge Point Timer"
+      },
+      "dynamic": {
+        "name": "Dynamic Intensity Modulation"
+      },
+      "pause_dynamic": {
+        "name": "Pause Dynamic Control Modulation"
       }
     }
   }

--- a/homeassistant/components/v2c/switch.py
+++ b/homeassistant/components/v2c/switch.py
@@ -7,7 +7,13 @@ import logging
 from typing import Any
 
 from pytrydan import Trydan, TrydanData
-from pytrydan.models.trydan import PauseState
+from pytrydan.models.trydan import (
+    ChargePointTimerState,
+    DynamicState,
+    LockState,
+    PauseDynamicState,
+    PauseState,
+)
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -43,6 +49,39 @@ TRYDAN_SWITCHES = (
         value_fn=lambda evse_data: evse_data.paused == PauseState.PAUSED,
         turn_on_fn=lambda evse: evse.pause(),
         turn_off_fn=lambda evse: evse.resume(),
+    ),
+    V2CSwitchEntityDescription(
+        key="locked",
+        translation_key="locked",
+        icon="mdi:lock",
+        value_fn=lambda evse_data: evse_data.locked == LockState.ENABLED,
+        turn_on_fn=lambda evse: evse.lock(),
+        turn_off_fn=lambda evse: evse.unlock(),
+    ),
+    V2CSwitchEntityDescription(
+        key="timer",
+        translation_key="timer",
+        icon="mdi:timer",
+        value_fn=lambda evse_data: evse_data.timer == ChargePointTimerState.TIMER_ON,
+        turn_on_fn=lambda evse: evse.timer(),
+        turn_off_fn=lambda evse: evse.timer_disable(),
+    ),
+    V2CSwitchEntityDescription(
+        key="dynamic",
+        translation_key="dynamic",
+        icon="mdi:gauge",
+        value_fn=lambda evse_data: evse_data.dynamic == DynamicState.ENABLED,
+        turn_on_fn=lambda evse: evse.dynamic(),
+        turn_off_fn=lambda evse: evse.dynamic_disable(),
+    ),
+    V2CSwitchEntityDescription(
+        key="pause_dynamic",
+        translation_key="pause_dynamic",
+        icon="mdi:pause",
+        value_fn=lambda evse_data: evse_data.pause_dynamic
+        == PauseDynamicState.NOT_MODULATING,
+        turn_on_fn=lambda evse: evse.pause_dynamic(),
+        turn_off_fn=lambda evse: evse.resume_dynamic(),
     ),
 )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds 4 more switches:
- EVSE Lock
- Charge Point Timer
- Dynamic Intensity Modulation
- Pause Dynamic Control Modulation

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30290

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
