### PR TITLE
Issue warning if glances server version is 2

### DIFF
--- a/homeassistant/components/glances/__init__.py
+++ b/homeassistant/components/glances/__init__.py
@@ -8,8 +8,9 @@ from homeassistant.const import CONF_NAME, CONF_VERIFY_SSL, Platform
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.httpx_client import get_async_client
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 
-from .const import DOMAIN
+from .const import CONF_VERSION, DOMAIN
 from .coordinator import GlancesDataUpdateCoordinator
 
 PLATFORMS = [Platform.SENSOR]
@@ -26,6 +27,16 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
+
+    if config_entry.data[CONF_VERSION] == 2:
+        async_create_issue(
+            hass,
+            DOMAIN,
+            "deprecated_version",
+            is_fixable=False,
+            severity=IssueSeverity.WARNING,
+            translation_key="deprecated_version",
+        )
 
     return True
 

--- a/homeassistant/components/glances/__init__.py
+++ b/homeassistant/components/glances/__init__.py
@@ -10,7 +10,15 @@ from glances_api.exceptions import (
 )
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME, CONF_VERIFY_SSL, Platform
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SSL,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import (
     ConfigEntryAuthFailed,
@@ -22,7 +30,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 
-from .const import CONF_VERSION, DOMAIN
+from .const import DOMAIN
 from .coordinator import GlancesDataUpdateCoordinator
 
 PLATFORMS = [Platform.SENSOR]
@@ -40,7 +48,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         raise ConfigEntryAuthFailed from err
     except GlancesApiError as err:
         raise ConfigEntryNotReady from err
-    except UnknownError as err:
+    except ServerVersionMismatch as err:
         raise ConfigEntryError(err) from err
     coordinator = GlancesDataUpdateCoordinator(hass, config_entry, api)
     await coordinator.async_config_entry_first_refresh()
@@ -63,29 +71,35 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def get_api(hass: HomeAssistant, entry_data: dict[str, Any]) -> Glances:
     """Return the api from glances_api."""
-    entry_data.pop(CONF_NAME, None)
-    entry_data.pop(CONF_VERSION, None)
-
     httpx_client = get_async_client(hass, verify_ssl=entry_data[CONF_VERIFY_SSL])
     for version in (3, 2):
-        api = Glances(httpx_client=httpx_client, version=version, **entry_data)
+        api = Glances(
+            host=entry_data[CONF_HOST],
+            port=entry_data[CONF_PORT],
+            version=version,
+            ssl=entry_data[CONF_SSL],
+            username=entry_data.get(CONF_USERNAME),
+            password=entry_data.get(CONF_PASSWORD),
+            httpx_client=httpx_client,
+        )
         try:
             await api.get_ha_sensor_data()
-            _LOGGER.debug("Connected to Glances API v%s", version)
-            if version == 2:
-                async_create_issue(
-                    hass,
-                    DOMAIN,
-                    "deprecated_version",
-                    is_fixable=False,
-                    severity=IssueSeverity.WARNING,
-                    translation_key="deprecated_version",
-                )
-            return api
         except GlancesApiNoDataAvailable as err:
             _LOGGER.debug("Failed to connect to Glances API v%s: %s", version, err)
-    raise UnknownError("Could not connect to Glances API")
+            continue
+        if version == 2:
+            async_create_issue(
+                hass,
+                DOMAIN,
+                "deprecated_version",
+                is_fixable=False,
+                severity=IssueSeverity.WARNING,
+                translation_key="deprecated_version",
+            )
+        _LOGGER.debug("Connected to Glances API v%s", version)
+        return api
+    raise ServerVersionMismatch("Could not connect to Glances API version 2 or 3")
 
 
-class UnknownError(HomeAssistantError):
+class ServerVersionMismatch(HomeAssistantError):
     """Raise exception if we fail to connect to Glances API."""

--- a/homeassistant/components/glances/__init__.py
+++ b/homeassistant/components/glances/__init__.py
@@ -92,7 +92,7 @@ async def get_api(hass: HomeAssistant, entry_data: dict[str, Any]) -> Glances:
                 hass,
                 DOMAIN,
                 "deprecated_version",
-                breaks_in_ha_version="2024.6.1",
+                breaks_in_ha_version="2024.8.1",
                 is_fixable=False,
                 severity=IssueSeverity.WARNING,
                 translation_key="deprecated_version",

--- a/homeassistant/components/glances/__init__.py
+++ b/homeassistant/components/glances/__init__.py
@@ -1,11 +1,23 @@
 """The Glances component."""
+import logging
 from typing import Any
 
 from glances_api import Glances
+from glances_api.exceptions import (
+    GlancesApiAuthorizationError,
+    GlancesApiError,
+    GlancesApiNoDataAvailable,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, CONF_VERIFY_SSL, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryError,
+    ConfigEntryNotReady,
+    HomeAssistantError,
+)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
@@ -17,26 +29,25 @@ PLATFORMS = [Platform.SENSOR]
 
 CONFIG_SCHEMA = cv.removed(DOMAIN, raise_if_present=False)
 
+_LOGGER = logging.getLogger(__name__)
+
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Set up Glances from config entry."""
-    api = get_api(hass, dict(config_entry.data))
+    try:
+        api = await get_api(hass, dict(config_entry.data))
+    except GlancesApiAuthorizationError as err:
+        raise ConfigEntryAuthFailed from err
+    except GlancesApiError as err:
+        raise ConfigEntryNotReady from err
+    except UnknownError as err:
+        raise ConfigEntryError(err) from err
     coordinator = GlancesDataUpdateCoordinator(hass, config_entry, api)
     await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
-
-    if config_entry.data[CONF_VERSION] == 2:
-        async_create_issue(
-            hass,
-            DOMAIN,
-            "deprecated_version",
-            is_fixable=False,
-            severity=IssueSeverity.WARNING,
-            translation_key="deprecated_version",
-        )
 
     return True
 
@@ -50,8 +61,31 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-def get_api(hass: HomeAssistant, entry_data: dict[str, Any]) -> Glances:
+async def get_api(hass: HomeAssistant, entry_data: dict[str, Any]) -> Glances:
     """Return the api from glances_api."""
     entry_data.pop(CONF_NAME, None)
+    entry_data.pop(CONF_VERSION, None)
+
     httpx_client = get_async_client(hass, verify_ssl=entry_data[CONF_VERIFY_SSL])
-    return Glances(httpx_client=httpx_client, **entry_data)
+    for version in (3, 2):
+        api = Glances(httpx_client=httpx_client, version=version, **entry_data)
+        try:
+            await api.get_ha_sensor_data()
+            _LOGGER.debug("Connected to Glances API v%s", version)
+            if version == 2:
+                async_create_issue(
+                    hass,
+                    DOMAIN,
+                    "deprecated_version",
+                    is_fixable=False,
+                    severity=IssueSeverity.WARNING,
+                    translation_key="deprecated_version",
+                )
+            return api
+        except GlancesApiNoDataAvailable as err:
+            _LOGGER.debug("Failed to connect to Glances API v%s: %s", version, err)
+    raise UnknownError("Could not connect to Glances API")
+
+
+class UnknownError(HomeAssistantError):
+    """Raise exception if we fail to connect to Glances API."""

--- a/homeassistant/components/glances/__init__.py
+++ b/homeassistant/components/glances/__init__.py
@@ -92,7 +92,7 @@ async def get_api(hass: HomeAssistant, entry_data: dict[str, Any]) -> Glances:
                 hass,
                 DOMAIN,
                 "deprecated_version",
-                breaks_in_ha_version="2024.8.1",
+                breaks_in_ha_version="2024.8.0",
                 is_fixable=False,
                 severity=IssueSeverity.WARNING,
                 translation_key="deprecated_version",

--- a/homeassistant/components/glances/__init__.py
+++ b/homeassistant/components/glances/__init__.py
@@ -92,6 +92,7 @@ async def get_api(hass: HomeAssistant, entry_data: dict[str, Any]) -> Glances:
                 hass,
                 DOMAIN,
                 "deprecated_version",
+                breaks_in_ha_version="2024.6.1",
                 is_fixable=False,
                 severity=IssueSeverity.WARNING,
                 translation_key="deprecated_version",

--- a/homeassistant/components/glances/config_flow.py
+++ b/homeassistant/components/glances/config_flow.py
@@ -21,15 +21,8 @@ from homeassistant.const import (
 )
 from homeassistant.data_entry_flow import FlowResult
 
-from . import get_api
-from .const import (
-    CONF_VERSION,
-    DEFAULT_HOST,
-    DEFAULT_PORT,
-    DEFAULT_VERSION,
-    DOMAIN,
-    SUPPORTED_VERSIONS,
-)
+from . import UnknownError, get_api
+from .const import DEFAULT_HOST, DEFAULT_PORT, DOMAIN
 
 DATA_SCHEMA = vol.Schema(
     {
@@ -37,7 +30,6 @@ DATA_SCHEMA = vol.Schema(
         vol.Optional(CONF_USERNAME): str,
         vol.Optional(CONF_PASSWORD): str,
         vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
-        vol.Required(CONF_VERSION, default=DEFAULT_VERSION): vol.In(SUPPORTED_VERSIONS),
         vol.Optional(CONF_SSL, default=False): bool,
         vol.Optional(CONF_VERIFY_SSL, default=False): bool,
     }
@@ -65,12 +57,11 @@ class GlancesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         assert self._reauth_entry
         if user_input is not None:
             user_input = {**self._reauth_entry.data, **user_input}
-            api = get_api(self.hass, user_input)
             try:
-                await api.get_ha_sensor_data()
+                await get_api(self.hass, user_input)
             except GlancesApiAuthorizationError:
                 errors["base"] = "invalid_auth"
-            except GlancesApiConnectionError:
+            except (GlancesApiConnectionError, UnknownError):
                 errors["base"] = "cannot_connect"
             else:
                 self.hass.config_entries.async_update_entry(
@@ -101,9 +92,8 @@ class GlancesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self._async_abort_entries_match(
                 {CONF_HOST: user_input[CONF_HOST], CONF_PORT: user_input[CONF_PORT]}
             )
-            api = get_api(self.hass, user_input)
             try:
-                await api.get_ha_sensor_data()
+                await get_api(self.hass, user_input)
             except GlancesApiAuthorizationError:
                 errors["base"] = "invalid_auth"
             except GlancesApiConnectionError:

--- a/homeassistant/components/glances/config_flow.py
+++ b/homeassistant/components/glances/config_flow.py
@@ -61,7 +61,7 @@ class GlancesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 await get_api(self.hass, user_input)
             except GlancesApiAuthorizationError:
                 errors["base"] = "invalid_auth"
-            except (GlancesApiConnectionError, ServerVersionMismatch):
+            except GlancesApiConnectionError:
                 errors["base"] = "cannot_connect"
             else:
                 self.hass.config_entries.async_update_entry(
@@ -96,7 +96,7 @@ class GlancesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 await get_api(self.hass, user_input)
             except GlancesApiAuthorizationError:
                 errors["base"] = "invalid_auth"
-            except GlancesApiConnectionError:
+            except (GlancesApiConnectionError, ServerVersionMismatch):
                 errors["base"] = "cannot_connect"
             else:
                 return self.async_create_entry(

--- a/homeassistant/components/glances/config_flow.py
+++ b/homeassistant/components/glances/config_flow.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
 )
 from homeassistant.data_entry_flow import FlowResult
 
-from . import UnknownError, get_api
+from . import ServerVersionMismatch, get_api
 from .const import DEFAULT_HOST, DEFAULT_PORT, DOMAIN
 
 DATA_SCHEMA = vol.Schema(
@@ -61,7 +61,7 @@ class GlancesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 await get_api(self.hass, user_input)
             except GlancesApiAuthorizationError:
                 errors["base"] = "invalid_auth"
-            except (GlancesApiConnectionError, UnknownError):
+            except (GlancesApiConnectionError, ServerVersionMismatch):
                 errors["base"] = "cannot_connect"
             else:
                 self.hass.config_entries.async_update_entry(

--- a/homeassistant/components/glances/const.py
+++ b/homeassistant/components/glances/const.py
@@ -8,9 +8,6 @@ CONF_VERSION = "version"
 
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 61208
-DEFAULT_VERSION = 3
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=60)
-
-SUPPORTED_VERSIONS = [2, 3]
 
 CPU_ICON = f"mdi:cpu-{64 if sys.maxsize > 2**32 else 32}-bit"

--- a/homeassistant/components/glances/strings.json
+++ b/homeassistant/components/glances/strings.json
@@ -30,5 +30,11 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
+  },
+  "issues": {
+    "deprecated_version": {
+      "title": "Glances servers with version 2 is deprecated",
+      "description": "Glances servers with version 2 is deprecated and will not be supported in future versions of HA. It is recommended to update to version 3."
+    }
   }
 }

--- a/homeassistant/components/glances/strings.json
+++ b/homeassistant/components/glances/strings.json
@@ -7,7 +7,6 @@
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
           "port": "[%key:common::config_flow::data::port%]",
-          "version": "Glances API Version (2 or 3)",
           "ssl": "[%key:common::config_flow::data::ssl%]",
           "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
         },
@@ -34,7 +33,7 @@
   "issues": {
     "deprecated_version": {
       "title": "Glances servers with version 2 is deprecated",
-      "description": "Glances servers with version 2 is deprecated and will not be supported in future versions of HA. It is recommended to update to version 3."
+      "description": "Glances servers with version 2 is deprecated and will not be supported in future versions of HA. It is recommended to update to version 3 then reload the config entry."
     }
   }
 }

--- a/homeassistant/components/glances/strings.json
+++ b/homeassistant/components/glances/strings.json
@@ -33,7 +33,7 @@
   "issues": {
     "deprecated_version": {
       "title": "Glances servers with version 2 is deprecated",
-      "description": "Glances servers with version 2 is deprecated and will not be supported in future versions of HA. It is recommended to update your server to Glances version 3 then reload the config entry."
+      "description": "Glances servers with version 2 is deprecated and will not be supported in future versions of HA. It is recommended to update your server to Glances version 3 then reload the integration."
     }
   }
 }

--- a/homeassistant/components/glances/strings.json
+++ b/homeassistant/components/glances/strings.json
@@ -33,7 +33,7 @@
   "issues": {
     "deprecated_version": {
       "title": "Glances servers with version 2 is deprecated",
-      "description": "Glances servers with version 2 is deprecated and will not be supported in future versions of HA. It is recommended to update to version 3 then reload the config entry."
+      "description": "Glances servers with version 2 is deprecated and will not be supported in future versions of HA. It is recommended to update your server to Glances version 3 then reload the config entry."
     }
   }
 }

--- a/tests/components/glances/__init__.py
+++ b/tests/components/glances/__init__.py
@@ -6,7 +6,6 @@ MOCK_USER_INPUT: dict[str, Any] = {
     "host": "0.0.0.0",
     "username": "username",
     "password": "password",
-    "version": 3,
     "port": 61208,
     "ssl": False,
     "verify_ssl": True,

--- a/tests/components/glances/test_config_flow.py
+++ b/tests/components/glances/test_config_flow.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 from glances_api.exceptions import (
     GlancesApiAuthorizationError,
     GlancesApiConnectionError,
+    GlancesApiNoDataAvailable,
 )
 import pytest
 
@@ -47,6 +48,7 @@ async def test_form(hass: HomeAssistant) -> None:
     [
         (GlancesApiAuthorizationError, "invalid_auth"),
         (GlancesApiConnectionError, "cannot_connect"),
+        (GlancesApiNoDataAvailable, "cannot_connect"),
     ],
 )
 async def test_form_fails(
@@ -54,7 +56,7 @@ async def test_form_fails(
 ) -> None:
     """Test flow fails when api exception is raised."""
 
-    mock_api.return_value.get_ha_sensor_data.side_effect = [error, HA_SENSOR_DATA]
+    mock_api.return_value.get_ha_sensor_data.side_effect = error
     result = await hass.config_entries.flow.async_init(
         glances.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -64,12 +66,6 @@ async def test_form_fails(
 
     assert result["type"] == FlowResultType.FORM
     assert result["errors"] == {"base": message}
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=MOCK_USER_INPUT
-    )
-
-    assert result["type"] == FlowResultType.CREATE_ENTRY
 
 
 async def test_form_already_configured(hass: HomeAssistant) -> None:

--- a/tests/components/glances/test_init.py
+++ b/tests/components/glances/test_init.py
@@ -1,27 +1,25 @@
 """Tests for Glances integration."""
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from glances_api.exceptions import (
     GlancesApiAuthorizationError,
     GlancesApiConnectionError,
+    GlancesApiNoDataAvailable,
 )
 import pytest
 
 from homeassistant.components.glances.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.issue_registry import (
-    IssueSeverity,
-    async_get as async_get_issue_registry,
-)
+from homeassistant.helpers import issue_registry as ir
 
-from . import MOCK_USER_INPUT
+from . import HA_SENSOR_DATA, MOCK_USER_INPUT
 
 from tests.common import MockConfigEntry
 
 
 async def test_successful_config_entry(hass: HomeAssistant) -> None:
-    """Test that Glances is configu red successfully."""
+    """Test that Glances is configured successfully."""
 
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT)
     entry.add_to_hass(hass)
@@ -31,25 +29,26 @@ async def test_successful_config_entry(hass: HomeAssistant) -> None:
     assert entry.state == ConfigEntryState.LOADED
 
 
-async def test_entry_deprecated_version(hass: HomeAssistant) -> None:
+async def test_entry_deprecated_version(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry, mock_api: AsyncMock
+) -> None:
     """Test creating an issue if glances server is version 2."""
-    registry = async_get_issue_registry(hass)
-    issue = registry.async_get_issue(DOMAIN, "deprecated_version")
-    assert issue is None
-
-    v2_config_entry = MOCK_USER_INPUT.copy()
-    v2_config_entry["version"] = 2
-
-    entry = MockConfigEntry(domain=DOMAIN, data=v2_config_entry)
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT)
     entry.add_to_hass(hass)
+
+    mock_api.return_value.get_ha_sensor_data.side_effect = [
+        GlancesApiNoDataAvailable("endpoint: 'all' is not valid"),
+        HA_SENSOR_DATA,
+        HA_SENSOR_DATA,
+    ]
 
     await hass.config_entries.async_setup(entry.entry_id)
 
     assert entry.state == ConfigEntryState.LOADED
 
-    issue = registry.async_get_issue(DOMAIN, "deprecated_version")
+    issue = issue_registry.async_get_issue(DOMAIN, "deprecated_version")
     assert issue is not None
-    assert issue.severity == IssueSeverity.WARNING
+    assert issue.severity == ir.IssueSeverity.WARNING
 
 
 @pytest.mark.parametrize(
@@ -57,6 +56,7 @@ async def test_entry_deprecated_version(hass: HomeAssistant) -> None:
     [
         (GlancesApiAuthorizationError, ConfigEntryState.SETUP_ERROR),
         (GlancesApiConnectionError, ConfigEntryState.SETUP_RETRY),
+        (GlancesApiNoDataAvailable, ConfigEntryState.SETUP_ERROR),
     ],
 )
 async def test_setup_error(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Servers running Glances version 2 will be unsupported in 2024.8. We highly recommend that you upgrade to Glances version 3.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Issue warning if glances server version 2 is detected.
- Fail setup if neither version 3 or 2 are detected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30572

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
