### PR TITLE
Extends prometheus component to produce device-tracker attributes

### DIFF
--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -25,6 +25,9 @@ from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
     ATTR_DEVICE_CLASS,
     ATTR_FRIENDLY_NAME,
+    ATTR_GPS_ACCURACY,
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
     ATTR_MODE,
     ATTR_TEMPERATURE,
     ATTR_UNIT_OF_MEASUREMENT,
@@ -40,7 +43,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     UnitOfTemperature,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant, State
 from homeassistant.helpers import entityfilter, state as state_helper
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_registry import EVENT_ENTITY_REGISTRY_UPDATED
@@ -168,7 +171,7 @@ class PrometheusMetrics:
         self._metrics = {}
         self._climate_units = climate_units
 
-    def handle_state_changed_event(self, event):
+    def handle_state_changed_event(self, event: Event):
         """Handle new messages from the bus."""
         if (state := event.data.get("new_state")) is None:
             return
@@ -184,7 +187,7 @@ class PrometheusMetrics:
 
         self.handle_state(state)
 
-    def handle_state(self, state):
+    def handle_state(self, state: State):
         """Add/update a state in Prometheus."""
         entity_id = state.entity_id
         _LOGGER.debug("Handling state update for %s", entity_id)
@@ -385,7 +388,9 @@ class PrometheusMetrics:
     def _handle_number(self, state):
         self._numeric_handler(state, "number", "number")
 
-    def _handle_device_tracker(self, state):
+    def _handle_device_tracker(self, state: State):
+        # state here converts the state string (usually home/not-home) to a numeric value.
+        # this is the same logic as _handle_binary_sensor but with its own metric name.
         metric = self._metric(
             "device_tracker_state",
             self.prometheus_cli.Gauge,
@@ -393,6 +398,34 @@ class PrometheusMetrics:
         )
         value = self.state_as_number(state)
         metric.labels(**self._labels(state)).set(value)
+
+        # record battery level of the device tracker if available
+        self._battery(state)
+
+        # device-tracker entities have certain well known attributes that we can record here in prometheus as a
+        # time series.
+        well_known_attributes = {
+            ATTR_LATITUDE: (
+                "device_tracker_latitude_degrees",
+                "Latitude of the device tracker measured in decimal degrees",
+            ),
+            ATTR_LONGITUDE: (
+                "device_tracker_longitude_degrees",
+                "Longitude of the device tracker measured in decimal degrees",
+            ),
+            ATTR_GPS_ACCURACY: (
+                "device_tracker_gps_accuracy",
+                "GPS accuracy of the device tracker location",
+            ),
+        }
+        for attr, (metric_name, description) in well_known_attributes.items():
+            value = state.attributes.get(attr)
+            if value is not None and isinstance(value, (int, float)):
+                self._metric(
+                    metric_name,
+                    self.prometheus_cli.Gauge,
+                    description,
+                ).labels(**self._labels(state)).set(value)
 
     def _handle_person(self, state):
         metric = self._metric(

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -40,6 +40,9 @@ from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
     ATTR_DEVICE_CLASS,
     ATTR_FRIENDLY_NAME,
+    ATTR_GPS_ACCURACY,
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
     ATTR_MODE,
     ATTR_TEMPERATURE,
     ATTR_UNIT_OF_MEASUREMENT,
@@ -584,6 +587,26 @@ async def test_device_tracker(client, device_tracker_entities) -> None:
         'device_tracker_state{domain="device_tracker",'
         'entity="device_tracker.phone",'
         'friendly_name="Phone"} 1.0' in body
+    )
+    assert (
+        'device_tracker_latitude_degrees{domain="device_tracker",'
+        'entity="device_tracker.phone",'
+        'friendly_name="Phone"} 51.509865' in body
+    )
+    assert (
+        'device_tracker_longitude_degrees{domain="device_tracker",'
+        'entity="device_tracker.phone",'
+        'friendly_name="Phone"} -0.118092' in body
+    )
+    assert (
+        'device_tracker_gps_accuracy{domain="device_tracker",'
+        'entity="device_tracker.phone",'
+        'friendly_name="Phone"} 42.0' in body
+    )
+    assert (
+        'battery_level_percent{domain="device_tracker",'
+        'entity="device_tracker.phone",'
+        'friendly_name="Phone"} 50.0' in body
     )
     assert (
         'device_tracker_state{domain="device_tracker",'
@@ -1657,7 +1680,17 @@ async def device_tracker_fixture(
         suggested_object_id="phone",
         original_name="Phone",
     )
-    set_state_with_entry(hass, device_tracker_1, STATE_HOME)
+    set_state_with_entry(
+        hass,
+        device_tracker_1,
+        STATE_HOME,
+        {
+            ATTR_BATTERY_LEVEL: 50,
+            ATTR_LATITUDE: 51.509865,
+            ATTR_LONGITUDE: -0.118092,
+            ATTR_GPS_ACCURACY: 42,
+        },
+    )
     data["device_tracker_1"] = device_tracker_1
 
     device_tracker_2 = entity_registry.async_get_or_create(


### PR DESCRIPTION
## Proposed change

The device tracker prometheus metrics are of limited utility because they can only convey 'home' / 'not home' as a binary state. 

Storing longitude, latitude, and battery percent as _long term_ time series data for device trackers allows us to store and track much longer term data. Personally I'm very interested in tracking a general heat map or route on a map in my prometheus/graphana database over months and even years.

This PR adds those extra attributes!

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information

Some implementations of device tracker also send custom attributes like speed, altitude, elevation, climb, etc. However the units and conventions are not clear so I decided not to produce them in this PR.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

```
Changed test files... 1. ['tests/components/prometheus/test_init.py']
Changed test folders... 0. []
Test session starts (platform: linux, Python 3.11.4, pytest 7.4.3, pytest-sugar 0.9.7)
rootdir: /workspaces/homeassistant-core
configfile: pyproject.toml
testpaths: tests
plugins: unordered-0.5.2, asyncio-0.21.0, syrupy-4.6.0, picked-0.5.0, respx-0.20.2, timeout-2.1.0, cov-4.1.0, xdist-3.3.1, requests-mock-1.11.0, socket-0.6.0, test-groups-1.0.3, pytest_freezer-0.4.8, aiohttp-1.0.5, sugar-0.9.7, anyio-4.1.0
asyncio: mode=Mode.AUTO
timeout: 10.0s
timeout method: signal
timeout func_only: False
collected 29 items                                                                                                                                                                                                                                                                               

 tests/components/prometheus/test_init.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                                                            100% ██████████

Results (1.49s):
      29 passed
```

If user exposed functionality or configuration variables are added/changed:

- [N/A] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
	- https://github.com/home-assistant/core/pull/105820#pullrequestreview-1785426848

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure


[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr