### PR TITLE
Detect when Yellow's CM4 is unseated

### DIFF
--- a/homeassistant/components/homeassistant_yellow/__init__.py
+++ b/homeassistant/components/homeassistant_yellow/__init__.py
@@ -40,7 +40,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             domain=DOMAIN,
             issue_id=ISSUE_CM4_UNSEATED,
             is_fixable=False,
-            is_persistent=True,
             learn_more_url="https://yellow.home-assistant.io/guides/remove-cm4/",
             severity=ir.IssueSeverity.ERROR,
             translation_key=ISSUE_CM4_UNSEATED,

--- a/homeassistant/components/homeassistant_yellow/__init__.py
+++ b/homeassistant/components/homeassistant_yellow/__init__.py
@@ -13,10 +13,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import discovery_flow, issue_registry as ir
 
-from .const import DOMAIN, RADIO_DEVICE, ZHA_HW_DISCOVERY_DATA
+from .const import DOMAIN, ISSUE_CM4_UNSEATED, RADIO_DEVICE, ZHA_HW_DISCOVERY_DATA
 from .helpers import async_validate_hardware_consistent
-
-ISSUE_CM4_UNSEATED = "cm4_unseated"
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/homeassistant_yellow/const.py
+++ b/homeassistant/components/homeassistant_yellow/const.py
@@ -2,6 +2,7 @@
 
 DOMAIN = "homeassistant_yellow"
 
+ISSUE_CM4_UNSEATED = "cm4_unseated"
 RADIO_DEVICE = "/dev/ttyAMA1"
 ZHA_HW_DISCOVERY_DATA = {
     "name": "Yellow",

--- a/homeassistant/components/homeassistant_yellow/helpers.py
+++ b/homeassistant/components/homeassistant_yellow/helpers.py
@@ -1,0 +1,127 @@
+"""Helper functions for the Yellow."""
+from __future__ import annotations
+
+import enum
+import time
+
+import usb
+
+from homeassistant.core import HomeAssistant
+
+
+class PinStatesUnstable(Exception):
+    """The state of the GPIO pins is unstable."""
+
+
+class YellowGPIO(enum.IntEnum):
+    """Yellow MGM210P GPIO pins."""
+
+    RADIO_SWDIO = 6
+    RADIO_SWCLK = 7
+    RADIO_TXD = 8
+    RADIO_RXD = 9
+    RADIO_CTS = 10
+    RADIO_RTS = 11
+    RADIO_BOOT = 24
+    RADIO_RESET = 25
+    SW_USER = 26
+    SW_WIPE = 27
+
+
+# Pin states on a properly installed CM4
+RUNNING_PIN_STATES = {
+    YellowGPIO.RADIO_BOOT: 1,
+    YellowGPIO.RADIO_RESET: 1,
+}
+
+GPIO_READ_ATTEMPTS = 5
+GPIO_READ_DELAY_S = 0.01
+
+
+# Bus 001 Device 001: ID 1d6b:0002
+CM4_USB_HUB_VENDOR = 0x1D6B
+CM4_USB_HUB_PRODUCT = 0x0002
+
+# Bus 001 Device 002: ID 1a40:0101
+YELLOW_USB_HUB_VENDOR = 0x1A40
+YELLOW_USB_HUB_PRODUCT = 0x0101
+
+
+def _read_gpio_pins(pins: list[int]) -> dict[int, bool]:
+    """Read the state of the given GPIO pins."""
+    # pylint: disable-next=import-outside-toplevel
+    import gpiod
+
+    chip = gpiod.chip("/dev/gpiochip0", gpiod.chip.OPEN_BY_PATH)
+    lines = chip.get_lines(pins)
+
+    config = gpiod.line_request()
+    config.consumer = "core-yellow"
+    config.request_type = gpiod.line_request.DIRECTION_INPUT
+
+    try:
+        lines.request(config)
+        return {p: bool(v) for p, v in zip(pins, lines.get_values())}
+    finally:
+        lines.release()
+
+
+def _read_gpio_pins_stable(pins: list[int]) -> dict[int, bool]:
+    """Read the state of the given GPIO pins and ensure the states are stable."""
+
+    values = _read_gpio_pins(pins)
+
+    for _ in range(GPIO_READ_ATTEMPTS - 1):
+        time.sleep(GPIO_READ_DELAY_S)
+        new_values = _read_gpio_pins(pins)
+
+        if new_values != values:
+            raise PinStatesUnstable()
+
+    return values
+
+
+async def async_validate_gpio_states(hass: HomeAssistant) -> bool:
+    """Validate the state of the GPIO pins."""
+    try:
+        pin_states = await hass.async_add_executor_job(
+            _read_gpio_pins_stable, list(RUNNING_PIN_STATES)
+        )
+    except PinStatesUnstable:
+        return False
+
+    return pin_states == RUNNING_PIN_STATES
+
+
+def validate_usb_hub_present() -> bool:
+    """Validate that the USB hub is present."""
+    root_hub = usb.core.find(
+        # The root hub has no parent
+        parent=None,
+        idVendor=CM4_USB_HUB_VENDOR,
+        idProduct=CM4_USB_HUB_PRODUCT,
+    )
+
+    # This really should not be possible
+    if root_hub is None:
+        return False
+
+    yellow_hub = usb.core.find(
+        # The Yellow's two-port hub is a child of the pi's root hub
+        parent=root_hub,
+        idVendor=YELLOW_USB_HUB_VENDOR,
+        idProduct=YELLOW_USB_HUB_PRODUCT,
+    )
+
+    return yellow_hub is not None
+
+
+async def async_validate_hardware_consistent(hass: HomeAssistant) -> bool:
+    """Validate the hardware is consistent with a properly installed CM4."""
+    if not validate_usb_hub_present():
+        return False
+
+    if not await async_validate_gpio_states(hass):
+        return False
+
+    return True

--- a/homeassistant/components/homeassistant_yellow/helpers.py
+++ b/homeassistant/components/homeassistant_yellow/helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Sequence
 import enum
 
 import usb
@@ -44,7 +45,7 @@ YELLOW_USB_HUB_VENDOR = 0x1A40
 YELLOW_USB_HUB_PRODUCT = 0x0101
 
 
-def _read_gpio_pins[_PinsT: int](pins: list[_PinsT]) -> dict[_PinsT, bool]:
+def _read_gpio_pins[_PinsT: int](pins: Sequence[_PinsT]) -> dict[_PinsT, bool]:
     """Read the state of the given GPIO pins."""
     # pylint: disable-next=import-outside-toplevel
     import gpiod

--- a/homeassistant/components/homeassistant_yellow/helpers.py
+++ b/homeassistant/components/homeassistant_yellow/helpers.py
@@ -105,7 +105,7 @@ def validate_usb_hub_present() -> bool:
 
 async def async_validate_hardware_consistent(hass: HomeAssistant) -> bool:
     """Validate the hardware is consistent with a properly installed CM4."""
-    if not validate_usb_hub_present():
+    if not await hass.async_add_executor_job(validate_usb_hub_present):
         return False
 
     if not await async_validate_gpio_states(hass):

--- a/homeassistant/components/homeassistant_yellow/helpers.py
+++ b/homeassistant/components/homeassistant_yellow/helpers.py
@@ -51,7 +51,7 @@ def _read_gpio_pins[_PinsT: int](pins: Sequence[_PinsT]) -> dict[_PinsT, bool]:
     import gpiod
 
     chip = gpiod.chip("/dev/gpiochip0", gpiod.chip.OPEN_BY_PATH)
-    lines = chip.get_lines(pins)
+    lines = chip.get_lines(list(pins))
 
     config = gpiod.line_request()
     config.consumer = "core-yellow"

--- a/homeassistant/components/homeassistant_yellow/manifest.json
+++ b/homeassistant/components/homeassistant_yellow/manifest.json
@@ -7,5 +7,5 @@
   "dependencies": ["hardware", "homeassistant_hardware"],
   "documentation": "https://www.home-assistant.io/integrations/homeassistant_yellow",
   "integration_type": "hardware",
-  "requirements": ["gpiod==1.5.4", "pyusb==1.2.1"]
+  "requirements": ["gpiod==2.2.0", "pyusb==1.2.1"]
 }

--- a/homeassistant/components/homeassistant_yellow/manifest.json
+++ b/homeassistant/components/homeassistant_yellow/manifest.json
@@ -6,5 +6,6 @@
   "config_flow": false,
   "dependencies": ["hardware", "homeassistant_hardware"],
   "documentation": "https://www.home-assistant.io/integrations/homeassistant_yellow",
-  "integration_type": "hardware"
+  "integration_type": "hardware",
+  "requirements": ["gpiod==1.5.4", "pyusb==1.2.1"]
 }

--- a/homeassistant/components/homeassistant_yellow/strings.json
+++ b/homeassistant/components/homeassistant_yellow/strings.json
@@ -99,5 +99,11 @@
       "install_addon": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::progress::install_addon%]",
       "start_addon": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::progress::start_addon%]"
     }
+  },
+  "issues": {
+    "cm4_unseated": {
+      "title": "Raspberry Pi Compute Module is not firmly installed",
+      "description": "Your Raspberry Pi Compute Module does not appear to be plugged in all the way and some pins are disconnected. Carefully disassemble the Yellow and securely click the Compute Module into place."
+    }
   }
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1004,7 +1004,7 @@ govee-ble==0.31.3
 govee-local-api==1.5.1
 
 # homeassistant.components.homeassistant_yellow
-gpiod==1.5.4
+gpiod==2.2.0
 
 # homeassistant.components.remote_rpi_gpio
 gpiozero==1.6.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1003,6 +1003,9 @@ govee-ble==0.31.3
 # homeassistant.components.govee_light_local
 govee-local-api==1.5.1
 
+# homeassistant.components.homeassistant_yellow
+gpiod==1.5.4
+
 # homeassistant.components.remote_rpi_gpio
 gpiozero==1.6.2
 
@@ -2373,6 +2376,9 @@ pyudev==0.24.1
 
 # homeassistant.components.uptimerobot
 pyuptimerobot==22.2.0
+
+# homeassistant.components.homeassistant_yellow
+pyusb==1.2.1
 
 # homeassistant.components.keyboard
 # pyuserinput==0.1.11

--- a/tests/components/homeassistant_yellow/conftest.py
+++ b/tests/components/homeassistant_yellow/conftest.py
@@ -153,3 +153,13 @@ def start_addon_fixture():
         "homeassistant.components.hassio.addon_manager.async_start_addon"
     ) as start_addon:
         yield start_addon
+
+
+@pytest.fixture(autouse=True)
+def mock_async_validate_hardware_consistent() -> Generator[None]:
+    """Mock validate hardware state."""
+    with patch(
+        "homeassistant.components.homeassistant_yellow.async_validate_hardware_consistent",
+        return_value=True,
+    ):
+        yield

--- a/tests/components/homeassistant_yellow/test_hardware.py
+++ b/tests/components/homeassistant_yellow/test_hardware.py
@@ -13,16 +13,6 @@ from tests.common import MockConfigEntry, MockModule, mock_integration
 from tests.typing import WebSocketGenerator
 
 
-@pytest.fixture(autouse=True)
-def mock_async_validate_hardware_consistent():
-    """Mock validate hardware state."""
-    with patch(
-        "homeassistant.components.homeassistant_yellow.async_validate_hardware_consistent",
-        return_value=True,
-    ):
-        yield
-
-
 async def test_hardware_info(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, addon_store_info
 ) -> None:

--- a/tests/components/homeassistant_yellow/test_hardware.py
+++ b/tests/components/homeassistant_yellow/test_hardware.py
@@ -13,6 +13,16 @@ from tests.common import MockConfigEntry, MockModule, mock_integration
 from tests.typing import WebSocketGenerator
 
 
+@pytest.fixture(autouse=True)
+def mock_async_validate_hardware_consistent():
+    """Mock validate hardware state."""
+    with patch(
+        "homeassistant.components.homeassistant_yellow.async_validate_hardware_consistent",
+        return_value=True,
+    ):
+        yield
+
+
 async def test_hardware_info(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, addon_store_info
 ) -> None:

