### PR TITLE
Reolink change ir to switch

### DIFF
--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
@@ -150,6 +150,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     )
 
     cleanup_disconnected_cams(hass, config_entry.entry_id, host)
+
+    # Can be remove in HA 2024.6.0
+    entity_reg = er.async_get(hass)
+    entities = er.async_entries_for_config_entry(entity_reg, config_entry.entry_id)
+    for entity in entities:
+        if entity.domain == "light" and entity.unique_id.endswith("ir_lights"):
+            entity_reg.async_remove(entity.entity_id)
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 

--- a/homeassistant/components/reolink/light.py
+++ b/homeassistant/components/reolink/light.py
@@ -51,16 +51,6 @@ LIGHT_ENTITIES = (
         set_brightness_fn=lambda api, ch, value: api.set_whiteled(ch, brightness=value),
     ),
     ReolinkLightEntityDescription(
-        key="ir_lights",
-        cmd_key="GetIrLights",
-        translation_key="ir_lights",
-        icon="mdi:led-off",
-        entity_category=EntityCategory.CONFIG,
-        supported=lambda api, ch: api.supported(ch, "ir_lights"),
-        is_on_fn=lambda api, ch: api.ir_enabled(ch),
-        turn_on_off_fn=lambda api, ch, value: api.set_ir_lights(ch, value),
-    ),
-    ReolinkLightEntityDescription(
         key="status_led",
         cmd_key="GetPowerLed",
         translation_key="status_led",

--- a/homeassistant/components/reolink/strings.json
+++ b/homeassistant/components/reolink/strings.json
@@ -238,9 +238,6 @@
       "floodlight": {
         "name": "Floodlight"
       },
-      "ir_lights": {
-        "name": "Infra red lights in night mode"
-      },
       "status_led": {
         "name": "Status LED"
       }
@@ -373,6 +370,9 @@
       }
     },
     "switch": {
+      "ir_lights": {
+        "name": "Infra red lights in night mode"
+      },
       "record_audio": {
         "name": "Record audio"
       },

--- a/homeassistant/components/reolink/switch.py
+++ b/homeassistant/components/reolink/switch.py
@@ -49,6 +49,16 @@ class ReolinkNVRSwitchEntityDescription(
 
 SWITCH_ENTITIES = (
     ReolinkSwitchEntityDescription(
+        key="ir_lights",
+        cmd_key="GetIrLights",
+        translation_key="ir_lights",
+        icon="mdi:led-off",
+        entity_category=EntityCategory.CONFIG,
+        supported=lambda api, ch: api.supported(ch, "ir_lights"),
+        value=lambda api, ch: api.ir_enabled(ch),
+        method=lambda api, ch, value: api.set_ir_lights(ch, value),
+    ),
+    ReolinkSwitchEntityDescription(
         key="record_audio",
         cmd_key="GetEnc",
         translation_key="record_audio",

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -172,7 +172,7 @@ async def test_cleanup_disconnected_cams(
     assert sorted(device_models) == sorted(expected_models)
 
 
-async def test_cleanup_depricated_entities(
+async def test_cleanup_deprecated_entities(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     reolink_connect: MagicMock,
@@ -191,10 +191,7 @@ async def test_cleanup_depricated_entities(
         disabled_by=None,
     )
 
-    assert (
-        entity_registry.async_get_entity_id(Platform.LIGHT, const.DOMAIN, ir_id)
-        is not None
-    )
+    assert entity_registry.async_get_entity_id(Platform.LIGHT, const.DOMAIN, ir_id)
     assert (
         entity_registry.async_get_entity_id(Platform.SWITCH, const.DOMAIN, ir_id)
         is None
@@ -208,10 +205,7 @@ async def test_cleanup_depricated_entities(
     assert (
         entity_registry.async_get_entity_id(Platform.LIGHT, const.DOMAIN, ir_id) is None
     )
-    assert (
-        entity_registry.async_get_entity_id(Platform.SWITCH, const.DOMAIN, ir_id)
-        is not None
-    )
+    assert entity_registry.async_get_entity_id(Platform.SWITCH, const.DOMAIN, ir_id)
 
 
 async def test_no_repair_issue(

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -19,7 +19,7 @@ from homeassistant.helpers import (
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
-from .conftest import TEST_CAM_MODEL, TEST_HOST_MODEL, TEST_NVR_NAME
+from .conftest import TEST_CAM_MODEL, TEST_HOST_MODEL, TEST_MAC, TEST_NVR_NAME
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -170,6 +170,48 @@ async def test_cleanup_disconnected_cams(
     )
     device_models = [device.model for device in device_entries]
     assert sorted(device_models) == sorted(expected_models)
+
+
+async def test_cleanup_depricated_entities(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test deprecated ir_lights light entity is cleaned."""
+    reolink_connect.channels = [0]
+    ir_id = f"{TEST_MAC}_0_ir_lights"
+
+    entity_registry.async_get_or_create(
+        domain=Platform.LIGHT,
+        platform=const.DOMAIN,
+        unique_id=ir_id,
+        config_entry=config_entry,
+        suggested_object_id=ir_id,
+        disabled_by=None,
+    )
+
+    assert (
+        entity_registry.async_get_entity_id(Platform.LIGHT, const.DOMAIN, ir_id)
+        is not None
+    )
+    assert (
+        entity_registry.async_get_entity_id(Platform.SWITCH, const.DOMAIN, ir_id)
+        is None
+    )
+
+    # setup CH 0 and NVR switch entities/device
+    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.SWITCH]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        entity_registry.async_get_entity_id(Platform.LIGHT, const.DOMAIN, ir_id) is None
+    )
+    assert (
+        entity_registry.async_get_entity_id(Platform.SWITCH, const.DOMAIN, ir_id)
+        is not None
+    )
 
 
 async def test_no_repair_issue(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The Reolink `Infra red lights in night mode` entity has been migrated from the `light` to the `switch` domain.
This means the entity_id also changed and automations and frontend may need to be adjusted to use the new entity_id.
If you want to go back to the light domain, use the [switch_as_x "Show as" option](https://www.home-assistant.io/integrations/switch_as_x/#change-device-type-of-a-switch-from-the-existing-entity) on the new `Infra red lights in night mode` switch entity and select light.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change the Reolink `Infra red lights in night mode` entity from the light to the switch domain.
This was requested by many users that accidentaly turned of the IR lights in night mode when targetting all lights to turn off.
See issue: https://github.com/home-assistant/core/issues/91082

People can switch it back to the light domain by using the switch_as_x functions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/91082
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30381

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
