### PR TITLE
Bump `brother` library, use `pysnmp-lextudio` with SNMP integration

### DIFF
--- a/homeassistant/components/brother/__init__.py
+++ b/homeassistant/components/brother/__init__.py
@@ -4,22 +4,17 @@ from __future__ import annotations
 from asyncio import timeout
 from datetime import timedelta
 import logging
-import sys
-from typing import Any
+
+from brother import Brother, BrotherSensors, SnmpError, UnsupportedModelError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_TYPE, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DATA_CONFIG_ENTRY, DOMAIN, SNMP
 from .utils import get_snmp_engine
-
-if sys.version_info < (3, 12):
-    from brother import Brother, BrotherSensors, SnmpError, UnsupportedModelError
-else:
-    BrotherSensors = Any
 
 PLATFORMS = [Platform.SENSOR]
 
@@ -30,10 +25,6 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Brother from a config entry."""
-    if sys.version_info >= (3, 12):
-        raise HomeAssistantError(
-            "Brother Printer is not supported on Python 3.12. Please use Python 3.11."
-        )
     host = entry.data[CONF_HOST]
     printer_type = entry.data[CONF_TYPE]
 

--- a/homeassistant/components/brother/manifest.json
+++ b/homeassistant/components/brother/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_polling",
   "loggers": ["brother", "pyasn1", "pysmi", "pysnmp"],
   "quality_scale": "platinum",
-  "requirements": ["brother==2.3.0"],
+  "requirements": ["brother==3.0.0"],
   "zeroconf": [
     {
       "type": "_printer._tcp.local.",

--- a/homeassistant/components/brother/utils.py
+++ b/homeassistant/components/brother/utils.py
@@ -2,17 +2,15 @@
 from __future__ import annotations
 
 import logging
-import sys
+
+import pysnmp.hlapi.asyncio as hlapi
+from pysnmp.hlapi.asyncio.cmdgen import lcd
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import singleton
 
 from .const import DOMAIN, SNMP
-
-if sys.version_info < (3, 12):
-    import pysnmp.hlapi.asyncio as hlapi
-    from pysnmp.hlapi.asyncio.cmdgen import lcd
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/snmp/device_tracker.py
+++ b/homeassistant/components/snmp/device_tracker.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 
 import binascii
 import logging
-import sys
 
+from pysnmp.entity import config as cfg
+from pysnmp.entity.rfc3413.oneliner import cmdgen
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
@@ -14,7 +15,6 @@ from homeassistant.components.device_tracker import (
 )
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
@@ -25,11 +25,6 @@ from .const import (
     CONF_PRIV_KEY,
     DEFAULT_COMMUNITY,
 )
-
-if sys.version_info < (3, 12):
-    from pysnmp.entity import config as cfg
-    from pysnmp.entity.rfc3413.oneliner import cmdgen
-
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,10 +41,6 @@ PLATFORM_SCHEMA = PARENT_PLATFORM_SCHEMA.extend(
 
 def get_scanner(hass: HomeAssistant, config: ConfigType) -> SnmpScanner | None:
     """Validate the configuration and return an SNMP scanner."""
-    if sys.version_info >= (3, 12):
-        raise HomeAssistantError(
-            "SNMP is not supported on Python 3.12. Please use Python 3.11."
-        )
     scanner = SnmpScanner(config[DOMAIN])
 
     return scanner if scanner.success_init else None

--- a/homeassistant/components/snmp/manifest.json
+++ b/homeassistant/components/snmp/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/snmp",
   "iot_class": "local_polling",
   "loggers": ["pyasn1", "pysmi", "pysnmp"],
-  "requirements": ["pysnmplib==5.0.21"]
+  "requirements": ["pysnmp-lextudio==5.0.31"]
 }

--- a/homeassistant/components/snmp/sensor.py
+++ b/homeassistant/components/snmp/sensor.py
@@ -3,8 +3,20 @@ from __future__ import annotations
 
 from datetime import timedelta
 import logging
-import sys
 
+from pysnmp.error import PySnmpError
+import pysnmp.hlapi.asyncio as hlapi
+from pysnmp.hlapi.asyncio import (
+    CommunityData,
+    ContextData,
+    ObjectIdentity,
+    ObjectType,
+    SnmpEngine,
+    Udp6TransportTarget,
+    UdpTransportTarget,
+    UsmUserData,
+    getCmd,
+)
 import voluptuous as vol
 
 from homeassistant.components.sensor import CONF_STATE_CLASS, PLATFORM_SCHEMA
@@ -21,7 +33,6 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.template import Template
@@ -55,21 +66,6 @@ from .const import (
     MAP_PRIV_PROTOCOLS,
     SNMP_VERSIONS,
 )
-
-if sys.version_info < (3, 12):
-    from pysnmp.error import PySnmpError
-    import pysnmp.hlapi.asyncio as hlapi
-    from pysnmp.hlapi.asyncio import (
-        CommunityData,
-        ContextData,
-        ObjectIdentity,
-        ObjectType,
-        SnmpEngine,
-        Udp6TransportTarget,
-        UdpTransportTarget,
-        UsmUserData,
-        getCmd,
-    )
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -115,10 +111,6 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the SNMP sensor."""
-    if sys.version_info >= (3, 12):
-        raise HomeAssistantError(
-            "SNMP is not supported on Python 3.12. Please use Python 3.11."
-        )
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
     community = config.get(CONF_COMMUNITY)

