### PR TITLE
Add button platform to Tailwind integration

### DIFF
--- a/homeassistant/components/tailwind/__init__.py
+++ b/homeassistant/components/tailwind/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from .const import DOMAIN
 from .coordinator import TailwindDataUpdateCoordinator
 
-PLATFORMS = [Platform.NUMBER]
+PLATFORMS = [Platform.BUTTON, Platform.NUMBER]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/tailwind/button.py
+++ b/homeassistant/components/tailwind/button.py
@@ -1,0 +1,75 @@
+"""Button entity platform for Tailwind."""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from gotailwind import Tailwind
+
+from homeassistant.components.button import (
+    ButtonDeviceClass,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import TailwindDataUpdateCoordinator
+from .entity import TailwindEntity
+
+
+@dataclass(kw_only=True)
+class TailwindButtonEntityDescription(ButtonEntityDescription):
+    """Class describing Tailwind button entities."""
+
+    press_fn: Callable[[Tailwind], Awaitable[Any]]
+
+
+DESCRIPTIONS = [
+    TailwindButtonEntityDescription(
+        key="identify",
+        device_class=ButtonDeviceClass.IDENTIFY,
+        entity_category=EntityCategory.CONFIG,
+        press_fn=lambda tailwind: tailwind.identify(),
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Tailwind button based on a config entry."""
+    coordinator: TailwindDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        TailwindButtonEntity(
+            coordinator,
+            description,
+        )
+        for description in DESCRIPTIONS
+    )
+
+
+class TailwindButtonEntity(TailwindEntity, ButtonEntity):
+    """Representation of a Tailwind button entity."""
+
+    entity_description: TailwindButtonEntityDescription
+
+    def __init__(
+        self,
+        coordinator: TailwindDataUpdateCoordinator,
+        description: TailwindButtonEntityDescription,
+    ) -> None:
+        """Initiate Tailwind button entity."""
+        super().__init__(coordinator=coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.data.device_id}-{description.key}"
+
+    async def async_press(self) -> None:
+        """Trigger button press on the Tailwind device."""
+        await self.entity_description.press_fn(self.coordinator.tailwind)

--- a/tests/components/tailwind/snapshots/test_button.ambr
+++ b/tests/components/tailwind/snapshots/test_button.ambr
@@ -1,0 +1,77 @@
+# serializer version: 1
+# name: test_number_entities
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'identify',
+      'friendly_name': 'Tailwind iQ3 Identify',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.tailwind_iq3_identify',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_number_entities.1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.tailwind_iq3_identify',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
+    'original_icon': None,
+    'original_name': 'Identify',
+    'platform': 'tailwind',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '_3c_e9_e_6d_21_84_-identify',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_number_entities.2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        '3c:e9:0e:6d:21:84',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'tailwind',
+        '_3c_e9_e_6d_21_84_',
+      ),
+    }),
+    'is_new': False,
+    'manufacturer': 'Tailwind',
+    'model': 'iQ3',
+    'name': 'Tailwind iQ3',
+    'name_by_user': None,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': '10.10',
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/tailwind/test_button.py
+++ b/tests/components/tailwind/test_button.py
@@ -1,0 +1,48 @@
+"""Tests for button entities provided by the Tailwind integration."""
+from unittest.mock import MagicMock
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+pytestmark = [
+    pytest.mark.usefixtures("init_integration"),
+    pytest.mark.freeze_time("2023-12-17 15:25:00"),
+]
+
+
+async def test_number_entities(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    mock_tailwind: MagicMock,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test button entities provided by the Tailwind integration."""
+    assert (state := hass.states.get("button.tailwind_iq3_identify"))
+    assert snapshot == state
+
+    assert (entity_entry := entity_registry.async_get(state.entity_id))
+    assert snapshot == entity_entry
+
+    assert entity_entry.device_id
+    assert (device_entry := device_registry.async_get(entity_entry.device_id))
+    assert snapshot == device_entry
+
+    assert len(mock_tailwind.identify.mock_calls) == 0
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: state.entity_id},
+        blocking=True,
+    )
+
+    assert len(mock_tailwind.identify.mock_calls) == 1
+    mock_tailwind.identify.assert_called_with()
+
+    assert (state := hass.states.get(state.entity_id))
+    assert state.state == "2023-12-17T15:25:00+00:00"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add the button platform to the Tailwind integration. Currently, it only provides an identify button.

![CleanShot 2023-12-18 at 12 41 19@2x](https://github.com/home-assistant/core/assets/195327/da552cd1-d65a-47cf-b92a-37b6b221100b)

--- 

Tailwind provides garage door controllers that work with most garage door openers and communicates fully locally.

More information: https://gotailwind.com/

The development of this integration will consist of multiple pull requests:

- [x] Add the minimal functional integration (#105926)
- [x] Add zeroconf discovery support (#105949)
- [x] Add re-authentication support in case the local key is changed (#105959)
- [x] Add DHCP discovery support for updating config entries (#105981)
- [ ] Add binary sensor platform (#106033)
- [ ] Add switch platform
- [ ] Add cover platform
- [x] Add button platform (#105961)
- [x] Add diagnostic platform (#105965)
- [ ] Add error handling to service calls (with translatable errors)
- [ ] General cleanup, as most is in at this point
- [ ] Upgrade integration to platinum level
- [ ] Leverage webhooks to make integration push-based

Big thanks to Tailwind for providing the devices for testing ❤️ 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30392

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
