### PR TITLE
Bump ZHA dependencies

### DIFF
--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -139,7 +139,6 @@ CONF_ENABLE_IDENTIFY_ON_JOIN = "enable_identify_on_join"
 CONF_ENABLE_QUIRKS = "enable_quirks"
 CONF_RADIO_TYPE = "radio_type"
 CONF_USB_PATH = "usb_path"
-CONF_USE_THREAD = "use_thread"
 CONF_ZIGPY = "zigpy_config"
 
 CONF_CONSIDER_UNAVAILABLE_MAINS = "consider_unavailable_mains"

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -46,7 +46,6 @@ from .const import (
     ATTR_SIGNATURE,
     ATTR_TYPE,
     CONF_RADIO_TYPE,
-    CONF_USE_THREAD,
     CONF_ZIGPY,
     DEBUG_COMP_BELLOWS,
     DEBUG_COMP_ZHA,
@@ -157,15 +156,6 @@ class ZHAGateway:
 
         if CONF_NWK_VALIDATE_SETTINGS not in app_config:
             app_config[CONF_NWK_VALIDATE_SETTINGS] = True
-
-        # The bellows UART thread sometimes propagates a cancellation into the main Core
-        # event loop, when a connection to a TCP coordinator fails in a specific way
-        if (
-            CONF_USE_THREAD not in app_config
-            and radio_type is RadioType.ezsp
-            and app_config[CONF_DEVICE][CONF_DEVICE_PATH].startswith("socket://")
-        ):
-            app_config[CONF_USE_THREAD] = False
 
         # Local import to avoid circular dependencies
         # pylint: disable-next=import-outside-toplevel

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,13 +21,13 @@
     "universal_silabs_flasher"
   ],
   "requirements": [
-    "bellows==0.37.1",
+    "bellows==0.37.3",
     "pyserial==3.5",
     "pyserial-asyncio==0.6",
     "zha-quirks==0.0.107",
-    "zigpy-deconz==0.22.0",
-    "zigpy==0.60.0",
-    "zigpy-xbee==0.20.0",
+    "zigpy-deconz==0.22.2",
+    "zigpy==0.60.1",
+    "zigpy-xbee==0.20.1",
     "zigpy-zigate==0.12.0",
     "zigpy-znp==0.12.0",
     "universal-silabs-flasher==0.0.15",

--- a/homeassistant/components/zha/radio_manager.py
+++ b/homeassistant/components/zha/radio_manager.py
@@ -10,7 +10,6 @@ import logging
 import os
 from typing import Any, Self
 
-from bellows.config import CONF_USE_THREAD
 import voluptuous as vol
 from zigpy.application import ControllerApplication
 import zigpy.backups
@@ -175,7 +174,6 @@ class ZhaRadioManager:
         app_config[CONF_DATABASE] = database_path
         app_config[CONF_DEVICE] = self.device_settings
         app_config[CONF_NWK_BACKUP_ENABLED] = False
-        app_config[CONF_USE_THREAD] = False
         app_config = self.radio_type.controller.SCHEMA(app_config)
 
         app = await self.radio_type.controller.new(

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -526,7 +526,7 @@ beautifulsoup4==4.12.2
 # beewi-smartclim==0.0.10
 
 # homeassistant.components.zha
-bellows==0.37.1
+bellows==0.37.3
 
 # homeassistant.components.bmw_connected_drive
 bimmer-connected[china]==0.14.6
@@ -2847,10 +2847,10 @@ zhong-hong-hvac==1.0.9
 ziggo-mediabox-xl==1.1.0
 
 # homeassistant.components.zha
-zigpy-deconz==0.22.0
+zigpy-deconz==0.22.2
 
 # homeassistant.components.zha
-zigpy-xbee==0.20.0
+zigpy-xbee==0.20.1
 
 # homeassistant.components.zha
 zigpy-zigate==0.12.0
@@ -2859,7 +2859,7 @@ zigpy-zigate==0.12.0
 zigpy-znp==0.12.0
 
 # homeassistant.components.zha
-zigpy==0.60.0
+zigpy==0.60.1
 
 # homeassistant.components.zoneminder
 zm-py==0.5.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -448,7 +448,7 @@ base36==0.1.1
 beautifulsoup4==4.12.2
 
 # homeassistant.components.zha
-bellows==0.37.1
+bellows==0.37.3
 
 # homeassistant.components.bmw_connected_drive
 bimmer-connected[china]==0.14.6
@@ -2139,10 +2139,10 @@ zeversolar==0.3.1
 zha-quirks==0.0.107
 
 # homeassistant.components.zha
-zigpy-deconz==0.22.0
+zigpy-deconz==0.22.2
 
 # homeassistant.components.zha
-zigpy-xbee==0.20.0
+zigpy-xbee==0.20.1
 
 # homeassistant.components.zha
 zigpy-zigate==0.12.0
@@ -2151,7 +2151,7 @@ zigpy-zigate==0.12.0
 zigpy-znp==0.12.0
 
 # homeassistant.components.zha
-zigpy==0.60.0
+zigpy==0.60.1
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.54.0

--- a/tests/components/zha/test_gateway.py
+++ b/tests/components/zha/test_gateway.py
@@ -1,9 +1,8 @@
 """Test ZHA Gateway."""
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
-from zigpy.application import ControllerApplication
 import zigpy.profiles.zha as zha
 import zigpy.zcl.clusters.general as general
 import zigpy.zcl.clusters.lighting as lighting
@@ -221,48 +220,6 @@ async def test_gateway_create_group_with_id(
     assert len(zha_group.members) == 1
     assert zha_group.members[0].device is device_light_1
     assert zha_group.group_id == 0x1234
-
-
-@patch(
-    "homeassistant.components.zha.core.gateway.ZHAGateway.async_load_devices",
-    MagicMock(),
-)
-@patch(
-    "homeassistant.components.zha.core.gateway.ZHAGateway.async_load_groups",
-    MagicMock(),
-)
-@pytest.mark.parametrize(
-    ("device_path", "thread_state", "config_override"),
-    [
-        ("/dev/ttyUSB0", True, {}),
-        ("socket://192.168.1.123:9999", False, {}),
-        ("socket://192.168.1.123:9999", True, {"use_thread": True}),
-    ],
-)
-async def test_gateway_initialize_bellows_thread(
-    device_path: str,
-    thread_state: bool,
-    config_override: dict,
-    hass: HomeAssistant,
-    zigpy_app_controller: ControllerApplication,
-    config_entry: MockConfigEntry,
-) -> None:
-    """Test ZHA disabling the UART thread when connecting to a TCP coordinator."""
-    config_entry.data = dict(config_entry.data)
-    config_entry.data["device"]["path"] = device_path
-    config_entry.add_to_hass(hass)
-
-    zha_gateway = ZHAGateway(hass, {"zigpy_config": config_override}, config_entry)
-
-    with patch(
-        "bellows.zigbee.application.ControllerApplication.new",
-        return_value=zigpy_app_controller,
-    ) as mock_new:
-        await zha_gateway.async_initialize()
-
-    mock_new.mock_calls[-1].kwargs["config"]["use_thread"] is thread_state
-
-    await zha_gateway.shutdown()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump ZHA dependencies:
- bellows to [0.37.3](https://github.com/zigpy/bellows/releases/tag/0.37.3)
- zigpy-deconz to [0.22.2](https://github.com/zigpy/zigpy-deconz/releases/tag/0.22.2)
- zigpy to [0.60.1](https://github.com/zigpy/zigpy/releases/tag/0.60.1)
- zigpy-xbee to [0.20.1](https://github.com/zigpy/zigpy-xbee/releases/tag/0.20.1)

Zigpy recently introduced a centralized watchdog feature that is having problems with ZHA startup. These library bumps attempt to address it to fix existing ZHA installations while we investigate further.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #105539, #105506, #105449, #105445
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
