### PR TITLE
Simplisafe outdoor camera motion media capture

### DIFF
--- a/homeassistant/components/simplisafe/binary_sensor.py
+++ b/homeassistant/components/simplisafe/binary_sensor.py
@@ -1,9 +1,25 @@
 """Support for SimpliSafe binary sensors."""
 from __future__ import annotations
 
+import asyncio
+
+from datetime import datetime
+import os
+import pathlib
+
 from simplipy.device import DeviceTypes, DeviceV3
 from simplipy.device.sensor.v3 import SensorV3
 from simplipy.system.v3 import SystemV3
+from simplipy.util.dt import utc_from_timestamp
+
+from simplipy.websocket import (
+    EVENT_CAMERA_MOTION_DETECTED,
+    WebsocketEvent,
+)
+
+from simplipy.errors import (
+    SimplipyError,
+)
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -13,9 +29,12 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import dt as dt_util
 
 from . import SimpliSafe, SimpliSafeEntity
 from .const import DOMAIN, LOGGER
+
+DEFAULT_IMAGE_WIDTH = 720
 
 SUPPORTED_BATTERY_SENSOR_TYPES = [
     DeviceTypes.CARBON_MONOXIDE,
@@ -35,6 +54,7 @@ SUPPORTED_BATTERY_SENSOR_TYPES = [
     DeviceTypes.SMOKE,
     DeviceTypes.SMOKE_AND_CARBON_MONOXIDE,
     DeviceTypes.TEMPERATURE,
+    DeviceTypes.OUTDOOR_CAMERA,
 ]
 
 TRIGGERED_SENSOR_TYPES = {
@@ -51,6 +71,9 @@ TRIGGERED_SENSOR_TYPES = {
     DeviceTypes.SMOKE_AND_CARBON_MONOXIDE: BinarySensorDeviceClass.SMOKE,
 }
 
+OUTDOOR_CAMERA_SENSOR_TYPES = {
+    DeviceTypes.OUTDOOR_CAMERA: BinarySensorDeviceClass.MOTION,
+}
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -58,7 +81,7 @@ async def async_setup_entry(
     """Set up SimpliSafe binary sensors based on a config entry."""
     simplisafe = hass.data[DOMAIN][entry.entry_id]
 
-    sensors: list[BatteryBinarySensor | TriggeredBinarySensor] = []
+    sensors: list[BatteryBinarySensor | TriggeredBinarySensor | OutdoorCameraSensor] = []
 
     for system in simplisafe.systems.values():
         if system.version == 2:
@@ -73,6 +96,16 @@ async def async_setup_entry(
                         system,
                         sensor,
                         TRIGGERED_SENSOR_TYPES[sensor.type],
+                    )
+                )
+            if sensor.type in OUTDOOR_CAMERA_SENSOR_TYPES:
+                sensors.append(
+                    OutdoorCameraSensor(
+                        hass,
+                        simplisafe,
+                        system,
+                        sensor,
+                        OUTDOOR_CAMERA_SENSOR_TYPES[sensor.type]
                     )
                 )
             if sensor.type in SUPPORTED_BATTERY_SENSOR_TYPES:
@@ -125,3 +158,218 @@ class BatteryBinarySensor(SimpliSafeEntity, BinarySensorEntity):
     def async_update_from_rest_api(self) -> None:
         """Update the entity with the provided REST API data."""
         self._attr_is_on = self._device.low_battery
+
+class OutdoorCameraSensor(SimpliSafeEntity, BinarySensorEntity):
+    """Define a binary sensor for the outdoor camera."""
+
+    """
+    The Simplisafe Outdoor camera is a motion based device that captures an image and
+    a short video clip when motion is detected.  When motion is detected, an event is
+    sent over the Simplisafe websocket, consumed by the Simplisafe class and forwarded to
+    this entity.  We then save clips and videos (mp4) into the local file system using this
+    structure:
+
+    /config/www/simplisafe/{outdoor_camera_name}/
+      latest_snapshot.jpg
+      latest_clip.mp4
+      clips/
+        YYYYMMDDHHmmss.mp4
+        ...
+
+    You can use a Gallery Card (https://github.com/TarheelGrad1998/gallery-card) pointed at
+    the clips/ directory, and use the latest_* files in automations if you want.
+    """
+
+    # Properties
+    _attr_image_last_updated: datetime | None = None
+    _attr_image_url: str | None = None
+    _attr_clip_url: str | None = None
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        simplisafe: SimpliSafe,
+        system: SystemV3,
+        sensor: SensorV3,
+        device_class: BinarySensorDeviceClass,
+    ) -> None:
+        """Initialize."""
+        super().__init__(
+            simplisafe,
+            system,
+            device=sensor,
+            additional_websocket_events=[EVENT_CAMERA_MOTION_DETECTED]
+        )
+
+        self._attr_device_class = device_class
+        # self._attr_unique_id = f"{super().unique_id}-motion-camera"
+        self._device: SensorV3
+        self._attr_is_on = False
+
+        # make the directories for storing media
+        self.storage = pathlib.Path(os.path.join(
+            hass.config.path("www"),
+            DOMAIN,
+            sensor.name.lower().replace(' ', '_'),
+        ))
+        self.storage.mkdir(parents=True, exist_ok=True)
+        clips = pathlib.Path(os.path.join(self.storage, "clips"))
+        clips.mkdir(parents=True, exist_ok=True)
+
+    @callback
+    def async_update_from_websocket_event(self, event: WebsocketEvent) -> None:
+        if event.event_type != EVENT_CAMERA_MOTION_DETECTED:
+            return
+        if event.sensor_type != DeviceTypes.OUTDOOR_CAMERA:
+            return
+
+        LOGGER.debug("Outdoor Camera %s received a websocket event: %s", self._device.serial, event)
+
+        if not hasattr(event, "mediaUrls"):
+            # Used when simplipy version is 2023.08.0 and below
+            self.hass.async_create_task(self._async_update_camera_media_the_old_way(event.timestamp))
+            return
+        if event.mediaUrls is not None:
+            # Used when simplipy version is greater 2023.08.0 (or when the "mediaUrls" pull request was approved)
+            imageUrl = event.mediaUrls["snapshot/jpg"]["href"]
+            clipUrl = event.mediaUrls["download/mp4"]["href"]
+            timestamp = event.timestamp
+            if timestamp != self._attr_image_last_updated:
+                self._attr_image_url = imageUrl
+                self._attr_clip_url = clipUrl
+                self._attr_is_on = True
+                self._attr_image_last_updated = timestamp
+                self.hass.async_create_task(self._async_update_camera_media())
+
+    async def _async_get_media_content(self, url: str) -> bytes | None:
+        """
+        When Simplisafe sends the websocket event containing urls to media files, IT
+        HAS APPARENTLY NOT yet written those files ... or at least those files are not yet
+        available to fetch (maybe they are still sneaking through AWS).  We'll get a 404
+        for these ... so we need to loop trying to get them, doing a small backoff in between,
+        and giving up after some reasonable number of attempts.  Nothing's easy.
+        """
+        LOGGER.debug("Outdoor Camera fetching media from %s", url)
+        api = self._simplisafe._api
+        access_token = api.access_token
+        session = api.session
+
+        # For me, the number of tries seems about 3-5, but just to be safe ...
+        tries = 30
+        tried = 0
+
+        payload = None
+
+        while True:
+          response = await session.request(
+              "get", url, headers={"Authorization": f"Bearer {access_token}"}
+          )
+          LOGGER.debug("Outdoor Camera fetch response status: %s", response.status)
+          if response.status == 200:
+              payload = response
+              break
+          if tried == tries:
+              break
+          tried = tried + 1
+          await asyncio.sleep(1)
+          LOGGER.debug("Outdoor Camera fetch retry %s", tried)
+
+        if payload is not None:
+            return await payload.read()
+        else:
+            return None
+
+    async def _async_get_image_content(self, url, width: int = DEFAULT_IMAGE_WIDTH) -> bytes | None:
+        return await self._async_get_media_content(url.replace("{&width}", '&width='+str(width)))
+
+    async def _async_update_camera_media_the_old_way(self, ws_timestamp: datetime) -> None:
+        """
+        The simplipy library <= 2023.08.0 did not transmit "mediaUrls" property in websocket events.
+        The only way to obtain media urls was to get the event "timeline" and parse that ...
+        """
+        try:
+            events = await self._system.async_get_events(num_events=10)
+            # filter for events belonging to me at the websocket timestamp
+            my_events = [ev for ev in events if ev.get("sensorSerial") == self._device.serial and ws_timestamp == utc_from_timestamp(ev["eventTimestamp"])]
+            if len(my_events) == 0:
+                LOGGER.error("Could not find an event for serial: %s at time: %s", self._device.serial, ws_timestamp)
+                LOGGER.debug("Here are the events fetched: %s", events)
+                return
+
+            ev = my_events[0]
+            vid = ev["videoStartedBy"]
+            # This happends sometimes ...
+            if vid == '':
+                LOGGER.warning("Received a motion event for serial %s, but videoStartedBy key is empty!", self._device.serial)
+                LOGGER.warning("Here are the events fetched: %s", events)
+                return
+
+            urls = ev["video"][vid]["_links"]
+            imageUrl = urls["snapshot/jpg"]["href"]
+            clipUrl = urls["download/mp4"]["href"]
+            timestamp = utc_from_timestamp(ev["eventTimestamp"])
+
+            if timestamp != self._attr_image_last_updated:
+                self._attr_image_url = imageUrl
+                self._attr_clip_url = clipUrl
+                self._attr_is_on = True
+                self._attr_image_last_updated = timestamp
+                await self._async_update_camera_media()
+
+        except SimplipyError as err:
+            LOGGER.error("Error while fetching most recent image: %s", err)
+
+    async def _save_media_file(self, hass: HomeAssistant, filename: str, content: bytes) -> None:
+        if content is None:
+            return
+        def save_file() -> None:
+            with open(filename, "wb") as fh:
+                fh.write(content)
+        try:
+            await hass.async_add_executor_job(save_file)
+        except OSError as err:
+            LOGGER.error("Can't write %s: %s", filename, err)
+
+    async def _async_get_and_store_media(
+        self, width: int | None = DEFAULT_IMAGE_WIDTH, height: int | None = None
+    ) -> bytes | None:
+
+        local_timestamp = dt_util.as_local(self._attr_image_last_updated)
+        datestr = local_timestamp.strftime("%Y%m%d%H%M%S")
+        start = datetime.now()
+
+        if self._attr_image_url is not None:
+            image_data = await self._async_get_image_content(self._attr_image_url, width)
+
+            await self._save_media_file(
+                self.hass,
+                os.path.join(self.storage, "latest_snapshot.jpg"),
+                image_data
+            )
+
+        if self._attr_clip_url is not None:
+            clip_data = await self._async_get_media_content(self._attr_clip_url)
+
+            await self._save_media_file(
+                self.hass,
+                os.path.join(self.storage, "latest_clip.mp4"),
+                clip_data
+            )
+
+            await self._save_media_file(
+                self.hass,
+                os.path.join(self.storage, "clips", datestr+".mp4"),
+                clip_data
+            )
+
+            delta = datetime.now() - start
+
+        LOGGER.debug("Outdoor Camera media fetch and save took %s seconds", delta.seconds)
+
+        return None
+
+    async def _async_update_camera_media(self):
+        await self._async_get_and_store_media()
+        self._attr_is_on = False
+        self.async_write_ha_state()
+

--- a/homeassistant/components/simplisafe/binary_sensor.py
+++ b/homeassistant/components/simplisafe/binary_sensor.py
@@ -11,21 +11,16 @@ from simplipy.errors import SimplipyError
 from simplipy.system.v3 import SystemV3
 from simplipy.util.dt import utc_from_timestamp
 from simplipy.websocket import EVENT_CAMERA_MOTION_DETECTED, WebsocketEvent
-
 import voluptuous as vol
-
-import homeassistant.helpers.config_validation as cv
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    EntityCategory,
-    ATTR_ENTITY_ID
-)
+from homeassistant.const import ATTR_ENTITY_ID, EntityCategory
 from homeassistant.core import HomeAssistant, ServiceCall, callback
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.template import Template
 
