### PR TITLE
Add volume_step property to MediaPlayerEntity

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -454,6 +454,7 @@ class MediaPlayerEntityDescription(EntityDescription):
     """A class that describes media player entities."""
 
     device_class: MediaPlayerDeviceClass | None = None
+    volume_step: float | None = None
 
 
 class MediaPlayerEntity(Entity):
@@ -505,6 +506,7 @@ class MediaPlayerEntity(Entity):
     _attr_state: MediaPlayerState | None = None
     _attr_supported_features: MediaPlayerEntityFeature = MediaPlayerEntityFeature(0)
     _attr_volume_level: float | None = None
+    _attr_volume_step: float
 
     # Implement these for your media player
     @property
@@ -532,6 +534,18 @@ class MediaPlayerEntity(Entity):
     def volume_level(self) -> float | None:
         """Volume level of the media player (0..1)."""
         return self._attr_volume_level
+
+    @property
+    def volume_step(self) -> float:
+        """Return the step to be used by the volume_up and volume_down services."""
+        if hasattr(self, "_attr_volume_step"):
+            return self._attr_volume_step
+        if (
+            hasattr(self, "entity_description")
+            and (volume_step := self.entity_description.volume_step) is not None
+        ):
+            return volume_step
+        return 0.1
 
     @property
     def is_volume_muted(self) -> bool | None:
@@ -956,7 +970,9 @@ class MediaPlayerEntity(Entity):
             and self.volume_level < 1
             and self.supported_features & MediaPlayerEntityFeature.VOLUME_SET
         ):
-            await self.async_set_volume_level(min(1, self.volume_level + 0.1))
+            await self.async_set_volume_level(
+                min(1, self.volume_level + self.volume_step)
+            )
 
     async def async_volume_down(self) -> None:
         """Turn volume down for media player.
@@ -972,7 +988,9 @@ class MediaPlayerEntity(Entity):
             and self.volume_level > 0
             and self.supported_features & MediaPlayerEntityFeature.VOLUME_SET
         ):
-            await self.async_set_volume_level(max(0, self.volume_level - 0.1))
+            await self.async_set_volume_level(
+                max(0, self.volume_level - self.volume_step)
+            )
 
     async def async_media_play_pause(self) -> None:
         """Play or pause the media player."""

--- a/tests/components/media_player/test_async_helpers.py
+++ b/tests/components/media_player/test_async_helpers.py
@@ -155,13 +155,10 @@ class AttrMediaPlayer(SimpleMediaPlayer):
     _attr_volume_step = 0.2
 
 
-descr = mp.MediaPlayerEntityDescription(key="test", volume_step=0.3)
-
-
 class DescrMediaPlayer(SimpleMediaPlayer):
     """Media player setting properties via entity description."""
 
-    entity_description = descr
+    entity_description = mp.MediaPlayerEntityDescription(key="test", volume_step=0.3)
 
 
 @pytest.fixture(params=[ExtendedMediaPlayer, SimpleMediaPlayer])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `volume_step` property to `MediaPlayerEntity`. By overriding the `volume_step` property,  media players can influence the volume step used by the default implementations of the `volume_up` and `volume_down` services.

To override the `volume_step`, either of these methods can be used:
- Set `_attr_volume_step`
- Set it in the `MediaPlayerEntityDescription`
- Implement a custom property method

Background in https://github.com/home-assistant/architecture/discussions/1012

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
  - Developer documentation https://github.com/home-assistant/developers.home-assistant/pull/2012

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
