### PR TITLE
Rename "satellite enabled" to "mute"

### DIFF
--- a/homeassistant/components/wyoming/devices.py
+++ b/homeassistant/components/wyoming/devices.py
@@ -17,14 +17,14 @@ class SatelliteDevice:
     satellite_id: str
     device_id: str
     is_active: bool = False
-    is_enabled: bool = True
+    is_muted: bool = False
     pipeline_name: str | None = None
     noise_suppression_level: int = 0
     auto_gain: int = 0
     volume_multiplier: float = 1.0
 
     _is_active_listener: Callable[[], None] | None = None
-    _is_enabled_listener: Callable[[], None] | None = None
+    _is_muted_listener: Callable[[], None] | None = None
     _pipeline_listener: Callable[[], None] | None = None
     _audio_settings_listener: Callable[[], None] | None = None
 
@@ -37,12 +37,12 @@ class SatelliteDevice:
                 self._is_active_listener()
 
     @callback
-    def set_is_enabled(self, enabled: bool) -> None:
-        """Set enabled state."""
-        if enabled != self.is_enabled:
-            self.is_enabled = enabled
-            if self._is_enabled_listener is not None:
-                self._is_enabled_listener()
+    def set_is_muted(self, muted: bool) -> None:
+        """Set muted state."""
+        if muted != self.is_muted:
+            self.is_muted = muted
+            if self._is_muted_listener is not None:
+                self._is_muted_listener()
 
     @callback
     def set_pipeline_name(self, pipeline_name: str) -> None:
@@ -82,9 +82,9 @@ class SatelliteDevice:
         self._is_active_listener = is_active_listener
 
     @callback
-    def set_is_enabled_listener(self, is_enabled_listener: Callable[[], None]) -> None:
-        """Listen for updates to is_enabled."""
-        self._is_enabled_listener = is_enabled_listener
+    def set_is_muted_listener(self, is_muted_listener: Callable[[], None]) -> None:
+        """Listen for updates to muted status."""
+        self._is_muted_listener = is_muted_listener
 
     @callback
     def set_pipeline_listener(self, pipeline_listener: Callable[[], None]) -> None:
@@ -105,11 +105,11 @@ class SatelliteDevice:
             "binary_sensor", DOMAIN, f"{self.satellite_id}-assist_in_progress"
         )
 
-    def get_satellite_enabled_entity_id(self, hass: HomeAssistant) -> str | None:
-        """Return entity id for satellite enabled switch."""
+    def get_satellite_is_muted_entity_id(self, hass: HomeAssistant) -> str | None:
+        """Return entity id for satellite muted switch."""
         ent_reg = er.async_get(hass)
         return ent_reg.async_get_entity_id(
-            "switch", DOMAIN, f"{self.satellite_id}-satellite_enabled"
+            "switch", DOMAIN, f"{self.satellite_id}-satellite_muted"
         )
 
     def get_pipeline_entity_id(self, hass: HomeAssistant) -> str | None:

--- a/homeassistant/components/wyoming/devices.py
+++ b/homeassistant/components/wyoming/devices.py
@@ -105,11 +105,11 @@ class SatelliteDevice:
             "binary_sensor", DOMAIN, f"{self.satellite_id}-assist_in_progress"
         )
 
-    def get_satellite_is_muted_entity_id(self, hass: HomeAssistant) -> str | None:
+    def get_muted_entity_id(self, hass: HomeAssistant) -> str | None:
         """Return entity id for satellite muted switch."""
         ent_reg = er.async_get(hass)
         return ent_reg.async_get_entity_id(
-            "switch", DOMAIN, f"{self.satellite_id}-satellite_muted"
+            "switch", DOMAIN, f"{self.satellite_id}-mute"
         )
 
     def get_pipeline_entity_id(self, hass: HomeAssistant) -> str | None:

--- a/homeassistant/components/wyoming/satellite.py
+++ b/homeassistant/components/wyoming/satellite.py
@@ -49,7 +49,6 @@ class WyomingSatellite:
         self.hass = hass
         self.service = service
         self.device = device
-        self.is_enabled = True
         self.is_running = True
 
         self._client: AsyncTcpClient | None = None
