### PR TITLE
Fix Fully Kiosk Browser MQTT event callbacks with non-standard event topics

### DIFF
--- a/homeassistant/components/fully_kiosk/entity.py
+++ b/homeassistant/components/fully_kiosk/entity.py
@@ -74,7 +74,8 @@ class FullyKioskEntity(CoordinatorEntity[FullyKioskDataUpdateCoordinator], Entit
         @callback
         def message_callback(message: mqtt.ReceiveMessage) -> None:
             payload = json.loads(message.payload)
-            event_callback(**payload)
+            if "event" in payload and payload["event"] == event:
+                event_callback(**payload)
 
         topic_template = data["settings"]["mqttEventTopic"]
         topic = (
@@ -82,4 +83,5 @@ class FullyKioskEntity(CoordinatorEntity[FullyKioskDataUpdateCoordinator], Entit
             .replace("$event", event)
             .replace("$deviceId", data["deviceID"])
         )
+
         return await mqtt.async_subscribe(self.hass, topic, message_callback)

--- a/tests/components/fully_kiosk/test_switch.py
+++ b/tests/components/fully_kiosk/test_switch.py
@@ -107,19 +107,35 @@ async def test_switches_mqtt_update(
     assert entity
     assert entity.state == "on"
 
-    async_fire_mqtt_message(hass, "fully/event/onScreensaverStart/abcdef-123456", "{}")
+    async_fire_mqtt_message(
+        hass,
+        "fully/event/onScreensaverStart/abcdef-123456",
+        '{"deviceId": "abcdef-123456","event": "onScreensaverStart"}',
+    )
     entity = hass.states.get("switch.amazon_fire_screensaver")
     assert entity.state == "on"
 
-    async_fire_mqtt_message(hass, "fully/event/onScreensaverStop/abcdef-123456", "{}")
+    async_fire_mqtt_message(
+        hass,
+        "fully/event/onScreensaverStop/abcdef-123456",
+        '{"deviceId": "abcdef-123456","event": "onScreensaverStop"}',
+    )
     entity = hass.states.get("switch.amazon_fire_screensaver")
     assert entity.state == "off"
 
-    async_fire_mqtt_message(hass, "fully/event/screenOff/abcdef-123456", "{}")
+    async_fire_mqtt_message(
+        hass,
+        "fully/event/screenOff/abcdef-123456",
+        '{"deviceId": "abcdef-123456","event": "screenOff"}',
+    )
     entity = hass.states.get("switch.amazon_fire_screen")
     assert entity.state == "off"
 
-    async_fire_mqtt_message(hass, "fully/event/screenOn/abcdef-123456", "{}")
+    async_fire_mqtt_message(
+        hass,
+        "fully/event/screenOn/abcdef-123456",
+        '{"deviceId": "abcdef-123456","event": "screenOn"}',
+    )
     entity = hass.states.get("switch.amazon_fire_screen")
     assert entity.state == "on"
 


### PR DESCRIPTION
## Proposed change
Adjust the handling of Fully Kiosk Browser MQTT event callbacks.
Fully Kiosk Browser allows you to set a custom MQTT topic for events. By default, this topic is: `$appId/event/$event/$deviceId` where $appId translates to `fully`, $event translates to the name of the event, and $deviceId is the ID of the device.

If a user configures a custom event topic without the `$event` placeholder, all of the events hit the same topic, so every event will trigger the callback regardless of what the event actually is.

The payload also contains the event name, so I adjusted the callback function to check that the event name in the payload is correct before firing the callback.

Tested with Fully Kiosk Browser 1.54.1 (current) and 1.42.5 and working.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/105263
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
