### PR TITLE
Bump hass-nabucasa from 0.74.0 to 0.75.1

### DIFF
--- a/homeassistant/components/cloud/client.py
+++ b/homeassistant/components/cloud/client.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from http import HTTPStatus
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import aiohttp
 from hass_nabucasa.client import CloudClient as Interface
@@ -22,11 +22,17 @@ from homeassistant.core import Context, HassJob, HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import SERVER_SOFTWARE
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.util.aiohttp import MockRequest, serialize_response
 
 from . import alexa_config, google_config
 from .const import DISPATCHER_REMOTE_UPDATE, DOMAIN
 from .prefs import CloudPreferences
+
+VALID_REPAIR_TRANSLATION_KEYS = {
+    "warn_bad_custom_domain_configuration",
+    "reset_bad_custom_domain_configuration",
+}
 
 
 class CloudClient(Interface):
@@ -302,3 +308,26 @@ class CloudClient(Interface):
     ) -> None:
         """Update local list of cloudhooks."""
         await self._prefs.async_update(cloudhooks=data)
+
+    async def async_create_repair_issue(
+        self,
+        identifier: str,
+        translation_key: str,
+        *,
+        placeholders: dict[str, str] | None = None,
+        severity: Literal["error", "warning"] = "warning",
+    ) -> None:
+        """Create a repair issue."""
+        if translation_key not in VALID_REPAIR_TRANSLATION_KEYS:
+            raise ValueError(f"Invalid translation key {translation_key}")
+        async_create_issue(
+            hass=self._hass,
+            domain=DOMAIN,
+            issue_id=identifier,
+            translation_key=translation_key,
+            translation_placeholders=placeholders,
+            severity=IssueSeverity.ERROR
+            if severity == "error"
+            else IssueSeverity.WARNING,
+            is_fixable=False,
+        )

--- a/homeassistant/components/cloud/client.py
+++ b/homeassistant/components/cloud/client.py
@@ -326,8 +326,6 @@ class CloudClient(Interface):
             issue_id=identifier,
             translation_key=translation_key,
             translation_placeholders=placeholders,
-            severity=IssueSeverity.ERROR
-            if severity == "error"
-            else IssueSeverity.WARNING,
+            severity=IssueSeverity(severity),
             is_fixable=False,
         )

--- a/homeassistant/components/cloud/manifest.json
+++ b/homeassistant/components/cloud/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "system",
   "iot_class": "cloud_push",
   "loggers": ["hass_nabucasa"],
-  "requirements": ["hass-nabucasa==0.74.0"]
+  "requirements": ["hass-nabucasa==0.75.1"]
 }

--- a/homeassistant/components/cloud/strings.json
+++ b/homeassistant/components/cloud/strings.json
@@ -30,6 +30,14 @@
           "operation_took_too_long": "The operation took too long. Please try again later."
         }
       }
+    },
+    "warn_bad_custom_domain_configuration": {
+      "title": "Detected wrong custom domain configuration",
+      "description": "The DNS configuration for your custom domain ({custom_domains}) is not correct. Please check the DNS configuration of your domain and make sure it points to the correct CNAME."
+    },
+    "reset_bad_custom_domain_configuration": {
+      "title": "Custom domain ignored",
+      "description": "The DNS configuration for your custom domain ({custom_domains}) is not correct. This domain has now been ignored and will not be used for Home Assistant Cloud. If you want to use this domain, please fix the DNS configuration and restart Home Assistant. If you do not need this anymore, you can remove it from the account page."
     }
   },
   "services": {

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -24,7 +24,7 @@ fnv-hash-fast==0.5.0
 ha-av==10.1.1
 ha-ffmpeg==3.1.0
 habluetooth==1.0.0
-hass-nabucasa==0.74.0
+hass-nabucasa==0.75.1
 hassil==1.5.1
 home-assistant-bluetooth==1.11.0
 home-assistant-frontend==20231208.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -992,7 +992,7 @@ habitipy==0.2.0
 habluetooth==1.0.0
 
 # homeassistant.components.cloud
-hass-nabucasa==0.74.0
+hass-nabucasa==0.75.1
 
 # homeassistant.components.splunk
 hass-splunk==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -791,7 +791,7 @@ habitipy==0.2.0
 habluetooth==1.0.0
 
 # homeassistant.components.cloud
-hass-nabucasa==0.74.0
+hass-nabucasa==0.75.1
 
 # homeassistant.components.conversation
 hassil==1.5.1

--- a/tests/components/cloud/test_client.py
+++ b/tests/components/cloud/test_client.py
@@ -392,14 +392,12 @@ async def test_cloud_connection_info(hass: HomeAssistant) -> None:
     sorted(VALID_REPAIR_TRANSLATION_KEYS),
 )
 async def test_async_create_repair_issue_known(
-    hass: HomeAssistant,
+    cloud: MagicMock,
+    mock_cloud_setup: None,
     issue_registry: IssueRegistry,
     translation_key: str,
 ) -> None:
     """Test create repair issue for known repairs."""
