### PR TITLE
Add Tailwind zeroconf discovery

### DIFF
--- a/homeassistant/components/tailwind/config_flow.py
+++ b/homeassistant/components/tailwind/config_flow.py
@@ -4,17 +4,21 @@ from __future__ import annotations
 from typing import Any
 
 from gotailwind import (
+    MIN_REQUIRED_FIRMWARE_VERSION,
     Tailwind,
     TailwindAuthenticationError,
     TailwindConnectionError,
     TailwindUnsupportedFirmwareVersionError,
+    tailwind_device_id_to_mac_address,
 )
 import voluptuous as vol
 
+from homeassistant.components import zeroconf
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import CONF_HOST, CONF_TOKEN
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.selector import (
     TextSelector,
     TextSelectorConfig,
@@ -23,11 +27,17 @@ from homeassistant.helpers.selector import (
 
 from .const import DOMAIN, LOGGER
 
+LOCAL_CONTROL_KEY_URL = (
+    "https://web.gotailwind.com/client/integration/local-control-key"
+)
+
 
 class TailwindFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a Tailwind config flow."""
 
     VERSION = 1
+
+    host: str
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -36,15 +46,13 @@ class TailwindFlowHandler(ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            tailwind = Tailwind(
-                host=user_input[CONF_HOST],
-                token=user_input[CONF_TOKEN],
-                session=async_get_clientsession(self.hass),
-            )
             try:
-                status = await tailwind.status()
-            except TailwindUnsupportedFirmwareVersionError:
-                return self.async_abort(reason="unsupported_firmware")
+                return await self._async_step_create_entry(
+                    host=user_input[CONF_HOST],
+                    token=user_input[CONF_TOKEN],
+                )
+            except AbortFlow:
+                raise
             except TailwindAuthenticationError:
                 errors[CONF_TOKEN] = "invalid_auth"
             except TailwindConnectionError:
@@ -52,11 +60,6 @@ class TailwindFlowHandler(ConfigFlow, domain=DOMAIN):
             except Exception:  # pylint: disable=broad-except
                 LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
-            else:
-                return self.async_create_entry(
-                    title=f"Tailwind {status.product}",
-                    data=user_input,
-                )
         else:
             user_input = {}
 
@@ -72,8 +75,93 @@ class TailwindFlowHandler(ConfigFlow, domain=DOMAIN):
                     ),
                 }
             ),
-            description_placeholders={
-                "url": "https://web.gotailwind.com/client/integration/local-control-key",
-            },
+            description_placeholders={"url": LOCAL_CONTROL_KEY_URL},
             errors=errors,
+        )
+
+    async def async_step_zeroconf(
+        self, discovery_info: zeroconf.ZeroconfServiceInfo
+    ) -> FlowResult:
+        """Handle zeroconf discovery of a Tailwind device."""
+        if not (device_id := discovery_info.properties.get("device_id")):
+            return self.async_abort(reason="no_device_id")
+
+        if (
+            version := discovery_info.properties.get("SW ver")
+        ) and version < MIN_REQUIRED_FIRMWARE_VERSION:
+            return self.async_abort(reason="unsupported_firmware")
+
+        await self.async_set_unique_id(
+            format_mac(tailwind_device_id_to_mac_address(device_id))
+        )
+        self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.host})
+
+        self.host = discovery_info.host
+        self.context.update(
+            {
+                "title_placeholders": {
+                    "name": f"Tailwind {discovery_info.properties.get('product')}"
+                },
+                "configuration_url": LOCAL_CONTROL_KEY_URL,
+            }
+        )
+        return await self.async_step_zeroconf_confirm()
+
+    async def async_step_zeroconf_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle a flow initiated by zeroconf."""
+        errors = {}
+
+        if user_input is not None:
+            try:
+                return await self._async_step_create_entry(
+                    host=self.host,
+                    token=user_input[CONF_TOKEN],
+                )
+            except TailwindAuthenticationError:
+                errors[CONF_TOKEN] = "invalid_auth"
+            except TailwindConnectionError:
+                errors["base"] = "cannot_connect"
+            except Exception:  # pylint: disable=broad-except
+                LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        return self.async_show_form(
+            step_id="zeroconf_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_TOKEN): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.PASSWORD)
+                    ),
+                }
+            ),
+            description_placeholders={"url": LOCAL_CONTROL_KEY_URL},
+            errors=errors,
+        )
+
+    async def _async_step_create_entry(self, *, host: str, token: str) -> FlowResult:
+        """Create entry."""
+        tailwind = Tailwind(
+            host=host, token=token, session=async_get_clientsession(self.hass)
+        )
+
+        try:
+            status = await tailwind.status()
+        except TailwindUnsupportedFirmwareVersionError:
+            return self.async_abort(reason="unsupported_firmware")
+
+        await self.async_set_unique_id(
+            format_mac(status.mac_address), raise_on_progress=False
+        )
+        self._abort_if_unique_id_configured(
+            updates={
+                CONF_HOST: host,
+                CONF_TOKEN: token,
+            }
+        )
+
+        return self.async_create_entry(
+            title=f"Tailwind {status.product}",
+            data={CONF_HOST: host, CONF_TOKEN: token},
         )