@@ -57,9 +56,9 @@ class WyomingSatellite:
         self._is_pipeline_running = False
         self._audio_queue: asyncio.Queue[bytes | None] = asyncio.Queue()
         self._pipeline_id: str | None = None
-        self._enabled_changed_event = asyncio.Event()
+        self._muted_changed_event = asyncio.Event()
 
-        self.device.set_is_enabled_listener(self._enabled_changed)
+        self.device.set_is_muted_listener(self._muted_changed)
         self.device.set_pipeline_listener(self._pipeline_changed)
         self.device.set_audio_settings_listener(self._audio_settings_changed)
 
@@ -70,11 +69,11 @@ class WyomingSatellite:
         try:
             while self.is_running:
                 try:
-                    # Check if satellite has been disabled
-                    while not self.device.is_enabled:
-                        await self.on_disabled()
+                    # Check if satellite has been muted
+                    while self.device.is_muted:
+                        await self.on_muted()
                         if not self.is_running:
-                            # Satellite was stopped while waiting to be enabled
+                            # Satellite was stopped while waiting to be unmuted
                             return
 
                     # Connect and run pipeline loop
@@ -93,8 +92,8 @@ class WyomingSatellite:
         """Signal satellite task to stop running."""
         self.is_running = False
 
-        # Unblock waiting for enabled
-        self._enabled_changed_event.set()
+        # Unblock waiting for unmuted
+        self._muted_changed_event.set()
 
     async def on_restart(self) -> None:
         """Block until pipeline loop will be restarted."""
@@ -112,9 +111,9 @@ class WyomingSatellite:
         )
         await asyncio.sleep(_RECONNECT_SECONDS)
 
-    async def on_disabled(self) -> None:
-        """Block until device may be enabled again."""
-        await self._enabled_changed_event.wait()
+    async def on_muted(self) -> None:
+        """Block until device may be unmated again."""
+        await self._muted_changed_event.wait()
 
     async def on_stopped(self) -> None:
         """Run when run() has fully stopped."""
@@ -122,15 +121,14 @@ class WyomingSatellite:
 
     # -------------------------------------------------------------------------
 
-    def _enabled_changed(self) -> None:
-        """Run when device enabled status changes."""
-
-        if not self.device.is_enabled:
+    def _muted_changed(self) -> None:
+        """Run when device muted status changes."""
+        if self.device.is_muted:
             # Cancel any running pipeline
             self._audio_queue.put_nowait(None)
 
-        self._enabled_changed_event.set()
-        self._enabled_changed_event.clear()
+        self._muted_changed_event.set()
+        self._muted_changed_event.clear()
 
     def _pipeline_changed(self) -> None:
         """Run when device pipeline changes."""
@@ -148,7 +146,7 @@ class WyomingSatellite:
         """Run pipelines until an error occurs."""
         self.device.set_is_active(False)
 
-        while self.is_running and self.is_enabled:
+        while self.is_running and (not self.device.is_muted):
             try:
                 await self._connect()
                 break
@@ -158,7 +156,7 @@ class WyomingSatellite:
         assert self._client is not None
         _LOGGER.debug("Connected to satellite")
 
-        if (not self.is_running) or (not self.is_enabled):
+        if (not self.is_running) or self.device.is_muted:
             # Run was cancelled or satellite was disabled during connection
             return
 
@@ -167,7 +165,7 @@ class WyomingSatellite:
 
         # Wait until we get RunPipeline event
         run_pipeline: RunPipeline | None = None
-        while self.is_running and self.is_enabled:
+        while self.is_running and (not self.device.is_muted):
             run_event = await self._client.read_event()
             if run_event is None:
                 raise ConnectionResetError("Satellite disconnected")
@@ -181,7 +179,7 @@ class WyomingSatellite:
         assert run_pipeline is not None
         _LOGGER.debug("Received run information: %s", run_pipeline)
 
-        if (not self.is_running) or (not self.is_enabled):
+        if (not self.is_running) or self.device.is_muted:
             # Run was cancelled or satellite was disabled while waiting for
             # RunPipeline event.
             return
@@ -196,7 +194,7 @@ class WyomingSatellite:
             raise ValueError(f"Invalid end stage: {end_stage}")
 
         # Each loop is a pipeline run
