### PR TITLE
Fix Hydrawise watering time duration unit

### DIFF
--- a/homeassistant/components/hydrawise/const.py
+++ b/homeassistant/components/hydrawise/const.py
@@ -9,7 +9,7 @@ ALLOWED_WATERING_TIME = [5, 10, 15, 30, 45, 60]
 CONF_WATERING_TIME = "watering_minutes"
 
 DOMAIN = "hydrawise"
-DEFAULT_WATERING_TIME = 15
+DEFAULT_WATERING_TIME = timedelta(minutes=15)
 
 MANUFACTURER = "Hydrawise"
 

--- a/homeassistant/components/hydrawise/switch.py
+++ b/homeassistant/components/hydrawise/switch.py
@@ -53,7 +53,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
             cv.ensure_list, [vol.In(SWITCH_KEYS)]
         ),
         vol.Optional(
-            CONF_WATERING_TIME, default=DEFAULT_WATERING_TIME.seconds
+            CONF_WATERING_TIME, default=DEFAULT_WATERING_TIME.total_seconds() // 60
         ): vol.All(vol.In(ALLOWED_WATERING_TIME)),
     }
 )

--- a/homeassistant/components/hydrawise/switch.py
+++ b/homeassistant/components/hydrawise/switch.py
@@ -52,9 +52,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_MONITORED_CONDITIONS, default=SWITCH_KEYS): vol.All(
             cv.ensure_list, [vol.In(SWITCH_KEYS)]
         ),
-        vol.Optional(CONF_WATERING_TIME, default=DEFAULT_WATERING_TIME): vol.All(
-            vol.In(ALLOWED_WATERING_TIME)
-        ),
+        vol.Optional(
+            CONF_WATERING_TIME, default=DEFAULT_WATERING_TIME.seconds
+        ): vol.All(vol.In(ALLOWED_WATERING_TIME)),
     }
 )
 
@@ -96,7 +96,7 @@ class HydrawiseSwitch(HydrawiseEntity, SwitchEntity):
         """Turn the device on."""
         if self.entity_description.key == "manual_watering":
             await self.coordinator.api.start_zone(
-                self.zone, custom_run_duration=DEFAULT_WATERING_TIME
+                self.zone, custom_run_duration=DEFAULT_WATERING_TIME.seconds
             )
         elif self.entity_description.key == "auto_watering":
             await self.coordinator.api.resume_zone(self.zone)

--- a/homeassistant/components/hydrawise/switch.py
+++ b/homeassistant/components/hydrawise/switch.py
@@ -96,7 +96,7 @@ class HydrawiseSwitch(HydrawiseEntity, SwitchEntity):
         """Turn the device on."""
         if self.entity_description.key == "manual_watering":
             await self.coordinator.api.start_zone(
-                self.zone, custom_run_duration=DEFAULT_WATERING_TIME.seconds
+                self.zone, custom_run_duration=DEFAULT_WATERING_TIME.total_seconds()
             )
         elif self.entity_description.key == "auto_watering":
             await self.coordinator.api.resume_zone(self.zone)

--- a/tests/components/hydrawise/test_switch.py
+++ b/tests/components/hydrawise/test_switch.py
@@ -51,7 +51,7 @@ async def test_manual_watering_services(
         blocking=True,
     )
     mock_pydrawise.start_zone.assert_called_once_with(
-        zones[0], custom_run_duration=DEFAULT_WATERING_TIME
+        zones[0], custom_run_duration=DEFAULT_WATERING_TIME.seconds
     )
     state = hass.states.get("switch.zone_one_manual_watering")
     assert state is not None

--- a/tests/components/hydrawise/test_switch.py
+++ b/tests/components/hydrawise/test_switch.py
@@ -51,7 +51,7 @@ async def test_manual_watering_services(
         blocking=True,
     )
     mock_pydrawise.start_zone.assert_called_once_with(
-        zones[0], custom_run_duration=DEFAULT_WATERING_TIME.seconds
+        zones[0], custom_run_duration=DEFAULT_WATERING_TIME.total_seconds()
     )
     state = hass.states.get("switch.zone_one_manual_watering")
     assert state is not None


### PR DESCRIPTION
## Proposed change
When starting a watering cycle manually, pass the duration using the correct units. When we switched this to the async API, the expected unit for the duration changed from minutes to seconds. This means we are now accidentally starting the watering cycles for 15 seconds every time instead of 15 minutes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
