### PR TITLE
Remove cloud details from assist pipeline

### DIFF
--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -115,6 +115,7 @@ async def _async_resolve_default_pipeline_settings(
     hass: HomeAssistant,
     stt_engine_id: str | None,
     tts_engine_id: str | None,
+    pipeline_name: str,
 ) -> dict[str, str | None]:
     """Resolve settings for a default pipeline.
 
@@ -123,7 +124,6 @@ async def _async_resolve_default_pipeline_settings(
     """
     conversation_language = "en"
     pipeline_language = "en"
-    pipeline_name = "Home Assistant"
     stt_engine = None
     stt_language = None
     tts_engine = None
@@ -195,9 +195,6 @@ async def _async_resolve_default_pipeline_settings(
             )
             tts_engine_id = None
 
-    if stt_engine_id == "cloud" and tts_engine_id == "cloud":
-        pipeline_name = "Home Assistant Cloud"
-
     return {
         "conversation_engine": conversation.HOME_ASSISTANT_AGENT,
         "conversation_language": conversation_language,
@@ -221,12 +218,17 @@ async def _async_create_default_pipeline(
     The default pipeline will use the homeassistant conversation agent and the
     default stt / tts engines.
     """
-    pipeline_settings = await _async_resolve_default_pipeline_settings(hass, None, None)
+    pipeline_settings = await _async_resolve_default_pipeline_settings(
+        hass, stt_engine_id=None, tts_engine_id=None, pipeline_name="Home Assistant"
+    )
     return await pipeline_store.async_create_item(pipeline_settings)
 
 
 async def async_create_default_pipeline(
-    hass: HomeAssistant, stt_engine_id: str, tts_engine_id: str
+    hass: HomeAssistant,
+    stt_engine_id: str,
+    tts_engine_id: str,
+    pipeline_name: str,
 ) -> Pipeline | None:
     """Create a pipeline with default settings.
 
@@ -236,7 +238,7 @@ async def async_create_default_pipeline(
     pipeline_data: PipelineData = hass.data[DOMAIN]
     pipeline_store = pipeline_data.pipeline_store
     pipeline_settings = await _async_resolve_default_pipeline_settings(
-        hass, stt_engine_id, tts_engine_id
+        hass, stt_engine_id, tts_engine_id, pipeline_name=pipeline_name
     )
     if (
         pipeline_settings["stt_engine"] != stt_engine_id

--- a/homeassistant/components/cloud/http_api.py
+++ b/homeassistant/components/cloud/http_api.py
@@ -232,7 +232,10 @@ class CloudLoginView(HomeAssistantView):
         new_cloud_pipeline_id: str | None = None
         if (cloud_assist_pipeline(hass)) is None:
             if cloud_pipeline := await assist_pipeline.async_create_default_pipeline(
-                hass, DOMAIN, DOMAIN
+                hass,
+                stt_engine_id=DOMAIN,
+                tts_engine_id=DOMAIN,
+                pipeline_name="Home Assistant Cloud",
             ):
                 new_cloud_pipeline_id = cloud_pipeline.id
         return self.json({"success": True, "cloud_pipeline": new_cloud_pipeline_id})

--- a/tests/components/assist_pipeline/test_pipeline.py
+++ b/tests/components/assist_pipeline/test_pipeline.py
@@ -1,6 +1,6 @@
 """Websocket tests for Voice Assistant integration."""
 from typing import Any
-from unittest.mock import ANY, AsyncMock, patch
+from unittest.mock import ANY, patch
 
 import pytest
 
@@ -21,9 +21,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import MANY_LANGUAGES
-from .conftest import MockSttPlatform, MockSttProvider, MockTTSPlatform, MockTTSProvider
+from .conftest import MockSttProvider, MockTTSProvider
 
-from tests.common import MockModule, flush_store, mock_integration, mock_platform
+from tests.common import flush_store
 
 
 @pytest.fixture(autouse=True)
@@ -237,13 +237,26 @@ async def test_create_default_pipeline(
     store = pipeline_data.pipeline_store
     assert len(store.data) == 1
 
-    assert await async_create_default_pipeline(hass, "bla", "bla") is None
-    assert await async_create_default_pipeline(hass, "test", "test") == Pipeline(
+    assert (
+        await async_create_default_pipeline(
+            hass,
+            stt_engine_id="bla",
+            tts_engine_id="bla",
+            pipeline_name="Bla pipeline",
+        )
+        is None
+    )
+    assert await async_create_default_pipeline(
+        hass,
+        stt_engine_id="test",
+        tts_engine_id="test",
+        pipeline_name="Test pipeline",
+    ) == Pipeline(
         conversation_engine="homeassistant",
         conversation_language="en",
         id=ANY,
         language="en",
-        name="Home Assistant",
+        name="Test pipeline",
         stt_engine="test",
         stt_language="en-US",
         tts_engine="test",
@@ -462,56 +475,6 @@ async def test_default_pipeline_unsupported_tts_language(
         tts_engine=None,
         tts_language=None,
         tts_voice=None,
-        wake_word_entity=None,
-        wake_word_id=None,
-    )
-
-
-async def test_default_pipeline_cloud(
-    hass: HomeAssistant,
-    mock_stt_provider: MockSttProvider,
-    mock_tts_provider: MockTTSProvider,
-) -> None:
-    """Test async_get_pipeline."""
-
-    mock_integration(hass, MockModule("cloud"))
-    mock_platform(
-        hass,
-        "cloud.tts",
-        MockTTSPlatform(
-            async_get_engine=AsyncMock(return_value=mock_tts_provider),
-        ),
-    )
-    mock_platform(
-        hass,
-        "cloud.stt",
-        MockSttPlatform(
-            async_get_engine=AsyncMock(return_value=mock_stt_provider),
-        ),
-    )
-    mock_platform(hass, "test.config_flow")
-
-    assert await async_setup_component(hass, "tts", {"tts": {"platform": "cloud"}})
-    assert await async_setup_component(hass, "stt", {"stt": {"platform": "cloud"}})
-    assert await async_setup_component(hass, "assist_pipeline", {})
-
-    pipeline_data: PipelineData = hass.data[DOMAIN]
-    store = pipeline_data.pipeline_store
-    assert len(store.data) == 1
-
-    # Check the default pipeline
-    pipeline = async_get_pipeline(hass, None)
-    assert pipeline == Pipeline(
-        conversation_engine="homeassistant",
-        conversation_language="en",
-        id=pipeline.id,
-        language="en",
-        name="Home Assistant Cloud",
-        stt_engine="cloud",
-        stt_language="en-US",
-        tts_engine="cloud",
-        tts_language="en-US",
-        tts_voice="james_earl_jones",
         wake_word_entity=None,
         wake_word_id=None,
     )

--- a/tests/components/cloud/test_http_api.py
+++ b/tests/components/cloud/test_http_api.py
@@ -193,7 +193,12 @@ async def test_login_view_create_pipeline(
     assert req.status == HTTPStatus.OK
     result = await req.json()
     assert result == {"success": True, "cloud_pipeline": "12345"}
-    create_pipeline_mock.assert_awaited_once_with(hass, "cloud", "cloud")
+    create_pipeline_mock.assert_awaited_once_with(
+        hass,
+        stt_engine_id="cloud",
+        tts_engine_id="cloud",
+        pipeline_name="Home Assistant Cloud",
+    )
 
 
 async def test_login_view_create_pipeline_fail(
@@ -227,7 +232,12 @@ async def test_login_view_create_pipeline_fail(
     assert req.status == HTTPStatus.OK
     result = await req.json()
     assert result == {"success": True, "cloud_pipeline": None}
-    create_pipeline_mock.assert_awaited_once_with(hass, "cloud", "cloud")
+    create_pipeline_mock.assert_awaited_once_with(
+        hass,
+        stt_engine_id="cloud",
+        tts_engine_id="cloud",
+        pipeline_name="Home Assistant Cloud",
+    )
 
 
 async def test_login_view_random_exception(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Remove cloud knowledge from assist pipeline and allow the cloud integration to name its default pipeline when creating that instead.
- Assist pipeline is an after dependency of cloud so the cloud integration won't be setup before the assist pipeline integration loads. So looking for cloud stt and tts engines when loading assist pipeline isn't realistic.
- Remove incorrect test and update existing test to use the new signature for `async_create_default_pipeline`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
