### PR TITLE
Allow Common Table Expressions (WITH ... SELECT) in SQL integration

### DIFF
--- a/homeassistant/components/sql/__init__.py
+++ b/homeassistant/components/sql/__init__.py
@@ -38,9 +38,7 @@ _LOGGER = logging.getLogger(__name__)
 
 def validate_sql_select(value: str) -> str:
     """Validate that value is a SQL SELECT or WITH ... SELECT (a SELECT using a Common Table Expression) query."""
-    if not value.lstrip().lower().startswith(
-        "select"
-    ) and not value.lstrip().lower().startswith("with"):
+    if not value.lstrip().lower().startswith(("select", "with")):
         raise vol.Invalid("Only SELECT queries allowed")
     return value
 

--- a/homeassistant/components/sql/__init__.py
+++ b/homeassistant/components/sql/__init__.py
@@ -38,7 +38,9 @@ _LOGGER = logging.getLogger(__name__)
 
 def validate_sql_select(value: str) -> str:
     """Validate that value is a SQL SELECT or WITH ... SELECT (a SELECT using a Common Table Expression) query."""
-    if not value.lstrip().lower().startswith("select") and not value.lstrip().lower().startswith("with"):
+    if not value.lstrip().lower().startswith(
+        "select"
+    ) and not value.lstrip().lower().startswith("with"):
         raise vol.Invalid("Only SELECT queries allowed")
     return value
 

--- a/homeassistant/components/sql/__init__.py
+++ b/homeassistant/components/sql/__init__.py
@@ -37,8 +37,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def validate_sql_select(value: str) -> str:
-    """Validate that value is a SQL SELECT query."""
-    if not value.lstrip().lower().startswith("select"):
+    """Validate that value is a SQL SELECT or WITH ... SELECT (a SELECT using a Common Table Expression) query."""
+    if not value.lstrip().lower().startswith("select") and not value.lstrip().lower().startswith("with"):
         raise vol.Invalid("Only SELECT queries allowed")
     return value
 

--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -82,7 +82,7 @@ CONFIG_SCHEMA: vol.Schema = vol.Schema(
 
 def validate_sql_select(value: str) -> str | None:
     """Validate that value is a SQL SELECT query."""
-    if not value.lstrip().lower().startswith("select"):
+    if not value.lstrip().lower().startswith(("select", "with")):
         raise ValueError("Incorrect Query")
     return value
 

--- a/tests/components/sql/__init__.py
+++ b/tests/components/sql/__init__.py
@@ -36,6 +36,15 @@ ENTRY_CONFIG = {
     CONF_STATE_CLASS: SensorStateClass.TOTAL,
 }
 
+ENTRY_CONFIG_WITH_CTE = {
+    CONF_NAME: "Get Value",
+    CONF_QUERY: "WITH test AS (SELECT 5 as value) SELECT value FROM test",
+    CONF_COLUMN_NAME: "value",
+    CONF_UNIT_OF_MEASUREMENT: "MiB",
+    CONF_DEVICE_CLASS: SensorDeviceClass.DATA_SIZE,
+    CONF_STATE_CLASS: SensorStateClass.TOTAL,
+}
+
 ENTRY_CONFIG_WITH_VALUE_TEMPLATE = {
     CONF_NAME: "Get Value",
     CONF_QUERY: "SELECT 5 as value",

--- a/tests/components/sql/test_init.py
+++ b/tests/components/sql/test_init.py
@@ -59,6 +59,15 @@ async def test_invalid_query(hass: HomeAssistant) -> None:
         validate_sql_select("DROP TABLE *")
 
 
+async def test_valid_query(hass: HomeAssistant) -> None:
+    """Test valid query."""
+    try:
+        validate_sql_select("SELECT 5 as value")
+        validate_sql_select("WITH test AS (SELECT 5 as value) SELECT value FROM test")
+    except vol.Invalid:
+        pytest.fail("Unexpected validation error")
+
+
 async def test_remove_configured_db_url_if_not_needed_when_not_needed(
     recorder_mock: Recorder,
     hass: HomeAssistant,


### PR DESCRIPTION
Fixes https://github.com/home-assistant/core/issues/102600 by allowing queries that start with `WITH` so validation doesn't fail on CTEs.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #102600

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
