### PR TITLE
Add translation to ServiceValidationError in Lock

### DIFF
--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
     STATE_UNLOCKING,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ServiceValidationError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
@@ -152,8 +153,17 @@ class LockEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         if not code:
             code = self._lock_option_default_code
         if self.code_format_cmp and not self.code_format_cmp.match(code):
-            raise ValueError(
-                f"Code '{code}' for locking {self.entity_id} doesn't match pattern {self.code_format}"
+            if TYPE_CHECKING:
+                assert self.code_format
+            raise ServiceValidationError(
+                f"Code '{code}' for locking {self.entity_id} doesn't match pattern {self.code_format}",
+                translation_domain=DOMAIN,
+                translation_key="add_default_code",
+                translation_placeholders={
+                    "code": code,
+                    "entity_id": self.entity_id,
+                    "code_format": self.code_format,
+                },
             )
         if code:
             data[ATTR_CODE] = code

--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -156,11 +156,10 @@ class LockEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
             if TYPE_CHECKING:
                 assert self.code_format
             raise ServiceValidationError(
-                f"Code '{code}' for locking {self.entity_id} doesn't match pattern {self.code_format}",
+                f"The code for {self.entity_id} doesn't match pattern {self.code_format}",
                 translation_domain=DOMAIN,
                 translation_key="add_default_code",
                 translation_placeholders={
-                    "code": code,
                     "entity_id": self.entity_id,
                     "code_format": self.code_format,
                 },

--- a/homeassistant/components/lock/strings.json
+++ b/homeassistant/components/lock/strings.json
@@ -69,7 +69,7 @@
   },
   "exceptions": {
     "add_default_code": {
-      "message": "Code '{code}' for locking {entity_id} doesn't match pattern {code_format}."
+      "message": "The code for {entity_id} doesn't match pattern {code_format}."
     }
   }
 }

--- a/homeassistant/components/lock/strings.json
+++ b/homeassistant/components/lock/strings.json
@@ -66,5 +66,10 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "add_default_code": {
+      "message": "Code '{code}' for locking {entity_id} doesn't match pattern {code_format}."
+    }
   }
 }

--- a/tests/components/lock/test_init.py
+++ b/tests/components/lock/test_init.py
@@ -1,6 +1,7 @@
 """The tests for the lock component."""
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import pytest
@@ -353,14 +354,19 @@ async def test_lock_with_illegal_default_code(
         await help_test_async_lock_service(
             hass, mock_lock_entity.entity_id, SERVICE_LOCK
         )
-    with pytest.raises(ServiceValidationError) as exc:
+    with pytest.raises(
+        ServiceValidationError,
+        match=re.escape(
+            rf"The code for lock.test_lock doesn't match pattern ^\d{{{4}}}$"
+        ),
+    ) as exc:
         await help_test_async_lock_service(
             hass, mock_lock_entity.entity_id, SERVICE_UNLOCK
         )
 
     assert (
         str(exc.value)
-        == rf"Code '' for locking lock.test_lock doesn't match pattern ^\d{{{4}}}$"
+        == rf"The code for lock.test_lock doesn't match pattern ^\d{{{4}}}$"
     )
     assert exc.value.translation_key == "add_default_code"
 

--- a/tests/components/matter/test_door_lock.py
+++ b/tests/components/matter/test_door_lock.py
@@ -14,6 +14,7 @@ from homeassistant.components.lock import (
 )
 from homeassistant.const import ATTR_CODE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 import homeassistant.helpers.entity_registry as er
 
 from .common import set_node_attribute, trigger_subscription_callback
@@ -113,7 +114,7 @@ async def test_lock_requires_pin(
     # set door state to unlocked
     set_node_attribute(door_lock, 1, 257, 0, 2)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ServiceValidationError):
         # Lock door using invalid code format
         await trigger_subscription_callback(hass, matter_client)
         await hass.services.async_call(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