--- a/tests/components/homeassistant_yellow/test_helpers.py
+++ b/tests/components/homeassistant_yellow/test_helpers.py
@@ -1,0 +1,131 @@
+"""Test the Home Assistant Yellow integration helpers."""
+from __future__ import annotations
+
+import contextlib
+import typing
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.components.homeassistant_yellow.helpers import (
+    YellowGPIO,
+    async_validate_gpio_states,
+    async_validate_hardware_consistent,
+    validate_usb_hub_present,
+)
+from homeassistant.core import HomeAssistant
+
+if typing.TYPE_CHECKING:
+    import gpiod
+
+
+@contextlib.contextmanager
+def mock_gpio_pin_states(pin_states: dict[int, list[bool]]):
+    """Mock the GPIO pin read function."""
+
+    read_count = 0
+
+    def mock_get_lines(pins: list[int]):
+        def mock_get_values() -> list[gpiod.line.Value]:
+            nonlocal read_count
+
+            values = [pin_states[pin][read_count] for pin in pins]
+            read_count += 1
+
+            return values
+
+        mock = MagicMock()
+        mock.get_values.side_effect = mock_get_values
+
+        return mock
+
+    mock_gpiod = MagicMock()
+    mock_gpiod.chip.return_value.get_lines = MagicMock(side_effect=mock_get_lines)
+
+    with patch.dict("sys.modules", gpiod=mock_gpiod):
+        yield
+
+
+@pytest.mark.parametrize(
+    ("states", "result"),
+    [
+        (
+            # Normal
+            {
+                YellowGPIO.RADIO_BOOT: [1, 1, 1, 1, 1],
+                YellowGPIO.RADIO_RESET: [1, 1, 1, 1, 1],
+            },
+            True,
+        ),
+        (
+            # Unstable
+            {
+                YellowGPIO.RADIO_BOOT: [1, 1, 0, 1, 1],
+                YellowGPIO.RADIO_RESET: [1, 1, 1, 1, 1],
+            },
+            False,
+        ),
+        (
+            # Stable but inverted
+            {
+                YellowGPIO.RADIO_BOOT: [0, 0, 0, 0, 0],
+                YellowGPIO.RADIO_RESET: [0, 0, 0, 0, 0],
+            },
+            False,
+        ),
+        (
+            # Half stable but inverted
+            {
+                YellowGPIO.RADIO_BOOT: [1, 1, 1, 1, 1],
+                YellowGPIO.RADIO_RESET: [0, 0, 0, 0, 0],
+            },
+            False,
+        ),
+    ],
+)
+async def test_validate_gpio_pins(
+    states: dict[YellowGPIO, list[int]], result: bool, hass: HomeAssistant
+) -> None:
+    """Test validating GPIO pin states, success."""
+    with mock_gpio_pin_states(states):
+        assert (await async_validate_gpio_states(hass)) is result
+
+
+@pytest.mark.parametrize(
+    ("find_result", "result"),
+    [
+        (["hub1", "hub2"], True),
+        (["hub1", None], False),
+        ([None], False),
+    ],
+)
+def test_validate_usb_hub_present(find_result: list[bool], result: bool) -> None:
+    """Test validating USB hubs."""
+    with patch(
+        "homeassistant.components.homeassistant_yellow.helpers.usb.core.find",
+        side_effect=find_result,
+    ):
+        assert validate_usb_hub_present() is result
+
+
+@pytest.mark.parametrize(
+    ("hub_present", "gpio_valid", "result"),
+    [
+        (True, True, True),
+        (True, False, False),
+        (False, True, False),
+        (False, False, False),
+    ],
+)
+async def test_async_validate_hardware_consistent(
+    hub_present: bool, gpio_valid: bool, result: bool, hass: HomeAssistant
+) -> None:
+    """Test validating hardware consistency."""
+    with patch(
+        "homeassistant.components.homeassistant_yellow.helpers.validate_usb_hub_present",
+        return_value=hub_present,
+    ), patch(
+        "homeassistant.components.homeassistant_yellow.helpers.async_validate_gpio_states",
+        return_value=gpio_valid,
+    ):
+        assert (await async_validate_hardware_consistent(hass)) is result

--- a/tests/components/homeassistant_yellow/test_helpers.py
+++ b/tests/components/homeassistant_yellow/test_helpers.py
@@ -1,4 +1,5 @@
 """Test the Home Assistant Yellow integration helpers."""
+
 from __future__ import annotations
 
 import contextlib
@@ -88,7 +89,7 @@ async def test_validate_gpio_pins(
 ) -> None:
     """Test validating GPIO pin states, success."""
     with mock_gpio_pin_states(states):
