### PR TITLE
Add config flow to Folder Watcher

### DIFF
--- a/homeassistant/components/folder_watcher/__init__.py
+++ b/homeassistant/components/folder_watcher/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import cast, Any
+from typing import Any, cast
 
 import voluptuous as vol
 from watchdog.events import (

--- a/homeassistant/components/folder_watcher/__init__.py
+++ b/homeassistant/components/folder_watcher/__init__.py
@@ -96,7 +96,7 @@ def create_event_handler(patterns: list[str], hass: HomeAssistant) -> EventHandl
 
 =======
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up System Monitor from a config entry."""
+    """Set up Folder watcher from a config entry."""
 
     path: str = entry.options[CONF_FOLDER]
     patterns: list[str] = entry.options[CONF_PATTERNS]

--- a/homeassistant/components/folder_watcher/__init__.py
+++ b/homeassistant/components/folder_watcher/__init__.py
@@ -61,11 +61,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 async_create_issue(
                     hass,
                     DOMAIN,
-                    f"not_allowed_path_{path}",
+                    f"import_failed_not_allowed_path_{path}",
                     is_fixable=False,
                     is_persistent=False,
                     severity=IssueSeverity.ERROR,
-                    translation_key="not_allowed_path",
+                    translation_key="import_failed_not_allowed_path",
                     translation_placeholders={"path": path},
                 )
                 continue

--- a/homeassistant/components/folder_watcher/__init__.py
+++ b/homeassistant/components/folder_watcher/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import cast
+from typing import cast, Any
 
 import voluptuous as vol
 from watchdog.events import (
@@ -19,17 +19,17 @@ from watchdog.events import (
 )
 from watchdog.observers import Observer
 
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType
+
+from .const import CONF_FOLDER, CONF_PATTERNS, DEFAULT_PATTERN, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_FOLDER = "folder"
-CONF_PATTERNS = "patterns"
-DEFAULT_PATTERN = "*"
-DOMAIN = "folder_watcher"
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -51,8 +51,9 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-def setup(hass: HomeAssistant, config: ConfigType) -> bool:
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the folder watcher."""
+<<<<<<< HEAD
     conf = config[DOMAIN]
     for watcher in conf:
         path: str = watcher[CONF_FOLDER]
@@ -61,13 +62,109 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
             _LOGGER.error("Folder %s is not valid or allowed", path)
             return False
         Watcher(path, patterns, hass)
+=======
+    if DOMAIN in config:
+        conf: list[dict[str, Any]] = config[DOMAIN]
+        for watcher in conf:
+            path: str = watcher[CONF_FOLDER]
+            if not hass.config.is_allowed_path(path):
+                async_create_issue(
+                    hass,
+                    DOMAIN,
+                    f"not_allowed_path_{path}",
+                    breaks_in_ha_version="2024.7.0",
+                    is_fixable=False,
+                    is_persistent=False,
+                    severity=IssueSeverity.WARNING,
+                    translation_key="not_allowed_path",
+                    translation_placeholders={"path": path},
+                )
+                continue
+            hass.async_create_task(
+                hass.config_entries.flow.async_init(
+                    DOMAIN, context={"source": SOURCE_IMPORT}, data=watcher
+                )
+            )
+>>>>>>> 70e3ed1a41 (Add config flow to Folder Watcher)
 
     return True
 
 
+<<<<<<< HEAD
 def create_event_handler(patterns: list[str], hass: HomeAssistant) -> EventHandler:
     """Return the Watchdog EventHandler object."""
 
+=======
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up System Monitor from a config entry."""
+
+    path: str = entry.options[CONF_FOLDER]
+    patterns: list[str] = entry.options[CONF_PATTERNS]
+    if not hass.config.is_allowed_path(path):
+        _LOGGER.error("Folder %s is not valid or allowed", path)
+        return False
+    Watcher(path, patterns, hass)
+    return True
+
+
+def create_event_handler(patterns: list[str], hass: HomeAssistant):
+    """Return the Watchdog EventHandler object."""
+
+    class EventHandler(PatternMatchingEventHandler):
+        """Class for handling Watcher events."""
+
+        def __init__(self, patterns: list[str], hass: HomeAssistant) -> None:
+            """Initialise the EventHandler."""
+            super().__init__(patterns)
+            self.hass = hass
+
+        def process(self, event: FileSystemMovedEvent, moved: bool = False) -> None:
+            """On Watcher event, fire HA event."""
+            _LOGGER.debug("process(%s)", event)
+            if not event.is_directory:
+                folder, file_name = os.path.split(event.src_path)
+                fireable = {
+                    "event_type": event.event_type,
+                    "path": event.src_path,
+                    "file": file_name,
+                    "folder": folder,
+                }
+
+                if moved:
+                    dest_folder, dest_file_name = os.path.split(event.dest_path)
+                    fireable.update(
+                        {
+                            "dest_path": event.dest_path,
+                            "dest_file": dest_file_name,
+                            "dest_folder": dest_folder,
+                        }
+                    )
+                self.hass.bus.fire(
+                    DOMAIN,
+                    fireable,
+                )
+
+        def on_modified(self, event: FileSystemMovedEvent) -> None:
+            """File modified."""
+            self.process(event)
+
+        def on_moved(self, event: FileSystemMovedEvent) -> None:
+            """File moved."""
+            self.process(event, moved=True)
+
+        def on_created(self, event: FileSystemMovedEvent) -> None:
+            """File created."""
+            self.process(event)
+
+        def on_deleted(self, event: FileSystemMovedEvent) -> None:
+            """File deleted."""
+            self.process(event)
+
+        def on_closed(self, event: FileSystemMovedEvent) -> None:
+            """File closed."""
+            self.process(event)
+
+>>>>>>> 70e3ed1a41 (Add config flow to Folder Watcher)
     return EventHandler(patterns, hass)
 
 
@@ -132,13 +229,25 @@ class Watcher:
 
     def __init__(self, path: str, patterns: list[str], hass: HomeAssistant) -> None:
         """Initialise the watchdog observer."""
+        self.hass = hass
         self._observer = Observer()
         self._observer.schedule(
             create_event_handler(patterns, hass), path, recursive=True
         )
-        hass.bus.listen_once(EVENT_HOMEASSISTANT_START, self.startup)
-        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, self.shutdown)
+        hass.bus.listen_once(EVENT_HOMEASSISTANT_START, self.async_startup)
+        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, self.async_shutdown)
 
+<<<<<<< HEAD
+=======
+    async def async_startup(self, event: Event) -> None:
+        """Start the watcher."""
+        self.hass.async_add_executor_job(self.startup)
+
+    async def async_shutdown(self, event: Event) -> None:
+        """Shutdown the watcher."""
+        self.hass.async_add_executor_job(self.shutdown)
+
+>>>>>>> 70e3ed1a41 (Add config flow to Folder Watcher)
     def startup(self, event: Event) -> None:
         """Start the watcher."""
         self._observer.start()

--- a/homeassistant/components/folder_watcher/__init__.py
+++ b/homeassistant/components/folder_watcher/__init__.py
@@ -66,7 +66,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                     is_persistent=False,
                     severity=IssueSeverity.ERROR,
                     translation_key="import_failed_not_allowed_path",
-                    translation_placeholders={"path": path},
+                    translation_placeholders={
+                        "path": path,
+                        "config_variable": "allowlist_external_dirs",
+                    },
                 )
                 continue
             hass.async_create_task(
@@ -93,7 +96,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             is_persistent=False,
             severity=IssueSeverity.ERROR,
             translation_key="setup_not_allowed_path",
-            translation_placeholders={"path": path},
+            translation_placeholders={
+                "path": path,
+                "config_variable": "allowlist_external_dirs",
+            },
             learn_more_url="https://www.home-assistant.io/docs/configuration/basic/#allowlist_external_dirs",
         )
         return False

--- a/homeassistant/components/folder_watcher/__init__.py
+++ b/homeassistant/components/folder_watcher/__init__.py
@@ -53,16 +53,6 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the folder watcher."""
-<<<<<<< HEAD
-    conf = config[DOMAIN]
-    for watcher in conf:
-        path: str = watcher[CONF_FOLDER]
-        patterns: list[str] = watcher[CONF_PATTERNS]
-        if not hass.config.is_allowed_path(path):
-            _LOGGER.error("Folder %s is not valid or allowed", path)
-            return False
-        Watcher(path, patterns, hass)
-=======
     if DOMAIN in config:
         conf: list[dict[str, Any]] = config[DOMAIN]
         for watcher in conf:
@@ -85,16 +75,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                     DOMAIN, context={"source": SOURCE_IMPORT}, data=watcher
                 )
             )
