### PR TITLE
Add diagnostics platform to Tailwind

### DIFF
--- a/homeassistant/components/tailwind/diagnostics.py
+++ b/homeassistant/components/tailwind/diagnostics.py
@@ -1,0 +1,18 @@
+"""Diagnostics platform for Tailwind."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .coordinator import TailwindDataUpdateCoordinator
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator: TailwindDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    return coordinator.data.to_dict()

--- a/tests/components/tailwind/snapshots/test_diagnostics.ambr
+++ b/tests/components/tailwind/snapshots/test_diagnostics.ambr
@@ -1,0 +1,28 @@
+# serializer version: 1
+# name: test_diagnostics
+  dict({
+    'data': dict({
+      'door1': dict({
+        'disabled': 0,
+        'door_id': 'door1',
+        'index': 0,
+        'lockup': 0,
+        'status': 'open',
+      }),
+      'door2': dict({
+        'disabled': 0,
+        'door_id': 'door2',
+        'index': 1,
+        'lockup': 0,
+        'status': 'open',
+      }),
+    }),
+    'dev_id': '_3c_e9_e_6d_21_84_',
+    'door_num': 2,
+    'fw_ver': '10.10',
+    'led_brightness': 100,
+    'night_mode_en': 0,
+    'product': 'iQ3',
+    'proto_ver': '0.1',
+  })
+# ---

--- a/tests/components/tailwind/test_diagnostics.py
+++ b/tests/components/tailwind/test_diagnostics.py
@@ -1,0 +1,22 @@
+"""Tests for diagnostics provided by the Tailwind integration."""
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+async def test_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    init_integration: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test diagnostics."""
+    assert (
+        await get_diagnostics_for_config_entry(hass, hass_client, init_integration)
+        == snapshot
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add the ability for users to download diagnostic information for the Tailwind integration.

![CleanShot 2023-12-18 at 13 01 25@2x](https://github.com/home-assistant/core/assets/195327/7a74e601-bf58-4ee0-adfa-3dbab1b5f6d0)

Example diagnostic download:

```json
{
  "home_assistant": {
    "installation_type": "Home Assistant Core",
    "version": "2024.1.0.dev0",
    "dev": true,
    "hassio": false,
    "virtualenv": true,
    "python_version": "3.11.4",
    "docker": false,
    "arch": "x86_64",
    "timezone": "UTC",
    "os_name": "Linux",
    "os_version": "5.10.0-21-amd64",
    "run_as_root": false
  },
  "custom_components": {},
  "integration_manifest": {
    "domain": "tailwind",
    "name": "Tailwind",
    "codeowners": [
      "@frenck"
    ],
    "config_flow": true,
    "documentation": "https://www.home-assistant.io/integrations/tailwind",
    "integration_type": "device",
    "iot_class": "local_polling",
    "requirements": [
      "gotailwind==0.2.1"
    ],
    "zeroconf": [
      {
        "type": "_http._tcp.local.",
        "properties": {
          "vendor": "tailwind"
        }
      }
    ],
    "is_built_in": true
  },
  "data": {
    "dev_id": "_3c_e9_e_6d_21_84_",
    "fw_ver": "10.10",
    "night_mode_en": 0,
    "product": "iQ3",
    "proto_ver": "0.1",
    "led_brightness": 100,
    "door_num": 2,
    "data": {
      "door1": {
        "disabled": 0,
        "door_id": "door1",
        "index": 0,
        "lockup": 0,
        "status": "close"
      },
      "door2": {
        "disabled": 0,
        "door_id": "door2",
        "index": 1,
        "lockup": 0,
        "status": "open"
      }
    }
  }
}
```

![CleanShot 2023-12-18 at 13 05 11@2x](https://github.com/home-assistant/core/assets/195327/5f4a70e5-7be3-4738-80c1-c21cf6364a71)

--- 

Tailwind provides garage door controllers that work with most garage door openers and communicates fully locally.

More information: https://gotailwind.com/

The development of this integration will consist of multiple pull requests:

- [x] Add the minimal functional integration (#105926)
- [x] Add zeroconf discovery support (#105949)
- [x] Add re-authentication support in case the local key is changed (#105959)
- [x] Add DHCP discovery support for updating config entries (#105981)
- [ ] Add binary sensor platform (#106033)
- [ ] Add switch platform
- [ ] Add cover platform
- [x] Add button platform (#105961)
- [x] Add diagnostic platform (#105965)
- [ ] Add error handling to service calls (with translatable errors)
- [ ] General cleanup, as most is in at this point
- [ ] Upgrade integration to platinum level
- [ ] Leverage webhooks to make integration push-based

Big thanks to Tailwind for providing the devices for testing ❤️ 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
