### PR TITLE
Add significant Change support for cover

### DIFF
--- a/homeassistant/components/cover/significant_change.py
+++ b/homeassistant/components/cover/significant_change.py
@@ -1,0 +1,55 @@
+"""Helper to test significant Cover state changes."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.significant_change import (
+    check_absolute_change,
+    check_valid_float,
+)
+
+from . import ATTR_CURRENT_POSITION, ATTR_CURRENT_TILT_POSITION
+
+SIGNIFICANT_ATTRIBUTES: set[str] = {
+    ATTR_CURRENT_POSITION,
+    ATTR_CURRENT_TILT_POSITION,
+}
+
+
+@callback
+def async_check_significant_change(
+    hass: HomeAssistant,
+    old_state: str,
+    old_attrs: dict,
+    new_state: str,
+    new_attrs: dict,
+    **kwargs: Any,
+) -> bool | None:
+    """Test if state significantly changed."""
+    if old_state != new_state:
+        return True
+
+    old_attrs_s = set(old_attrs.items())
+    new_attrs_s = set(new_attrs.items())
+    changed_attrs: set[str] = {item[0] for item in old_attrs_s ^ new_attrs_s}
+
+    for attr_name in changed_attrs:
+        if attr_name not in SIGNIFICANT_ATTRIBUTES:
+            continue
+
+        old_attr_value = old_attrs.get(attr_name)
+        new_attr_value = new_attrs.get(attr_name)
+        if new_attr_value is None or not check_valid_float(new_attr_value):
+            # New attribute value is invalid, ignore it
+            continue
+
+        if old_attr_value is None or not check_valid_float(old_attr_value):
+            # Old attribute value was invalid, we should report again
+            return True
+
+        if check_absolute_change(old_attr_value, new_attr_value, 1.0):
+            return True
+
+    # no significant attribute change detected
+    return False

--- a/tests/components/cover/test_significant_change.py
+++ b/tests/components/cover/test_significant_change.py
@@ -1,0 +1,65 @@
+"""Test the Cover significant change platform."""
+import pytest
+
+from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION,
+    ATTR_CURRENT_TILT_POSITION,
+)
+from homeassistant.components.cover.significant_change import (
+    async_check_significant_change,
+)
+
+
+async def test_significant_state_change() -> None:
+    """Detect Cover significant state changes."""
+    attrs = {}
+    assert not async_check_significant_change(None, "on", attrs, "on", attrs)
+    assert async_check_significant_change(None, "on", attrs, "off", attrs)
+
+
+@pytest.mark.parametrize(
+    ("old_attrs", "new_attrs", "expected_result"),
+    [
+        # float attributes
+        ({ATTR_CURRENT_POSITION: 60.0}, {ATTR_CURRENT_POSITION: 61.0}, True),
+        ({ATTR_CURRENT_POSITION: 60.0}, {ATTR_CURRENT_POSITION: 60.9}, False),
+        ({ATTR_CURRENT_POSITION: "invalid"}, {ATTR_CURRENT_POSITION: 60.0}, True),
+        ({ATTR_CURRENT_POSITION: 60.0}, {ATTR_CURRENT_POSITION: "invalid"}, False),
+        ({ATTR_CURRENT_TILT_POSITION: 60.0}, {ATTR_CURRENT_TILT_POSITION: 61.0}, True),
+        ({ATTR_CURRENT_TILT_POSITION: 60.0}, {ATTR_CURRENT_TILT_POSITION: 60.9}, False),
+        # multiple attributes
+        (
+            {
+                ATTR_CURRENT_POSITION: 60,
+                ATTR_CURRENT_TILT_POSITION: 60,
+            },
+            {
+                ATTR_CURRENT_POSITION: 60,
+                ATTR_CURRENT_TILT_POSITION: 61,
+            },
+            True,
+        ),
+        (
+            {
+                ATTR_CURRENT_POSITION: 60,
+                ATTR_CURRENT_TILT_POSITION: 59.1,
+            },
+            {
+                ATTR_CURRENT_POSITION: 60,
+                ATTR_CURRENT_TILT_POSITION: 60.9,
+            },
+            True,
+        ),
+        # insignificant attributes
+        ({"unknown_attr": "old_value"}, {"unknown_attr": "old_value"}, False),
+        ({"unknown_attr": "old_value"}, {"unknown_attr": "new_value"}, False),
+    ],
+)
+async def test_significant_atributes_change(
+    old_attrs: dict, new_attrs: dict, expected_result: bool
+) -> None:
+    """Detect Cover significant attribute changes."""
+    assert (
+        async_check_significant_change(None, "state", old_attrs, "state", new_attrs)
+        == expected_result
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #45651
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