->>>>>>> 70e3ed1a41 (Add config flow to Folder Watcher)
 
     return True
 
 
-<<<<<<< HEAD
-def create_event_handler(patterns: list[str], hass: HomeAssistant) -> EventHandler:
-    """Return the Watchdog EventHandler object."""
-
-=======
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Folder watcher from a config entry."""
 
@@ -103,68 +87,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not hass.config.is_allowed_path(path):
         _LOGGER.error("Folder %s is not valid or allowed", path)
         return False
-    Watcher(path, patterns, hass)
+    await hass.async_add_executor_job(Watcher, path, patterns, hass)
     return True
 
 
-def create_event_handler(patterns: list[str], hass: HomeAssistant):
+def create_event_handler(patterns: list[str], hass: HomeAssistant) -> EventHandler:
     """Return the Watchdog EventHandler object."""
 
-    class EventHandler(PatternMatchingEventHandler):
-        """Class for handling Watcher events."""
-
-        def __init__(self, patterns: list[str], hass: HomeAssistant) -> None:
-            """Initialise the EventHandler."""
-            super().__init__(patterns)
-            self.hass = hass
-
-        def process(self, event: FileSystemMovedEvent, moved: bool = False) -> None:
-            """On Watcher event, fire HA event."""
-            _LOGGER.debug("process(%s)", event)
-            if not event.is_directory:
-                folder, file_name = os.path.split(event.src_path)
-                fireable = {
-                    "event_type": event.event_type,
-                    "path": event.src_path,
-                    "file": file_name,
-                    "folder": folder,
-                }
-
-                if moved:
-                    dest_folder, dest_file_name = os.path.split(event.dest_path)
-                    fireable.update(
-                        {
-                            "dest_path": event.dest_path,
-                            "dest_file": dest_file_name,
-                            "dest_folder": dest_folder,
-                        }
-                    )
-                self.hass.bus.fire(
-                    DOMAIN,
-                    fireable,
-                )
-
-        def on_modified(self, event: FileSystemMovedEvent) -> None:
-            """File modified."""
-            self.process(event)
-
-        def on_moved(self, event: FileSystemMovedEvent) -> None:
-            """File moved."""
-            self.process(event, moved=True)
-
-        def on_created(self, event: FileSystemMovedEvent) -> None:
-            """File created."""
-            self.process(event)
-
-        def on_deleted(self, event: FileSystemMovedEvent) -> None:
-            """File deleted."""
-            self.process(event)
-
-        def on_closed(self, event: FileSystemMovedEvent) -> None:
-            """File closed."""
-            self.process(event)
-
->>>>>>> 70e3ed1a41 (Add config flow to Folder Watcher)
     return EventHandler(patterns, hass)
 
 
@@ -229,25 +158,13 @@ class Watcher:
 
     def __init__(self, path: str, patterns: list[str], hass: HomeAssistant) -> None:
         """Initialise the watchdog observer."""
-        self.hass = hass
         self._observer = Observer()
         self._observer.schedule(
             create_event_handler(patterns, hass), path, recursive=True
         )
-        hass.bus.listen_once(EVENT_HOMEASSISTANT_START, self.async_startup)
-        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, self.async_shutdown)
+        hass.bus.listen_once(EVENT_HOMEASSISTANT_START, self.startup)
+        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, self.shutdown)
 
-<<<<<<< HEAD
-=======
-    async def async_startup(self, event: Event) -> None:
-        """Start the watcher."""
-        self.hass.async_add_executor_job(self.startup)
-
-    async def async_shutdown(self, event: Event) -> None:
-        """Shutdown the watcher."""
-        self.hass.async_add_executor_job(self.shutdown)
-
->>>>>>> 70e3ed1a41 (Add config flow to Folder Watcher)
     def startup(self, event: Event) -> None:
         """Start the watcher."""
         self._observer.start()

--- a/homeassistant/components/folder_watcher/__init__.py
+++ b/homeassistant/components/folder_watcher/__init__.py
@@ -62,10 +62,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                     hass,
                     DOMAIN,
                     f"not_allowed_path_{path}",
-                    breaks_in_ha_version="2024.7.0",
                     is_fixable=False,
                     is_persistent=False,
-                    severity=IssueSeverity.WARNING,
+                    severity=IssueSeverity.ERROR,
                     translation_key="not_allowed_path",
                     translation_placeholders={"path": path},
                 )
@@ -86,6 +85,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     patterns: list[str] = entry.options[CONF_PATTERNS]
     if not hass.config.is_allowed_path(path):
         _LOGGER.error("Folder %s is not valid or allowed", path)
+        async_create_issue(
+            hass,
+            DOMAIN,
+            f"setup_not_allowed_path_{path}",
+            is_fixable=False,
+            is_persistent=False,
+            severity=IssueSeverity.ERROR,
+            translation_key="setup_not_allowed_path",
+            translation_placeholders={"path": path},
+            learn_more_url="https://www.home-assistant.io/docs/configuration/basic/#allowlist_external_dirs",
+        )
         return False
     await hass.async_add_executor_job(Watcher, path, patterns, hass)
     return True

--- a/homeassistant/components/folder_watcher/config_flow.py
+++ b/homeassistant/components/folder_watcher/config_flow.py
@@ -1,0 +1,111 @@
+"""Adds config flow for System Monitor."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+import os
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.homeassistant import DOMAIN as HOMEASSISTANT_DOMAIN
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
+from homeassistant.helpers.schema_config_entry_flow import (
+    SchemaCommonFlowHandler,
+    SchemaConfigFlowHandler,
+    SchemaFlowError,
+    SchemaFlowFormStep,
+)
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+    TextSelector,
+)
+
+from .const import CONF_FOLDER, CONF_PATTERNS, DEFAULT_PATTERN, DOMAIN
+
+
+async def validate_setup(
+    handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
+) -> dict[str, Any]:
+    """Check path is a folder."""
+    value: str = user_input[CONF_FOLDER]
+    dir_in = os.path.expanduser(str(value))
+
+    if not os.path.isdir(dir_in):
+        raise SchemaFlowError("not_dir")
+    if not os.access(dir_in, os.R_OK):
+        raise SchemaFlowError("not_readable_dir")
+    if not handler.parent_handler.hass.config.is_allowed_path(value):
+        raise SchemaFlowError("not_allowed_dir")
+    return user_input
+
+
+async def validate_import_setup(
+    handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
+) -> dict[str, Any]:
+    """Create issue on successful import."""
+    async_create_issue(
+        handler.parent_handler.hass,
+        HOMEASSISTANT_DOMAIN,
+        f"deprecated_yaml_{DOMAIN}",
+        breaks_in_ha_version="2024.7.0",
+        is_fixable=False,
+        is_persistent=False,
+        issue_domain=DOMAIN,
+        severity=IssueSeverity.WARNING,
+        translation_key="deprecated_yaml",
+        translation_placeholders={
+            "domain": DOMAIN,
+            "integration_title": "Folder Watcher",
+        },
+    )
+    return user_input
+
+
+OPTIONS_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_PATTERNS, default=[DEFAULT_PATTERN]): SelectSelector(
+            SelectSelectorConfig(
+                options=[DEFAULT_PATTERN],
+                multiple=True,
+                custom_value=True,
+                mode=SelectSelectorMode.DROPDOWN,
+            )
+        ),
+    }
+)
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_FOLDER): TextSelector(),
+    }
+).extend(OPTIONS_SCHEMA.schema)
+
+CONFIG_FLOW = {
+    "user": SchemaFlowFormStep(schema=DATA_SCHEMA, validate_user_input=validate_setup),
+    "import": SchemaFlowFormStep(
+        schema=DATA_SCHEMA, validate_user_input=validate_import_setup
+    ),
+}
+OPTIONS_FLOW = {
+    "init": SchemaFlowFormStep(schema=OPTIONS_SCHEMA),
+}
+
+
+class FolderWatcherConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
+    """Handle a config flow for Folder Watcher."""
+
+    config_flow = CONFIG_FLOW
+    options_flow = OPTIONS_FLOW
+
+    def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
+        """Return config entry title."""
+        return f"Folder Watcher {options[CONF_FOLDER]}"
+
+    @callback
+    def async_create_entry(self, data: Mapping[str, Any], **kwargs: Any) -> FlowResult:
+        """Finish config flow and create a config entry."""
+        self._async_abort_entries_match({CONF_FOLDER: data[CONF_FOLDER]})
+        return super().async_create_entry(data, **kwargs)