--- a/homeassistant/components/snmp/switch.py
+++ b/homeassistant/components/snmp/switch.py
@@ -2,9 +2,34 @@
 from __future__ import annotations
 
 import logging
-import sys
 from typing import Any
 
+import pysnmp.hlapi.asyncio as hlapi
+from pysnmp.hlapi.asyncio import (
+    CommunityData,
+    ContextData,
+    ObjectIdentity,
+    ObjectType,
+    SnmpEngine,
+    UdpTransportTarget,
+    UsmUserData,
+    getCmd,
+    setCmd,
+)
+from pysnmp.proto.rfc1902 import (
+    Counter32,
+    Counter64,
+    Gauge32,
+    Integer,
+    Integer32,
+    IpAddress,
+    Null,
+    ObjectIdentifier,
+    OctetString,
+    Opaque,
+    TimeTicks,
+    Unsigned32,
+)
 import voluptuous as vol
 
 from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchEntity
@@ -17,7 +42,6 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -43,34 +67,6 @@ from .const import (
     SNMP_VERSIONS,
 )
 
-if sys.version_info < (3, 12):
-    import pysnmp.hlapi.asyncio as hlapi
-    from pysnmp.hlapi.asyncio import (
-        CommunityData,
-        ContextData,
-        ObjectIdentity,
-        ObjectType,
-        SnmpEngine,
-        UdpTransportTarget,
-        UsmUserData,
-        getCmd,
-        setCmd,
-    )
-    from pysnmp.proto.rfc1902 import (
-        Counter32,
-        Counter64,
-        Gauge32,
-        Integer,
-        Integer32,
-        IpAddress,
-        Null,
-        ObjectIdentifier,
-        OctetString,
-        Opaque,
-        TimeTicks,
-        Unsigned32,
-    )
-
 _LOGGER = logging.getLogger(__name__)
 
 CONF_COMMAND_OID = "command_oid"
@@ -81,22 +77,21 @@ DEFAULT_COMMUNITY = "private"
 DEFAULT_PAYLOAD_OFF = 0
 DEFAULT_PAYLOAD_ON = 1
 
