### PR TITLE
Reload ZHA integration on any error, not just recoverable ones

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -37,8 +37,6 @@ from .core.const import (
     DOMAIN,
     PLATFORMS,
     SIGNAL_ADD_ENTITIES,
-    STARTUP_FAILURE_DELAY_S,
-    STARTUP_RETRIES,
     RadioType,
 )
 from .core.device import get_device_automation_triggers
@@ -161,49 +159,40 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     _LOGGER.debug("Trigger cache: %s", zha_data.device_trigger_cache)
 
-    # Retry setup a few times before giving up to deal with missing serial ports in VMs
-    for attempt in range(STARTUP_RETRIES):
-        try:
-            zha_gateway = await ZHAGateway.async_from_config(
-                hass=hass,
-                config=zha_data.yaml_config,
-                config_entry=config_entry,
-            )
-            break
-        except NetworkSettingsInconsistent as exc:
-            await warn_on_inconsistent_network_settings(
-                hass,
-                config_entry=config_entry,
-                old_state=exc.old_state,
-                new_state=exc.new_state,
-            )
-            raise ConfigEntryError(
-                "Network settings do not match most recent backup"
-            ) from exc
-        except TransientConnectionError as exc:
-            raise ConfigEntryNotReady from exc
-        except Exception as exc:
-            _LOGGER.debug(
-                "Couldn't start coordinator (attempt %s of %s)",
-                attempt + 1,
-                STARTUP_RETRIES,
-                exc_info=exc,
-            )
+    try:
+        zha_gateway = await ZHAGateway.async_from_config(
+            hass=hass,
+            config=zha_data.yaml_config,
+            config_entry=config_entry,
+        )
+    except NetworkSettingsInconsistent as exc:
+        await warn_on_inconsistent_network_settings(
+            hass,
+            config_entry=config_entry,
+            old_state=exc.old_state,
+            new_state=exc.new_state,
+        )
+        raise ConfigEntryError(
+            "Network settings do not match most recent backup"
+        ) from exc
+    except TransientConnectionError as exc:
+        raise ConfigEntryNotReady from exc
+    except Exception as exc:
+        _LOGGER.debug("Failed to set up ZHA", exc_info=exc)
+        device_path = config_entry.data[CONF_DEVICE][CONF_DEVICE_PATH]
 
-            if attempt < STARTUP_RETRIES - 1:
-                await asyncio.sleep(STARTUP_FAILURE_DELAY_S)
-                continue
+        if (
+            not device_path.startswith("socket://")
+            and RadioType[config_entry.data[CONF_RADIO_TYPE]] == RadioType.ezsp
+        ):
+            try:
+                # Ignore all exceptions during probing, they shouldn't halt setup
+                if await warn_on_wrong_silabs_firmware(hass, device_path):
+                    raise ConfigEntryError("Incorrect firmware installed") from exc
+            except AlreadyRunningEZSP as ezsp_exc:
+                raise ConfigEntryNotReady from ezsp_exc
 
-            if RadioType[config_entry.data[CONF_RADIO_TYPE]] == RadioType.ezsp:
-                try:
-                    # Ignore all exceptions during probing, they shouldn't halt setup
-                    await warn_on_wrong_silabs_firmware(
-                        hass, config_entry.data[CONF_DEVICE][CONF_DEVICE_PATH]
-                    )
-                except AlreadyRunningEZSP as ezsp_exc:
-                    raise ConfigEntryNotReady from ezsp_exc
-
-            raise
+        raise ConfigEntryNotReady from exc
 
     repairs.async_delete_blocking_issues(hass)
 

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -409,9 +409,6 @@ class Strobe(t.enum8):
     Strobe = 0x01
 
 
-STARTUP_FAILURE_DELAY_S = 3
-STARTUP_RETRIES = 3
-
 EZSP_OVERWRITE_EUI64 = (
     "i_understand_i_can_update_eui64_only_once_and_i_still_want_to_do_it"
 )

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -46,7 +46,7 @@ def disable_request_retry_delay():
     with patch(
         "homeassistant.components.zha.core.cluster_handlers.RETRYABLE_REQUEST_DECORATOR",
         zigpy.util.retryable_request(tries=3, delay=0),
-    ), patch("homeassistant.components.zha.STARTUP_FAILURE_DELAY_S", 0.01):
+    ):
         yield
 
 

--- a/tests/components/zha/test_repairs.py
+++ b/tests/components/zha/test_repairs.py
@@ -175,7 +175,7 @@ async def test_multipan_firmware_no_repair_on_probe_failure(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-        assert config_entry.state == ConfigEntryState.SETUP_ERROR
+        assert config_entry.state == ConfigEntryState.SETUP_RETRY
 
     await hass.config_entries.async_unload(config_entry.entry_id)
 

--- a/tests/components/zha/test_repairs.py
+++ b/tests/components/zha/test_repairs.py
@@ -95,7 +95,6 @@ def test_detect_radio_hardware_failure(hass: HomeAssistant) -> None:
         assert _detect_radio_hardware(hass, SKYCONNECT_DEVICE) == HardwareType.OTHER
 
 
-@patch("homeassistant.components.zha.STARTUP_RETRIES", new=1)
 @pytest.mark.parametrize(
     ("detected_hardware", "expected_learn_more_url"),
     [
@@ -189,7 +188,6 @@ async def test_multipan_firmware_no_repair_on_probe_failure(
     assert issue is None
 
 
-@patch("homeassistant.components.zha.STARTUP_RETRIES", new=1)
 async def test_multipan_firmware_retry_on_probe_ezsp(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
#104335 changed the behavior of ZHA and it no longer reloaded on unrecoverable errors (USB stick missing). This PR adjusts the behavior so that ZHA will always try to reload (unless the wrong firmware is installed on your SiLabs stick).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #105539, #105506, #105449, #105445
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