--- a/homeassistant/components/folder_watcher/config_flow.py
+++ b/homeassistant/components/folder_watcher/config_flow.py
@@ -1,4 +1,4 @@
-"""Adds config flow for System Monitor."""
+"""Adds config flow for Folder watcher."""
 from __future__ import annotations
 
 from collections.abc import Mapping

--- a/homeassistant/components/folder_watcher/config_flow.py
+++ b/homeassistant/components/folder_watcher/config_flow.py
@@ -33,6 +33,7 @@ async def validate_setup(
     """Check path is a folder."""
     value: str = user_input[CONF_FOLDER]
     dir_in = os.path.expanduser(str(value))
+    handler.parent_handler._async_abort_entries_match({CONF_FOLDER: value})  # pylint: disable=protected-access
 
     if not os.path.isdir(dir_in):
         raise SchemaFlowError("not_dir")
@@ -40,6 +41,7 @@ async def validate_setup(
         raise SchemaFlowError("not_readable_dir")
     if not handler.parent_handler.hass.config.is_allowed_path(value):
         raise SchemaFlowError("not_allowed_dir")
+
     return user_input
 
 

--- a/homeassistant/components/folder_watcher/config_flow.py
+++ b/homeassistant/components/folder_watcher/config_flow.py
@@ -1,4 +1,5 @@
 """Adds config flow for Folder watcher."""
+
 from __future__ import annotations
 
 from collections.abc import Mapping
@@ -53,7 +54,7 @@ async def validate_import_setup(
         handler.parent_handler.hass,
         HOMEASSISTANT_DOMAIN,
         f"deprecated_yaml_{DOMAIN}",
-        breaks_in_ha_version="2024.7.0",
+        breaks_in_ha_version="2024.11.0",
         is_fixable=False,
         is_persistent=False,
         issue_domain=DOMAIN,

--- a/homeassistant/components/folder_watcher/config_flow.py
+++ b/homeassistant/components/folder_watcher/config_flow.py
@@ -8,8 +8,8 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.components.homeassistant import DOMAIN as HOMEASSISTANT_DOMAIN
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.schema_config_entry_flow import (
     SchemaCommonFlowHandler,
@@ -107,7 +107,9 @@ class FolderWatcherConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
         return f"Folder Watcher {options[CONF_FOLDER]}"
 
     @callback
-    def async_create_entry(self, data: Mapping[str, Any], **kwargs: Any) -> FlowResult:
+    def async_create_entry(
+        self, data: Mapping[str, Any], **kwargs: Any
+    ) -> ConfigFlowResult:
         """Finish config flow and create a config entry."""
         self._async_abort_entries_match({CONF_FOLDER: data[CONF_FOLDER]})
         return super().async_create_entry(data, **kwargs)

--- a/homeassistant/components/folder_watcher/const.py
+++ b/homeassistant/components/folder_watcher/const.py
@@ -1,4 +1,4 @@
-"""Constants for System Monitor."""
+"""Constants for Folder watcher."""
 
 CONF_FOLDER = "folder"
 CONF_PATTERNS = "patterns"

--- a/homeassistant/components/folder_watcher/const.py
+++ b/homeassistant/components/folder_watcher/const.py
@@ -1,0 +1,6 @@
+"""Constants for System Monitor."""
+
+CONF_FOLDER = "folder"
+CONF_PATTERNS = "patterns"
+DEFAULT_PATTERN = "*"
+DOMAIN = "folder_watcher"

--- a/homeassistant/components/folder_watcher/manifest.json
+++ b/homeassistant/components/folder_watcher/manifest.json
@@ -2,6 +2,7 @@
   "domain": "folder_watcher",
   "name": "Folder Watcher",
   "codeowners": [],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/folder_watcher",
   "iot_class": "local_polling",
   "loggers": ["watchdog"],

--- a/homeassistant/components/folder_watcher/strings.json
+++ b/homeassistant/components/folder_watcher/strings.json
@@ -10,7 +10,15 @@
     },
     "step": {
       "user": {
-        "description": "Press submit for initial setup. On the created config entry, press configure to add sensors for selected processes"
+        "description": "Press submit for initial setup. On the created config entry, press configure to add sensors for selected processes",
+        "data": {
+          "folder": "Path to the watched folder",
+          "patterns": "Pattern(s) to monitor"
+        },
+        "data_description": {
+          "folder": "Path needs to be from root, as example `/config`",
+          "patterns": "Example is `*.yaml` to only see yaml files"
+        }
       }
     }
   },

--- a/homeassistant/components/folder_watcher/strings.json
+++ b/homeassistant/components/folder_watcher/strings.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
+    },
+    "error": {
+      "not_dir": "Configured path is not a directory",
+      "not_readable_dir": "Configured path is not readable",
+      "not_allowed_dir": "Configured path is not in allowlist"
+    },
+    "step": {
+      "user": {
+        "description": "Press submit for initial setup. On the created config entry, press configure to add sensors for selected processes"
+      }
+    }
+  },
+  "issues": {
+    "not_allowed_path": {
+      "title": "The Folder Watcher YAML configuration could not be imported",
+      "description": "Configuring Folder Watcher using YAML is being removed but your configuration\ncould not be imported as the folder {path} is not in the configured allowlist.\n\nPlease add it to your allowlist and restart Home Assistant to import it and fix this issue."
+    }
+  }
+}

