### PR TITLE
Raise translatable exceptions in rest_command services

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1066,6 +1066,8 @@ build.json @home-assistant/supervisor
 /homeassistant/components/repairs/ @home-assistant/core
 /tests/components/repairs/ @home-assistant/core
 /homeassistant/components/repetier/ @ShadowBr0ther
+/homeassistant/components/rest_command/ @jpbede
+/tests/components/rest_command/ @jpbede
 /homeassistant/components/rflink/ @javicalle
 /tests/components/rflink/ @javicalle
 /homeassistant/components/rfxtrx/ @danielhiversen @elupus @RobBie1221

--- a/homeassistant/components/rest_command/manifest.json
+++ b/homeassistant/components/rest_command/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "rest_command",
   "name": "RESTful Command",
-  "codeowners": [],
+  "codeowners": ["@jpbede"],
   "documentation": "https://www.home-assistant.io/integrations/rest_command",
   "iot_class": "local_push"
 }

--- a/homeassistant/components/rest_command/strings.json
+++ b/homeassistant/components/rest_command/strings.json
@@ -7,10 +7,10 @@
   },
   "exceptions": {
     "timeout": {
-      "message": "Timeout while waiting for response from the server."
+      "message": "Timeout while waiting for response from the server"
     },
     "client_error": {
-      "message": "An error occurred while requesting the resource."
+      "message": "An error occurred while requesting the resource"
     },
     "non_ok_status_code": {
       "message": "The server answered with a {status_code} status code"

--- a/homeassistant/components/rest_command/strings.json
+++ b/homeassistant/components/rest_command/strings.json
@@ -4,5 +4,16 @@
       "name": "[%key:common::action::reload%]",
       "description": "Reloads RESTful commands from the YAML-configuration."
     }
+  },
+  "exceptions": {
+    "timeout": {
+      "message": "Timeout while waiting for response from the server."
+    },
+    "client_error": {
+      "message": "An error occurred while requesting the resource."
+    },
+    "non_ok_status_code": {
+      "message": "The server answered with a {status_code} status code"
+    }
   }
 }


### PR DESCRIPTION
## Breaking change
A RESTful command service call now raises an error when a timeout, non-200 response or unknown error occurs instead of failing silently. Please update your automations and use `continue_on_error` where necessary. 

## Proposed change
Add exceptions and translations to the rest_command services

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
