### PR TITLE
Replace Starline horn switch with button

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1216,6 +1216,7 @@ omit =
     homeassistant/components/starline/__init__.py
     homeassistant/components/starline/account.py
     homeassistant/components/starline/binary_sensor.py
+    homeassistant/components/starline/button.py
     homeassistant/components/starline/device_tracker.py
     homeassistant/components/starline/entity.py
     homeassistant/components/starline/lock.py

--- a/homeassistant/components/starline/button.py
+++ b/homeassistant/components/starline/button.py
@@ -30,7 +30,7 @@ class StarlineButtonEntityDescription(
 BUTTON_TYPES: tuple[StarlineButtonEntityDescription, ...] = (
     StarlineButtonEntityDescription(
         key="poke",
-        name_="Horn",
+        translation_key="horn",
         icon="mdi:bullhorn-outline",
     ),
 )

--- a/homeassistant/components/starline/button.py
+++ b/homeassistant/components/starline/button.py
@@ -1,8 +1,6 @@
 """Support for StarLine button."""
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -13,22 +11,8 @@ from .const import DOMAIN
 from .entity import StarlineEntity
 
 
-@dataclass
-class StarlineRequiredKeysMixin:
-    """Mixin for required keys."""
-
-    name_: str
-
-
-@dataclass
-class StarlineButtonEntityDescription(
-    ButtonEntityDescription, StarlineRequiredKeysMixin
-):
-    """Describes Starline button entity."""
-
-
-BUTTON_TYPES: tuple[StarlineButtonEntityDescription, ...] = (
-    StarlineButtonEntityDescription(
+BUTTON_TYPES: tuple[ButtonEntityDescription, ...] = (
+    ButtonEntityDescription(
         key="poke",
         translation_key="horn",
         icon="mdi:bullhorn-outline",
@@ -52,13 +36,13 @@ async def async_setup_entry(
 class StarlineButton(StarlineEntity, ButtonEntity):
     """Representation of a StarLine button."""
 
-    entity_description: StarlineButtonEntityDescription
+    entity_description: ButtonEntityDescription
 
     def __init__(
         self,
         account: StarlineAccount,
         device: StarlineDevice,
-        description: StarlineButtonEntityDescription,
+        description: ButtonEntityDescription,
     ) -> None:
         """Initialize the button."""
         super().__init__(account, device, description.key)

--- a/homeassistant/components/starline/button.py
+++ b/homeassistant/components/starline/button.py
@@ -10,7 +10,6 @@ from .account import StarlineAccount, StarlineDevice
 from .const import DOMAIN
 from .entity import StarlineEntity
 
-
 BUTTON_TYPES: tuple[ButtonEntityDescription, ...] = (
     ButtonEntityDescription(
         key="poke",

--- a/homeassistant/components/starline/button.py
+++ b/homeassistant/components/starline/button.py
@@ -1,0 +1,74 @@
+"""Support for StarLine button."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .account import StarlineAccount, StarlineDevice
+from .const import DOMAIN
+from .entity import StarlineEntity
+
+
+@dataclass
+class StarlineRequiredKeysMixin:
+    """Mixin for required keys."""
+
+    name_: str
+
+
+@dataclass
+class StarlineButtonEntityDescription(
+    ButtonEntityDescription, StarlineRequiredKeysMixin
+):
+    """Describes Starline button entity."""
+
+
+BUTTON_TYPES: tuple[StarlineButtonEntityDescription, ...] = (
+    StarlineButtonEntityDescription(
+        key="poke",
+        name_="Horn",
+        icon="mdi:bullhorn-outline",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the StarLine button."""
+    account: StarlineAccount = hass.data[DOMAIN][entry.entry_id]
+    entities = []
+    for device in account.api.devices.values():
+        if device.support_state:
+            for description in BUTTON_TYPES:
+                entities.append(StarlineButton(account, device, description))
+    async_add_entities(entities)
+
+
+class StarlineButton(StarlineEntity, ButtonEntity):
+    """Representation of a StarLine button."""
+
+    entity_description: StarlineButtonEntityDescription
+
+    def __init__(
+        self,
+        account: StarlineAccount,
+        device: StarlineDevice,
+        description: StarlineButtonEntityDescription,
+    ) -> None:
+        """Initialize the button."""
+        super().__init__(account, device, description.key)
+        self.entity_description = description
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return super().available and self._device.online
+
+    def press(self):
+        """Press the button."""
+        self._account.api.set_car_state(self._device.device_id, self._key, True)

--- a/homeassistant/components/starline/const.py
+++ b/homeassistant/components/starline/const.py
@@ -12,6 +12,7 @@ PLATFORMS = [
     Platform.SENSOR,
     Platform.LOCK,
     Platform.SWITCH,
+    Platform.BUTTON,
 ]
 
 CONF_APP_ID = "app_id"

--- a/homeassistant/components/starline/const.py
+++ b/homeassistant/components/starline/const.py
@@ -7,12 +7,12 @@ _LOGGER = logging.getLogger(__package__)
 
 DOMAIN = "starline"
 PLATFORMS = [
-    Platform.DEVICE_TRACKER,
     Platform.BINARY_SENSOR,
-    Platform.SENSOR,
-    Platform.LOCK,
-    Platform.SWITCH,
     Platform.BUTTON,
+    Platform.DEVICE_TRACKER,
+    Platform.LOCK,
+    Platform.SENSOR,
+    Platform.SWITCH,
 ]
 
 CONF_APP_ID = "app_id"

--- a/homeassistant/components/starline/strings.json
+++ b/homeassistant/components/starline/strings.json
@@ -101,7 +101,9 @@
       },
       "additional_channel": {
         "name": "Additional channel"
-      },
+      }
+    },
+    "button": {
       "horn": {
         "name": "Horn"
       }

--- a/homeassistant/components/starline/strings.json
+++ b/homeassistant/components/starline/strings.json
@@ -101,12 +101,21 @@
       },
       "additional_channel": {
         "name": "Additional channel"
+      },
+      "horn": {
+        "name": "Horn"
       }
     },
     "button": {
       "horn": {
         "name": "Horn"
       }
+    }
+  },
+  "issues": {
+    "deprecated_horn_switch": {
+      "title": "The Starline Horn switch entity is being removed",
+      "description": "Using the Horn switch is now deprecated and will be removed in a future version of Home Assistant.\n\nPlease adjust any automations or scripts that use Horn switch entity to instead use the Horn button entity."
     }
   },
   "services": {

--- a/homeassistant/components/starline/switch.py
+++ b/homeassistant/components/starline/switch.py
@@ -48,12 +48,6 @@ SWITCH_TYPES: tuple[StarlineSwitchEntityDescription, ...] = (
         icon_on="mdi:access-point-network",
         icon_off="mdi:access-point-network-off",
     ),
-    StarlineSwitchEntityDescription(
-        key="poke",
-        translation_key="horn",
-        icon_on="mdi:bullhorn-outline",
-        icon_off="mdi:bullhorn-outline",
-    ),
 )
 
 
@@ -113,8 +107,6 @@ class StarlineSwitch(StarlineEntity, SwitchEntity):
     @property
     def is_on(self):
         """Return True if entity is on."""
-        if self._key == "poke":
-            return False
         return self._device.car_state.get(self._key)
 
     def turn_on(self, **kwargs: Any) -> None:
@@ -123,6 +115,4 @@ class StarlineSwitch(StarlineEntity, SwitchEntity):
 
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
-        if self._key == "poke":
-            return
         self._account.api.set_car_state(self._device.device_id, self._key, False)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Using the Horn switch is now deprecated and will be removed in 2024.8.0.
Instead of switch the Horn button entity was added. Please update your automations accordingly.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Starline horn switch replaced by button entity because horn doesn't have state and you can only trigger it.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30330

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
