### PR TITLE
Migrate google related tests to use freezegun

### DIFF
--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Generator
 import datetime
 import http
+import time
 from typing import Any, TypeVar
 from unittest.mock import Mock, mock_open, patch
 
@@ -189,9 +190,9 @@ def creds(
 
 
 @pytest.fixture
-def config_entry_token_expiry(token_expiry: datetime.datetime) -> float:
+def config_entry_token_expiry() -> float:
     """Fixture for token expiration value stored in the config entry."""
-    return token_expiry.replace(tzinfo=dt_util.UTC).timestamp()
+    return time.time() + 86400
 
 
 @pytest.fixture

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -168,7 +168,7 @@ def token_scopes() -> list[str]:
 def token_expiry() -> datetime.datetime:
     """Expiration time for credentials used in the test."""
     # OAuth library returns an offset-naive timestamp
-    return dt_util.utcnow() + datetime.timedelta(hours=1)
+    return dt_util.utcnow().replace(tzinfo=None) + datetime.timedelta(hours=1)
 
 
 @pytest.fixture
@@ -191,7 +191,7 @@ def creds(
 @pytest.fixture
 def config_entry_token_expiry(token_expiry: datetime.datetime) -> float:
     """Fixture for token expiration value stored in the config entry."""
-    return token_expiry.timestamp()
+    return token_expiry.replace(tzinfo=dt_util.UTC).timestamp()
 
 
 @pytest.fixture

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -168,7 +168,7 @@ def token_scopes() -> list[str]:
 def token_expiry() -> datetime.datetime:
     """Expiration time for credentials used in the test."""
     # OAuth library returns an offset-naive timestamp
-    return dt_util.utcnow().replace(tzinfo=None) + datetime.timedelta(hours=1)
+    return dt_util.utcnow() + datetime.timedelta(hours=1)
 
 
 @pytest.fixture

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import urllib
 
 from aiohttp.client_exceptions import ClientError
+from freezegun.api import FrozenDateTimeFactory
 from gcal_sync.auth import API_BASE_URL
 import pytest
 
@@ -578,11 +579,13 @@ async def test_scan_calendar_error(
 
 
 async def test_future_event_update_behavior(
-    hass: HomeAssistant, mock_events_list_items, component_setup
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_events_list_items,
+    component_setup,
 ) -> None:
     """Test an future event that becomes active."""
     now = dt_util.now()
-    now_utc = dt_util.utcnow()
     one_hour_from_now = now + datetime.timedelta(minutes=60)
     end_event = one_hour_from_now + datetime.timedelta(minutes=90)
     event = {
@@ -600,12 +603,9 @@ async def test_future_event_update_behavior(
 
     # Advance time until event has started
     now += datetime.timedelta(minutes=60)
-    now_utc += datetime.timedelta(minutes=60)
-    with patch("homeassistant.util.dt.utcnow", return_value=now_utc), patch(
-        "homeassistant.util.dt.now", return_value=now
-    ):
-        async_fire_time_changed(hass, now)
-        await hass.async_block_till_done()
+    freezer.move_to(now)
+    async_fire_time_changed(hass, now)
+    await hass.async_block_till_done()
 
     # Event has started
     state = hass.states.get(TEST_ENTITY)
@@ -613,11 +613,13 @@ async def test_future_event_update_behavior(
 
 
 async def test_future_event_offset_update_behavior(
-    hass: HomeAssistant, mock_events_list_items, component_setup
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_events_list_items,
+    component_setup,
 ) -> None:
     """Test an future event that becomes active."""
     now = dt_util.now()
-    now_utc = dt_util.utcnow()
     one_hour_from_now = now + datetime.timedelta(minutes=60)
     end_event = one_hour_from_now + datetime.timedelta(minutes=90)
     event_summary = "Test Event in Progress"
@@ -638,12 +640,9 @@ async def test_future_event_offset_update_behavior(
 
     # Advance time until event has started
     now += datetime.timedelta(minutes=45)
-    now_utc += datetime.timedelta(minutes=45)
-    with patch("homeassistant.util.dt.utcnow", return_value=now_utc), patch(
-        "homeassistant.util.dt.now", return_value=now
-    ):
-        async_fire_time_changed(hass, now)
-        await hass.async_block_till_done()
+    freezer.move_to(now)
+    async_fire_time_changed(hass, now)
+    await hass.async_block_till_done()
 
     # Event has not started, but the offset was reached
     state = hass.states.get(TEST_ENTITY)

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -586,7 +586,7 @@ async def test_future_event_update_behavior(
 ) -> None:
     """Test an future event that becomes active."""
     now = dt_util.now()
-    one_hour_from_now = now + datetime.timedelta(minutes=55)
+    one_hour_from_now = now + datetime.timedelta(minutes=60)
     end_event = one_hour_from_now + datetime.timedelta(minutes=90)
     event = {
         **TEST_EVENT,
@@ -602,7 +602,7 @@ async def test_future_event_update_behavior(
     assert state.state == STATE_OFF
 
     # Advance time until event has started
-    now += datetime.timedelta(minutes=55)
+    now += datetime.timedelta(minutes=60)
     freezer.move_to(now)
     async_fire_time_changed(hass, now)
     await hass.async_block_till_done()

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -586,7 +586,7 @@ async def test_future_event_update_behavior(
 ) -> None:
     """Test an future event that becomes active."""
     now = dt_util.now()
-    one_hour_from_now = now + datetime.timedelta(minutes=60)
+    one_hour_from_now = now + datetime.timedelta(minutes=55)
     end_event = one_hour_from_now + datetime.timedelta(minutes=90)
     event = {
         **TEST_EVENT,
@@ -602,7 +602,7 @@ async def test_future_event_update_behavior(
     assert state.state == STATE_OFF
 
     # Advance time until event has started
-    now += datetime.timedelta(minutes=60)
+    now += datetime.timedelta(minutes=55)
     freezer.move_to(now)
     async_fire_time_changed(hass, now)
     await hass.async_block_till_done()

--- a/tests/components/google/test_config_flow.py
+++ b/tests/components/google/test_config_flow.py
@@ -9,6 +9,7 @@ from typing import Any
 from unittest.mock import Mock, patch
 
 from aiohttp.client_exceptions import ClientError
+from freezegun import freeze_time
 from oauth2client.client import (
     DeviceFlowInfo,
     FlowExchangeError,
@@ -130,7 +131,7 @@ async def primary_calendar(
 
 async def fire_alarm(hass, point_in_time):
     """Fire an alarm and wait for callbacks to run."""
-    with patch("homeassistant.util.dt.utcnow", return_value=point_in_time):
+    with freeze_time(point_in_time):
         async_fire_time_changed(hass, point_in_time)
         await hass.async_block_till_done()
 

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -699,7 +699,10 @@ async def test_add_event_location(
 
 @pytest.mark.parametrize(
     "config_entry_token_expiry",
-    [datetime.datetime.max.replace(tzinfo=UTC).timestamp() + 1],
+    [
+        (datetime.datetime.max.replace(tzinfo=UTC).timestamp() + 1),
+        (utcnow().replace(tzinfo=None).timestamp()),
+    ],
 )
 async def test_invalid_token_expiry_in_config_entry(
     hass: HomeAssistant,

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -703,7 +703,7 @@ async def test_add_event_location(
         (datetime.datetime.max.replace(tzinfo=UTC).timestamp() + 1),
         (utcnow().replace(tzinfo=None).timestamp()),
     ],
-    ids=["max_timestamp","timestamp_naive"],
+    ids=["max_timestamp", "timestamp_naive"],
 )
 async def test_invalid_token_expiry_in_config_entry(
     hass: HomeAssistant,

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -703,6 +703,7 @@ async def test_add_event_location(
         (datetime.datetime.max.replace(tzinfo=UTC).timestamp() + 1),
         (utcnow().replace(tzinfo=None).timestamp()),
     ],
+    ids=["max_timestamp","timestamp_naive"],
 )
 async def test_invalid_token_expiry_in_config_entry(
     hass: HomeAssistant,

--- a/tests/components/nest/test_camera.py
+++ b/tests/components/nest/test_camera.py
@@ -8,6 +8,7 @@ from http import HTTPStatus
 from unittest.mock import AsyncMock, Mock, patch
 
 import aiohttp
+from freezegun import freeze_time
 from google_nest_sdm.event import EventMessage
 import pytest
 
@@ -173,7 +174,7 @@ async def async_get_image(hass, width=None, height=None):
 
 async def fire_alarm(hass, point_in_time):
     """Fire an alarm and wait for callbacks to run."""
-    with patch("homeassistant.util.dt.utcnow", return_value=point_in_time):
+    with freeze_time(point_in_time):
         async_fire_time_changed(hass, point_in_time)
         await hass.async_block_till_done()
 


### PR DESCRIPTION
## Proposed change
Migrate `google`, `google_assistant` and `nest` tests to use freezegun

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
