### PR TITLE
Migrate homekit_controller tests to use freezegun

### DIFF
--- a/tests/components/homekit_controller/conftest.py
+++ b/tests/components/homekit_controller/conftest.py
@@ -13,8 +13,8 @@ from tests.components.light.conftest import mock_light_profiles  # noqa: F401
 pytest.register_assert_rewrite("tests.components.homekit_controller.common")
 
 
-@pytest.fixture
-def utcnow(request):
+@pytest.fixture(autouse=True)
+def freeze_time_in_future(request):
     """Freeze time at a known point."""
     now = dt_util.utcnow()
     start_dt = datetime.datetime(now.year + 1, 1, 1, 0, 0, 0, tzinfo=now.tzinfo)

--- a/tests/components/homekit_controller/conftest.py
+++ b/tests/components/homekit_controller/conftest.py
@@ -1,9 +1,9 @@
 """HomeKit controller session fixtures."""
 import datetime
-from unittest import mock
 import unittest.mock
 
 from aiohomekit.testing import FakeController
+from freezegun import freeze_time
 import pytest
 
 import homeassistant.util.dt as dt_util
@@ -18,9 +18,8 @@ def utcnow(request):
     """Freeze time at a known point."""
     now = dt_util.utcnow()
     start_dt = datetime.datetime(now.year + 1, 1, 1, 0, 0, 0, tzinfo=now.tzinfo)
-    with mock.patch("homeassistant.util.dt.utcnow") as dt_utcnow:
-        dt_utcnow.return_value = start_dt
-        yield dt_utcnow
+    with freeze_time(start_dt) as frozen_time:
+        yield frozen_time
 
 
 @pytest.fixture

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
@@ -21,7 +21,7 @@ LIGHT_ON = ("lightbulb", "on")
 
 
 @pytest.mark.parametrize("failure_cls", [AccessoryDisconnectedError, EncryptionError])
-async def test_recover_from_failure(hass: HomeAssistant, utcnow, failure_cls) -> None:
+async def test_recover_from_failure(hass: HomeAssistant, failure_cls) -> None:
     """Test that entity actually recovers from a network connection drop.
 
     See https://github.com/home-assistant/core/issues/18949

--- a/tests/components/homekit_controller/test_alarm_control_panel.py
+++ b/tests/components/homekit_controller/test_alarm_control_panel.py
@@ -26,7 +26,7 @@ def create_security_system_service(accessory):
     targ_state.value = 50
 
 
-async def test_switch_change_alarm_state(hass: HomeAssistant, utcnow) -> None:
+async def test_switch_change_alarm_state(hass: HomeAssistant) -> None:
     """Test that we can turn a HomeKit alarm on and off again."""
     helper = await setup_test_component(hass, create_security_system_service)
 
@@ -83,7 +83,7 @@ async def test_switch_change_alarm_state(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_switch_read_alarm_state(hass: HomeAssistant, utcnow) -> None:
+async def test_switch_read_alarm_state(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit alarm accessory."""
     helper = await setup_test_component(hass, create_security_system_service)
 