-    with patch("hass_nabucasa.Cloud.initialize"):
-        assert await async_setup_component(hass, "cloud", {"cloud": {}})
-    cloud = hass.data["cloud"]
     identifier = f"test_identifier_{translation_key}"
     await cloud.client.async_create_repair_issue(
         identifier=identifier,
@@ -412,13 +410,11 @@ async def test_async_create_repair_issue_known(
 
 
 async def test_async_create_repair_issue_unknown(
-    hass: HomeAssistant,
+    cloud: MagicMock,
+    mock_cloud_setup: None,
     issue_registry: IssueRegistry,
 ) -> None:
     """Test not creating repair issue for unknown repairs."""
-    with patch("hass_nabucasa.Cloud.initialize"):
-        assert await async_setup_component(hass, "cloud", {"cloud": {}})
-    cloud = hass.data["cloud"]
     identifier = "abc123"
     with pytest.raises(
         ValueError,

--- a/tests/components/cloud/test_client.py
+++ b/tests/components/cloud/test_client.py
@@ -7,7 +7,10 @@ from aiohttp import web
 import pytest
 
 from homeassistant.components.cloud import DOMAIN
-from homeassistant.components.cloud.client import CloudClient
+from homeassistant.components.cloud.client import (
+    VALID_REPAIR_TRANSLATION_KEYS,
+    CloudClient,
+)
 from homeassistant.components.cloud.const import (
     PREF_ALEXA_REPORT_STATE,
     PREF_ENABLE_ALEXA,
@@ -21,6 +24,7 @@ from homeassistant.components.homeassistant.exposed_entities import (
 from homeassistant.const import CONTENT_TYPE_JSON, __version__ as HA_VERSION
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.issue_registry import IssueRegistry
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -381,3 +385,50 @@ async def test_cloud_connection_info(hass: HomeAssistant) -> None:
         "version": HA_VERSION,
         "instance_id": "12345678901234567890",
     }
+
+
+@pytest.mark.parametrize(
+    "translation_key",
+    VALID_REPAIR_TRANSLATION_KEYS,
+)
+async def test_async_create_repair_issue_known(
+    hass: HomeAssistant,
+    issue_registry: IssueRegistry,
+    translation_key: str,
+) -> None:
+    """Test create repair issue for known repairs."""
+    with patch("hass_nabucasa.Cloud.initialize"):
+        assert await async_setup_component(hass, "cloud", {"cloud": {}})
+    cloud = hass.data["cloud"]
+    identifier = f"test_identifier_{translation_key}"
+    await cloud.client.async_create_repair_issue(
+        identifier=identifier,
+        translation_key=translation_key,
+        placeholders={"custom_domains": "example.com"},
+        severity="warning",
+    )
+    issue = issue_registry.async_get_issue(domain=DOMAIN, issue_id=identifier)
+    assert issue is not None
+
+
+async def test_async_create_repair_issue_unknown(
+    hass: HomeAssistant,
+    issue_registry: IssueRegistry,
+) -> None:
+    """Test not creating repair issue for unknown repairs."""
+    with patch("hass_nabucasa.Cloud.initialize"):
+        assert await async_setup_component(hass, "cloud", {"cloud": {}})
+    cloud = hass.data["cloud"]
+    identifier = "abc123"
+    with pytest.raises(
+        ValueError,
+        match="Invalid translation key unknown_translation_key",
+    ):
+        await cloud.client.async_create_repair_issue(
+            identifier=identifier,
+            translation_key="unknown_translation_key",
+            placeholders={"custom_domains": "example.com"},
+            severity="error",
+        )
+    issue = issue_registry.async_get_issue(domain=DOMAIN, issue_id=identifier)
+    assert issue is None

--- a/tests/components/cloud/test_client.py
+++ b/tests/components/cloud/test_client.py
@@ -389,7 +389,7 @@ async def test_cloud_connection_info(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize(
     "translation_key",
-    VALID_REPAIR_TRANSLATION_KEYS,
+    sorted(VALID_REPAIR_TRANSLATION_KEYS),
 )
 async def test_async_create_repair_issue_known(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps the hass-nabucasa package from [0.74.0 to 0.75.1](https://github.com/NabuCasa/hass-nabucasa/compare/0.74.0...0.75.1)

This version adds an `async_create_repair_issue` staticmethod to the abstract `CloudClient`class.
Because of that change, this PR is on the larger side.

2 New repair issues can be shown with this version:
![2023-12-18_10-46-30](https://github.com/home-assistant/core/assets/15093472/de3c4bc9-8d28-4310-9bb4-6e0d4b09b522)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
