### PR TITLE
Add option for exposing users on local networks

### DIFF
--- a/homeassistant/auth/providers/homeassistant.py
+++ b/homeassistant/auth/providers/homeassistant.py
@@ -31,7 +31,18 @@ def _disallow_id(conf: dict[str, Any]) -> dict[str, Any]:
     return conf
 
 
-CONFIG_SCHEMA = vol.All(AUTH_PROVIDER_SCHEMA, _disallow_id)
+EXPOSE_USERS_ON_LOCAL_NETWORK = "expose_users_on_local_network"
+
+
+CONFIG_SCHEMA = vol.All(
+    AUTH_PROVIDER_SCHEMA.extend(
+        {
+            vol.Optional(EXPOSE_USERS_ON_LOCAL_NETWORK, default=True): bool,
+        },
+        extra=vol.PREVENT_EXTRA,
+    ),
+    _disallow_id,
+)
 
 
 @callback
@@ -224,6 +235,11 @@ class HassAuthProvider(AuthProvider):
         super().__init__(*args, **kwargs)
         self.data: Data | None = None
         self._init_lock = asyncio.Lock()
+
+    @property
+    def expose_users_on_local_network(self) -> bool:
+        """Return if users are exposed on local network."""
+        return self.config[EXPOSE_USERS_ON_LOCAL_NETWORK]  # type: ignore[no-any-return]
 
     async def async_initialize(self) -> None:
         """Initialize the auth provider."""

--- a/homeassistant/auth/providers/homeassistant.py
+++ b/homeassistant/auth/providers/homeassistant.py
@@ -239,7 +239,7 @@ class HassAuthProvider(AuthProvider):
     @property
     def expose_users_on_local_network(self) -> bool:
         """Return if users are exposed on local network."""
-        return self.config[EXPOSE_USERS_ON_LOCAL_NETWORK]  # type: ignore[no-any-return]
+        return self.config.get(EXPOSE_USERS_ON_LOCAL_NETWORK, True)  # type: ignore[no-any-return]
 
     async def async_initialize(self) -> None:
         """Initialize the auth provider."""

--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -96,6 +96,7 @@ from homeassistant.util.network import is_local
 from . import indieauth
 
 if TYPE_CHECKING:
+    from homeassistant.auth.providers.homeassistant import HassAuthProvider
     from homeassistant.auth.providers.trusted_networks import (
         TrustedNetworksAuthProvider,
     )
@@ -181,6 +182,7 @@ class AuthProvidersView(HomeAssistantView):
                     continue
             elif (
                 provider.type == "homeassistant"
+                and cast("HassAuthProvider", provider).expose_users_on_local_network
                 and not cloud_connection
                 and is_local(remote_address)
                 and "person" in hass.config.components


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Extend homeassistant auth provider config by `expose_users_on_local_network` with the default value `True` to control if users should be exposed on local networks for the new login screen (added with #103906)

When `expose_users_on_local_network=False`:
- No username will be returned by `auth/providers`
- `/api/person/list` will not be registered and therefore not available

In addition, the `/api/person/list` endpoint will only be registred if homeassistant auth provider is configured.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