@@ -125,7 +125,7 @@ async def test_switch_read_alarm_state(hass: HomeAssistant, utcnow) -> None:
 
 
 async def test_migrate_unique_id(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test a we can migrate a alarm_control_panel unique id."""
     aid = get_next_aid()

--- a/tests/components/homekit_controller/test_binary_sensor.py
+++ b/tests/components/homekit_controller/test_binary_sensor.py
@@ -17,7 +17,7 @@ def create_motion_sensor_service(accessory):
     cur_state.value = 0
 
 
-async def test_motion_sensor_read_state(hass: HomeAssistant, utcnow) -> None:
+async def test_motion_sensor_read_state(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit motion sensor accessory."""
     helper = await setup_test_component(hass, create_motion_sensor_service)
 
@@ -44,7 +44,7 @@ def create_contact_sensor_service(accessory):
     cur_state.value = 0
 
 
-async def test_contact_sensor_read_state(hass: HomeAssistant, utcnow) -> None:
+async def test_contact_sensor_read_state(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit contact accessory."""
     helper = await setup_test_component(hass, create_contact_sensor_service)
 
@@ -71,7 +71,7 @@ def create_smoke_sensor_service(accessory):
     cur_state.value = 0
 
 
-async def test_smoke_sensor_read_state(hass: HomeAssistant, utcnow) -> None:
+async def test_smoke_sensor_read_state(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit contact accessory."""
     helper = await setup_test_component(hass, create_smoke_sensor_service)
 
@@ -98,7 +98,7 @@ def create_carbon_monoxide_sensor_service(accessory):
     cur_state.value = 0
 
 
-async def test_carbon_monoxide_sensor_read_state(hass: HomeAssistant, utcnow) -> None:
+async def test_carbon_monoxide_sensor_read_state(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit contact accessory."""
     helper = await setup_test_component(hass, create_carbon_monoxide_sensor_service)
 
@@ -127,7 +127,7 @@ def create_occupancy_sensor_service(accessory):
     cur_state.value = 0
 
 
-async def test_occupancy_sensor_read_state(hass: HomeAssistant, utcnow) -> None:
+async def test_occupancy_sensor_read_state(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit occupancy sensor accessory."""
     helper = await setup_test_component(hass, create_occupancy_sensor_service)
 
@@ -154,7 +154,7 @@ def create_leak_sensor_service(accessory):
     cur_state.value = 0
 
 
-async def test_leak_sensor_read_state(hass: HomeAssistant, utcnow) -> None:
+async def test_leak_sensor_read_state(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit leak sensor accessory."""
     helper = await setup_test_component(hass, create_leak_sensor_service)
 
@@ -174,7 +174,7 @@ async def test_leak_sensor_read_state(hass: HomeAssistant, utcnow) -> None:
 
 
 async def test_migrate_unique_id(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test a we can migrate a binary_sensor unique id."""
     aid = get_next_aid()

--- a/tests/components/homekit_controller/test_button.py
+++ b/tests/components/homekit_controller/test_button.py
@@ -95,7 +95,7 @@ async def test_ecobee_clear_hold_press_button(hass: HomeAssistant) -> None:
 
 
 async def test_migrate_unique_id(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test a we can migrate a button unique id."""
     aid = get_next_aid()

--- a/tests/components/homekit_controller/test_camera.py
+++ b/tests/components/homekit_controller/test_camera.py
@@ -17,7 +17,7 @@ def create_camera(accessory):
 
 
 async def test_migrate_unique_ids(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test migrating entity unique ids."""
     aid = get_next_aid()
@@ -33,7 +33,7 @@ async def test_migrate_unique_ids(
     )
 
 
-async def test_read_state(hass: HomeAssistant, utcnow) -> None:
+async def test_read_state(hass: HomeAssistant) -> None:
     """Test reading the state of a HomeKit camera."""
     helper = await setup_test_component(hass, create_camera)
 
@@ -41,7 +41,7 @@ async def test_read_state(hass: HomeAssistant, utcnow) -> None:
     assert state.state == "idle"
 
 
-async def test_get_image(hass: HomeAssistant, utcnow) -> None:
+async def test_get_image(hass: HomeAssistant) -> None:
     """Test getting a JPEG from a camera."""
     helper = await setup_test_component(hass, create_camera)
     image = await camera.async_get_image(hass, helper.entity_id)

--- a/tests/components/homekit_controller/test_climate.py
+++ b/tests/components/homekit_controller/test_climate.py
@@ -72,9 +72,7 @@ def create_thermostat_service_min_max(accessory):
     char.maxValue = 1
 
 
-async def test_climate_respect_supported_op_modes_1(
-    hass: HomeAssistant, utcnow
-) -> None:
+async def test_climate_respect_supported_op_modes_1(hass: HomeAssistant) -> None:
     """Test that climate respects minValue/maxValue hints."""
     helper = await setup_test_component(hass, create_thermostat_service_min_max)
     state = await helper.poll_and_get_state()
@@ -89,16 +87,14 @@ def create_thermostat_service_valid_vals(accessory):
     char.valid_values = [0, 1, 2]
 
 
-async def test_climate_respect_supported_op_modes_2(
-    hass: HomeAssistant, utcnow
-) -> None:
+async def test_climate_respect_supported_op_modes_2(hass: HomeAssistant) -> None:
     """Test that climate respects validValue hints."""
     helper = await setup_test_component(hass, create_thermostat_service_valid_vals)
     state = await helper.poll_and_get_state()
     assert state.attributes["hvac_modes"] == ["off", "heat", "cool"]
 
 
-async def test_climate_change_thermostat_state(hass: HomeAssistant, utcnow) -> None:
+async def test_climate_change_thermostat_state(hass: HomeAssistant) -> None:
     """Test that we can turn a HomeKit thermostat on and off again."""
     helper = await setup_test_component(hass, create_thermostat_service)
 
@@ -181,9 +177,7 @@ async def test_climate_change_thermostat_state(hass: HomeAssistant, utcnow) -> N
     )
 
 
-async def test_climate_check_min_max_values_per_mode(
-    hass: HomeAssistant, utcnow
-) -> None:
+async def test_climate_check_min_max_values_per_mode(hass: HomeAssistant) -> None:
     """Test that we we get the appropriate min/max values for each mode."""
     helper = await setup_test_component(hass, create_thermostat_service)
 
@@ -218,9 +212,7 @@ async def test_climate_check_min_max_values_per_mode(
     assert climate_state.attributes["max_temp"] == 40
 
 
-async def test_climate_change_thermostat_temperature(
-    hass: HomeAssistant, utcnow
-) -> None:
+async def test_climate_change_thermostat_temperature(hass: HomeAssistant) -> None:
     """Test that we can turn a HomeKit thermostat on and off again."""
     helper = await setup_test_component(hass, create_thermostat_service)
 
@@ -251,9 +243,7 @@ async def test_climate_change_thermostat_temperature(
     )
 
 
-async def test_climate_change_thermostat_temperature_range(
-    hass: HomeAssistant, utcnow
-) -> None:
+async def test_climate_change_thermostat_temperature_range(hass: HomeAssistant) -> None:
     """Test that we can set separate heat and cool setpoints in heat_cool mode."""
     helper = await setup_test_component(hass, create_thermostat_service)
 
@@ -287,7 +277,7 @@ async def test_climate_change_thermostat_temperature_range(
 
 
 async def test_climate_change_thermostat_temperature_range_iphone(
-    hass: HomeAssistant, utcnow
+    hass: HomeAssistant
 ) -> None:
     """Test that we can set all three set points at once (iPhone heat_cool mode support)."""
     helper = await setup_test_component(hass, create_thermostat_service)
@@ -322,7 +312,7 @@ async def test_climate_change_thermostat_temperature_range_iphone(
 
 
 async def test_climate_cannot_set_thermostat_temp_range_in_wrong_mode(
-    hass: HomeAssistant, utcnow
+    hass: HomeAssistant
 ) -> None:
     """Test that we cannot set range values when not in heat_cool mode."""
     helper = await setup_test_component(hass, create_thermostat_service)
@@ -381,7 +371,7 @@ def create_thermostat_single_set_point_auto(accessory):
 
 
 async def test_climate_check_min_max_values_per_mode_sspa_device(
-    hass: HomeAssistant, utcnow
+    hass: HomeAssistant
 ) -> None:
     """Test appropriate min/max values for each mode on sspa devices."""
     helper = await setup_test_component(hass, create_thermostat_single_set_point_auto)
@@ -417,9 +407,7 @@ async def test_climate_check_min_max_values_per_mode_sspa_device(
     assert climate_state.attributes["max_temp"] == 35
 
 
-async def test_climate_set_thermostat_temp_on_sspa_device(
-    hass: HomeAssistant, utcnow
-) -> None:
+async def test_climate_set_thermostat_temp_on_sspa_device(hass: HomeAssistant) -> None:
     """Test setting temperature in different modes on device with single set point in auto."""
     helper = await setup_test_component(hass, create_thermostat_single_set_point_auto)
 
@@ -473,7 +461,7 @@ async def test_climate_set_thermostat_temp_on_sspa_device(
     )
 
 
-async def test_climate_set_mode_via_temp(hass: HomeAssistant, utcnow) -> None:
+async def test_climate_set_mode_via_temp(hass: HomeAssistant) -> None:
     """Test setting temperature and mode at same tims."""
     helper = await setup_test_component(hass, create_thermostat_single_set_point_auto)
 
@@ -514,7 +502,7 @@ async def test_climate_set_mode_via_temp(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_climate_change_thermostat_humidity(hass: HomeAssistant, utcnow) -> None:
+async def test_climate_change_thermostat_humidity(hass: HomeAssistant) -> None:
     """Test that we can turn a HomeKit thermostat on and off again."""
     helper = await setup_test_component(hass, create_thermostat_service)
 
@@ -545,7 +533,7 @@ async def test_climate_change_thermostat_humidity(hass: HomeAssistant, utcnow) -
     )
 
 
-async def test_climate_read_thermostat_state(hass: HomeAssistant, utcnow) -> None:
+async def test_climate_read_thermostat_state(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit thermostat accessory."""
     helper = await setup_test_component(hass, create_thermostat_service)
 
@@ -602,7 +590,7 @@ async def test_climate_read_thermostat_state(hass: HomeAssistant, utcnow) -> Non
     assert state.state == HVACMode.HEAT_COOL
 
 
-async def test_hvac_mode_vs_hvac_action(hass: HomeAssistant, utcnow) -> None:
+async def test_hvac_mode_vs_hvac_action(hass: HomeAssistant) -> None:
     """Check that we haven't conflated hvac_mode and hvac_action."""
     helper = await setup_test_component(hass, create_thermostat_service)
 
@@ -639,9 +627,7 @@ async def test_hvac_mode_vs_hvac_action(hass: HomeAssistant, utcnow) -> None:
     assert state.attributes["hvac_action"] == "heating"
 
 
-async def test_hvac_mode_vs_hvac_action_current_mode_wrong(
-    hass: HomeAssistant, utcnow
-) -> None:
+async def test_hvac_mode_vs_hvac_action_current_mode_wrong(hass: HomeAssistant) -> None:
     """Check that we cope with buggy HEATING_COOLING_CURRENT."""
     helper = await setup_test_component(hass, create_thermostat_service)
 
@@ -705,9 +691,7 @@ def create_heater_cooler_service_min_max(accessory):
     char.maxValue = 2
 
 
-async def test_heater_cooler_respect_supported_op_modes_1(
-    hass: HomeAssistant, utcnow
-) -> None:
+async def test_heater_cooler_respect_supported_op_modes_1(hass: HomeAssistant) -> None:
     """Test that climate respects minValue/maxValue hints."""
     helper = await setup_test_component(hass, create_heater_cooler_service_min_max)
     state = await helper.poll_and_get_state()
@@ -722,18 +706,14 @@ def create_theater_cooler_service_valid_vals(accessory):
     char.valid_values = [1, 2]
 
 
-async def test_heater_cooler_respect_supported_op_modes_2(
-    hass: HomeAssistant, utcnow
-) -> None:
+async def test_heater_cooler_respect_supported_op_modes_2(hass: HomeAssistant) -> None:
     """Test that climate respects validValue hints."""
     helper = await setup_test_component(hass, create_theater_cooler_service_valid_vals)
     state = await helper.poll_and_get_state()
     assert state.attributes["hvac_modes"] == ["heat", "cool", "off"]
 
 
-async def test_heater_cooler_change_thermostat_state(
-    hass: HomeAssistant, utcnow
-) -> None:
+async def test_heater_cooler_change_thermostat_state(hass: HomeAssistant) -> None:
     """Test that we can change the operational mode."""
     helper = await setup_test_component(hass, create_heater_cooler_service)
 
@@ -790,7 +770,7 @@ async def test_heater_cooler_change_thermostat_state(
     )
 
 
-async def test_can_turn_on_after_off(hass: HomeAssistant, utcnow) -> None:
+async def test_can_turn_on_after_off(hass: HomeAssistant) -> None:
     """Test that we always force device from inactive to active when setting mode.
 
     This is a regression test for #81863.
@@ -825,9 +805,7 @@ async def test_can_turn_on_after_off(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_heater_cooler_change_thermostat_temperature(
-    hass: HomeAssistant, utcnow
-) -> None:
+async def test_heater_cooler_change_thermostat_temperature(hass: HomeAssistant) -> None:
     """Test that we can change the target temperature."""
     helper = await setup_test_component(hass, create_heater_cooler_service)
 
@@ -870,7 +848,7 @@ async def test_heater_cooler_change_thermostat_temperature(
     )
 
 
-async def test_heater_cooler_change_fan_speed(hass: HomeAssistant, utcnow) -> None:
+async def test_heater_cooler_change_fan_speed(hass: HomeAssistant) -> None:
     """Test that we can change the target fan speed."""
     helper = await setup_test_component(hass, create_heater_cooler_service)
 
@@ -918,7 +896,7 @@ async def test_heater_cooler_change_fan_speed(hass: HomeAssistant, utcnow) -> No
     )
 
 
-async def test_heater_cooler_read_fan_speed(hass: HomeAssistant, utcnow) -> None:
+async def test_heater_cooler_read_fan_speed(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit thermostat accessory."""
     helper = await setup_test_component(hass, create_heater_cooler_service)
 
@@ -967,7 +945,7 @@ async def test_heater_cooler_read_fan_speed(hass: HomeAssistant, utcnow) -> None
     assert state.attributes["fan_mode"] == "high"
 
 
-async def test_heater_cooler_read_thermostat_state(hass: HomeAssistant, utcnow) -> None:
+async def test_heater_cooler_read_thermostat_state(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit thermostat accessory."""
     helper = await setup_test_component(hass, create_heater_cooler_service)
 
@@ -1021,9 +999,7 @@ async def test_heater_cooler_read_thermostat_state(hass: HomeAssistant, utcnow) 
     assert state.state == HVACMode.HEAT_COOL
 
 
-async def test_heater_cooler_hvac_mode_vs_hvac_action(
-    hass: HomeAssistant, utcnow
-) -> None:
+async def test_heater_cooler_hvac_mode_vs_hvac_action(hass: HomeAssistant) -> None:
     """Check that we haven't conflated hvac_mode and hvac_action."""
     helper = await setup_test_component(hass, create_heater_cooler_service)
 
@@ -1062,7 +1038,7 @@ async def test_heater_cooler_hvac_mode_vs_hvac_action(
     assert state.attributes["hvac_action"] == "heating"
 
 
-async def test_heater_cooler_change_swing_mode(hass: HomeAssistant, utcnow) -> None:
+async def test_heater_cooler_change_swing_mode(hass: HomeAssistant) -> None:
     """Test that we can change the swing mode."""
     helper = await setup_test_component(hass, create_heater_cooler_service)
 
@@ -1093,7 +1069,7 @@ async def test_heater_cooler_change_swing_mode(hass: HomeAssistant, utcnow) -> N
     )
 
 
-async def test_heater_cooler_turn_off(hass: HomeAssistant, utcnow) -> None:
+async def test_heater_cooler_turn_off(hass: HomeAssistant) -> None:
     """Test that both hvac_action and hvac_mode return "off" when turned off."""
     helper = await setup_test_component(hass, create_heater_cooler_service)
 
@@ -1113,7 +1089,7 @@ async def test_heater_cooler_turn_off(hass: HomeAssistant, utcnow) -> None:
 
 
 async def test_migrate_unique_id(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test a we can migrate a switch unique id."""
     aid = get_next_aid()

--- a/tests/components/homekit_controller/test_cover.py
+++ b/tests/components/homekit_controller/test_cover.py
@@ -93,7 +93,7 @@ def create_window_covering_service_with_v_tilt_2(accessory):
     tilt_target.maxValue = 0
 
 
-async def test_change_window_cover_state(hass: HomeAssistant, utcnow) -> None:
+async def test_change_window_cover_state(hass: HomeAssistant) -> None:
     """Test that we can turn a HomeKit alarm on and off again."""
     helper = await setup_test_component(hass, create_window_covering_service)
 
@@ -118,7 +118,7 @@ async def test_change_window_cover_state(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_read_window_cover_state(hass: HomeAssistant, utcnow) -> None:
+async def test_read_window_cover_state(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit alarm accessory."""
     helper = await setup_test_component(hass, create_window_covering_service)
 
@@ -151,7 +151,7 @@ async def test_read_window_cover_state(hass: HomeAssistant, utcnow) -> None:
     assert state.attributes["obstruction-detected"] is True
 
 
-async def test_read_window_cover_tilt_horizontal(hass: HomeAssistant, utcnow) -> None:
+async def test_read_window_cover_tilt_horizontal(hass: HomeAssistant) -> None:
     """Test that horizontal tilt is handled correctly."""
     helper = await setup_test_component(
         hass, create_window_covering_service_with_h_tilt
@@ -166,7 +166,7 @@ async def test_read_window_cover_tilt_horizontal(hass: HomeAssistant, utcnow) ->
     assert state.attributes["current_tilt_position"] == 83
 
 
-async def test_read_window_cover_tilt_horizontal_2(hass: HomeAssistant, utcnow) -> None:
+async def test_read_window_cover_tilt_horizontal_2(hass: HomeAssistant) -> None:
     """Test that horizontal tilt is handled correctly."""
     helper = await setup_test_component(
         hass, create_window_covering_service_with_h_tilt_2
@@ -181,7 +181,7 @@ async def test_read_window_cover_tilt_horizontal_2(hass: HomeAssistant, utcnow) 
     assert state.attributes["current_tilt_position"] == 83
 
 
-async def test_read_window_cover_tilt_vertical(hass: HomeAssistant, utcnow) -> None:
+async def test_read_window_cover_tilt_vertical(hass: HomeAssistant) -> None:
     """Test that vertical tilt is handled correctly."""
     helper = await setup_test_component(
         hass, create_window_covering_service_with_v_tilt
@@ -196,7 +196,7 @@ async def test_read_window_cover_tilt_vertical(hass: HomeAssistant, utcnow) -> N
     assert state.attributes["current_tilt_position"] == 83
 
 
-async def test_read_window_cover_tilt_vertical_2(hass: HomeAssistant, utcnow) -> None:
+async def test_read_window_cover_tilt_vertical_2(hass: HomeAssistant) -> None:
     """Test that vertical tilt is handled correctly."""
     helper = await setup_test_component(
         hass, create_window_covering_service_with_v_tilt_2
@@ -211,7 +211,7 @@ async def test_read_window_cover_tilt_vertical_2(hass: HomeAssistant, utcnow) ->
     assert state.attributes["current_tilt_position"] == 83
 
 
-async def test_write_window_cover_tilt_horizontal(hass: HomeAssistant, utcnow) -> None:
+async def test_write_window_cover_tilt_horizontal(hass: HomeAssistant) -> None:
     """Test that horizontal tilt is written correctly."""
     helper = await setup_test_component(
         hass, create_window_covering_service_with_h_tilt
@@ -232,9 +232,7 @@ async def test_write_window_cover_tilt_horizontal(hass: HomeAssistant, utcnow) -
     )
 
 
-async def test_write_window_cover_tilt_horizontal_2(
-    hass: HomeAssistant, utcnow
-) -> None:
+async def test_write_window_cover_tilt_horizontal_2(hass: HomeAssistant) -> None:
     """Test that horizontal tilt is written correctly."""
     helper = await setup_test_component(
         hass, create_window_covering_service_with_h_tilt_2
@@ -255,7 +253,7 @@ async def test_write_window_cover_tilt_horizontal_2(
     )
 
 
-async def test_write_window_cover_tilt_vertical(hass: HomeAssistant, utcnow) -> None:
+async def test_write_window_cover_tilt_vertical(hass: HomeAssistant) -> None:
     """Test that vertical tilt is written correctly."""
     helper = await setup_test_component(
         hass, create_window_covering_service_with_v_tilt
@@ -276,7 +274,7 @@ async def test_write_window_cover_tilt_vertical(hass: HomeAssistant, utcnow) -> 
     )
 
 
-async def test_write_window_cover_tilt_vertical_2(hass: HomeAssistant, utcnow) -> None:
+async def test_write_window_cover_tilt_vertical_2(hass: HomeAssistant) -> None:
     """Test that vertical tilt is written correctly."""
     helper = await setup_test_component(
         hass, create_window_covering_service_with_v_tilt_2
@@ -297,7 +295,7 @@ async def test_write_window_cover_tilt_vertical_2(hass: HomeAssistant, utcnow) -
     )
 
 
-async def test_window_cover_stop(hass: HomeAssistant, utcnow) -> None:
+async def test_window_cover_stop(hass: HomeAssistant) -> None:
     """Test that vertical tilt is written correctly."""
     helper = await setup_test_component(
         hass, create_window_covering_service_with_v_tilt
@@ -333,7 +331,7 @@ def create_garage_door_opener_service(accessory):
     return service
 
 
-async def test_change_door_state(hass: HomeAssistant, utcnow) -> None:
+async def test_change_door_state(hass: HomeAssistant) -> None:
     """Test that we can turn open and close a HomeKit garage door."""
     helper = await setup_test_component(hass, create_garage_door_opener_service)
 
@@ -358,7 +356,7 @@ async def test_change_door_state(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_read_door_state(hass: HomeAssistant, utcnow) -> None:
+async def test_read_door_state(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit garage door."""
     helper = await setup_test_component(hass, create_garage_door_opener_service)
 
@@ -399,7 +397,7 @@ async def test_read_door_state(hass: HomeAssistant, utcnow) -> None:
 
 
 async def test_migrate_unique_id(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test a we can migrate a cover unique id."""
     aid = get_next_aid()

--- a/tests/components/homekit_controller/test_device_trigger.py
+++ b/tests/components/homekit_controller/test_device_trigger.py
@@ -87,7 +87,6 @@ async def test_enumerate_remote(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    utcnow,
 ) -> None:
     """Test that remote is correctly enumerated."""
     await setup_test_component(hass, create_remote)
@@ -139,7 +138,6 @@ async def test_enumerate_button(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    utcnow,
 ) -> None:
     """Test that a button is correctly enumerated."""
     await setup_test_component(hass, create_button)
@@ -190,7 +188,6 @@ async def test_enumerate_doorbell(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    utcnow,
 ) -> None:
     """Test that a button is correctly enumerated."""
     await setup_test_component(hass, create_doorbell)
@@ -241,7 +238,6 @@ async def test_handle_events(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    utcnow,
     calls,
 ) -> None:
     """Test that events are handled."""
@@ -362,7 +358,6 @@ async def test_handle_events_late_setup(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    utcnow,
     calls,
 ) -> None:
     """Test that events are handled when setup happens after startup."""

--- a/tests/components/homekit_controller/test_diagnostics.py
+++ b/tests/components/homekit_controller/test_diagnostics.py
@@ -1,8 +1,6 @@
 """Test homekit_controller diagnostics."""
 from unittest.mock import ANY
 
-import pytest
-
 from homeassistant.components.homekit_controller.const import KNOWN_DEVICES
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -16,7 +14,6 @@ from tests.components.diagnostics import (
 from tests.typing import ClientSessionGenerator
 
 
-@pytest.mark.usefixtures("utcnow")
 async def test_config_entry(
     hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
@@ -292,7 +289,6 @@ async def test_config_entry(
     }
 
 
-@pytest.mark.usefixtures("utcnow")
 async def test_device(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,

--- a/tests/components/homekit_controller/test_diagnostics.py
+++ b/tests/components/homekit_controller/test_diagnostics.py
@@ -1,6 +1,8 @@
 """Test homekit_controller diagnostics."""
 from unittest.mock import ANY
 
+import pytest
+
 from homeassistant.components.homekit_controller.const import KNOWN_DEVICES
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -14,8 +16,9 @@ from tests.components.diagnostics import (
 from tests.typing import ClientSessionGenerator
 
 
+@pytest.mark.usefixtures("utcnow")
 async def test_config_entry(
-    utcnow, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
     """Test generating diagnostics for a config entry."""
     accessories = await setup_accessories_from_file(hass, "koogeek_ls1.json")
@@ -289,8 +292,8 @@ async def test_config_entry(
     }
 
 
+@pytest.mark.usefixtures("utcnow")
 async def test_device(
-    utcnow,
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     device_registry: dr.DeviceRegistry,

--- a/tests/components/homekit_controller/test_diagnostics.py
+++ b/tests/components/homekit_controller/test_diagnostics.py
@@ -15,7 +15,7 @@ from tests.typing import ClientSessionGenerator
 
 
 async def test_config_entry(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, utcnow
+    utcnow, hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
     """Test generating diagnostics for a config entry."""
     accessories = await setup_accessories_from_file(hass, "koogeek_ls1.json")
@@ -290,10 +290,10 @@ async def test_config_entry(
 
 
 async def test_device(
+    utcnow,
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     device_registry: dr.DeviceRegistry,
-    utcnow,
 ) -> None:
     """Test generating diagnostics for a device entry."""
     accessories = await setup_accessories_from_file(hass, "koogeek_ls1.json")

--- a/tests/components/homekit_controller/test_event.py
+++ b/tests/components/homekit_controller/test_event.py
@@ -64,9 +64,7 @@ def create_doorbell(accessory):
     battery.add_char(CharacteristicsTypes.BATTERY_LEVEL)
 
 
-async def test_remote(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
-) -> None:
+async def test_remote(hass: HomeAssistant, entity_registry: er.EntityRegistry) -> None:
     """Test that remote is supported."""
     helper = await setup_test_component(hass, create_remote)
 
@@ -109,9 +107,7 @@ async def test_remote(
         assert state.attributes["event_type"] == "long_press"
 
 
-async def test_button(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
-) -> None:
+async def test_button(hass: HomeAssistant, entity_registry: er.EntityRegistry) -> None:
     """Test that a button is correctly enumerated."""
     helper = await setup_test_component(hass, create_button)
     entity_id = "event.testdevice_button_1"
@@ -148,7 +144,7 @@ async def test_button(
 
 
 async def test_doorbell(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test that doorbell service is handled."""
     helper = await setup_test_component(hass, create_doorbell)

--- a/tests/components/homekit_controller/test_fan.py
+++ b/tests/components/homekit_controller/test_fan.py
@@ -89,7 +89,7 @@ def create_fanv2_service_without_rotation_speed(accessory):
     swing_mode.value = 0
 
 
-async def test_fan_read_state(hass: HomeAssistant, utcnow) -> None:
+async def test_fan_read_state(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit fan accessory."""
     helper = await setup_test_component(hass, create_fan_service)
 
@@ -104,7 +104,7 @@ async def test_fan_read_state(hass: HomeAssistant, utcnow) -> None:
     assert state.state == "on"
 
 
-async def test_turn_on(hass: HomeAssistant, utcnow) -> None:
+async def test_turn_on(hass: HomeAssistant) -> None:
     """Test that we can turn a fan on."""
     helper = await setup_test_component(hass, create_fan_service)
 
@@ -151,7 +151,7 @@ async def test_turn_on(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_turn_on_off_without_rotation_speed(hass: HomeAssistant, utcnow) -> None:
+async def test_turn_on_off_without_rotation_speed(hass: HomeAssistant) -> None:
     """Test that we can turn a fan on."""
     helper = await setup_test_component(
         hass, create_fanv2_service_without_rotation_speed
@@ -184,7 +184,7 @@ async def test_turn_on_off_without_rotation_speed(hass: HomeAssistant, utcnow) -
     )
 
 
-async def test_turn_off(hass: HomeAssistant, utcnow) -> None:
+async def test_turn_off(hass: HomeAssistant) -> None:
     """Test that we can turn a fan off."""
     helper = await setup_test_component(hass, create_fan_service)
 
@@ -204,7 +204,7 @@ async def test_turn_off(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_set_speed(hass: HomeAssistant, utcnow) -> None:
+async def test_set_speed(hass: HomeAssistant) -> None:
     """Test that we set fan speed."""
     helper = await setup_test_component(hass, create_fan_service)
 
@@ -263,7 +263,7 @@ async def test_set_speed(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_set_percentage(hass: HomeAssistant, utcnow) -> None:
+async def test_set_percentage(hass: HomeAssistant) -> None:
     """Test that we set fan speed by percentage."""
     helper = await setup_test_component(hass, create_fan_service)
 
@@ -296,7 +296,7 @@ async def test_set_percentage(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_speed_read(hass: HomeAssistant, utcnow) -> None:
+async def test_speed_read(hass: HomeAssistant) -> None:
     """Test that we can read a fans oscillation."""
     helper = await setup_test_component(hass, create_fan_service)
 
@@ -336,7 +336,7 @@ async def test_speed_read(hass: HomeAssistant, utcnow) -> None:
     assert state.attributes["percentage"] == 0
 
 
-async def test_set_direction(hass: HomeAssistant, utcnow) -> None:
+async def test_set_direction(hass: HomeAssistant) -> None:
     """Test that we can set fan spin direction."""
     helper = await setup_test_component(hass, create_fan_service)
 
@@ -367,7 +367,7 @@ async def test_set_direction(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_direction_read(hass: HomeAssistant, utcnow) -> None:
+async def test_direction_read(hass: HomeAssistant) -> None:
     """Test that we can read a fans oscillation."""
     helper = await setup_test_component(hass, create_fan_service)
 
@@ -382,7 +382,7 @@ async def test_direction_read(hass: HomeAssistant, utcnow) -> None:
     assert state.attributes["direction"] == "reverse"
 
 
-async def test_fanv2_read_state(hass: HomeAssistant, utcnow) -> None:
+async def test_fanv2_read_state(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit fan accessory."""
     helper = await setup_test_component(hass, create_fanv2_service)
 
@@ -397,7 +397,7 @@ async def test_fanv2_read_state(hass: HomeAssistant, utcnow) -> None:
     assert state.state == "on"
 
 
-async def test_v2_turn_on(hass: HomeAssistant, utcnow) -> None:
+async def test_v2_turn_on(hass: HomeAssistant) -> None:
     """Test that we can turn a fan on."""
     helper = await setup_test_component(hass, create_fanv2_service)
 
@@ -472,7 +472,7 @@ async def test_v2_turn_on(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_v2_turn_off(hass: HomeAssistant, utcnow) -> None:
+async def test_v2_turn_off(hass: HomeAssistant) -> None:
     """Test that we can turn a fan off."""
     helper = await setup_test_component(hass, create_fanv2_service)
 
@@ -492,7 +492,7 @@ async def test_v2_turn_off(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_v2_set_speed(hass: HomeAssistant, utcnow) -> None:
+async def test_v2_set_speed(hass: HomeAssistant) -> None:
     """Test that we set fan speed."""
     helper = await setup_test_component(hass, create_fanv2_service)
 
@@ -551,7 +551,7 @@ async def test_v2_set_speed(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_v2_set_percentage(hass: HomeAssistant, utcnow) -> None:
+async def test_v2_set_percentage(hass: HomeAssistant) -> None:
     """Test that we set fan speed by percentage."""
     helper = await setup_test_component(hass, create_fanv2_service)
 
@@ -584,7 +584,7 @@ async def test_v2_set_percentage(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_v2_set_percentage_with_min_step(hass: HomeAssistant, utcnow) -> None:
+async def test_v2_set_percentage_with_min_step(hass: HomeAssistant) -> None:
     """Test that we set fan speed by percentage."""
     helper = await setup_test_component(hass, create_fanv2_service_with_min_step)
 
@@ -617,7 +617,7 @@ async def test_v2_set_percentage_with_min_step(hass: HomeAssistant, utcnow) -> N
     )
 
 
-async def test_v2_speed_read(hass: HomeAssistant, utcnow) -> None:
+async def test_v2_speed_read(hass: HomeAssistant) -> None:
     """Test that we can read a fans oscillation."""
     helper = await setup_test_component(hass, create_fanv2_service)
 
@@ -656,7 +656,7 @@ async def test_v2_speed_read(hass: HomeAssistant, utcnow) -> None:
     assert state.attributes["percentage"] == 0
 
 
-async def test_v2_set_direction(hass: HomeAssistant, utcnow) -> None:
+async def test_v2_set_direction(hass: HomeAssistant) -> None:
     """Test that we can set fan spin direction."""
     helper = await setup_test_component(hass, create_fanv2_service)
 
@@ -687,7 +687,7 @@ async def test_v2_set_direction(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_v2_direction_read(hass: HomeAssistant, utcnow) -> None:
+async def test_v2_direction_read(hass: HomeAssistant) -> None:
     """Test that we can read a fans oscillation."""
     helper = await setup_test_component(hass, create_fanv2_service)
 
@@ -702,7 +702,7 @@ async def test_v2_direction_read(hass: HomeAssistant, utcnow) -> None:
     assert state.attributes["direction"] == "reverse"
 
 
-async def test_v2_oscillate(hass: HomeAssistant, utcnow) -> None:
+async def test_v2_oscillate(hass: HomeAssistant) -> None:
     """Test that we can control a fans oscillation."""
     helper = await setup_test_component(hass, create_fanv2_service)
 
@@ -733,7 +733,7 @@ async def test_v2_oscillate(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_v2_oscillate_read(hass: HomeAssistant, utcnow) -> None:
+async def test_v2_oscillate_read(hass: HomeAssistant) -> None:
     """Test that we can read a fans oscillation."""
     helper = await setup_test_component(hass, create_fanv2_service)
 
@@ -749,7 +749,7 @@ async def test_v2_oscillate_read(hass: HomeAssistant, utcnow) -> None:
 
 
 async def test_v2_set_percentage_non_standard_rotation_range(
-    hass: HomeAssistant, utcnow
+    hass: HomeAssistant
 ) -> None:
     """Test that we set fan speed with a non-standard rotation range."""
     helper = await setup_test_component(
@@ -812,7 +812,7 @@ async def test_v2_set_percentage_non_standard_rotation_range(
 
 
 async def test_migrate_unique_id(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test a we can migrate a fan unique id."""
     aid = get_next_aid()

--- a/tests/components/homekit_controller/test_humidifier.py
+++ b/tests/components/homekit_controller/test_humidifier.py
@@ -63,7 +63,7 @@ def create_dehumidifier_service(accessory):
     return service
 
 
-async def test_humidifier_active_state(hass: HomeAssistant, utcnow) -> None:
+async def test_humidifier_active_state(hass: HomeAssistant) -> None:
     """Test that we can turn a HomeKit humidifier on and off again."""
     helper = await setup_test_component(hass, create_humidifier_service)
 
@@ -86,7 +86,7 @@ async def test_humidifier_active_state(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_dehumidifier_active_state(hass: HomeAssistant, utcnow) -> None:
+async def test_dehumidifier_active_state(hass: HomeAssistant) -> None:
     """Test that we can turn a HomeKit dehumidifier on and off again."""
     helper = await setup_test_component(hass, create_dehumidifier_service)
 
@@ -109,7 +109,7 @@ async def test_dehumidifier_active_state(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_humidifier_read_humidity(hass: HomeAssistant, utcnow) -> None:
+async def test_humidifier_read_humidity(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit humidifier accessory."""
     helper = await setup_test_component(hass, create_humidifier_service)
 
@@ -148,7 +148,7 @@ async def test_humidifier_read_humidity(hass: HomeAssistant, utcnow) -> None:
     assert state.state == "off"
 
 
-async def test_dehumidifier_read_humidity(hass: HomeAssistant, utcnow) -> None:
+async def test_dehumidifier_read_humidity(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit dehumidifier accessory."""
     helper = await setup_test_component(hass, create_dehumidifier_service)
 
@@ -185,7 +185,7 @@ async def test_dehumidifier_read_humidity(hass: HomeAssistant, utcnow) -> None:
     assert state.attributes["humidity"] == 40
 
 
-async def test_humidifier_set_humidity(hass: HomeAssistant, utcnow) -> None:
+async def test_humidifier_set_humidity(hass: HomeAssistant) -> None:
     """Test that we can set the state of a HomeKit humidifier accessory."""
     helper = await setup_test_component(hass, create_humidifier_service)
 
@@ -201,7 +201,7 @@ async def test_humidifier_set_humidity(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_dehumidifier_set_humidity(hass: HomeAssistant, utcnow) -> None:
+async def test_dehumidifier_set_humidity(hass: HomeAssistant) -> None:
     """Test that we can set the state of a HomeKit dehumidifier accessory."""
     helper = await setup_test_component(hass, create_dehumidifier_service)
 
@@ -217,7 +217,7 @@ async def test_dehumidifier_set_humidity(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_humidifier_set_mode(hass: HomeAssistant, utcnow) -> None:
+async def test_humidifier_set_mode(hass: HomeAssistant) -> None:
     """Test that we can set the mode of a HomeKit humidifier accessory."""
     helper = await setup_test_component(hass, create_humidifier_service)
 
@@ -250,7 +250,7 @@ async def test_humidifier_set_mode(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_dehumidifier_set_mode(hass: HomeAssistant, utcnow) -> None:
+async def test_dehumidifier_set_mode(hass: HomeAssistant) -> None:
     """Test that we can set the mode of a HomeKit dehumidifier accessory."""
     helper = await setup_test_component(hass, create_dehumidifier_service)
 
@@ -283,7 +283,7 @@ async def test_dehumidifier_set_mode(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_humidifier_read_only_mode(hass: HomeAssistant, utcnow) -> None:
+async def test_humidifier_read_only_mode(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit humidifier accessory."""
     helper = await setup_test_component(hass, create_humidifier_service)
 
@@ -323,7 +323,7 @@ async def test_humidifier_read_only_mode(hass: HomeAssistant, utcnow) -> None:
     assert state.attributes["mode"] == "normal"
 
 
-async def test_dehumidifier_read_only_mode(hass: HomeAssistant, utcnow) -> None:
+async def test_dehumidifier_read_only_mode(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit dehumidifier accessory."""
     helper = await setup_test_component(hass, create_dehumidifier_service)
 
@@ -363,7 +363,7 @@ async def test_dehumidifier_read_only_mode(hass: HomeAssistant, utcnow) -> None:
     assert state.attributes["mode"] == "normal"
 
 
-async def test_humidifier_target_humidity_modes(hass: HomeAssistant, utcnow) -> None:
+async def test_humidifier_target_humidity_modes(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit humidifier accessory."""
     helper = await setup_test_component(hass, create_humidifier_service)
 
@@ -408,7 +408,7 @@ async def test_humidifier_target_humidity_modes(hass: HomeAssistant, utcnow) -> 
     assert state.attributes["humidity"] == 37
 
 
-async def test_dehumidifier_target_humidity_modes(hass: HomeAssistant, utcnow) -> None:
+async def test_dehumidifier_target_humidity_modes(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit dehumidifier accessory."""
     helper = await setup_test_component(hass, create_dehumidifier_service)
 
@@ -456,7 +456,7 @@ async def test_dehumidifier_target_humidity_modes(hass: HomeAssistant, utcnow) -
 
 
 async def test_migrate_entity_ids(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test that we can migrate humidifier entity ids."""
     aid = get_next_aid()

--- a/tests/components/homekit_controller/test_init.py
+++ b/tests/components/homekit_controller/test_init.py
@@ -46,7 +46,7 @@ def create_motion_sensor_service(accessory):
     cur_state.value = 0
 
 
-async def test_unload_on_stop(hass: HomeAssistant, utcnow) -> None:
+async def test_unload_on_stop(hass: HomeAssistant) -> None:
     """Test async_unload is called on stop."""
     await setup_test_component(hass, create_motion_sensor_service)
     with patch(

--- a/tests/components/homekit_controller/test_light.py
+++ b/tests/components/homekit_controller/test_light.py
@@ -54,7 +54,7 @@ def create_lightbulb_service_with_color_temp(accessory):
     return service
 
 
-async def test_switch_change_light_state(hass: HomeAssistant, utcnow) -> None:
+async def test_switch_change_light_state(hass: HomeAssistant) -> None:
     """Test that we can turn a HomeKit light on and off again."""
     helper = await setup_test_component(hass, create_lightbulb_service_with_hs)
 
@@ -85,9 +85,7 @@ async def test_switch_change_light_state(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_switch_change_light_state_color_temp(
-    hass: HomeAssistant, utcnow
-) -> None:
+async def test_switch_change_light_state_color_temp(hass: HomeAssistant) -> None:
     """Test that we can turn change color_temp."""
     helper = await setup_test_component(hass, create_lightbulb_service_with_color_temp)
 
@@ -107,7 +105,7 @@ async def test_switch_change_light_state_color_temp(
     )
 
 
-async def test_switch_read_light_state_dimmer(hass: HomeAssistant, utcnow) -> None:
+async def test_switch_read_light_state_dimmer(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit light accessory."""
     helper = await setup_test_component(hass, create_lightbulb_service)
 
@@ -142,7 +140,7 @@ async def test_switch_read_light_state_dimmer(hass: HomeAssistant, utcnow) -> No
     assert state.state == "off"
 
 
-async def test_switch_push_light_state_dimmer(hass: HomeAssistant, utcnow) -> None:
+async def test_switch_push_light_state_dimmer(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit light accessory."""
     helper = await setup_test_component(hass, create_lightbulb_service)
 
@@ -170,7 +168,7 @@ async def test_switch_push_light_state_dimmer(hass: HomeAssistant, utcnow) -> No
     assert state.state == "off"
 
 
-async def test_switch_read_light_state_hs(hass: HomeAssistant, utcnow) -> None:
+async def test_switch_read_light_state_hs(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit light accessory."""
     helper = await setup_test_component(hass, create_lightbulb_service_with_hs)
 
@@ -208,7 +206,7 @@ async def test_switch_read_light_state_hs(hass: HomeAssistant, utcnow) -> None:
     assert state.state == "off"
 
 
-async def test_switch_push_light_state_hs(hass: HomeAssistant, utcnow) -> None:
+async def test_switch_push_light_state_hs(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit light accessory."""
     helper = await setup_test_component(hass, create_lightbulb_service_with_hs)
 
@@ -239,7 +237,7 @@ async def test_switch_push_light_state_hs(hass: HomeAssistant, utcnow) -> None:
     assert state.state == "off"
 
 
-async def test_switch_read_light_state_color_temp(hass: HomeAssistant, utcnow) -> None:
+async def test_switch_read_light_state_color_temp(hass: HomeAssistant) -> None:
     """Test that we can read the color_temp of a  light accessory."""
     helper = await setup_test_component(hass, create_lightbulb_service_with_color_temp)
 
@@ -267,7 +265,7 @@ async def test_switch_read_light_state_color_temp(hass: HomeAssistant, utcnow) -
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
 
 
-async def test_switch_push_light_state_color_temp(hass: HomeAssistant, utcnow) -> None:
+async def test_switch_push_light_state_color_temp(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit light accessory."""
     helper = await setup_test_component(hass, create_lightbulb_service_with_color_temp)
 
@@ -288,9 +286,7 @@ async def test_switch_push_light_state_color_temp(hass: HomeAssistant, utcnow) -
     assert state.attributes["color_temp"] == 400
 
 
-async def test_light_becomes_unavailable_but_recovers(
-    hass: HomeAssistant, utcnow
-) -> None:
+async def test_light_becomes_unavailable_but_recovers(hass: HomeAssistant) -> None:
     """Test transition to and from unavailable state."""
     helper = await setup_test_component(hass, create_lightbulb_service_with_color_temp)
 
@@ -318,7 +314,7 @@ async def test_light_becomes_unavailable_but_recovers(
     assert state.attributes["color_temp"] == 400
 
 
-async def test_light_unloaded_removed(hass: HomeAssistant, utcnow) -> None:
+async def test_light_unloaded_removed(hass: HomeAssistant) -> None:
     """Test entity and HKDevice are correctly unloaded and removed."""
     helper = await setup_test_component(hass, create_lightbulb_service_with_color_temp)
 
@@ -344,7 +340,7 @@ async def test_light_unloaded_removed(hass: HomeAssistant, utcnow) -> None:
 
 
 async def test_migrate_unique_id(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test a we can migrate a light unique id."""
     aid = get_next_aid()
@@ -362,7 +358,7 @@ async def test_migrate_unique_id(
 
 
 async def test_only_migrate_once(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test a we handle migration happening after an upgrade and than a downgrade and then an upgrade."""
     aid = get_next_aid()

--- a/tests/components/homekit_controller/test_lock.py
+++ b/tests/components/homekit_controller/test_lock.py
@@ -28,7 +28,7 @@ def create_lock_service(accessory):
     return service
 
 
-async def test_switch_change_lock_state(hass: HomeAssistant, utcnow) -> None:
+async def test_switch_change_lock_state(hass: HomeAssistant) -> None:
     """Test that we can turn a HomeKit lock on and off again."""
     helper = await setup_test_component(hass, create_lock_service)
 
@@ -53,7 +53,7 @@ async def test_switch_change_lock_state(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_switch_read_lock_state(hass: HomeAssistant, utcnow) -> None:
+async def test_switch_read_lock_state(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit lock accessory."""
     helper = await setup_test_component(hass, create_lock_service)
 
@@ -118,7 +118,7 @@ async def test_switch_read_lock_state(hass: HomeAssistant, utcnow) -> None:
 
 
 async def test_migrate_unique_id(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test a we can migrate a lock unique id."""
     aid = get_next_aid()

--- a/tests/components/homekit_controller/test_media_player.py
+++ b/tests/components/homekit_controller/test_media_player.py
@@ -61,7 +61,7 @@ def create_tv_service_with_target_media_state(accessory):
     return service
 
 
-async def test_tv_read_state(hass: HomeAssistant, utcnow) -> None:
+async def test_tv_read_state(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit fan accessory."""
     helper = await setup_test_component(hass, create_tv_service)
 
@@ -90,7 +90,7 @@ async def test_tv_read_state(hass: HomeAssistant, utcnow) -> None:
     assert state.state == "idle"
 
 
-async def test_tv_read_sources(hass: HomeAssistant, utcnow) -> None:
+async def test_tv_read_sources(hass: HomeAssistant) -> None:
     """Test that we can read the input source of a HomeKit TV."""
     helper = await setup_test_component(hass, create_tv_service)
 
@@ -99,7 +99,7 @@ async def test_tv_read_sources(hass: HomeAssistant, utcnow) -> None:
     assert state.attributes["source_list"] == ["HDMI 1", "HDMI 2"]
 
 
-async def test_play_remote_key(hass: HomeAssistant, utcnow) -> None:
+async def test_play_remote_key(hass: HomeAssistant) -> None:
     """Test that we can play media on a media player."""
     helper = await setup_test_component(hass, create_tv_service)
 
@@ -146,7 +146,7 @@ async def test_play_remote_key(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_pause_remote_key(hass: HomeAssistant, utcnow) -> None:
+async def test_pause_remote_key(hass: HomeAssistant) -> None:
     """Test that we can pause a media player."""
     helper = await setup_test_component(hass, create_tv_service)
 
@@ -193,7 +193,7 @@ async def test_pause_remote_key(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_play(hass: HomeAssistant, utcnow) -> None:
+async def test_play(hass: HomeAssistant) -> None:
     """Test that we can play media on a media player."""
     helper = await setup_test_component(hass, create_tv_service_with_target_media_state)
 
@@ -242,7 +242,7 @@ async def test_play(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_pause(hass: HomeAssistant, utcnow) -> None:
+async def test_pause(hass: HomeAssistant) -> None:
     """Test that we can turn pause a media player."""
     helper = await setup_test_component(hass, create_tv_service_with_target_media_state)
 
@@ -290,7 +290,7 @@ async def test_pause(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_stop(hass: HomeAssistant, utcnow) -> None:
+async def test_stop(hass: HomeAssistant) -> None:
     """Test that we can  stop a media player."""
     helper = await setup_test_component(hass, create_tv_service_with_target_media_state)
 
@@ -331,7 +331,7 @@ async def test_stop(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_tv_set_source(hass: HomeAssistant, utcnow) -> None:
+async def test_tv_set_source(hass: HomeAssistant) -> None:
     """Test that we can set the input source of a HomeKit TV."""
     helper = await setup_test_component(hass, create_tv_service)
 
@@ -352,7 +352,7 @@ async def test_tv_set_source(hass: HomeAssistant, utcnow) -> None:
     assert state.attributes["source"] == "HDMI 2"
 
 
-async def test_tv_set_source_fail(hass: HomeAssistant, utcnow) -> None:
+async def test_tv_set_source_fail(hass: HomeAssistant) -> None:
     """Test that we can set the input source of a HomeKit TV."""
     helper = await setup_test_component(hass, create_tv_service)
 
@@ -369,7 +369,7 @@ async def test_tv_set_source_fail(hass: HomeAssistant, utcnow) -> None:
 
 
 async def test_migrate_unique_id(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test a we can migrate a media_player unique id."""
     aid = get_next_aid()

--- a/tests/components/homekit_controller/test_number.py
+++ b/tests/components/homekit_controller/test_number.py
@@ -30,7 +30,7 @@ def create_switch_with_spray_level(accessory):
 
 
 async def test_migrate_unique_id(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test a we can migrate a number unique id."""
     aid = get_next_aid()
@@ -48,7 +48,7 @@ async def test_migrate_unique_id(
     )
 
 
-async def test_read_number(hass: HomeAssistant, utcnow) -> None:
+async def test_read_number(hass: HomeAssistant) -> None:
     """Test a switch service that has a sensor characteristic is correctly handled."""
     helper = await setup_test_component(hass, create_switch_with_spray_level)
 
@@ -74,7 +74,7 @@ async def test_read_number(hass: HomeAssistant, utcnow) -> None:
     assert state.state == "5"
 
 
-async def test_write_number(hass: HomeAssistant, utcnow) -> None:
+async def test_write_number(hass: HomeAssistant) -> None:
     """Test a switch service that has a sensor characteristic is correctly handled."""
     helper = await setup_test_component(hass, create_switch_with_spray_level)
 

--- a/tests/components/homekit_controller/test_select.py
+++ b/tests/components/homekit_controller/test_select.py
@@ -34,7 +34,7 @@ def create_service_with_temperature_units(accessory: Accessory):
 
 
 async def test_migrate_unique_id(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test we can migrate a select unique id."""
     aid = get_next_aid()
@@ -53,7 +53,7 @@ async def test_migrate_unique_id(
     )
 
 
-async def test_read_current_mode(hass: HomeAssistant, utcnow) -> None:
+async def test_read_current_mode(hass: HomeAssistant) -> None:
     """Test that Ecobee mode can be correctly read and show as human readable text."""
     helper = await setup_test_component(hass, create_service_with_ecobee_mode)
 
@@ -91,7 +91,7 @@ async def test_read_current_mode(hass: HomeAssistant, utcnow) -> None:
     assert state.state == "away"
 
 
-async def test_write_current_mode(hass: HomeAssistant, utcnow) -> None:
+async def test_write_current_mode(hass: HomeAssistant) -> None:
     """Test can set a specific mode."""
     helper = await setup_test_component(hass, create_service_with_ecobee_mode)
     helper.accessory.services.first(service_type=ServicesTypes.THERMOSTAT)
@@ -139,7 +139,7 @@ async def test_write_current_mode(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_read_select(hass: HomeAssistant, utcnow) -> None:
+async def test_read_select(hass: HomeAssistant) -> None:
     """Test the generic select can read the current value."""
     helper = await setup_test_component(hass, create_service_with_temperature_units)
 
@@ -169,7 +169,7 @@ async def test_read_select(hass: HomeAssistant, utcnow) -> None:
     assert state.state == "fahrenheit"
 
 
-async def test_write_select(hass: HomeAssistant, utcnow) -> None:
+async def test_write_select(hass: HomeAssistant) -> None:
     """Test can set a value."""
     helper = await setup_test_component(hass, create_service_with_temperature_units)
     helper.accessory.services.first(service_type=ServicesTypes.THERMOSTAT)

--- a/tests/components/homekit_controller/test_sensor.py
+++ b/tests/components/homekit_controller/test_sensor.py
@@ -69,7 +69,7 @@ def create_battery_level_sensor(accessory):
     return service
 
 
-async def test_temperature_sensor_read_state(hass: HomeAssistant, utcnow) -> None:
+async def test_temperature_sensor_read_state(hass: HomeAssistant) -> None:
     """Test reading the state of a HomeKit temperature sensor accessory."""
     helper = await setup_test_component(
         hass, create_temperature_sensor_service, suffix="temperature"
@@ -95,7 +95,7 @@ async def test_temperature_sensor_read_state(hass: HomeAssistant, utcnow) -> Non
     assert state.attributes["state_class"] == SensorStateClass.MEASUREMENT
 
 
-async def test_temperature_sensor_not_added_twice(hass: HomeAssistant, utcnow) -> None:
+async def test_temperature_sensor_not_added_twice(hass: HomeAssistant) -> None:
     """A standalone temperature sensor should not get a characteristic AND a service entity."""
     helper = await setup_test_component(
         hass, create_temperature_sensor_service, suffix="temperature"
@@ -109,7 +109,7 @@ async def test_temperature_sensor_not_added_twice(hass: HomeAssistant, utcnow) -
     assert created_sensors == {helper.entity_id}
 
 
-async def test_humidity_sensor_read_state(hass: HomeAssistant, utcnow) -> None:
+async def test_humidity_sensor_read_state(hass: HomeAssistant) -> None:
     """Test reading the state of a HomeKit humidity sensor accessory."""
     helper = await setup_test_component(
         hass, create_humidity_sensor_service, suffix="humidity"
@@ -134,7 +134,7 @@ async def test_humidity_sensor_read_state(hass: HomeAssistant, utcnow) -> None:
     assert state.attributes["device_class"] == SensorDeviceClass.HUMIDITY
 
 
-async def test_light_level_sensor_read_state(hass: HomeAssistant, utcnow) -> None:
+async def test_light_level_sensor_read_state(hass: HomeAssistant) -> None:
     """Test reading the state of a HomeKit temperature sensor accessory."""
     helper = await setup_test_component(
         hass, create_light_level_sensor_service, suffix="light_level"
@@ -159,9 +159,7 @@ async def test_light_level_sensor_read_state(hass: HomeAssistant, utcnow) -> Non
     assert state.attributes["device_class"] == SensorDeviceClass.ILLUMINANCE
 
 
-async def test_carbon_dioxide_level_sensor_read_state(
-    hass: HomeAssistant, utcnow
-) -> None:
+async def test_carbon_dioxide_level_sensor_read_state(hass: HomeAssistant) -> None:
     """Test reading the state of a HomeKit carbon dioxide sensor accessory."""
     helper = await setup_test_component(
         hass, create_carbon_dioxide_level_sensor_service, suffix="carbon_dioxide"
@@ -184,7 +182,7 @@ async def test_carbon_dioxide_level_sensor_read_state(
     assert state.state == "20"
 
 
-async def test_battery_level_sensor(hass: HomeAssistant, utcnow) -> None:
+async def test_battery_level_sensor(hass: HomeAssistant) -> None:
     """Test reading the state of a HomeKit battery level sensor."""
     helper = await setup_test_component(
         hass, create_battery_level_sensor, suffix="battery"
@@ -211,7 +209,7 @@ async def test_battery_level_sensor(hass: HomeAssistant, utcnow) -> None:
     assert state.attributes["device_class"] == SensorDeviceClass.BATTERY
 
 
-async def test_battery_charging(hass: HomeAssistant, utcnow) -> None:
+async def test_battery_charging(hass: HomeAssistant) -> None:
     """Test reading the state of a HomeKit battery's charging state."""
     helper = await setup_test_component(
         hass, create_battery_level_sensor, suffix="battery"
@@ -235,7 +233,7 @@ async def test_battery_charging(hass: HomeAssistant, utcnow) -> None:
     assert state.attributes["icon"] == "mdi:battery-charging-20"
 
 
-async def test_battery_low(hass: HomeAssistant, utcnow) -> None:
+async def test_battery_low(hass: HomeAssistant) -> None:
     """Test reading the state of a HomeKit battery's low state."""
     helper = await setup_test_component(
         hass, create_battery_level_sensor, suffix="battery"
@@ -277,7 +275,7 @@ def create_switch_with_sensor(accessory):
     return service
 
 
-async def test_switch_with_sensor(hass: HomeAssistant, utcnow) -> None:
+async def test_switch_with_sensor(hass: HomeAssistant) -> None:
     """Test a switch service that has a sensor characteristic is correctly handled."""
     helper = await setup_test_component(hass, create_switch_with_sensor)
 
@@ -307,7 +305,7 @@ async def test_switch_with_sensor(hass: HomeAssistant, utcnow) -> None:
     assert state.state == "50"
 
 
-async def test_sensor_unavailable(hass: HomeAssistant, utcnow) -> None:
+async def test_sensor_unavailable(hass: HomeAssistant) -> None:
     """Test a sensor becoming unavailable."""
     helper = await setup_test_component(hass, create_switch_with_sensor)
 
@@ -384,7 +382,6 @@ def test_thread_status_to_str() -> None:
 
 async def test_rssi_sensor(
     hass: HomeAssistant,
-    utcnow,
     entity_registry_enabled_by_default: None,
     enable_bluetooth: None,
 ) -> None:
@@ -410,7 +407,6 @@ async def test_rssi_sensor(
 async def test_migrate_rssi_sensor_unique_id(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    utcnow,
     entity_registry_enabled_by_default: None,
     enable_bluetooth: None,
 ) -> None:

--- a/tests/components/homekit_controller/test_storage.py
+++ b/tests/components/homekit_controller/test_storage.py
@@ -71,7 +71,7 @@ def create_lightbulb_service(accessory):
 
 
 async def test_storage_is_updated_on_add(
-    hass: HomeAssistant, hass_storage: dict[str, Any], utcnow
+    hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:
     """Test entity map storage is cleaned up on adding an accessory."""
     await setup_test_component(hass, create_lightbulb_service)

--- a/tests/components/homekit_controller/test_switch.py
+++ b/tests/components/homekit_controller/test_switch.py
@@ -49,7 +49,7 @@ def create_char_switch_service(accessory):
     on_char.value = False
 
 
-async def test_switch_change_outlet_state(hass: HomeAssistant, utcnow) -> None:
+async def test_switch_change_outlet_state(hass: HomeAssistant) -> None:
     """Test that we can turn a HomeKit outlet on and off again."""
     helper = await setup_test_component(hass, create_switch_service)
 
@@ -74,7 +74,7 @@ async def test_switch_change_outlet_state(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_switch_read_outlet_state(hass: HomeAssistant, utcnow) -> None:
+async def test_switch_read_outlet_state(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit outlet accessory."""
     helper = await setup_test_component(hass, create_switch_service)
 
@@ -107,7 +107,7 @@ async def test_switch_read_outlet_state(hass: HomeAssistant, utcnow) -> None:
     assert switch_1.attributes["outlet_in_use"] is True
 
 
-async def test_valve_change_active_state(hass: HomeAssistant, utcnow) -> None:
+async def test_valve_change_active_state(hass: HomeAssistant) -> None:
     """Test that we can turn a valve on and off again."""
     helper = await setup_test_component(hass, create_valve_service)
 
@@ -132,7 +132,7 @@ async def test_valve_change_active_state(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_valve_read_state(hass: HomeAssistant, utcnow) -> None:
+async def test_valve_read_state(hass: HomeAssistant) -> None:
     """Test that we can read the state of a valve accessory."""
     helper = await setup_test_component(hass, create_valve_service)
 
@@ -165,7 +165,7 @@ async def test_valve_read_state(hass: HomeAssistant, utcnow) -> None:
     assert switch_1.attributes["in_use"] is False
 
 
-async def test_char_switch_change_state(hass: HomeAssistant, utcnow) -> None:
+async def test_char_switch_change_state(hass: HomeAssistant) -> None:
     """Test that we can turn a characteristic on and off again."""
     helper = await setup_test_component(
         hass, create_char_switch_service, suffix="pairing_mode"
@@ -198,7 +198,7 @@ async def test_char_switch_change_state(hass: HomeAssistant, utcnow) -> None:
     )
 
 
-async def test_char_switch_read_state(hass: HomeAssistant, utcnow) -> None:
+async def test_char_switch_read_state(hass: HomeAssistant) -> None:
     """Test that we can read the state of a HomeKit characteristic switch."""
     helper = await setup_test_component(
         hass, create_char_switch_service, suffix="pairing_mode"
@@ -220,7 +220,7 @@ async def test_char_switch_read_state(hass: HomeAssistant, utcnow) -> None:
 
 
 async def test_migrate_unique_id(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, utcnow
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test a we can migrate a switch unique id."""
     aid = get_next_aid()


### PR DESCRIPTION
## Proposed change
Migrate the homekit_controller tests to use freezegun.

TIL: It is important how the fixtures of the test function are ordered. I now make use of `mark.usefixtures` so that the time is frozen when we create the token for the `hass_client`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
