### PR TITLE
Add name slot to HassClimateGetTemperature intent

### DIFF
--- a/homeassistant/components/climate/intent.py
+++ b/homeassistant/components/climate/intent.py
@@ -21,7 +21,7 @@ class GetTemperatureIntent(intent.IntentHandler):
     """Handle GetTemperature intents."""
 
     intent_type = INTENT_GET_TEMPERATURE
-    slot_schema = {vol.Optional("area"): str}
+    slot_schema = {vol.Optional("area"): str, vol.Optional("name"): str}
 
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the intent."""
@@ -48,6 +48,20 @@ class GetTemperatureIntent(intent.IntentHandler):
 
             if climate_state is None:
                 raise intent.IntentHandleError(f"No climate entity in area {area_name}")
+
+            climate_entity = component.get_entity(climate_state.entity_id)
+        elif "name" in slots:
+            # Filter by name
+            entity_name = slots["name"]["value"]
+
+            for maybe_climate in intent.async_match_states(
+                hass, name=entity_name, domains=[DOMAIN]
+            ):
+                climate_state = maybe_climate
+                break
+
+            if climate_state is None:
+                raise intent.IntentHandleError(f"No climate entity named {entity_name}")
 
             climate_entity = component.get_entity(climate_state.entity_id)
         else:

--- a/tests/components/climate/test_intent.py
+++ b/tests/components/climate/test_intent.py
@@ -153,12 +153,25 @@ async def test_get_temperature(
     state = response.matched_states[0]
     assert state.attributes["current_temperature"] == 10.0
 
-    # Select by area instead (climate_2)
+    # Select by area (climate_2)
     response = await intent.async_handle(
         hass,
         "test",
         climate_intent.INTENT_GET_TEMPERATURE,
         {"area": {"value": "Bedroom"}},
+    )
+    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert len(response.matched_states) == 1
+    assert response.matched_states[0].entity_id == climate_2.entity_id
+    state = response.matched_states[0]
+    assert state.attributes["current_temperature"] == 22.0
+
+    # Select by name (climate_2)
+    response = await intent.async_handle(
+        hass,
+        "test",
+        climate_intent.INTENT_GET_TEMPERATURE,
+        {"name": {"value": "Climate 2"}},
     )
     assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the `name` slot to `HassClimateGetTemperature`. The intent sentences already use this slot, but the current intent only supports `area`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
