### PR TITLE
Add binary sensor platform to Tailwind integration

### DIFF
--- a/homeassistant/components/tailwind/__init__.py
+++ b/homeassistant/components/tailwind/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from .const import DOMAIN
 from .coordinator import TailwindDataUpdateCoordinator
 
-PLATFORMS = [Platform.BUTTON, Platform.NUMBER]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.NUMBER]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/tailwind/binary_sensor.py
+++ b/homeassistant/components/tailwind/binary_sensor.py
@@ -1,0 +1,78 @@
+"""Binary sensor entity platform for Tailwind."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from gotailwind.models import TailwindDoor
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import TailwindDataUpdateCoordinator
+from .entity import TailwindDoorEntity
+
+
+@dataclass(kw_only=True, frozen=True)
+class TailwindDoorBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Class describing Tailwind door binary sensor entities."""
+
+    is_on_fn: Callable[[TailwindDoor], bool]
+
+
+DESCRIPTIONS: tuple[TailwindDoorBinarySensorEntityDescription, ...] = (
+    TailwindDoorBinarySensorEntityDescription(
+        key="locked_out",
+        translation_key="operational_status",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:garage-alert",
+        is_on_fn=lambda door: door.locked_out,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Tailwind binary sensor based on a config entry."""
+    coordinator: TailwindDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        TailwindDoorBinarySensorEntity(coordinator, description, door_id)
+        for description in DESCRIPTIONS
+        for door_id in coordinator.data.doors
+    )
+
+
+class TailwindDoorBinarySensorEntity(TailwindDoorEntity, BinarySensorEntity):
+    """Representation of a Tailwind door binary sensor entity."""
+
+    entity_description: TailwindDoorBinarySensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: TailwindDataUpdateCoordinator,
+        description: TailwindDoorBinarySensorEntityDescription,
+        door_id: str,
+    ) -> None:
+        """Initiate Tailwind button entity."""
+        super().__init__(coordinator, door_id)
+        self.entity_description = description
+        self._attr_unique_id = (
+            f"{coordinator.data.device_id}-{door_id}-{description.key}"
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the state of the binary sensor."""
+        return self.entity_description.is_on_fn(
+            self.coordinator.data.doors[self.door_id]
+        )

--- a/homeassistant/components/tailwind/binary_sensor.py
+++ b/homeassistant/components/tailwind/binary_sensor.py
@@ -33,7 +33,7 @@ DESCRIPTIONS: tuple[TailwindDoorBinarySensorEntityDescription, ...] = (
         translation_key="operational_status",
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:garage-alert",
-        is_on_fn=lambda door: door.locked_out,
+        is_on_fn=lambda door: not door.locked_out,
     ),
 )
 

--- a/homeassistant/components/tailwind/entity.py
+++ b/homeassistant/components/tailwind/entity.py
@@ -29,7 +29,7 @@ class TailwindDoorEntity(CoordinatorEntity[TailwindDataUpdateCoordinator]):
     """Defines an Tailwind door entity.
 
     These are the entities that belong to a specific garage door opener
-    that is through to the Tailwind controller.
+    that is connected via the Tailwind controller.
     """
 
     _attr_has_entity_name = True

--- a/homeassistant/components/tailwind/entity.py
+++ b/homeassistant/components/tailwind/entity.py
@@ -23,3 +23,28 @@ class TailwindEntity(CoordinatorEntity[TailwindDataUpdateCoordinator]):
             model=coordinator.data.product,
             sw_version=coordinator.data.firmware_version,
         )
+
+
+class TailwindDoorEntity(CoordinatorEntity[TailwindDataUpdateCoordinator]):
+    """Defines an Tailwind door entity.
+
+    These are the entities that belong to a specific garage door opener
+    that is through to the Tailwind controller.
+    """
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self, coordinator: TailwindDataUpdateCoordinator, door_id: str
+    ) -> None:
+        """Initialize an Tailwind door entity."""
+        self.door_id = door_id
+        super().__init__(coordinator)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{coordinator.data.device_id}-{door_id}")},
+            via_device=(DOMAIN, coordinator.data.device_id),
+            name=f"Door {coordinator.data.doors[door_id].index+1}",
+            manufacturer="Tailwind",
+            model=coordinator.data.product,
+            sw_version=coordinator.data.firmware_version,
+        )