@@ -87,15 +82,14 @@ SERVICE_OC_SNAPSHOT_SCHEMA = cv.make_entity_service_schema(
     }
 )
 SERVICE_OC_CLIP_SCHEMA = cv.make_entity_service_schema(
-    {
-        vol.Required(ATTR_FILENAME): cv.template
-    }
+    {vol.Required(ATTR_FILENAME): cv.template}
 )
 
 SERVICES = (
     SERVICE_OUTDOOR_CAMERA_SAVE_LATEST_SNAPSHOT,
-    SERVICE_OUTDOOR_CAMERA_SAVE_LATEST_CLIP
+    SERVICE_OUTDOOR_CAMERA_SAVE_LATEST_CLIP,
 )
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -222,9 +216,7 @@ class OutdoorCameraSensor(SimpliSafeEntity, BinarySensorEntity):
         # self._attr_unique_id = f"{super().unique_id}-motion-camera"
         self._device: SensorV3
         self._attr_is_on = False
-        self._attr_supported_features = (
-            MotionEntityFeature.MOTION_MEDIA
-        )
+        self._attr_supported_features = MotionEntityFeature.MOTION_MEDIA
 
     @callback
     def async_unload(self) -> None:
@@ -256,10 +248,11 @@ class OutdoorCameraSensor(SimpliSafeEntity, BinarySensorEntity):
                 return
 
             try:
-                await self.hass.async_add_executor_job(_write_image, snapshot_file, snapshot)
+                await self.hass.async_add_executor_job(
+                    _write_image, snapshot_file, snapshot
+                )
             except OSError as err:
                 LOGGER.error("Can't write image to file: %s", err)
-
 
         async def save_clip_handler(call: ServiceCall) -> None:
             if self._attr_clip_url is None:
@@ -282,14 +275,14 @@ class OutdoorCameraSensor(SimpliSafeEntity, BinarySensorEntity):
             DOMAIN,
             SERVICE_OUTDOOR_CAMERA_SAVE_LATEST_SNAPSHOT,
             save_snapshot_handler,
-            schema=SERVICE_OC_SNAPSHOT_SCHEMA
+            schema=SERVICE_OC_SNAPSHOT_SCHEMA,
         )
 
         self.hass.services.async_register(
             DOMAIN,
             SERVICE_OUTDOOR_CAMERA_SAVE_LATEST_CLIP,
             save_clip_handler,
-            schema=SERVICE_OC_CLIP_SCHEMA
+            schema=SERVICE_OC_CLIP_SCHEMA,
         )
 
     @callback
@@ -304,7 +297,7 @@ class OutdoorCameraSensor(SimpliSafeEntity, BinarySensorEntity):
             "Outdoor Camera %s received a websocket event: %s, at %s",
             self._device.serial,
             event,