-if sys.version_info < (3, 12):
-    MAP_SNMP_VARTYPES = {
-        "Counter32": Counter32,
-        "Counter64": Counter64,
-        "Gauge32": Gauge32,
-        "Integer32": Integer32,
-        "Integer": Integer,
-        "IpAddress": IpAddress,
-        "Null": Null,
-        # some work todo to support tuple ObjectIdentifier, this just supports str
-        "ObjectIdentifier": ObjectIdentifier,
-        "OctetString": OctetString,
-        "Opaque": Opaque,
-        "TimeTicks": TimeTicks,
-        "Unsigned32": Unsigned32,
-    }
+MAP_SNMP_VARTYPES = {
+    "Counter32": Counter32,
+    "Counter64": Counter64,
+    "Gauge32": Gauge32,
+    "Integer32": Integer32,
+    "Integer": Integer,
+    "IpAddress": IpAddress,
+    "Null": Null,
+    # some work todo to support tuple ObjectIdentifier, this just supports str
+    "ObjectIdentifier": ObjectIdentifier,
+    "OctetString": OctetString,
+    "Opaque": Opaque,
+    "TimeTicks": TimeTicks,
+    "Unsigned32": Unsigned32,
+}
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -132,10 +127,6 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the SNMP switch."""
-    if sys.version_info >= (3, 12):
-        raise HomeAssistantError(
-            "SNMP is not supported on Python 3.12. Please use Python 3.11."
-        )
     name = config.get(CONF_NAME)
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -583,7 +583,7 @@ boto3==1.28.17
 broadlink==0.18.3
 
 # homeassistant.components.brother
-brother==2.3.0
+brother==3.0.0
 
 # homeassistant.components.brottsplatskartan
 brottsplatskartan==0.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2089,7 +2089,7 @@ pysmartthings==0.7.8
 pysml==0.0.12
 
 # homeassistant.components.snmp
-pysnmplib==5.0.21
+pysnmp-lextudio==5.0.31
 
 # homeassistant.components.snooz
 pysnooz==0.8.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1588,7 +1588,7 @@ pysmartthings==0.7.8
 pysml==0.0.12
 
 # homeassistant.components.snmp
-pysnmplib==5.0.21
+pysnmp-lextudio==5.0.31
 
 # homeassistant.components.snooz
 pysnooz==0.8.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -491,7 +491,7 @@ boschshcpy==0.2.75
 broadlink==0.18.3
 
 # homeassistant.components.brother
-brother==2.3.0
+brother==3.0.0
 
 # homeassistant.components.brottsplatskartan
 brottsplatskartan==0.0.1

--- a/tests/components/brother/__init__.py
+++ b/tests/components/brother/__init__.py
@@ -1,15 +1,12 @@
 """Tests for Brother Printer integration."""
 import json
-import sys
 from unittest.mock import patch
 
+from homeassistant.components.brother.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_TYPE
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_fixture
-
-if sys.version_info < (3, 12):
-    from homeassistant.components.brother.const import DOMAIN
 
 
 async def init_integration(

--- a/tests/components/brother/conftest.py
+++ b/tests/components/brother/conftest.py
@@ -1,12 +1,8 @@
 """Test fixtures for brother."""
 from collections.abc import Generator
-import sys
 from unittest.mock import AsyncMock, patch
 
 import pytest
-
-if sys.version_info >= (3, 12):
-    collect_ignore_glob = ["test_*.py"]
 
 
 @pytest.fixture

--- a/tests/components/snmp/conftest.py
+++ b/tests/components/snmp/conftest.py
@@ -1,5 +1,0 @@
-"""Skip test collection for Python 3.12."""
-import sys
-
-if sys.version_info >= (3, 12):
-    collect_ignore_glob = ["test_*.py"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, SNMP integration and `brother` library use [this pysnmp fork](https://github.com/pysnmp/pysnmp), which is not compatible with python 3.12 and is rarely updated. The author of the original [pysnmp library](https://github.com/etingof/pysnmp) has passed away.
I suggest changing the library for `snmp` integration and `brother` library to [pysnmp-lexstudio](https://github.com/lextudio/pysnmp), which is compatible with python 3.12.

I tested HA running under python 3.12 and both `brother` integration and `snmp` sensor work fine.

`brother` changelog: https://github.com/bieniu/brother/compare/2.3.0...3.0.0
`pysnmp-lextudio` repo: https://github.com/lextudio/pysnmp

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