--- a/homeassistant/components/tailwind/strings.json
+++ b/homeassistant/components/tailwind/strings.json
@@ -46,6 +46,15 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "operational_status": {
+        "name": "Operational status",
+        "state": {
+          "on": "Locked out",
+          "off": "Operational"
+        }
+      }
+    },
     "number": {
       "brightness": {
         "name": "Status LED brightness"

--- a/homeassistant/components/tailwind/strings.json
+++ b/homeassistant/components/tailwind/strings.json
@@ -50,8 +50,8 @@
       "operational_status": {
         "name": "Operational status",
         "state": {
-          "on": "Locked out",
-          "off": "Operational"
+          "off": "Locked out",
+          "on": "Operational"
         }
       }
     },

--- a/tests/components/tailwind/snapshots/test_binary_sensor.ambr
+++ b/tests/components/tailwind/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,145 @@
+# serializer version: 1
+# name: test_number_entities
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Door 1 Operational status',
+      'icon': 'mdi:garage-alert',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.door_1_operational_status',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_number_entities.1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.door_1_operational_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:garage-alert',
+    'original_name': 'Operational status',
+    'platform': 'tailwind',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'operational_status',
+    'unique_id': '_3c_e9_e_6d_21_84_-door1-locked_out',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_number_entities.2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'tailwind',
+        '_3c_e9_e_6d_21_84_-door1',
+      ),
+    }),
+    'is_new': False,
+    'manufacturer': 'Tailwind',
+    'model': 'iQ3',
+    'name': 'Door 1',
+    'name_by_user': None,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': '10.10',
+    'via_device_id': None,
+  })
+# ---
+# name: test_number_entities.3
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Door 2 Operational status',
+      'icon': 'mdi:garage-alert',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.door_2_operational_status',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_number_entities.4
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.door_2_operational_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:garage-alert',
+    'original_name': 'Operational status',
+    'platform': 'tailwind',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'operational_status',
+    'unique_id': '_3c_e9_e_6d_21_84_-door2-locked_out',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_number_entities.5
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'tailwind',
+        '_3c_e9_e_6d_21_84_-door2',
+      ),
+    }),
+    'is_new': False,
+    'manufacturer': 'Tailwind',
+    'model': 'iQ3',
+    'name': 'Door 2',
+    'name_by_user': None,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': '10.10',
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/tailwind/snapshots/test_binary_sensor.ambr
+++ b/tests/components/tailwind/snapshots/test_binary_sensor.ambr
@@ -9,7 +9,7 @@
     'entity_id': 'binary_sensor.door_1_operational_status',
     'last_changed': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'on',
   })
 # ---
 # name: test_number_entities.1
@@ -81,7 +81,7 @@
     'entity_id': 'binary_sensor.door_2_operational_status',
     'last_changed': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'on',
   })
 # ---
 # name: test_number_entities.4

--- a/tests/components/tailwind/test_binary_sensor.py
+++ b/tests/components/tailwind/test_binary_sensor.py
@@ -1,0 +1,31 @@
+"""Tests for binary sensor entities provided by the Tailwind integration."""
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+pytestmark = pytest.mark.usefixtures("init_integration")
+
+
+async def test_number_entities(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test binary sensor entities provided by the Tailwind integration."""
+    for entity_id in (
+        "binary_sensor.door_1_operational_status",
+        "binary_sensor.door_2_operational_status",
+    ):
+        assert (state := hass.states.get(entity_id))
+        assert snapshot == state
+
+        assert (entity_entry := entity_registry.async_get(state.entity_id))
+        assert snapshot == entity_entry
+
+        assert entity_entry.device_id
+        assert (device_entry := device_registry.async_get(entity_entry.device_id))
+        assert snapshot == device_entry


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds the binary sensor platform to the Tailwind integration. Initial with an operations status sensor that reports to off in case the door can't be operated, and thus in a locked out state.

![image](https://github.com/home-assistant/core/assets/195327/e0f521ff-952d-453e-8652-e95ecf7ed2b4)

Also in this PR is the initial addition of door devices. The Tailwind iQ3 controller can interface with up to 3 garage door openers.

![CleanShot 2023-12-19 at 10 09 08@2x](https://github.com/home-assistant/core/assets/195327/be4308f8-b1f4-473e-b43f-d8d05720bdec)

--- 

Tailwind provides garage door controllers that work with most garage door openers and communicates fully locally.

More information: https://gotailwind.com/

The development of this integration will consist of multiple pull requests:

- [x] Add the minimal functional integration (#105926)
- [x] Add zeroconf discovery support (#105949)
- [x] Add re-authentication support in case the local key is changed (#105959)
- [x] Add DHCP discovery support for updating config entries (#105981)
- [ ] **Add binary sensor platform** (#106033 This PR!)
- [ ] Add switch platform
- [ ] Add cover platform
- [x] Add button platform (#105961)
- [x] Add diagnostic platform (#105965)
- [ ] Add error handling to service calls (with translatable errors)
- [ ] General cleanup, as most is in at this point
- [ ] Upgrade integration to platinum level
- [ ] Leverage webhooks to make integration push-based

Big thanks to Tailwind for providing the devices for testing ❤️ 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30405

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