-            datetime.now()
+            datetime.now(),
         )
 
         self._attr_is_on = True

--- a/homeassistant/components/simplisafe/binary_sensor.py
+++ b/homeassistant/components/simplisafe/binary_sensor.py
@@ -2,24 +2,16 @@
 from __future__ import annotations
 
 import asyncio
-
 from datetime import datetime
 import os
 import pathlib
 
 from simplipy.device import DeviceTypes, DeviceV3
 from simplipy.device.sensor.v3 import SensorV3
+from simplipy.errors import SimplipyError
 from simplipy.system.v3 import SystemV3
 from simplipy.util.dt import utc_from_timestamp
-
-from simplipy.websocket import (
-    EVENT_CAMERA_MOTION_DETECTED,
-    WebsocketEvent,
-)
-
-from simplipy.errors import (
-    SimplipyError,
-)
+from simplipy.websocket import EVENT_CAMERA_MOTION_DETECTED, WebsocketEvent
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -75,13 +67,16 @@ OUTDOOR_CAMERA_SENSOR_TYPES = {
     DeviceTypes.OUTDOOR_CAMERA: BinarySensorDeviceClass.MOTION,
 }
 
+
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up SimpliSafe binary sensors based on a config entry."""
     simplisafe = hass.data[DOMAIN][entry.entry_id]
 
-    sensors: list[BatteryBinarySensor | TriggeredBinarySensor | OutdoorCameraSensor] = []
+    sensors: list[
+        BatteryBinarySensor | TriggeredBinarySensor | OutdoorCameraSensor
+    ] = []
 
     for system in simplisafe.systems.values():
         if system.version == 2:
@@ -105,7 +100,7 @@ async def async_setup_entry(
                         simplisafe,
                         system,
                         sensor,
-                        OUTDOOR_CAMERA_SENSOR_TYPES[sensor.type]
+                        OUTDOOR_CAMERA_SENSOR_TYPES[sensor.type],
                     )
                 )
             if sensor.type in SUPPORTED_BATTERY_SENSOR_TYPES:
@@ -159,10 +154,10 @@ class BatteryBinarySensor(SimpliSafeEntity, BinarySensorEntity):
         """Update the entity with the provided REST API data."""
         self._attr_is_on = self._device.low_battery
 
-class OutdoorCameraSensor(SimpliSafeEntity, BinarySensorEntity):
-    """Define a binary sensor for the outdoor camera."""
 
-    """
+class OutdoorCameraSensor(SimpliSafeEntity, BinarySensorEntity):
+    """Define a binary sensor for the outdoor camera.
+
     The Simplisafe Outdoor camera is a motion based device that captures an image and
     a short video clip when motion is detected.  When motion is detected, an event is
     sent over the Simplisafe websocket, consumed by the Simplisafe class and forwarded to
@@ -198,7 +193,7 @@ class OutdoorCameraSensor(SimpliSafeEntity, BinarySensorEntity):
             simplisafe,
             system,
             device=sensor,
-            additional_websocket_events=[EVENT_CAMERA_MOTION_DETECTED]
+            additional_websocket_events=[EVENT_CAMERA_MOTION_DETECTED],
         )
 
         self._attr_device_class = device_class
@@ -207,27 +202,36 @@ class OutdoorCameraSensor(SimpliSafeEntity, BinarySensorEntity):
         self._attr_is_on = False
 
         # make the directories for storing media
-        self.storage = pathlib.Path(os.path.join(
-            hass.config.path("www"),
-            DOMAIN,
-            sensor.name.lower().replace(' ', '_'),
-        ))
+        self.storage = pathlib.Path(
+            os.path.join(
+                hass.config.path("www"),
+                DOMAIN,
+                sensor.name.lower().replace(" ", "_"),
+            )
+        )
         self.storage.mkdir(parents=True, exist_ok=True)
         clips = pathlib.Path(os.path.join(self.storage, "clips"))
         clips.mkdir(parents=True, exist_ok=True)
 
     @callback
     def async_update_from_websocket_event(self, event: WebsocketEvent) -> None:
+        """Receive a Simplisafe WebsocketEvent aimed at me specifically."""
         if event.event_type != EVENT_CAMERA_MOTION_DETECTED:
             return
         if event.sensor_type != DeviceTypes.OUTDOOR_CAMERA:
             return
 
-        LOGGER.debug("Outdoor Camera %s received a websocket event: %s", self._device.serial, event)
+        LOGGER.debug(
+            "Outdoor Camera %s received a websocket event: %s",
+            self._device.serial,
+            event,
+        )
 
         if not hasattr(event, "mediaUrls"):
             # Used when simplipy version is 2023.08.0 and below
-            self.hass.async_create_task(self._async_update_camera_media_the_old_way(event.timestamp))
+            self.hass.async_create_task(
+                self._async_update_camera_media_the_old_way(event.timestamp)
+            )
             return
         if event.mediaUrls is not None:
             # Used when simplipy version is greater 2023.08.0 (or when the "mediaUrls" pull request was approved)
@@ -242,7 +246,8 @@ class OutdoorCameraSensor(SimpliSafeEntity, BinarySensorEntity):
                 self.hass.async_create_task(self._async_update_camera_media())
 
     async def _async_get_media_content(self, url: str) -> bytes | None:
-        """
+        """Get a media file from a URL.
+
         When Simplisafe sends the websocket event containing urls to media files, IT
         HAS APPARENTLY NOT yet written those files ... or at least those files are not yet
         available to fetch (maybe they are still sneaking through AWS).  We'll get a 404
@@ -250,6 +255,9 @@ class OutdoorCameraSensor(SimpliSafeEntity, BinarySensorEntity):
         and giving up after some reasonable number of attempts.  Nothing's easy.
         """
         LOGGER.debug("Outdoor Camera fetching media from %s", url)