-        assert (await async_validate_gpio_states(hass)) is result
+        assert (await async_validate_gpio_states(hass)) == result
 
 
 @pytest.mark.parametrize(
@@ -121,11 +122,14 @@ async def test_async_validate_hardware_consistent(
     hub_present: bool, gpio_valid: bool, result: bool, hass: HomeAssistant
 ) -> None:
     """Test validating hardware consistency."""
-    with patch(
-        "homeassistant.components.homeassistant_yellow.helpers.validate_usb_hub_present",
-        return_value=hub_present,
-    ), patch(
-        "homeassistant.components.homeassistant_yellow.helpers.async_validate_gpio_states",
-        return_value=gpio_valid,
+    with (
+        patch(
+            "homeassistant.components.homeassistant_yellow.helpers.validate_usb_hub_present",
+            return_value=hub_present,
+        ),
+        patch(
+            "homeassistant.components.homeassistant_yellow.helpers.async_validate_gpio_states",
+            return_value=gpio_valid,
+        ),
     ):
         assert (await async_validate_hardware_consistent(hass)) is result

--- a/tests/components/homeassistant_yellow/test_init.py
+++ b/tests/components/homeassistant_yellow/test_init.py
@@ -19,16 +19,6 @@ from homeassistant.setup import async_setup_component
 from tests.common import MockConfigEntry, MockModule, mock_integration
 
 
-@pytest.fixture(autouse=True)
-def mock_async_validate_hardware_consistent():
-    """Mock validate hardware state."""
-    with patch(
-        "homeassistant.components.homeassistant_yellow.async_validate_hardware_consistent",
-        return_value=True,
-    ):
-        yield
-
-
 @pytest.mark.parametrize(
     ("onboarded", "num_entries", "num_flows"), [(False, 1, 0), (True, 0, 1)]
 )

--- a/tests/components/homeassistant_yellow/test_init.py
+++ b/tests/components/homeassistant_yellow/test_init.py
@@ -416,7 +416,7 @@ async def test_unseated_repair(hass: HomeAssistant) -> None:
 
         issue = issue_registry.async_get_issue(DOMAIN, ISSUE_CM4_UNSEATED)
         assert issue.is_fixable is False
-        assert issue.is_persistent is True
+        assert issue.is_persistent is False
         assert (
             issue.learn_more_url
             == "https://yellow.home-assistant.io/guides/remove-cm4/"

--- a/tests/components/homeassistant_yellow/test_init.py
+++ b/tests/components/homeassistant_yellow/test_init.py
@@ -1,16 +1,19 @@
 """Test the Home Assistant Yellow integration."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 
 from homeassistant.components import zha
 from homeassistant.components.hassio import DOMAIN as HASSIO_DOMAIN
 from homeassistant.components.hassio.handler import HassioAPIError
-from homeassistant.components.homeassistant_yellow.const import DOMAIN
+from homeassistant.components.homeassistant_yellow.const import (
+    DOMAIN,
+    ISSUE_CM4_UNSEATED,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, MockModule, mock_integration
@@ -370,47 +373,12 @@ async def test_setup_entry_addon_not_running(
     start_addon.assert_called_once()
 
 
-async def test_create_unseated_repair(hass: HomeAssistant) -> None:
-    """Test that a repair is created when hardware is inconsistent."""
-    mock_integration(hass, MockModule("hassio"))
-
-    # Setup the config entry
-    config_entry = MockConfigEntry(
-        data={},
-        domain=DOMAIN,
-        options={},
-        title="Home Assistant Yellow",
-    )
-    config_entry.add_to_hass(hass)
-
-    with patch(
-        "homeassistant.components.homeassistant_yellow.get_os_info",
-        return_value={"board": "yellow"},
-    ), patch(
-        "homeassistant.components.onboarding.async_is_onboarded", return_value=True
-    ), patch(
-        "homeassistant.components.homeassistant_yellow.check_multi_pan_addon",
-        side_effect=HomeAssistantError(),
-    ), patch(
-        "homeassistant.components.homeassistant_yellow.async_validate_hardware_consistent",
-        return_value=False,
-    ), patch("homeassistant.components.homeassistant_yellow.ir") as ir:
-        assert not await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
-
-    assert len(ir.async_create_issue.mock_calls) == 1
-    assert (
-        ir.async_create_issue.mock_calls[0].kwargs["domain"] == "homeassistant_yellow"
-    )
-    assert ir.async_create_issue.mock_calls[0].kwargs["issue_id"] == "cm4_unseated"
-
-
-async def test_clear_unseated_repair(hass: HomeAssistant) -> None:
+async def test_unseated_repair(hass: HomeAssistant) -> None:
     """Test that a repair is cleared when hardware is consistent."""
     mock_integration(hass, MockModule("hassio"))
 
+    issue_registry = ir.async_get(hass)
+
     # Setup the config entry
     config_entry = MockConfigEntry(
         data={},
@@ -420,21 +388,39 @@ async def test_clear_unseated_repair(hass: HomeAssistant) -> None:
     )
     config_entry.add_to_hass(hass)
 
-    with patch(
-        "homeassistant.components.homeassistant_yellow.get_os_info",
-        return_value={"board": "yellow"},
-    ), patch(
-        "homeassistant.components.onboarding.async_is_onboarded", return_value=True
-    ), patch(
-        "homeassistant.components.homeassistant_yellow.check_multi_pan_addon",
-        side_effect=HomeAssistantError(),
-    ), patch(
-        "homeassistant.components.homeassistant_yellow.async_validate_hardware_consistent",
-        return_value=True,
-    ), patch("homeassistant.components.homeassistant_yellow.ir") as ir:
-        assert not await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
+    with (
+        patch(
+            "homeassistant.components.homeassistant_yellow.is_hassio", return_value=True
+        ),
+        patch(
+            "homeassistant.components.homeassistant_yellow.get_os_info",
+            return_value={"board": "yellow"},
+        ),
+        patch(
+            "homeassistant.components.onboarding.async_is_onboarded", return_value=True
+        ),
+        patch(
+            "homeassistant.components.homeassistant_yellow.check_multi_pan_addon",
+            return_value=None,
+        ),
+    ):
+        # Cause an issue to be created
+        with patch(
+            "homeassistant.components.homeassistant_yellow.async_validate_hardware_consistent",
+            return_value=False,
+        ):
+            await hass.config_entries.async_setup(config_entry.entry_id)
 
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+        # The integration is loaded but the issue is present
+        assert config_entry.state == ConfigEntryState.LOADED
+        assert issue_registry.async_get_issue(DOMAIN, ISSUE_CM4_UNSEATED) is not None
 
-    assert ir.async_delete_issue.mock_calls == [call(hass, DOMAIN, "cm4_unseated")]
+        # The issue will be cleared once pins are consistent
+        with patch(
+            "homeassistant.components.homeassistant_yellow.async_validate_hardware_consistent",
+            return_value=True,
+        ):
+            await hass.config_entries.async_reload(config_entry.entry_id)
+
+        assert config_entry.state == ConfigEntryState.LOADED
+        assert issue_registry.async_get_issue(DOMAIN, ISSUE_CM4_UNSEATED) is None

--- a/tests/components/homeassistant_yellow/test_init.py
+++ b/tests/components/homeassistant_yellow/test_init.py
@@ -413,7 +413,15 @@ async def test_unseated_repair(hass: HomeAssistant) -> None:
 
         # The integration is loaded but the issue is present
         assert config_entry.state == ConfigEntryState.LOADED
-        assert issue_registry.async_get_issue(DOMAIN, ISSUE_CM4_UNSEATED) is not None
+
+        issue = issue_registry.async_get_issue(DOMAIN, ISSUE_CM4_UNSEATED)
+        assert issue.is_fixable is False
+        assert issue.is_persistent is True
+        assert (
+            issue.learn_more_url
+            == "https://yellow.home-assistant.io/guides/remove-cm4/"
+        )
+        assert issue.severity == ir.IssueSeverity.ERROR
 
         # The issue will be cleared once pins are consistent
         with patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Yellow's CM4 module can become partially unseated. To catch this:

 - We can read the state of GPIO pins in the middle of the board and make sure their state is correct.
 - Check if the USB hub on the Yellow's PCB is connected

This PR will open a repair telling you how to take apart the Yellow and remove its CM4.

This won't catch all mis-seating issues but it's a start. More GPIO pins and peripherals should be explored.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