--- a/homeassistant/components/folder_watcher/strings.json
+++ b/homeassistant/components/folder_watcher/strings.json
@@ -10,14 +10,25 @@
     },
     "step": {
       "user": {
-        "description": "Press submit for initial setup. On the created config entry, press configure to add sensors for selected processes",
         "data": {
           "folder": "Path to the watched folder",
           "patterns": "Pattern(s) to monitor"
         },
         "data_description": {
           "folder": "Path needs to be from root, as example `/config`",
-          "patterns": "Example is `*.yaml` to only see yaml files"
+          "patterns": "Example: `*.yaml` to only see yaml files"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "patterns": "[%key:component::folder_watcher::config::step::user::data::patterns%]"
+        },
+        "data_description": {
+          "patterns": "[%key:component::folder_watcher::config::step::user::data_description::patterns%]"
         }
       }
     }

--- a/homeassistant/components/folder_watcher/strings.json
+++ b/homeassistant/components/folder_watcher/strings.json
@@ -36,11 +36,11 @@
   "issues": {
     "import_failed_not_allowed_path": {
       "title": "The Folder Watcher YAML configuration could not be imported",
-      "description": "Configuring Folder Watcher using YAML is being removed but your configuration could not be imported as the folder {path} is not in the configured allowlist.\n\nPlease add it to `allowlist_external_dirs` in config.yaml and restart Home Assistant to import it and fix this issue."
+      "description": "Configuring Folder Watcher using YAML is being removed but your configuration could not be imported as the folder {path} is not in the configured allowlist.\n\nPlease add it to `{config_variable}` in config.yaml and restart Home Assistant to import it and fix this issue."
     },
     "setup_not_allowed_path": {
       "title": "The Folder Watcher configuration for {path} could not start",
-      "description": "The path {path} is not accessible or not allowed to be accessed.\n\nPlease check the path is accessible and add it to `allowlist_external_dirs` in config.yaml and restart Home Assistant to fix this issue."
+      "description": "The path {path} is not accessible or not allowed to be accessed.\n\nPlease check the path is accessible and add it to `{config_variable}` in config.yaml and restart Home Assistant to fix this issue."
     }
   }
 }