+        # I need access to the Authorization header (access_token) to call these media endpoints,
+        # as they are not known in simplipy!
+        # pylint: disable=protected-access
         api = self._simplisafe._api
         access_token = api.access_token
         session = api.session
@@ -261,46 +269,64 @@ class OutdoorCameraSensor(SimpliSafeEntity, BinarySensorEntity):
         payload = None
 
         while True:
-          response = await session.request(
-              "get", url, headers={"Authorization": f"Bearer {access_token}"}
-          )
-          LOGGER.debug("Outdoor Camera fetch response status: %s", response.status)
-          if response.status == 200:
-              payload = response
-              break
-          if tried == tries:
-              break
-          tried = tried + 1
-          await asyncio.sleep(1)
-          LOGGER.debug("Outdoor Camera fetch retry %s", tried)
+            response = await session.request(
+                "get", url, headers={"Authorization": f"Bearer {access_token}"}
+            )
+            LOGGER.debug("Outdoor Camera fetch response status: %s", response.status)
+            if response.status == 200:
+                payload = response
+                break
+            if tried == tries:
+                break
+            tried = tried + 1
+            await asyncio.sleep(1)
+            LOGGER.debug("Outdoor Camera fetch retry %s", tried)
 
         if payload is not None:
             return await payload.read()
