### PR TITLE
Correct logic in honeywell for cleaning up stale devices

### DIFF
--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -118,23 +118,19 @@ def remove_stale_devices(
     device_entries = dr.async_entries_for_config_entry(
         device_registry, config_entry.entry_id
     )
-    all_device_ids: set = set()
-    for device in devices.values():
-        all_device_ids.add(device.deviceid)
+    all_device_ids = {device.deviceid for device in devices.values()}
 
     for device_entry in device_entries:
         device_id: str | None = None
-        remove = True
 
         for identifier in device_entry.identifiers:
             if identifier[0] != DOMAIN:
-                remove = False
                 continue
 
             device_id = identifier[1]
             break
 
-        if remove and (device_id is None or device_id not in all_device_ids):
+        if device_id is None or device_id not in all_device_ids:
             # If device_id is None an invalid device entry was found for this config entry.
             # If the device_id is not in existing device ids it's a stale device entry.
             # Remove config entry from this device entry in either case.

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -124,11 +124,9 @@ def remove_stale_devices(
         device_id: str | None = None
 
         for identifier in device_entry.identifiers:
-            if identifier[0] != DOMAIN:
-                continue
-
-            device_id = identifier[1]
-            break
+            if identifier[0] == DOMAIN:
+                device_id = identifier[1]
+                break
 
         if device_id is None or device_id not in all_device_ids:
             # If device_id is None an invalid device entry was found for this config entry.

--- a/tests/components/honeywell/test_init.py
+++ b/tests/components/honeywell/test_init.py
@@ -155,9 +155,7 @@ async def test_remove_stale_device(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
     assert config_entry.state is ConfigEntryState.LOADED
-    assert (
-        hass.states.async_entity_ids_count() == 6
-    )  # 2 climate entities; 4 sensor entities
+    assert hass.states.async_entity_ids_count() == 6
 
     device_entry = dr.async_entries_for_config_entry(
         device_registry, config_entry.entry_id

--- a/tests/components/honeywell/test_init.py
+++ b/tests/components/honeywell/test_init.py
@@ -156,25 +156,28 @@ async def test_remove_stale_device(
     assert config_entry.state is ConfigEntryState.LOADED
     assert hass.states.async_entity_ids_count() == 6
 
-    device_entry = dr.async_entries_for_config_entry(
+    device_entries = dr.async_entries_for_config_entry(
         device_registry, config_entry.entry_id
     )
 
-    device_entry_other = dr.async_entries_for_config_entry(
+    device_entries_other = dr.async_entries_for_config_entry(
         device_registry, config_entry_other.entry_id
     )
 
-    assert len(device_entry) == 2
-    assert any((DOMAIN, 1234567) in device.identifiers for device in device_entry)
-    assert any((DOMAIN, 7654321) in device.identifiers for device in device_entry)
+    assert len(device_entries) == 2
+    assert any((DOMAIN, 1234567) in device.identifiers for device in device_entries)
+    assert any((DOMAIN, 7654321) in device.identifiers for device in device_entries)
     assert any(
-        ("OtherDomain", 7654321) in device.identifiers for device in device_entry
+        ("OtherDomain", 7654321) in device.identifiers for device in device_entries
     )
-    assert len(device_entry_other) == 1
+    assert len(device_entries_other) == 1
     assert any(
-        ("OtherDomain", 7654321) in device.identifiers for device in device_entry_other
+        ("OtherDomain", 7654321) in device.identifiers
+        for device in device_entries_other
     )
-    assert any((DOMAIN, 7654321) in device.identifiers for device in device_entry_other)
+    assert any(
+        (DOMAIN, 7654321) in device.identifiers for device in device_entries_other
+    )
 
     assert await config_entry.async_unload(hass)
     await hass.async_block_till_done()
@@ -189,20 +192,21 @@ async def test_remove_stale_device(
         hass.states.async_entity_ids_count() == 3
     )  # 1 climate entities; 2 sensor entities
 
-    device_entry = dr.async_entries_for_config_entry(
+    device_entries = dr.async_entries_for_config_entry(
         device_registry, config_entry.entry_id
     )
-    assert len(device_entry) == 1
-    assert any((DOMAIN, 1234567) in device.identifiers for device in device_entry)
-    assert not any((DOMAIN, 7654321) in device.identifiers for device in device_entry)
+    assert len(device_entries) == 1
+    assert any((DOMAIN, 1234567) in device.identifiers for device in device_entries)
+    assert not any((DOMAIN, 7654321) in device.identifiers for device in device_entries)
     assert not any(
-        ("OtherDomain", 7654321) in device.identifiers for device in device_entry
+        ("OtherDomain", 7654321) in device.identifiers for device in device_entries
     )
 
-    device_entry_other = dr.async_entries_for_config_entry(
+    device_entries_other = dr.async_entries_for_config_entry(
         device_registry, config_entry_other.entry_id
     )
-    assert len(device_entry_other) == 1
+    assert len(device_entries_other) == 1
     assert any(
-        ("OtherDomain", 7654321) in device.identifiers for device in device_entry_other
+        ("OtherDomain", 7654321) in device.identifiers
+        for device in device_entries_other
     )

--- a/tests/components/honeywell/test_init.py
+++ b/tests/components/honeywell/test_init.py
@@ -132,15 +132,12 @@ async def test_remove_stale_device(
     """Test that the stale device is removed."""
     location.devices_by_id[another_device.deviceid] = another_device
 
-    config_entry.add_to_hass(hass)
-
     config_entry_other = MockConfigEntry(
         domain="OtherDomain",
         data={},
         unique_id="unique_id",
     )
     config_entry_other.add_to_hass(hass)
-
     device_entry_other = device_registry.async_get_or_create(
         config_entry_id=config_entry_other.entry_id,
         identifiers={("OtherDomain", 7654321)},
@@ -151,6 +148,8 @@ async def test_remove_stale_device(
         add_config_entry_id=config_entry.entry_id,
         merge_identifiers={(DOMAIN, 7654321)},
     )
+
+    config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -195,6 +194,10 @@ async def test_remove_stale_device(
     )
     assert len(device_entry) == 1
     assert any((DOMAIN, 1234567) in device.identifiers for device in device_entry)
+    assert not any((DOMAIN, 7654321) in device.identifiers for device in device_entry)
+    assert not any(
+        ("OtherDomain", 7654321) in device.identifiers for device in device_entry
+    )
 
     device_entry_other = dr.async_entries_for_config_entry(
         device_registry, config_entry_other.entry_id

--- a/tests/components/honeywell/test_init.py
+++ b/tests/components/honeywell/test_init.py
@@ -134,9 +134,32 @@ async def test_remove_stale_device(
 
     config_entry.add_to_hass(hass)
 
-    device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+    config_entry_other = MockConfigEntry(
+        domain="OtherDomain",
+        data={},
+        unique_id="unique_id",
+    )
+    config_entry_other.add_to_hass(hass)
+
+    device_entry_other = device_registry.async_get_or_create(
+        config_entry_id=config_entry_other.entry_id,
         identifiers={("OtherDomain", 7654321)},
+    )
+
+    device_registry.async_update_device(
+        device_entry_other.id,
+        add_config_entry_id=config_entry.entry_id,
+        merge_identifiers={(DOMAIN, 7654321)},
+    )
+
+    device_entry = dr.async_entries_for_config_entry(
+        device_registry, config_entry.entry_id
+    )
+
+    device_registry.async_update_device(
+        device_entry_other.id,
+        add_config_entry_id=config_entry.entry_id,
+        merge_identifiers={("OtherDomain", 7654321)},
     )
 
     await hass.config_entries.async_setup(config_entry.entry_id)
@@ -149,12 +172,22 @@ async def test_remove_stale_device(
     device_entry = dr.async_entries_for_config_entry(
         device_registry, config_entry.entry_id
     )
-    assert len(device_entry) == 3
+
+    device_entry_other = dr.async_entries_for_config_entry(
+        device_registry, config_entry_other.entry_id
+    )
+
+    assert len(device_entry) == 2
     assert any((DOMAIN, 1234567) in device.identifiers for device in device_entry)
     assert any((DOMAIN, 7654321) in device.identifiers for device in device_entry)
     assert any(
         ("OtherDomain", 7654321) in device.identifiers for device in device_entry
     )
+    assert len(device_entry_other) == 1
+    assert any(
+        ("OtherDomain", 7654321) in device.identifiers for device in device_entry_other
+    )
+    assert any((DOMAIN, 7654321) in device.identifiers for device in device_entry_other)
 
     assert await config_entry.async_unload(hass)
     await hass.async_block_till_done()
@@ -172,8 +205,13 @@ async def test_remove_stale_device(
     device_entry = dr.async_entries_for_config_entry(
         device_registry, config_entry.entry_id
     )
-    assert len(device_entry) == 2
+    assert len(device_entry) == 1
     assert any((DOMAIN, 1234567) in device.identifiers for device in device_entry)
+
+    device_entry_other = dr.async_entries_for_config_entry(
+        device_registry, config_entry_other.entry_id
+    )
+    assert len(device_entry_other) == 1
     assert any(
-        ("OtherDomain", 7654321) in device.identifiers for device in device_entry
+        ("OtherDomain", 7654321) in device.identifiers for device in device_entry_other
     )

--- a/tests/components/honeywell/test_init.py
+++ b/tests/components/honeywell/test_init.py
@@ -152,16 +152,6 @@ async def test_remove_stale_device(
         merge_identifiers={(DOMAIN, 7654321)},
     )
 
-    device_entry = dr.async_entries_for_config_entry(
-        device_registry, config_entry.entry_id
-    )
-
-    device_registry.async_update_device(
-        device_entry_other.id,
-        add_config_entry_id=config_entry.entry_id,
-        merge_identifiers={("OtherDomain", 7654321)},
-    )
-
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
     assert config_entry.state is ConfigEntryState.LOADED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Correct logic in honeywell for cleaning up stale devices

honeywell should remove itself from devices regardless of if a device has identifiers from other config entries or not.

Based on a discussion in PR https://github.com/home-assistant/core/pull/99743 where the logic from honeywell was copied

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