--- a/homeassistant/components/folder_watcher/strings.json
+++ b/homeassistant/components/folder_watcher/strings.json
@@ -34,13 +34,13 @@
     }
   },
   "issues": {
-    "not_allowed_path": {
+    "import_failed_not_allowed_path": {
       "title": "The Folder Watcher YAML configuration could not be imported",
-      "description": "Configuring Folder Watcher using YAML is being removed but your configuration\ncould not be imported as the folder {path} is not in the configured allowlist.\n\nPlease add it to your allowlist and restart Home Assistant to import it and fix this issue."
+      "description": "Configuring Folder Watcher using YAML is being removed but your configuration could not be imported as the folder {path} is not in the configured allowlist.\n\nPlease add it to `allowlist_external_dirs` in config.yaml and restart Home Assistant to import it and fix this issue."
     },
     "setup_not_allowed_path": {
       "title": "The Folder Watcher configuration for {path} could not start",
-      "description": "The path {path} is not accessible or not allowed to be accessed.\n\nPlease check the path is accessible and add it to your allowlist and restart Home Assistant to fix this issue."
+      "description": "The path {path} is not accessible or not allowed to be accessed.\n\nPlease check the path is accessible and add it to `allowlist_external_dirs` in config.yaml and restart Home Assistant to fix this issue."
     }
   }
 }

