### PR TITLE
Add full coverage to Fast.com

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -363,8 +363,6 @@ omit =
     homeassistant/components/faa_delays/binary_sensor.py
     homeassistant/components/faa_delays/coordinator.py
     homeassistant/components/familyhub/camera.py
-    homeassistant/components/fastdotcom/sensor.py
-    homeassistant/components/fastdotcom/__init__.py
     homeassistant/components/ffmpeg/camera.py
     homeassistant/components/fibaro/__init__.py
     homeassistant/components/fibaro/binary_sensor.py

--- a/tests/components/fastdotcom/test_coordinator.py
+++ b/tests/components/fastdotcom/test_coordinator.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
 
-from homeassistant.components.fastdotcom.const import DOMAIN
+from homeassistant.components.fastdotcom.const import DEFAULT_NAME, DOMAIN
 from homeassistant.components.fastdotcom.coordinator import DEFAULT_INTERVAL
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
@@ -19,6 +19,7 @@ async def test_fastdotcom_data_update_coordinator(
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="UNIQUE_TEST_ID",
+        title=DEFAULT_NAME,
     )
     config_entry.add_to_hass(hass)
 
@@ -28,7 +29,7 @@ async def test_fastdotcom_data_update_coordinator(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.mock_title_download")
+    state = hass.states.get("sensor.fast_com_download")
     assert state is not None
     assert state.state == "5.0"
 
@@ -39,7 +40,7 @@ async def test_fastdotcom_data_update_coordinator(
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.mock_title_download")
+    state = hass.states.get("sensor.fast_com_download")
     assert state.state == "10.0"
 
     with patch(
@@ -50,5 +51,5 @@ async def test_fastdotcom_data_update_coordinator(
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.mock_title_download")
+    state = hass.states.get("sensor.fast_com_download")
     assert state.state is STATE_UNAVAILABLE

--- a/tests/components/fastdotcom/test_init.py
+++ b/tests/components/fastdotcom/test_init.py
@@ -1,0 +1,79 @@
+"""Test for Sensibo component Init."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from freezegun.api import FrozenDateTimeFactory
+
+from homeassistant import config_entries
+from homeassistant.components.fastdotcom.const import DEFAULT_NAME, DOMAIN
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import CoreState, HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+
+async def test_unload_entry(hass: HomeAssistant) -> None:
+    """Test unload an entry."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="UNIQUE_TEST_ID",
+        title=DEFAULT_NAME,
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.fastdotcom.coordinator.fast_com", return_value=5.0
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state == config_entries.ConfigEntryState.LOADED
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is config_entries.ConfigEntryState.NOT_LOADED
+
+
+async def test_from_import(hass: HomeAssistant) -> None:
+    """Test imported entry."""
+    with patch(
+        "homeassistant.components.fastdotcom.coordinator.fast_com", return_value=5.0
+    ):
+        await async_setup_component(
+            hass,
+            DOMAIN,
+            {"fastdotcom": {}},
+        )
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.fast_com_download")
+    assert state is not None
+    assert state.state == "5.0"
+
+
+async def test_not_start_until_hass_started(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
+    """Test unload an entry."""
+    await hass.async_stop()
+    await hass.async_block_till_done()
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="UNIQUE_TEST_ID",
+        title=DEFAULT_NAME,
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    with patch(
+        "homeassistant.components.fastdotcom.coordinator.fast_com", return_value=5.0
+    ), patch.object(hass, "state", CoreState.starting):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    assert config_entry.state == config_entries.ConfigEntryState.LOADED

--- a/tests/components/fastdotcom/test_init.py
+++ b/tests/components/fastdotcom/test_init.py
@@ -56,17 +56,12 @@ async def test_not_start_until_hass_started(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
     """Test unload an entry."""
-    await hass.async_stop()
-    await hass.async_block_till_done()
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="UNIQUE_TEST_ID",
         title=DEFAULT_NAME,
     )
     config_entry.add_to_hass(hass)
-
-    await hass.async_start()
-    await hass.async_block_till_done()
 
     with patch(
         "homeassistant.components.fastdotcom.coordinator.fast_com", return_value=5.0

--- a/tests/components/fastdotcom/test_init.py
+++ b/tests/components/fastdotcom/test_init.py
@@ -9,6 +9,7 @@ from homeassistant import config_entries
 from homeassistant.components.fastdotcom.const import DEFAULT_NAME, DOMAIN
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import CoreState, HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -72,3 +73,32 @@ async def test_not_start_until_hass_started(
     await hass.async_block_till_done()
 
     assert config_entry.state == config_entries.ConfigEntryState.LOADED
+
+
+async def test_service_deprecated(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
+) -> None:
+    """Test deprecated service."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="UNIQUE_TEST_ID",
+        title=DEFAULT_NAME,
+    )
+    config_entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.fastdotcom.coordinator.fast_com", return_value=5.0
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+    await hass.services.async_call(
+        DOMAIN,
+        "speedtest",
+        {},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    issue = issue_registry.async_get_issue(DOMAIN, "service_deprecation")
+    assert issue
+    assert issue.is_fixable is True
+    assert issue.translation_key == "service_deprecation"

--- a/tests/components/fastdotcom/test_init.py
+++ b/tests/components/fastdotcom/test_init.py
@@ -53,10 +53,10 @@ async def test_from_import(hass: HomeAssistant) -> None:
     assert state.state == "5.0"
 
 
-async def test_not_start_until_hass_started(
+async def test_delayed_speedtest_during_startup(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
-    """Test unload an entry."""
+    """Test delayed speedtest during startup."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="UNIQUE_TEST_ID",

--- a/tests/components/fastdotcom/test_sensor.py
+++ b/tests/components/fastdotcom/test_sensor.py
@@ -1,0 +1,31 @@
+"""Test the FastdotcomDataUpdateCoordindator."""
+from unittest.mock import patch
+
+from freezegun.api import FrozenDateTimeFactory
+
+from homeassistant.components.fastdotcom.const import DEFAULT_NAME, DOMAIN
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_fastdotcom_data_update_coordinator(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
+    """Test the update coordinator."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="UNIQUE_TEST_ID",
+        title=DEFAULT_NAME,
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.fastdotcom.coordinator.fast_com", return_value=5.0
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.fast_com_download")
+    assert state is not None
+    assert state.state == "5.0"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Full coverage for Fast.com
```
---------- coverage: platform linux, python 3.11.4-final-0 -----------
Name                                                 Stmts   Miss  Cover   Missing
----------------------------------------------------------------------------------
homeassistant/components/fastdotcom/__init__.py         36      0   100%
homeassistant/components/fastdotcom/config_flow.py      18      0   100%
homeassistant/components/fastdotcom/const.py             9      0   100%
homeassistant/components/fastdotcom/coordinator.py      14      0   100%
homeassistant/components/fastdotcom/sensor.py           28      0   100%
----------------------------------------------------------------------------------
TOTAL                                                  105      0   100%
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
