### PR TITLE
OpenAI Conversation: Enable querying entity list and states

### DIFF
--- a/homeassistant/components/openai_conversation/__init__.py
+++ b/homeassistant/components/openai_conversation/__init__.py
@@ -168,7 +168,9 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
         else:
             conversation_id = ulid.ulid_now()
             try:
-                prompt = self._async_generate_prompt(raw_prompt, user_input.device_id)
+                prompt = self._async_generate_prompt(
+                    raw_prompt, user_input.device_id, user_input.context.user_id
+                )
             except TemplateError as err:
                 _LOGGER.error("Error rendering prompt: %s", err)
                 intent_response = intent.IntentResponse(language=user_input.language)
@@ -239,12 +241,15 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
             response=intent_response, conversation_id=conversation_id
         )
 
-    def _async_generate_prompt(self, raw_prompt: str, device_id: str | None) -> str:
+    def _async_generate_prompt(
+        self, raw_prompt: str, device_id: str | None, user_id: str | None
+    ) -> str:
         """Generate a prompt for the user."""
         return template.Template(raw_prompt, self.hass).async_render(
             {
                 "ha_name": self.hass.config.location_name,
                 "device_id": device_id,
+                "user_id": user_id,
             },
             parse_result=False,
         )

--- a/homeassistant/components/openai_conversation/__init__.py
+++ b/homeassistant/components/openai_conversation/__init__.py
@@ -217,7 +217,10 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
             if tool_calls:
                 for tool_call in tool_calls:  # type: ignore[attr-defined]
                     function_response = await tools.async_call_function(
-                        self.hass, user_input.context, tool_call.function.name, tool_call.function.arguments
+                        self.hass,
+                        user_input.context,
+                        tool_call.function.name,
+                        tool_call.function.arguments,
                     )
                     messages.append(
                         {

--- a/homeassistant/components/openai_conversation/__init__.py
+++ b/homeassistant/components/openai_conversation/__init__.py
@@ -217,7 +217,7 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
             if tool_calls:
                 for tool_call in tool_calls:  # type: ignore[attr-defined]
                     function_response = await tools.async_call_function(
-                        self.hass, tool_call.function.name, tool_call.function.arguments
+                        self.hass, user_input.context, tool_call.function.name, tool_call.function.arguments
                     )
                     messages.append(
                         {

--- a/homeassistant/components/openai_conversation/__init__.py
+++ b/homeassistant/components/openai_conversation/__init__.py
@@ -187,7 +187,7 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
 
         client = self.hass.data[DOMAIN][self.entry.entry_id]
 
-        tool_calls = [True]
+        tool_calls = True
         while tool_calls:
             try:
                 result = await client.chat.completions.create(
@@ -215,7 +215,7 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
             tool_calls = response.tool_calls
 
             if tool_calls:
-                for tool_call in tool_calls:
+                for tool_call in tool_calls:  # mypy: disable-error-code="attr-defined"
                     function_response = tools.call_function(
                         self.hass, tool_call.function.name, tool_call.function.arguments
                     )

--- a/homeassistant/components/openai_conversation/__init__.py
+++ b/homeassistant/components/openai_conversation/__init__.py
@@ -187,7 +187,7 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
 
         client = self.hass.data[DOMAIN][self.entry.entry_id]
 
-        tool_calls = True
+        tool_calls = [True]
         while tool_calls:
             try:
                 result = await client.chat.completions.create(

--- a/homeassistant/components/openai_conversation/__init__.py
+++ b/homeassistant/components/openai_conversation/__init__.py
@@ -215,7 +215,7 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
             tool_calls = response.tool_calls
 
             if tool_calls:
-                for tool_call in tool_calls:  # mypy: disable-error-code="attr-defined"
+                for tool_call in tool_calls:  # type: ignore[attr-defined]
                     function_response = tools.call_function(
                         self.hass, tool_call.function.name, tool_call.function.arguments
                     )

--- a/homeassistant/components/openai_conversation/__init__.py
+++ b/homeassistant/components/openai_conversation/__init__.py
@@ -216,7 +216,7 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
 
             if tool_calls:
                 for tool_call in tool_calls:  # type: ignore[attr-defined]
-                    function_response = tools.call_function(
+                    function_response = await tools.async_call_function(
                         self.hass, tool_call.function.name, tool_call.function.arguments
                     )
                     messages.append(

--- a/homeassistant/components/openai_conversation/__init__.py
+++ b/homeassistant/components/openai_conversation/__init__.py
@@ -168,7 +168,7 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
         else:
             conversation_id = ulid.ulid_now()
             try:
-                prompt = self._async_generate_prompt(raw_prompt)
+                prompt = self._async_generate_prompt(raw_prompt, user_input.device_id)
             except TemplateError as err:
                 _LOGGER.error("Error rendering prompt: %s", err)
                 intent_response = intent.IntentResponse(language=user_input.language)
@@ -239,11 +239,12 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
             response=intent_response, conversation_id=conversation_id
         )
 
-    def _async_generate_prompt(self, raw_prompt: str) -> str:
+    def _async_generate_prompt(self, raw_prompt: str, device_id: str | None) -> str:
         """Generate a prompt for the user."""
         return template.Template(raw_prompt, self.hass).async_render(
             {
                 "ha_name": self.hass.config.location_name,
+                "device_id": device_id,
             },
             parse_result=False,
         )

--- a/homeassistant/components/openai_conversation/const.py
+++ b/homeassistant/components/openai_conversation/const.py
@@ -116,5 +116,6 @@ EXPORTED_ATTRIBUTES = [
     "wind_speed_unit",
     "dew_point",
     "cloud_coverage",
+    "forecast",
     "persons",
 ]

--- a/homeassistant/components/openai_conversation/const.py
+++ b/homeassistant/components/openai_conversation/const.py
@@ -4,24 +4,14 @@ DOMAIN = "openai_conversation"
 CONF_PROMPT = "prompt"
 DEFAULT_PROMPT = """This smart home is controlled by Home Assistant.
 
-An overview of the areas and the devices in this smart home:
-{%- for area in areas() %}
-  {%- set area_info = namespace(printed=false) %}
-  {%- for device in area_devices(area) -%}
-    {%- if not device_attr(device, "disabled_by") and not device_attr(device, "entry_type") and device_attr(device, "name") %}
-      {%- if not area_info.printed %}
-
-{{ area_name(area) }}:
-        {%- set area_info.printed = true %}
-      {%- endif %}
-- {{ device_attr(device, "name") }}{% if device_attr(device, "model") and (device_attr(device, "model") | string) not in (device_attr(device, "name") | string) %} ({{ device_attr(device, "model") }}){% endif %}
-    {%- endif %}
-  {%- endfor %}
-{%- endfor %}
+There are following areas in this smart home:
+{%- for area in areas() %}{{area_name(area)}}{{ ", " if not loop.last else "" }}{%- endfor %}.
 
 Answer the user's questions about the world truthfully.
 
 If the user wants to control a device, reject the request and suggest using the Home Assistant app.
+
+The response may be used in Text-to-Speech synthesizers, so prefer shorter responses that are optimized to be spoken.
 """
 CONF_CHAT_MODEL = "chat_model"
 DEFAULT_CHAT_MODEL = "gpt-3.5-turbo"
@@ -31,3 +21,100 @@ CONF_TOP_P = "top_p"
 DEFAULT_TOP_P = 1
 CONF_TEMPERATURE = "temperature"
 DEFAULT_TEMPERATURE = 0.5
+EXPORTED_ATTRIBUTES = [
+    "device_class",
+    "message",
+    "all_day",
+    "start_time",
+    "end_time",
+    "location",
+    "description",
+    "hvac_modes",
+    "min_temp",
+    "max_temp",
+    "fan_modes",
+    "preset_modes",
+    "swing_modes",
+    "current_temperature",
+    "temperature",
+    "target_temp_high",
+    "target_temp_low",
+    "fan_mode",
+    "preset_mode",
+    "swing_mode",
+    "hvac_action",
+    "aux_heat",
+    "current_position",
+    "current_tilt_position",
+    "latitude",
+    "longitude",
+    "percentage",
+    "direction",
+    "oscillating",
+    "available_modes",
+    "max_humidity",
+    "min_humidity",
+    "action",
+    "current_humidity",
+    "humidity",
+    "mode",
+    "faces",
+    "total_faces",
+    "min",
+    "max",
+    "step",
+    "min_color_temp_kelvin",
+    "max_color_temp_kelvin",
+    "min_mireds",
+    "max_mireds",
+    "effect_list",
+    "supported_color_modes",
+    "color_mode",
+    "brightness",
+    "color_temp_kelvin",
+    "color_temp",
+    "hs_color",
+    "rgb_color",
+    "xy_color",
+    "rgbw_color",
+    "rgbww_color",
+    "effect",
+    "sound_mode_list",
+    "volume_level",
+    "is_volume_muted",
+    "media_content_type",
+    "media_duration",
+    "media_position",
+    "media_title",
+    "media_artist",
+    "media_album_name",
+    "media_track",
+    "media_series_title",
+    "media_season",
+    "media_episode",
+    "app_name",
+    "sound_mode",
+    "shuffle",
+    "repeat",
+    "source",
+    "options",
+    "battery_level",
+    "available_tones",
+    "elevation",
+    "rising",
+    "fan_speed_list",
+    "fan_speed",
+    "status",
+    "cleaned_area",
+    "operation_list",
+    "operation_mode",
+    "away_mode",
+    "temperature_unit",
+    "pressure",
+    "pressure_unit",
+    "wind_speed",
+    "wind_speed_unit",
+    "dew_point",
+    "cloud_coverage",
+    "persons",
+]

--- a/homeassistant/components/openai_conversation/const.py
+++ b/homeassistant/components/openai_conversation/const.py
@@ -16,7 +16,7 @@ The response may be used in Text-to-Speech synthesizers, so prefer shorter respo
 CONF_CHAT_MODEL = "chat_model"
 DEFAULT_CHAT_MODEL = "gpt-3.5-turbo"
 CONF_MAX_TOKENS = "max_tokens"
-DEFAULT_MAX_TOKENS = 250
+DEFAULT_MAX_TOKENS = 256
 CONF_TOP_P = "top_p"
 DEFAULT_TOP_P = 1
 CONF_TEMPERATURE = "temperature"

--- a/homeassistant/components/openai_conversation/const.py
+++ b/homeassistant/components/openai_conversation/const.py
@@ -16,7 +16,7 @@ The response may be used in Text-to-Speech synthesizers, so prefer shorter respo
 CONF_CHAT_MODEL = "chat_model"
 DEFAULT_CHAT_MODEL = "gpt-3.5-turbo"
 CONF_MAX_TOKENS = "max_tokens"
-DEFAULT_MAX_TOKENS = 150
+DEFAULT_MAX_TOKENS = 250
 CONF_TOP_P = "top_p"
 DEFAULT_TOP_P = 1
 CONF_TEMPERATURE = "temperature"

--- a/homeassistant/components/openai_conversation/tools.py
+++ b/homeassistant/components/openai_conversation/tools.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from typing import Any
 
 from homeassistant.components.conversation import DOMAIN as CONVERSATION_DOMAIN
 from homeassistant.core import HomeAssistant, callback
@@ -50,7 +51,7 @@ TOOLS = [
 
 
 @callback
-def call_function(hass: HomeAssistant, function_name: str, function_args: str) -> dict:
+def call_function(hass: HomeAssistant, function_name: str, function_args: str) -> str:
     """Wrap the function call to parse the arguments and handle exceptions."""
 
     available_functions = {"entity_registry_inquiry": entity_registry_inquiry}
@@ -59,13 +60,13 @@ def call_function(hass: HomeAssistant, function_name: str, function_args: str) -
 
     try:
         function_to_call = available_functions[function_name]
-        function_args = json.loads(function_args)
+        function_args : dict = json.loads(function_args)
         response = function_to_call(hass, **function_args)
         response = json.dumps(response)
 
-    except Exception as e:
+    except Exception as e:  # pylint: disable=broad-exception-caught
         response = {"error": type(e).__name__}
-        if len(str(e)):
+        if str(e):
             response["error_text"] = str(e)
         response = json.dumps(response)
 
@@ -107,7 +108,7 @@ def entity_registry_inquiry(
         ):
             continue
 
-        entry = {
+        entry : dict["str", Any] = {
             "name": entity_state.name,
             "entity_id": entity_state.entity_id,
             "state": entity_state.state_with_unit,

--- a/homeassistant/components/openai_conversation/tools.py
+++ b/homeassistant/components/openai_conversation/tools.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any
 
 from homeassistant.components.conversation import DOMAIN as CONVERSATION_DOMAIN
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er, intent, template
 from homeassistant.util import dt as dt_util
 
@@ -46,22 +46,25 @@ TOOLS = [
                 "required": [],
             },
         },
-    }
+    },
 ]
 
 
-@callback
-def call_function(hass: HomeAssistant, function_name: str, function_args: str) -> str:
+async def async_call_function(
+    hass: HomeAssistant, function_name: str, function_args: str
+) -> str:
     """Wrap the function call to parse the arguments and handle exceptions."""
 
-    available_functions = {"entity_registry_inquiry": entity_registry_inquiry}
+    available_functions = {
+        "entity_registry_inquiry": entity_registry_inquiry,
+    }
 
     _LOGGER.debug("Function call: %s(%s)", function_name, function_args)
 
     try:
         function_to_call = available_functions[function_name]
         parsed_args = json.loads(function_args)
-        response = function_to_call(hass, **parsed_args)
+        response = await function_to_call(hass, **parsed_args)
         response_str = json.dumps(response)
 
     except Exception as e:  # pylint: disable=broad-exception-caught
@@ -75,8 +78,7 @@ def call_function(hass: HomeAssistant, function_name: str, function_args: str) -
     return response_str
 
 
-@callback
-def entity_registry_inquiry(
+async def entity_registry_inquiry(
     hass: HomeAssistant,
     name: str | None = None,
     area: str | None = None,

--- a/homeassistant/components/openai_conversation/tools.py
+++ b/homeassistant/components/openai_conversation/tools.py
@@ -1,0 +1,140 @@
+"""OpenAI functions to be called from GPT."""
+
+import json
+import logging
+
+from homeassistant.components.conversation import DOMAIN as CONVERSATION_DOMAIN
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er, intent, template
+
+from .const import EXPORTED_ATTRIBUTES
+
+_LOGGER = logging.getLogger(__name__)
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "entity_registry_inquiry",
+            "description": "Get entities defined in Home Assistant",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Return the entity with this name only.",
+                    },
+                    "area": {
+                        "type": "string",
+                        "description": "Return entities in this area only.",
+                    },
+                    "domain": {
+                        "type": "string",
+                        "description": "Return entities with this domain only. Only valid Home Assistant domains are accepted.",
+                    },
+                    "device_class": {
+                        "type": "string",
+                        "description": "Return entities with this device class. Only valid Home Assistant device classes are accepted.",
+                    },
+                    "state": {
+                        "type": "string",
+                        "description": "Return entities with this state only.",
+                    },
+                },
+                "required": [],
+            },
+        },
+    }
+]
+
+
+@callback
+def call_function(hass: HomeAssistant, function_name: str, function_args: str) -> dict:
+    """Wrap the function call to parse the arguments and handle exceptions."""
+
+    available_functions = {"entity_registry_inquiry": entity_registry_inquiry}
+
+    _LOGGER.debug("Function call: %s(%s)", function_name, function_args)
+
+    try:
+        function_to_call = available_functions[function_name]
+        function_args = json.loads(function_args)
+        response = function_to_call(hass, **function_args)
+        response = json.dumps(response)
+
+    except Exception as e:
+        response = {"error": type(e).__name__}
+        if len(str(e)):
+            response["error_text"] = str(e)
+        response = json.dumps(response)
+
+    _LOGGER.debug("Function response: %s", response)
+
+    return response
+
+
+@callback
+def entity_registry_inquiry(
+    hass: HomeAssistant,
+    name: str | None = None,
+    area: str | None = None,
+    domain: str | None = None,
+    device_class: str | None = None,
+    state: str | None = None,
+) -> dict:
+    """Get entities defined in Home Assistant."""
+
+    states = intent.async_match_states(
+        hass,
+        name=name,
+        area_name=area,
+        domains=[domain] if domain is not None else None,
+        device_classes=[device_class] if device_class is not None else None,
+        assistant=CONVERSATION_DOMAIN,
+    )
+
+    entity_registry = er.async_get(hass)
+    result = []
+
+    for entity_state in states:
+        entity_state = template.TemplateState(hass, entity_state, collect=False)
+
+        if (
+            state is not None
+            and entity_state.state != state
+            and entity_state.state_with_unit != state
+        ):
+            continue
+
+        entry = {
+            "name": entity_state.name,
+            "entity_id": entity_state.entity_id,
+            "state": entity_state.state_with_unit,
+        }
+
+        if registry_entry := entity_registry.async_get(entity_state.entity_id):
+            if area_name := template.area_name(hass, entity_state.entity_id):
+                entry["area"] = area_name
+            if len(registry_entry.aliases):
+                entry["aliases"] = registry_entry.aliases
+
+        attributes = {}
+        for attribute, value in entity_state.attributes.items():
+            if attribute in EXPORTED_ATTRIBUTES:
+                attributes[attribute] = value
+        if attributes:
+            entry["attributes"] = attributes
+
+        result.append(entry)
+
+    if result:
+        return {"entities": result}
+
+    error_text = "Entities matching the criteria are not found or not exposed"
+    if device_class:
+        error_text += (
+            ". Please note that not all entities have device_class set up,"
+            " so you may want to repeat the function call without device_class parameter"
+            " if the expected entities were not found."
+        )
+    return {"error": error_text}

--- a/homeassistant/components/openai_conversation/tools.py
+++ b/homeassistant/components/openai_conversation/tools.py
@@ -141,6 +141,8 @@ async def entity_registry_inquiry(
         error_text += (
             ". Please note that not all entities have device_class set up,"
             " so you may want to repeat the function call without device_class parameter"
-            " if the expected entities were not found."
+            " if the expected entities were not found"
         )
+    if domain:
+        error_text += ". You may want to check different domains as well"
     return {"error": error_text}

--- a/homeassistant/components/openai_conversation/tools.py
+++ b/homeassistant/components/openai_conversation/tools.py
@@ -60,19 +60,19 @@ def call_function(hass: HomeAssistant, function_name: str, function_args: str) -
 
     try:
         function_to_call = available_functions[function_name]
-        function_args : dict = json.loads(function_args)
-        response = function_to_call(hass, **function_args)
-        response = json.dumps(response)
+        parsed_args = json.loads(function_args)
+        response = function_to_call(hass, **parsed_args)
+        response_str = json.dumps(response)
 
     except Exception as e:  # pylint: disable=broad-exception-caught
         response = {"error": type(e).__name__}
         if str(e):
             response["error_text"] = str(e)
-        response = json.dumps(response)
+        response_str = json.dumps(response)
 
-    _LOGGER.debug("Function response: %s", response)
+    _LOGGER.debug("Function response: %s", response_str)
 
-    return response
+    return response_str
 
 
 @callback
@@ -108,7 +108,7 @@ def entity_registry_inquiry(
         ):
             continue
 
-        entry : dict["str", Any] = {
+        entry: dict["str", Any] = {
             "name": entity_state.name,
             "entity_id": entity_state.entity_id,
             "state": entity_state.state_with_unit,

--- a/homeassistant/components/openai_conversation/tools.py
+++ b/homeassistant/components/openai_conversation/tools.py
@@ -121,7 +121,7 @@ async def entity_registry_inquiry(
             if area_name := template.area_name(hass, entity_state.entity_id):
                 entry["area"] = area_name
             if len(registry_entry.aliases):
-                entry["aliases"] = registry_entry.aliases
+                entry["aliases"] = list(registry_entry.aliases)
 
         attributes = {}
         for attribute, value in entity_state.attributes.items():

--- a/homeassistant/components/openai_conversation/tools.py
+++ b/homeassistant/components/openai_conversation/tools.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any
 
 from homeassistant.components.conversation import DOMAIN as CONVERSATION_DOMAIN
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import entity_registry as er, intent, template
 from homeassistant.util import dt as dt_util
 
@@ -51,7 +51,7 @@ TOOLS = [
 
 
 async def async_call_function(
-    hass: HomeAssistant, function_name: str, function_args: str
+    hass: HomeAssistant, context: Context, function_name: str, function_args: str
 ) -> str:
     """Wrap the function call to parse the arguments and handle exceptions."""
 
@@ -64,7 +64,7 @@ async def async_call_function(
     try:
         function_to_call = available_functions[function_name]
         parsed_args = json.loads(function_args)
-        response = await function_to_call(hass, **parsed_args)
+        response = await function_to_call(hass, context, **parsed_args)
         response_str = json.dumps(response)
 
     except Exception as e:  # pylint: disable=broad-exception-caught
@@ -80,6 +80,7 @@ async def async_call_function(
 
 async def entity_registry_inquiry(
     hass: HomeAssistant,
+    context: Context,
     name: str | None = None,
     area: str | None = None,
     domain: str | None = None,

--- a/homeassistant/components/openai_conversation/tools.py
+++ b/homeassistant/components/openai_conversation/tools.py
@@ -6,6 +6,7 @@ import logging
 from homeassistant.components.conversation import DOMAIN as CONVERSATION_DOMAIN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er, intent, template
+from homeassistant.util import dt as dt_util
 
 from .const import EXPORTED_ATTRIBUTES
 
@@ -110,6 +111,7 @@ def entity_registry_inquiry(
             "name": entity_state.name,
             "entity_id": entity_state.entity_id,
             "state": entity_state.state_with_unit,
+            "last_changed": dt_util.get_age(entity_state.last_changed) + " ago",
         }
 
         if registry_entry := entity_registry.async_get(entity_state.entity_id):

--- a/tests/components/openai_conversation/snapshots/test_init.ambr
+++ b/tests/components/openai_conversation/snapshots/test_init.ambr
@@ -5,20 +5,13 @@
       'content': '''
         This smart home is controlled by Home Assistant.
         
-        An overview of the areas and the devices in this smart home:
-        
-        Test Area:
-        - Test Device (Test Model)
-        
-        Test Area 2:
-        - Test Device 2
-        - Test Device 3 (Test Model 3A)
-        - Test Device 4
-        - 1 (3)
+        There are following areas in this smart home:0Empty Area, 1Empty Area, 2Empty Area, Test Area, Test Area 2.
         
         Answer the user's questions about the world truthfully.
         
         If the user wants to control a device, reject the request and suggest using the Home Assistant app.
+        
+        The response may be used in Text-to-Speech synthesizers, so prefer shorter responses that are optimized to be spoken.
       ''',
       'role': 'system',
     }),
@@ -26,9 +19,6 @@
       'content': 'hello',
       'role': 'user',
     }),
-    dict({
-      'content': 'Hello, how can I help you?',
-      'role': 'assistant',
-    }),
+    ChatCompletionMessage(content='Hello, how can I help you?', role='assistant', function_call=None, tool_calls=None),
   ])
 # ---

--- a/tests/components/openai_conversation/test_init.py
+++ b/tests/components/openai_conversation/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the OpenAI integration."""
+import datetime as dt
 from unittest.mock import AsyncMock, patch
 
 from httpx import Response
@@ -30,6 +31,7 @@ from homeassistant.helpers import (
     intent,
 )
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry
 
@@ -240,6 +242,7 @@ async def test_function_call(
             State(
                 entity_id="light.bed_light",
                 state="off",
+                last_changed=dt_util.now() - dt.timedelta(hours=2),
                 attributes={
                     "friendly_name": "Bed Light",
                     "min_color_temp_kelvin": 2000,
@@ -249,11 +252,13 @@ async def test_function_call(
             State(
                 entity_id="light.office_rgbw_lights",
                 state="on",
+                last_changed=dt_util.now() - dt.timedelta(hours=1),
                 attributes={"friendly_name": "Office RGBW Lights", "brightness": 180},
             ),
             State(
                 entity_id="light.living_room_rgbww_lights",
                 state="on",
+                last_changed=dt_util.now() - dt.timedelta(minutes=30),
                 attributes={"friendly_name": "Living Room RGBWW Lights"},
             ),
         ],
@@ -272,8 +277,8 @@ async def test_function_call(
         "tool_call_id": "call_AbCdEfGhIjKlMnOpQrStUvWx",
         "name": "entity_registry_inquiry",
         "content": '{"entities": [{"name": "Bed Light", "entity_id": "light.bed_light", '
-        '"state": "off", "area": "Bedroom", "aliases": ["Bettlicht"], "attributes": '
-        '{"min_color_temp_kelvin": 2000, "max_color_temp_kelvin": 6535}}]}',
+        '"state": "off", "last_changed": "2 hours ago", "area": "Bedroom", "aliases": '
+        '["Bettlicht"], "attributes": {"min_color_temp_kelvin": 2000, "max_color_temp_kelvin": 6535}}]}',
     }
 
 

--- a/tests/components/openai_conversation/test_init.py
+++ b/tests/components/openai_conversation/test_init.py
@@ -463,7 +463,8 @@ async def test_function_call_no_entities(
         "name": "entity_registry_inquiry",
         "content": '{"error": "Entities matching the criteria are not found or not exposed. '
         "Please note that not all entities have device_class set up, so you may want to repeat "
-        'the function call without device_class parameter if the expected entities were not found."}',
+        "the function call without device_class parameter if the expected entities were not found. "
+        'You may want to check different domains as well"}',
     }
 
 

--- a/tests/components/openai_conversation/test_init.py
+++ b/tests/components/openai_conversation/test_init.py
@@ -169,7 +169,7 @@ async def test_function_call(
     )
     entity_registry.async_update_entity(
         entity_id="light.bed_light",
-        aliases=["Bettlicht"],
+        aliases={"Bettlicht"},
         area_id=area_registry.async_get_area_by_name("Bedroom").id,
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
## Breaking change
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR allows OpenAI Conversation platform (backed by OpenAI large lanquage models) to query entities and their states using the new [parallel function calling feature](https://platform.openai.com/docs/guides/function-calling/parallel-function-calling). It allows it to answer questions like "Which room is the warmest?", "Is it dark in the living room?", "Are windows open?", etc.

Thanks to our great community and good documentation, LLM already familiar with Home Assistant entity model from its training data, so most of the time it already know which domain or device class to query, i.e. that shades are on `cover` domain.

Only entities exposed to 'conversation' are returned.

Both `gpt-3.5-turbo-1106` and `gpt-4-1106-preview` were tested.

One limitation is that the `conversation` platform only supports one response, while the model may output several messages in the process when calling additional functions. We only keep the last message, which is probably fine because the intermediate messages are usually excuses that it couldn't do the task in one iteration, so let's just consider it an inner voice.

I am also working on controlling of the entities, my initial PoC tests look promising, stay tuned!

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30361

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