--- a/homeassistant/components/folder_watcher/strings.json
+++ b/homeassistant/components/folder_watcher/strings.json
@@ -37,6 +37,10 @@
     "not_allowed_path": {
       "title": "The Folder Watcher YAML configuration could not be imported",
       "description": "Configuring Folder Watcher using YAML is being removed but your configuration\ncould not be imported as the folder {path} is not in the configured allowlist.\n\nPlease add it to your allowlist and restart Home Assistant to import it and fix this issue."
+    },
+    "setup_not_allowed_path": {
+      "title": "The Folder Watcher configuration for {path} could not start",
+      "description": "The path {path} is not accessible or not allowed to be accessed.\n\nPlease check the path is accessible and add it to your allowlist and restart Home Assistant to fix this issue."
     }
   }
 }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -175,6 +175,7 @@ FLOWS = {
         "flo",
         "flume",
         "flux_led",
+        "folder_watcher",
         "forecast_solar",
         "forked_daapd",
         "foscam",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -1956,7 +1956,7 @@
     "folder_watcher": {
       "name": "Folder Watcher",
       "integration_type": "hub",
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "local_polling"
     },
     "foobot": {

--- a/tests/components/folder_watcher/conftest.py
+++ b/tests/components/folder_watcher/conftest.py
@@ -1,0 +1,16 @@
+"""Fixtures for Folder Watcher integration tests."""
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[None, None, None]:
+    """Mock setting up a config entry."""
+    with patch(
+        "homeassistant.components.folder_watcher.async_setup_entry", return_value=True
+    ):
+        yield

--- a/tests/components/folder_watcher/conftest.py
+++ b/tests/components/folder_watcher/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Folder Watcher integration tests."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/components/folder_watcher/test_config_flow.py
+++ b/tests/components/folder_watcher/test_config_flow.py
@@ -1,0 +1,185 @@
+"""Test the Folder Watcher config flow."""
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.folder_watcher.const import (
+    CONF_FOLDER,
+    CONF_PATTERNS,
+    DOMAIN,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+pytestmark = pytest.mark.usefixtures("mock_setup_entry")
+
+
+async def test_form(hass: HomeAssistant, tmp_path: Path) -> None:
+    """Test we get the form."""
+    path = tmp_path.as_posix()
+    hass.config.allowlist_external_dirs = {path}
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_FOLDER: path},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == f"Folder Watcher {path}"
+    assert result["options"] == {CONF_FOLDER: path, CONF_PATTERNS: ["*"]}
+
+
+async def test_form_not_allowed_path(hass: HomeAssistant, tmp_path: Path) -> None:
+    """Test we handle not allowed path."""
+    path = tmp_path.as_posix()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_FOLDER: path},
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "not_allowed_dir"}
+
+    hass.config.allowlist_external_dirs = {tmp_path}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_FOLDER: path},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == f"Folder Watcher {path}"
+    assert result["options"] == {CONF_FOLDER: path, CONF_PATTERNS: ["*"]}
+
+
+async def test_form_not_directory(hass: HomeAssistant, tmp_path: Path) -> None:
+    """Test we handle not a directory."""
+    path = tmp_path.as_posix()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_FOLDER: "not_a_directory"},
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "not_dir"}
+
+    hass.config.allowlist_external_dirs = {path}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_FOLDER: path},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == f"Folder Watcher {path}"
+    assert result["options"] == {CONF_FOLDER: path, CONF_PATTERNS: ["*"]}
+
+
+async def test_form_not_readable_dir(hass: HomeAssistant, tmp_path: Path) -> None:
+    """Test we handle not able to read directory."""
+    path = tmp_path.as_posix()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch("os.access", return_value=False):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_FOLDER: path},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "not_readable_dir"}
+
+    hass.config.allowlist_external_dirs = {path}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_FOLDER: path},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == f"Folder Watcher {path}"
+    assert result["options"] == {CONF_FOLDER: path, CONF_PATTERNS: ["*"]}
+
+
+async def test_form_already_configured(hass: HomeAssistant, tmp_path: Path) -> None:
+    """Test we abort when entry is already configured."""
+    path = tmp_path.as_posix()
+    hass.config.allowlist_external_dirs = {path}
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=f"Folder Watcher {path}",
+        data={CONF_FOLDER: path},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_FOLDER: path},
+    )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_import(hass: HomeAssistant, tmp_path: Path) -> None:
+    """Test import flow."""
+    path = tmp_path.as_posix()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_IMPORT},
+        data={CONF_FOLDER: path, CONF_PATTERNS: ["*"]},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == f"Folder Watcher {path}"
+    assert result["options"] == {CONF_FOLDER: path, CONF_PATTERNS: ["*"]}
+
+
+async def test_import_already_configured(hass: HomeAssistant, tmp_path: Path) -> None:
+    """Test we abort import when entry is already configured."""
+    path = tmp_path.as_posix()
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=f"Folder Watcher {path}",
+        data={CONF_FOLDER: path},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_IMPORT},
+        data={CONF_FOLDER: path},
+    )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/components/folder_watcher/test_config_flow.py
+++ b/tests/components/folder_watcher/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Folder Watcher config flow."""
+
 from pathlib import Path
 from unittest.mock import patch
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Folder Watcher is now configured via config entry and your configuration has been imported automatically

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30321

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
