### PR TITLE
Allow inheriting `FrozenOrThawed` with custom init

### DIFF
--- a/homeassistant/util/frozen_dataclass_compat.py
+++ b/homeassistant/util/frozen_dataclass_compat.py
@@ -117,4 +117,5 @@ class FrozenOrThawed(type):
                 return object.__new__(cls)
             return cls._dataclass(*_args, **kwargs)
 
+        cls.__init__ = cls._dataclass.__init__  # type: ignore[misc]
         cls.__new__ = __new__  # type: ignore[method-assign]

--- a/tests/helpers/snapshots/test_entity.ambr
+++ b/tests/helpers/snapshots/test_entity.ambr
@@ -36,6 +36,24 @@
 # name: test_extending_entity_description.1
   "test_extending_entity_description.<locals>.FrozenEntityDescription(key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
 # ---
+# name: test_extending_entity_description.10
+  dict({
+    'device_class': None,
+    'entity_category': None,
+    'entity_registry_enabled_default': True,
+    'entity_registry_visible_default': True,
+    'force_update': False,
+    'has_entity_name': False,
+    'icon': None,
+    'key': 'blah',
+    'name': 'name',
+    'translation_key': None,
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_extending_entity_description.11
+  "test_extending_entity_description.<locals>.CustomInitEntityDescription(key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None)"
+# ---
 # name: test_extending_entity_description.2
   dict({
     'device_class': None,

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1749,3 +1749,15 @@ def test_extending_entity_description(snapshot: SnapshotAssertion):
         key="blah", extra="foo", mixin="mixin", name="name"
     )
     assert repr(obj) == snapshot
+
+    # Try inheriting with custom init
+    @dataclasses.dataclass
+    class CustomInitEntityDescription(entity.EntityDescription):
+        def __init__(self, extra, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.extra: str = extra
+
+    obj = CustomInitEntityDescription(key="blah", extra="foo", name="name")
+    assert obj == snapshot
+    assert obj == CustomInitEntityDescription(key="blah", extra="foo", name="name")
+    assert repr(obj) == snapshot


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow inheriting `FrozenOrThawed` with custom `__init__`

The pattern is used by `philips_js` in a misguided workaround to allow adding fields without default values in a subclass:
https://github.com/home-assistant/core/blob/a6f3d1988c0794520149e054efe277f59ad210a7/homeassistant/components/philips_js/binary_sensor.py#L21-L28

While `philips_js` should just set the `kw_only` flag to `True`, we should still allow this to lessen the risk of breaking similar patterns in custom integrations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