--- a/homeassistant/components/tailwind/manifest.json
+++ b/homeassistant/components/tailwind/manifest.json
@@ -6,5 +6,13 @@
   "documentation": "https://www.home-assistant.io/integrations/tailwind",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "requirements": ["gotailwind==0.2.1"]
+  "requirements": ["gotailwind==0.2.1"],
+  "zeroconf": [
+    {
+      "type": "_http._tcp.local.",
+      "properties": {
+        "vendor": "tailwind"
+      }
+    }
+  ]
 }

--- a/homeassistant/components/tailwind/strings.json
+++ b/homeassistant/components/tailwind/strings.json
@@ -11,6 +11,15 @@
           "host": "The hostname or IP address of your Tailwind device. You can find the IP address by going into the Tailwind app and selecting your Tailwind device's cog icon. The IP address is shown in the **Device Info** section.",
           "token": "To find local control key token, browse to the [Tailwind web portal]({url}), log in with your Tailwind account, and select the [**Local Control Key**]({url}) tab. The 6-digit number shown is your local control key token."
         }
+      },
+      "zeroconf_confirm": {
+        "description": "Set up your discovered Tailwind garage door opener to integrate with Home Assistant.\n\nTo do so, you will need to get the local control key of your Tailwind device. For more details, see the description below the field down below.",
+        "data": {
+          "token": "[%key:component::tailwind::config::step::user::data::token%]"
+        },
+        "data_description": {
+          "token": "[%key:component::tailwind::config::step::user::data_description::token%]"
+        }
       }
     },
     "error": {
@@ -21,6 +30,7 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "no_device_id": "The discovered Tailwind device did not provide a device ID.",
       "unsupported_firmware": "The firmware of your Tailwind device is not supported. Please update your Tailwind device to the latest firmware version using the Tailwind app."
     }
   },

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -494,6 +494,12 @@ ZEROCONF = {
                 "vendor": "synology*",
             },
         },
