### PR TITLE
Ensure it's safe to call Entity.__repr__ on non added entity

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -705,17 +705,6 @@ class SensorEntity(Entity):
 
         return value
 
-    def __repr__(self) -> str:
-        """Return the representation.
-
-        Entity.__repr__ includes the state in the generated string, this fails if we're
-        called before self.hass is set.
-        """
-        if not self.hass:
-            return f"<Entity {self.name}>"
-
-        return super().__repr__()
-
     def _suggested_precision_or_none(self) -> int | None:
         """Return suggested display precision, or None if not set."""
         assert self.registry_entry

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -1289,7 +1289,12 @@ class Entity(ABC):
             self.async_on_remove(self._async_unsubscribe_device_updates)
 
     def __repr__(self) -> str:
-        """Return the representation."""
+        """Return the representation.
+
+        If the entity is not added to a platform it's not safe to call _stringify_state.
+        """
+        if self._platform_state != EntityPlatformState.ADDED:
+            return f"<entity {self.entity_id}={STATE_UNKNOWN}>"
         return f"<entity {self.entity_id}={self._stringify_state(self.available)}>"
 
     async def async_request_call(self, coro: Coroutine[Any, Any, _T]) -> _T:

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1401,8 +1401,8 @@ async def test_translation_key(hass: HomeAssistant) -> None:
     assert mock_entity2.translation_key == "from_entity_description"
 
 
-async def test_repr_using_stringify_state() -> None:
-    """Test that repr uses stringify state."""
+async def test_repr(hass) -> None:
+    """Test Entity.__repr__."""
 
     class MyEntity(MockEntity):
         """Mock entity."""
@@ -1412,8 +1412,19 @@ async def test_repr_using_stringify_state() -> None:
             """Return the state."""
             raise ValueError("Boom")
 
+    platform = MockEntityPlatform(hass, domain="hello")
     my_entity = MyEntity(entity_id="test.test", available=False)
+
+    # Not yet added
+    assert str(my_entity) == "<entity test.test=unknown>"
+
+    # Added
+    await platform.async_add_entities([my_entity])
     assert str(my_entity) == "<entity test.test=unavailable>"
+
+    # Removed
+    await platform.async_remove_entity(my_entity.entity_id)
+    assert str(my_entity) == "<entity test.test=unknown>"
 
 
 async def test_warn_using_async_update_ha_state(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure it's safe to call `Entity.__repr__` on non added entity and remove the overridden `SensorEntity.__repr__` which had the same, not fully working, intention.

Calls to `Entity.__repr__` mostly cause problems when integrations log the entities passed to `add_entities`.

This fixes a crash seen in reolink:
```
2023-12-19 08:28:23.260 ERROR    MainThread homeassistant.components.sensor:entity_platform.py:419 Error while setting up upnp platform for sensor
Traceback (most recent call last):
  File "/home/erik/development/home-assistant_fork/homeassistant/helpers/entity_platform.py", line 361, in _async_setup_platform
    await asyncio.shield(task)
  File "/home/erik/development/home-assistant_fork/homeassistant/components/upnp/sensor.py", line 174, in async_setup_entry
    LOGGER.debug("Adding sensor entities: %s", entities)
  File "/home/erik/.pyenv/versions/3.11.5/lib/python3.11/logging/__init__.py", line 1477, in debug
    self._log(DEBUG, msg, args, **kwargs)
  File "/home/erik/.pyenv/versions/3.11.5/lib/python3.11/logging/__init__.py", line 1634, in _log
    self.handle(record)
  File "/home/erik/.pyenv/versions/3.11.5/lib/python3.11/logging/__init__.py", line 1644, in handle
    self.callHandlers(record)
  File "/home/erik/.pyenv/versions/3.11.5/lib/python3.11/logging/__init__.py", line 1706, in callHandlers
    hdlr.handle(record)
  File "/home/erik/.pyenv/versions/3.11.5/lib/python3.11/logging/__init__.py", line 978, in handle
    self.emit(record)
  File "/home/erik/development/home-assistant_fork/.venv/lib/python3.11/site-packages/_pytest/logging.py", line 372, in emit
    super().emit(record)
  File "/home/erik/.pyenv/versions/3.11.5/lib/python3.11/logging/__init__.py", line 1118, in emit
    self.handleError(record)
  File "/home/erik/.pyenv/versions/3.11.5/lib/python3.11/logging/__init__.py", line 1110, in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "/home/erik/.pyenv/versions/3.11.5/lib/python3.11/logging/__init__.py", line 953, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "/home/erik/development/home-assistant_fork/.venv/lib/python3.11/site-packages/_pytest/logging.py", line 136, in format
    return super().format(record)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/erik/.pyenv/versions/3.11.5/lib/python3.11/logging/__init__.py", line 687, in format
    record.message = record.getMessage()
                     ^^^^^^^^^^^^^^^^^^^
  File "/home/erik/.pyenv/versions/3.11.5/lib/python3.11/logging/__init__.py", line 377, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
  File "/home/erik/development/home-assistant_fork/homeassistant/components/sensor/__init__.py", line 715, in __repr__
    return f"<Entity {self.name}>"
                      ^^^^^^^^^
  File "/home/erik/development/home-assistant_fork/homeassistant/helpers/entity.py", line 500, in name
    return self._name_internal(None, {})
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/erik/development/home-assistant_fork/homeassistant/helpers/entity.py", line 461, in _name_internal
    and (name_translation_key := self._name_translation_key)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/erik/development/home-assistant_fork/homeassistant/backports/functools.py", line 70, in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
  File "/home/erik/development/home-assistant_fork/homeassistant/helpers/entity.py", line 447, in _name_translation_key
    f"component.{platform.platform_name}.entity.{platform.domain}"
                 ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'platform_name'
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