-        else:
-            return None
+        return None
 
-    async def _async_get_image_content(self, url, width: int = DEFAULT_IMAGE_WIDTH) -> bytes | None:
-        return await self._async_get_media_content(url.replace("{&width}", '&width='+str(width)))
+    async def _async_get_image_content(
+        self, url, width: int = DEFAULT_IMAGE_WIDTH
+    ) -> bytes | None:
+        return await self._async_get_media_content(
+            url.replace("{&width}", "&width=" + str(width))
+        )
 
-    async def _async_update_camera_media_the_old_way(self, ws_timestamp: datetime) -> None:
-        """
-        The simplipy library <= 2023.08.0 did not transmit "mediaUrls" property in websocket events.
-        The only way to obtain media urls was to get the event "timeline" and parse that ...
+    async def _async_update_camera_media_the_old_way(
+        self, ws_timestamp: datetime
+    ) -> None:
+        """Obtain media URLs by fetching timeline from Simplisafe API.
+
+        The simplipy library <= 2023.08.0 does not transmit "mediaUrls" property in websocket events.
+        The only way to obtain media urls is to get the event "timeline" and parse that ...
         """
         try:
             events = await self._system.async_get_events(num_events=10)
             # filter for events belonging to me at the websocket timestamp
-            my_events = [ev for ev in events if ev.get("sensorSerial") == self._device.serial and ws_timestamp == utc_from_timestamp(ev["eventTimestamp"])]
+            my_events = [
+                ev
+                for ev in events
+                if ev.get("sensorSerial") == self._device.serial
+                and ws_timestamp == utc_from_timestamp(ev["eventTimestamp"])
+            ]
             if len(my_events) == 0:
-                LOGGER.error("Could not find an event for serial: %s at time: %s", self._device.serial, ws_timestamp)
+                LOGGER.error(
+                    "Could not find an event for serial: %s at time: %s",
+                    self._device.serial,
+                    ws_timestamp,
+                )
                 LOGGER.debug("Here are the events fetched: %s", events)
                 return
 
             ev = my_events[0]
             vid = ev["videoStartedBy"]
             # This happends sometimes ...
-            if vid == '':
-                LOGGER.warning("Received a motion event for serial %s, but videoStartedBy key is empty!", self._device.serial)
+            if vid == "":
+                LOGGER.warning(
+                    "Received a motion event for serial %s, but videoStartedBy key is empty!",
+                    self._device.serial,
+                )
                 LOGGER.warning("Here are the events fetched: %s", events)
                 return
 
@@ -314,17 +340,22 @@ class OutdoorCameraSensor(SimpliSafeEntity, BinarySensorEntity):
                 self._attr_clip_url = clipUrl
                 self._attr_is_on = True
                 self._attr_image_last_updated = timestamp
+                self.async_write_ha_state()
                 await self._async_update_camera_media()
 
         except SimplipyError as err:
             LOGGER.error("Error while fetching most recent image: %s", err)
 
-    async def _save_media_file(self, hass: HomeAssistant, filename: str, content: bytes) -> None:
+    async def _save_media_file(
+        self, hass: HomeAssistant, filename: str, content: bytes
+    ) -> None:
         if content is None:
             return
+
         def save_file() -> None:
             with open(filename, "wb") as fh:
                 fh.write(content)
+
         try:
             await hass.async_add_executor_job(save_file)
         except OSError as err:
@@ -333,38 +364,37 @@ class OutdoorCameraSensor(SimpliSafeEntity, BinarySensorEntity):
     async def _async_get_and_store_media(
         self, width: int | None = DEFAULT_IMAGE_WIDTH, height: int | None = None
     ) -> bytes | None:
-
         local_timestamp = dt_util.as_local(self._attr_image_last_updated)
         datestr = local_timestamp.strftime("%Y%m%d%H%M%S")
         start = datetime.now()
 
         if self._attr_image_url is not None:
-            image_data = await self._async_get_image_content(self._attr_image_url, width)
+            image_data = await self._async_get_image_content(
+                self._attr_image_url, width
+            )
 
             await self._save_media_file(
-                self.hass,
-                os.path.join(self.storage, "latest_snapshot.jpg"),
-                image_data
+                self.hass, os.path.join(self.storage, "latest_snapshot.jpg"), image_data
             )
 
         if self._attr_clip_url is not None:
             clip_data = await self._async_get_media_content(self._attr_clip_url)
 
             await self._save_media_file(
-                self.hass,
-                os.path.join(self.storage, "latest_clip.mp4"),
-                clip_data
+                self.hass, os.path.join(self.storage, "latest_clip.mp4"), clip_data
             )
 
             await self._save_media_file(
                 self.hass,
-                os.path.join(self.storage, "clips", datestr+".mp4"),
-                clip_data
+                os.path.join(self.storage, "clips", datestr + ".mp4"),
+                clip_data,
             )
 
             delta = datetime.now() - start
 
-        LOGGER.debug("Outdoor Camera media fetch and save took %s seconds", delta.seconds)
+        LOGGER.debug(
+            "Outdoor Camera media fetch and save took %s seconds", delta.seconds
+        )
 
         return None
 
@@ -372,4 +402,3 @@ class OutdoorCameraSensor(SimpliSafeEntity, BinarySensorEntity):
         await self._async_get_and_store_media()
         self._attr_is_on = False
         self.async_write_ha_state()
-

--- a/homeassistant/components/simplisafe/const.py
+++ b/homeassistant/components/simplisafe/const.py
@@ -1,5 +1,6 @@
 """Define constants for the SimpliSafe component."""
 import logging
+from enum import IntFlag
 
 LOGGER = logging.getLogger(__package__)
 
@@ -14,3 +15,8 @@ ATTR_EXIT_DELAY_AWAY = "exit_delay_away"
 ATTR_EXIT_DELAY_HOME = "exit_delay_home"
 ATTR_LIGHT = "light"
 ATTR_VOICE_PROMPT_VOLUME = "voice_prompt_volume"
+
+class MotionEntityFeature(IntFlag):
+    """Supported features of the outdoor camera entity."""
+
+    MOTION_MEDIA = 1

--- a/homeassistant/components/simplisafe/const.py
+++ b/homeassistant/components/simplisafe/const.py
@@ -1,6 +1,6 @@
 """Define constants for the SimpliSafe component."""
-import logging
 from enum import IntFlag
+import logging
 
 LOGGER = logging.getLogger(__package__)
 

--- a/homeassistant/components/simplisafe/services.yaml
+++ b/homeassistant/components/simplisafe/services.yaml
@@ -98,3 +98,35 @@ set_system_properties:
             - "medium"
             - "high"
             - "off"
+save_latest_snapshot:
+  target:
+    entity:
+      integration: simplisafe
+      domain: binary_sensor
+  fields:
+    width:
+      description: Width of image in pixels
+      example: 720
+      default: 720
+      selector:
+        number:
+          min: 240
+          max: 1080
+    filename:
+      description: Name of file to save
+      required: true
+      example: "/tmp/snapshot_{{ now().strftime('%Y%m%d%H%M%S') }}.jpg"
+      selector:
+        text:
+save_latest_clip:
+  target:
+    entity:
+      integration: simplisafe
+      domain: binary_sensor
+  fields:
+    filename:
+      description: Name of file to save
+      required: true
+      example: "/tmp/clip_{{ now().strftime('%Y%m%d%H%M%S') }}.mp4"
+      selector:
+        text:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add some support for the Simplisafe Outdoor Camera.  With this change, the outdoor camera is added as a new motion sensor.  When a motion-detected websocket event arrives, the Simplisafe "timeline" is fetched and parsed for the media urls associated with the motion event.  The urls are saved as instance attributes.

There are two custom services added; save_latest_snapshot and save_latest_clip.  Called in automations with a filename argument, these will fetch the content of the snapshot or clip to the given filename.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

When the websocket event arrives for an outdoor camera motion event, the binary_sensor is "Detected" and after the Simplisafe timeline is fetched, the sensor is "Clear".  The save_* services should be called on the Detected=>Clear transition os that the media urls are present/updated.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