+        {
+            "domain": "tailwind",
+            "properties": {
+                "vendor": "tailwind",
+            },
+        },
     ],
     "_hue._tcp.local.": [
         {

--- a/tests/components/tailwind/snapshots/test_config_flow.ambr
+++ b/tests/components/tailwind/snapshots/test_config_flow.ambr
@@ -3,6 +3,7 @@
   FlowResultSnapshot({
     'context': dict({
       'source': 'user',
+      'unique_id': '3c:e9:0e:6d:21:84',
     }),
     'data': dict({
       'host': '127.0.0.1',
@@ -30,7 +31,51 @@
       'pref_disable_polling': False,
       'source': 'user',
       'title': 'Tailwind iQ3',
-      'unique_id': None,
+      'unique_id': '3c:e9:0e:6d:21:84',
+      'version': 1,
+    }),
+    'title': 'Tailwind iQ3',
+    'type': <FlowResultType.CREATE_ENTRY: 'create_entry'>,
+    'version': 1,
+  })
+# ---
+# name: test_zeroconf_flow
+  FlowResultSnapshot({
+    'context': dict({
+      'configuration_url': 'https://web.gotailwind.com/client/integration/local-control-key',
+      'source': 'zeroconf',
+      'title_placeholders': dict({
+        'name': 'Tailwind iQ3',
+      }),
+      'unique_id': '3c:e9:0e:6d:21:84',
+    }),
+    'data': dict({
+      'host': '127.0.0.1',
+      'token': '987654',
+    }),
+    'description': None,
+    'description_placeholders': None,
+    'flow_id': <ANY>,
+    'handler': 'tailwind',
+    'minor_version': 1,
+    'options': dict({
+    }),
+    'result': ConfigEntrySnapshot({
+      'data': dict({
+        'host': '127.0.0.1',
+        'token': '987654',
+      }),
+      'disabled_by': None,
+      'domain': 'tailwind',
+      'entry_id': <ANY>,
+      'minor_version': 1,
+      'options': dict({
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'zeroconf',
+      'title': 'Tailwind iQ3',
+      'unique_id': '3c:e9:0e:6d:21:84',
       'version': 1,
     }),
     'title': 'Tailwind iQ3',

--- a/tests/components/tailwind/test_config_flow.py
+++ b/tests/components/tailwind/test_config_flow.py
@@ -1,4 +1,5 @@
 """Configuration flow tests for the Tailwind integration."""
+from ipaddress import ip_address
 from unittest.mock import MagicMock
 
 from gotailwind import (
@@ -9,11 +10,14 @@ from gotailwind import (
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components import zeroconf
 from homeassistant.components.tailwind.const import DOMAIN
-from homeassistant.config_entries import SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
@@ -85,7 +89,7 @@ async def test_user_flow_errors(
     assert result2.get("type") == FlowResultType.CREATE_ENTRY
 
 
-async def test_unsupported_firmware_version(
+async def test_user_flow_unsupported_firmware_version(
     hass: HomeAssistant, mock_tailwind: MagicMock
 ) -> None:
     """Test configuration flow aborts when the firmware version is not supported."""
@@ -101,3 +105,191 @@ async def test_unsupported_firmware_version(
 
     assert result.get("type") == FlowResultType.ABORT
     assert result.get("reason") == "unsupported_firmware"
+
+
+@pytest.mark.usefixtures("mock_tailwind")
+async def test_user_flow_already_configured(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test configuration flow aborts when the device is already configured.
+
+    Also, ensures the existing config entry is updated with the new host.
+    """
+    mock_config_entry.add_to_hass(hass)
+    assert mock_config_entry.data[CONF_HOST] == "127.0.0.127"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={
+            CONF_HOST: "127.0.0.1",
+            CONF_TOKEN: "987654",
+        },
+    )
+
+    assert result.get("type") == FlowResultType.ABORT
+    assert result.get("reason") == "already_configured"
+    assert mock_config_entry.data[CONF_HOST] == "127.0.0.1"
+    assert mock_config_entry.data[CONF_TOKEN] == "987654"
+
+
+@pytest.mark.usefixtures("mock_tailwind")
+async def test_zeroconf_flow(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the zeroconf happy flow from start to finish."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=zeroconf.ZeroconfServiceInfo(
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
+            port=80,
+            hostname="tailwind-3ce90e6d2184.local.",
+            name="mock_name",
+            properties={
+                "device_id": "_3c_e9_e_6d_21_84_",
+                "product": "iQ3",
+                "SW ver": "10.10",
+                "vendor": "tailwind",
+            },
+            type="mock_type",
+        ),
+    )
+
+    assert result.get("step_id") == "zeroconf_confirm"
+    assert result.get("type") == FlowResultType.FORM
+
+    progress = hass.config_entries.flow.async_progress()
+    assert len(progress) == 1
+    assert progress[0].get("flow_id") == result["flow_id"]
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_TOKEN: "987654"}
+    )
+
+    assert result2.get("type") == FlowResultType.CREATE_ENTRY
+    assert result2 == snapshot
+
+
+@pytest.mark.parametrize(
+    ("properties", "expected_reason"),
+    [
+        ({"SW ver": "10.10"}, "no_device_id"),
+        ({"device_id": "_3c_e9_e_6d_21_84_", "SW ver": "0.0"}, "unsupported_firmware"),
+    ],
+)
+async def test_zeroconf_flow_abort_incompatible_properties(
+    hass: HomeAssistant, properties: dict[str, str], expected_reason: str
+) -> None:
+    """Test the zeroconf aborts when it advertises incompatible data."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=zeroconf.ZeroconfServiceInfo(
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
+            port=80,
+            hostname="tailwind-3ce90e6d2184.local.",
+            name="mock_name",
+            properties=properties,
+            type="mock_type",
+        ),
+    )
+
+    assert result.get("type") == FlowResultType.ABORT
+    assert result.get("reason") == expected_reason
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected_error"),
+    [
+        (TailwindConnectionError, {"base": "cannot_connect"}),
+        (TailwindAuthenticationError, {CONF_TOKEN: "invalid_auth"}),
+        (Exception, {"base": "unknown"}),
+    ],
+)
+async def test_zeroconf_flow_errors(
+    hass: HomeAssistant,
+    mock_tailwind: MagicMock,
+    side_effect: Exception,
+    expected_error: dict[str, str],
+) -> None:
+    """Test we show form on a error."""
+    mock_tailwind.status.side_effect = side_effect
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=zeroconf.ZeroconfServiceInfo(
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
+            port=80,
+            hostname="tailwind-3ce90e6d2184.local.",
+            name="mock_name",
+            properties={
+                "device_id": "_3c_e9_e_6d_21_84_",
+                "product": "iQ3",
+                "SW ver": "10.10",
+                "vendor": "tailwind",
+            },
+            type="mock_type",
+        ),
+    )
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_TOKEN: "123456",
+        },
+    )
+
+    assert result2.get("type") == FlowResultType.FORM
+    assert result2.get("step_id") == "zeroconf_confirm"
+    assert result2.get("errors") == expected_error
+
+    mock_tailwind.status.side_effect = None
+    result3 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_TOKEN: "123456",
+        },
+    )
+    assert result3.get("type") == FlowResultType.CREATE_ENTRY
+
+
+@pytest.mark.usefixtures("mock_tailwind")
+async def test_zeroconf_flow_not_discovered_again(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the zeroconf doesn't re-discover an existing device.
+
+    Also, ensures the existing config entry is updated with the new host.
+    """
+    mock_config_entry.add_to_hass(hass)
+    assert mock_config_entry.data[CONF_HOST] == "127.0.0.127"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=zeroconf.ZeroconfServiceInfo(
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
+            port=80,
+            hostname="tailwind-3ce90e6d2184.local.",
+            name="mock_name",
+            properties={
+                "device_id": "_3c_e9_e_6d_21_84_",
+                "product": "iQ3",
+                "SW ver": "10.10",
+                "vendor": "tailwind",
+            },
+            type="mock_type",
+        ),
+    )
+
+    assert result.get("type") == FlowResultType.ABORT
+    assert result.get("reason") == "already_configured"
+    assert mock_config_entry.data[CONF_HOST] == "127.0.0.1"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds discovery support for Tailwind devices.

It adds the unique ID for the configuration entry to ensure we don't discover devices that are already configured (and updates existing config entries in that case, so it automatically solves the case if a devices gets a new IP address).

![CleanShot 2023-12-18 at 10 29 02@2x](https://github.com/home-assistant/core/assets/195327/c70d384a-228d-4a75-8b98-ccf465bbb23b)

![CleanShot 2023-12-18 at 10 29 15@2x](https://github.com/home-assistant/core/assets/195327/d974d12e-519f-4c30-a81f-2523c35ede64)

![CleanShot 2023-12-18 at 10 29 28@2x](https://github.com/home-assistant/core/assets/195327/f3c92c0e-42d3-4c99-9147-78c07528bebe)

Test coverage is up to 100%

![CleanShot 2023-12-18 at 10 39 01@2x](https://github.com/home-assistant/core/assets/195327/87d00ee5-82b0-4d00-932a-b81dac268a6e)

--- 

Tailwind provides garage door controllers that work with most garage door openers and communicates fully locally.

More information: https://gotailwind.com/

The development of this integration will consist of multiple pull requests:

- [x] Add the minimal functional integration (#105926)
- [x] Add zeroconf discovery support (#105949)
- [x] Add re-authentication support in case the local key is changed (#105959)
- [x] Add DHCP discovery support for updating config entries (#105981)
- [ ] Add binary sensor platform (#106033)
- [ ] Add switch platform
- [ ] Add cover platform
- [x] Add button platform (#105961)
- [x] Add diagnostic platform (#105965)
- [ ] Add error handling to service calls (with translatable errors)
- [ ] General cleanup, as most is in at this point
- [ ] Upgrade integration to platinum level
- [ ] Leverage webhooks to make integration push-based

Big thanks to Tailwind for providing the devices for testing ❤️ 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
