### PR TITLE
Patch aiohttp server app router freeze in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -487,6 +487,8 @@ def aiohttp_client(
         if isinstance(__param, Application):
             server_kwargs = server_kwargs or {}
             server = TestServer(__param, loop=loop, **server_kwargs)
+            # Registering the view after starting the server should still work.
+            server.app._router.freeze = lambda: None
             client = CoalescingClient(server, loop=loop, **kwargs)
         elif isinstance(__param, BaseTestServer):
             client = TestClient(__param, loop=loop, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -487,7 +487,7 @@ def aiohttp_client(
         if isinstance(__param, Application):
             server_kwargs = server_kwargs or {}
             server = TestServer(__param, loop=loop, **server_kwargs)
-            # Registering the view after starting the server should still work.
+            # Registering a view after starting the server should still work.
             server.app._router.freeze = lambda: None
             client = CoalescingClient(server, loop=loop, **kwargs)
         elif isinstance(__param, BaseTestServer):

--- a/tests/test_test_fixtures.py
+++ b/tests/test_test_fixtures.py
@@ -1,10 +1,16 @@
 """Test test fixture configuration."""
+from http import HTTPStatus
 import socket
 
+from aiohttp import web
 import pytest
 import pytest_socket
 
+from homeassistant.components.http import HomeAssistantView
 from homeassistant.core import HomeAssistant, async_get_hass
+from homeassistant.setup import async_setup_component
+
+from .typing import ClientSessionGenerator
 
 
 def test_sockets_disabled() -> None:
@@ -27,3 +33,38 @@ async def test_hass_cv(hass: HomeAssistant) -> None:
     in the fixture and that async_get_hass() works correctly.
     """
     assert async_get_hass() is hass
+
+
+def register_view(hass: HomeAssistant) -> None:
+    """Register a view."""
+
+    class TestView(HomeAssistantView):
+        """Test view to serve the test."""
+
+        requires_auth = False
+        url = "/api/test"
+        name = "api:test"
+
+        async def get(self, request: web.Request) -> web.Response:
+            """Return a test result."""
+            return self.json({"test": True})
+
+    hass.http.register_view(TestView())
+
+
+async def test_aiohttp_client_frozen_router_view(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test aiohttp_client fixture patches frozen router for views."""
+    assert await async_setup_component(hass, "http", {})
+    await hass.async_block_till_done()
+
+    # Registering the view after starting the server should still work.
+    client = await hass_client()
+    register_view(hass)
+
+    response = await client.get("/api/test")
+    assert response.status == HTTPStatus.OK
+    result = await response.json()
+    assert result["test"] is True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- We currently patch the server app router freeze method in production to allow routes to be registered dynamically during the app lifetime.
- Copy this behavior to our aiohttp client test fixture too, to make sure our tests can run close to production behavior.

https://github.com/home-assistant/core/blob/fb615817b4ccb3a0dcfeaf0384a1ff29633170cd/homeassistant/components/http/__init__.py#L516-L521

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