-        while self.is_running and self.is_enabled:
+        while self.is_running and (not self.device.is_muted):
             # Use select to get pipeline each time in case it's changed
             pipeline_id = pipeline_select.get_chosen_pipeline(
                 self.hass,

--- a/homeassistant/components/wyoming/strings.json
+++ b/homeassistant/components/wyoming/strings.json
@@ -49,8 +49,8 @@
       }
     },
     "switch": {
-      "satellite_enabled": {
-        "name": "Satellite enabled"
+      "mute": {
+        "name": "Mute"
       }
     },
     "number": {

--- a/homeassistant/components/wyoming/switch.py
+++ b/homeassistant/components/wyoming/switch.py
@@ -29,17 +29,17 @@ async def async_setup_entry(
     # Setup is only forwarded for satellites
     assert item.satellite is not None
 
-    async_add_entities([WyomingSatelliteEnabledSwitch(item.satellite.device)])
+    async_add_entities([WyomingSatelliteMuteSwitch(item.satellite.device)])
 
 
-class WyomingSatelliteEnabledSwitch(
+class WyomingSatelliteMuteSwitch(
     WyomingSatelliteEntity, restore_state.RestoreEntity, SwitchEntity
 ):
-    """Entity to represent if satellite is enabled."""
+    """Entity to represent if satellite is muted."""
 
     entity_description = SwitchEntityDescription(
-        key="satellite_enabled",
-        translation_key="satellite_enabled",
+        key="mute",
+        translation_key="mute",
         entity_category=EntityCategory.CONFIG,
     )
 
@@ -49,17 +49,17 @@ class WyomingSatelliteEnabledSwitch(
 
         state = await self.async_get_last_state()
 
-        # Default to on
-        self._attr_is_on = (state is None) or (state.state == STATE_ON)
+        # Default to off
+        self._attr_is_on = (state is not None) and (state.state == STATE_ON)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on."""
         self._attr_is_on = True
         self.async_write_ha_state()
-        self._device.set_is_enabled(True)
+        self._device.set_is_muted(True)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off."""
         self._attr_is_on = False
         self.async_write_ha_state()
-        self._device.set_is_enabled(False)
+        self._device.set_is_muted(False)

--- a/tests/components/wyoming/test_devices.py
+++ b/tests/components/wyoming/test_devices.py
@@ -5,7 +5,7 @@ from homeassistant.components.assist_pipeline.select import OPTION_PREFERRED
 from homeassistant.components.wyoming import DOMAIN
 from homeassistant.components.wyoming.devices import SatelliteDevice
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.const import STATE_OFF
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
@@ -34,11 +34,11 @@ async def test_device_registry_info(
     assert assist_in_progress_state is not None
     assert assist_in_progress_state.state == STATE_OFF
 
-    satellite_enabled_id = satellite_device.get_satellite_enabled_entity_id(hass)
-    assert satellite_enabled_id
-    satellite_enabled_state = hass.states.get(satellite_enabled_id)
-    assert satellite_enabled_state is not None
-    assert satellite_enabled_state.state == STATE_ON
+    muted_id = satellite_device.get_muted_entity_id(hass)
+    assert muted_id
+    muted_state = hass.states.get(muted_id)
+    assert muted_state is not None
+    assert muted_state.state == STATE_OFF
 
     pipeline_entity_id = satellite_device.get_pipeline_entity_id(hass)
     assert pipeline_entity_id
@@ -59,9 +59,9 @@ async def test_remove_device_registry_entry(
     assert assist_in_progress_id
     assert hass.states.get(assist_in_progress_id) is not None
 
-    satellite_enabled_id = satellite_device.get_satellite_enabled_entity_id(hass)
-    assert satellite_enabled_id
-    assert hass.states.get(satellite_enabled_id) is not None
+    muted_id = satellite_device.get_muted_entity_id(hass)
+    assert muted_id
+    assert hass.states.get(muted_id) is not None
 
     pipeline_entity_id = satellite_device.get_pipeline_entity_id(hass)
     assert pipeline_entity_id
@@ -74,5 +74,5 @@ async def test_remove_device_registry_entry(
 
     # Everything should be gone
     assert hass.states.get(assist_in_progress_id) is None
-    assert hass.states.get(satellite_enabled_id) is None
+    assert hass.states.get(muted_id) is None
     assert hass.states.get(pipeline_entity_id) is None

--- a/tests/components/wyoming/test_satellite.py
+++ b/tests/components/wyoming/test_satellite.py
@@ -196,7 +196,7 @@ async def test_satellite_pipeline(hass: HomeAssistant) -> None:
             await mock_client.detect_event.wait()
 
         assert not device.is_active
-        assert device.is_enabled
+        assert not device.is_muted
 
         # Wake word is detected
         event_callback(
@@ -312,36 +312,36 @@ async def test_satellite_pipeline(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
 
-async def test_satellite_disabled(hass: HomeAssistant) -> None:
-    """Test callback for a satellite that has been disabled."""
-    on_disabled_event = asyncio.Event()
+async def test_satellite_muted(hass: HomeAssistant) -> None:
+    """Test callback for a satellite that has been muted."""
+    on_muted_event = asyncio.Event()
 
     original_make_satellite = wyoming._make_satellite
 
-    def make_disabled_satellite(
+    def make_muted_satellite(
         hass: HomeAssistant, config_entry: ConfigEntry, service: WyomingService
     ):
         satellite = original_make_satellite(hass, config_entry, service)
-        satellite.device.set_is_enabled(False)
+        satellite.device.set_is_muted(True)
 
         return satellite
 
-    async def on_disabled(self):
-        self.device.set_is_enabled(True)
-        on_disabled_event.set()
+    async def on_muted(self):
+        self.device.set_is_muted(False)
+        on_muted_event.set()
 
     with patch(
         "homeassistant.components.wyoming.data.load_wyoming_info",
         return_value=SATELLITE_INFO,
     ), patch(
-        "homeassistant.components.wyoming._make_satellite", make_disabled_satellite
+        "homeassistant.components.wyoming._make_satellite", make_muted_satellite
     ), patch(
-        "homeassistant.components.wyoming.satellite.WyomingSatellite.on_disabled",
-        on_disabled,
+        "homeassistant.components.wyoming.satellite.WyomingSatellite.on_muted",
+        on_muted,
     ):
         await setup_config_entry(hass)
         async with asyncio.timeout(1):
-            await on_disabled_event.wait()
+            await on_muted_event.wait()
 
 
 async def test_satellite_restart(hass: HomeAssistant) -> None:

--- a/tests/components/wyoming/test_switch.py
+++ b/tests/components/wyoming/test_switch.py
@@ -7,35 +7,35 @@ from homeassistant.core import HomeAssistant
 from . import reload_satellite
 
 
-async def test_satellite_enabled(
+async def test_muted(
     hass: HomeAssistant,
     satellite_config_entry: ConfigEntry,
     satellite_device: SatelliteDevice,
 ) -> None:
-    """Test satellite enabled."""
-    satellite_enabled_id = satellite_device.get_satellite_enabled_entity_id(hass)
-    assert satellite_enabled_id
+    """Test satellite muted."""
+    muted_id = satellite_device.get_muted_entity_id(hass)
+    assert muted_id
 
-    state = hass.states.get(satellite_enabled_id)
+    state = hass.states.get(muted_id)
     assert state is not None
-    assert state.state == STATE_ON
-    assert satellite_device.is_enabled
+    assert state.state == STATE_OFF
+    assert not satellite_device.is_muted
 
     await hass.services.async_call(
         "switch",
-        "turn_off",
-        {"entity_id": satellite_enabled_id},
+        "turn_on",
+        {"entity_id": muted_id},
         blocking=True,
     )
 
-    state = hass.states.get(satellite_enabled_id)
+    state = hass.states.get(muted_id)
     assert state is not None
-    assert state.state == STATE_OFF
-    assert not satellite_device.is_enabled
+    assert state.state == STATE_ON
+    assert satellite_device.is_muted
 
     # test restore
     satellite_device = await reload_satellite(hass, satellite_config_entry.entry_id)
 
-    state = hass.states.get(satellite_enabled_id)
+    state = hass.states.get(muted_id)
     assert state is not None
-    assert state.state == STATE_OFF
+    assert state.state == STATE_ON


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Renames the "satellite enabled" switch for Wyoming satellites to "mute". This will also be changed in ESPHome.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
