### PR TITLE
Add reauth support to Tailwind

### DIFF
--- a/homeassistant/components/tailwind/coordinator.py
+++ b/homeassistant/components/tailwind/coordinator.py
@@ -1,11 +1,17 @@
 """Data update coordinator for Tailwind."""
 from datetime import timedelta
 
-from gotailwind import Tailwind, TailwindDeviceStatus, TailwindError
+from gotailwind import (
+    Tailwind,
+    TailwindAuthenticationError,
+    TailwindDeviceStatus,
+    TailwindError,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_TOKEN
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -35,5 +41,7 @@ class TailwindDataUpdateCoordinator(DataUpdateCoordinator[TailwindDeviceStatus])
         """Fetch data from the Tailwind device."""
         try:
             return await self.tailwind.status()
+        except TailwindAuthenticationError as err:
+            raise ConfigEntryAuthFailed from err
         except TailwindError as err:
             raise UpdateFailed(err) from err

--- a/homeassistant/components/tailwind/strings.json
+++ b/homeassistant/components/tailwind/strings.json
@@ -1,6 +1,15 @@
 {
   "config": {
     "step": {
+      "reauth_confirm": {
+        "description": "Reauthenticate with your Tailwind garage door opener.\n\nTo do so, you will need to get your new local control key of your Tailwind device. For more details, see the description below the field down below.",
+        "data": {
+          "token": "[%key:component::tailwind::config::step::user::data::token%]"
+        },
+        "data_description": {
+          "token": "[%key:component::tailwind::config::step::user::data_description::token%]"
+        }
+      },
       "user": {
         "description": "Set up your Tailwind garage door opener to integrate with Home Assistant.\n\nTo do so, you will need to get the local control key and IP address of your Tailwind device. For more details, see the description below the fields down below.",
         "data": {
@@ -31,6 +40,7 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "no_device_id": "The discovered Tailwind device did not provide a device ID.",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "unsupported_firmware": "The firmware of your Tailwind device is not supported. Please update your Tailwind device to the latest firmware version using the Tailwind app."
     }
   },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for re-authenticating with a Tailwind device, in case it has changed.
Home Assistant will pop up asking for the new token.

![CleanShot 2023-12-18 at 11 22 31@2x](https://github.com/home-assistant/core/assets/195327/b15e29aa-e68f-4171-a2eb-997b944cbd4e)

![CleanShot 2023-12-18 at 11 22 37@2x](https://github.com/home-assistant/core/assets/195327/c02a4a94-6d62-4be0-a860-414a329cbcf3)

![CleanShot 2023-12-18 at 11 24 15@2x](https://github.com/home-assistant/core/assets/195327/932f803b-7fc2-4f07-828c-68e00343c6ab)


![CleanShot 2023-12-18 at 11 25 13@2x](https://github.com/home-assistant/core/assets/195327/756e7f47-db0a-4ba1-8994-800c0d9f2bbb)

--- 

Tailwind provides garage door controllers that work with most garage door openers and communicates fully locally.

More information: https://gotailwind.com/

The development of this integration will consist of multiple pull requests:

- [x] Add the minimal functional integration (#105926)
- [x] Add zeroconf discovery support (#105949)
- [x] Add re-authentication support in case the local key is changed (#105959)
- [x] Add DHCP discovery support for updating config entries (#105981)
- [ ] Add binary sensor platform (#106033)
- [ ] Add switch platform
- [ ] Add cover platform
- [x] Add button platform (#105961)
- [x] Add diagnostic platform (#105965)
- [ ] Add error handling to service calls (with translatable errors)
- [ ] General cleanup, as most is in at this point
- [ ] Upgrade integration to platinum level
- [ ] Leverage webhooks to make integration push-based

Big thanks to Tailwind for providing the devices for testing ❤️ 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
