### PR TITLE
Add cover platform to Tailwind integration

### DIFF
--- a/homeassistant/components/tailwind/__init__.py
+++ b/homeassistant/components/tailwind/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from .const import DOMAIN
 from .coordinator import TailwindDataUpdateCoordinator
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.NUMBER]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.COVER, Platform.BUTTON, Platform.NUMBER]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/tailwind/cover.py
+++ b/homeassistant/components/tailwind/cover.py
@@ -1,0 +1,88 @@
+"""Cover entity platform for Tailwind."""
+from __future__ import annotations
+
+from typing import Any
+
+from gotailwind import TailwindDoorOperationCommand, TailwindDoorState
+
+from homeassistant.components.cover import (
+    CoverDeviceClass,
+    CoverEntity,
+    CoverEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import TailwindDataUpdateCoordinator
+from .entity import TailwindDoorEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Tailwind cover based on a config entry."""
+    coordinator: TailwindDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        TailwindDoorCoverEntity(coordinator, door_id)
+        for door_id in coordinator.data.doors
+    )
+
+
+class TailwindDoorCoverEntity(TailwindDoorEntity, CoverEntity):
+    """Representation of a Tailwind door binary sensor entity."""
+
+    _attr_device_class = CoverDeviceClass.GARAGE
+    _attr_is_closing = False
+    _attr_is_opening = False
+    _attr_name = None
+    _attr_supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+
+    def __init__(
+        self,
+        coordinator: TailwindDataUpdateCoordinator,
+        door_id: str,
+    ) -> None:
+        """Initiate Tailwind button entity."""
+        super().__init__(coordinator, door_id)
+        self._attr_unique_id = f"{coordinator.data.device_id}-{door_id}"
+
+    @property
+    def is_closed(self) -> bool:
+        """Return if the cover is closed or not."""
+        return (
+            self.coordinator.data.doors[self.door_id].state == TailwindDoorState.CLOSED
+        )
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open the garage door.
+
+        The Tailwind operating command will await the confirmation of the
+        door being opened before returning.
+        """
+        self._attr_is_opening = True
+        self.async_write_ha_state()
+        await self.coordinator.tailwind.operate(
+            door=self.coordinator.data.doors[self.door_id],
+            operation=TailwindDoorOperationCommand.OPEN,
+        )
+        self._attr_is_opening = False
+        await self.coordinator.async_request_refresh()
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close the garage door.
+
+        The Tailwind operating command will await the confirmation of the
+        door being closed before returning.
+        """
+        self._attr_is_closing = True
+        self.async_write_ha_state()
+        await self.coordinator.tailwind.operate(
+            door=self.coordinator.data.doors[self.door_id],
+            operation=TailwindDoorOperationCommand.CLOSE,
+        )
+        self._attr_is_closing = False
+        await self.coordinator.async_request_refresh()

--- a/tests/components/tailwind/snapshots/test_cover.ambr
+++ b/tests/components/tailwind/snapshots/test_cover.ambr
@@ -1,0 +1,63 @@
+# serializer version: 1
+# name: test_cover_entities[cover.door_1]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.door_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.GARAGE: 'garage'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tailwind',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 3>,
+    'translation_key': None,
+    'unique_id': '_3c_e9_e_6d_21_84_-door1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover_entities[cover.door_2]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.door_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.GARAGE: 'garage'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tailwind',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 3>,
+    'translation_key': None,
+    'unique_id': '_3c_e9_e_6d_21_84_-door2',
+    'unit_of_measurement': None,
+  })
+# ---

--- a/tests/components/tailwind/snapshots/test_cover.ambr
+++ b/tests/components/tailwind/snapshots/test_cover.ambr
@@ -1,5 +1,19 @@
 # serializer version: 1
 # name: test_cover_entities[cover.door_1]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'garage',
+      'friendly_name': 'Door 1',
+      'supported_features': <CoverEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.door_1',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---
+# name: test_cover_entities[cover.door_1].1
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -30,7 +44,49 @@
     'unit_of_measurement': None,
   })
 # ---
+# name: test_cover_entities[cover.door_1].2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'tailwind',
+        '_3c_e9_e_6d_21_84_-door1',
+      ),
+    }),
+    'is_new': False,
+    'manufacturer': 'Tailwind',
+    'model': 'iQ3',
+    'name': 'Door 1',
+    'name_by_user': None,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': '10.10',
+    'via_device_id': None,
+  })
+# ---
 # name: test_cover_entities[cover.door_2]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'garage',
+      'friendly_name': 'Door 2',
+      'supported_features': <CoverEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.door_2',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---
+# name: test_cover_entities[cover.door_2].1
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -59,5 +115,33 @@
     'translation_key': None,
     'unique_id': '_3c_e9_e_6d_21_84_-door2',
     'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover_entities[cover.door_2].2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'tailwind',
+        '_3c_e9_e_6d_21_84_-door2',
+      ),
+    }),
+    'is_new': False,
+    'manufacturer': 'Tailwind',
+    'model': 'iQ3',
+    'name': 'Door 2',
+    'name_by_user': None,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': '10.10',
+    'via_device_id': <ANY>,
   })
 # ---

--- a/tests/components/tailwind/snapshots/test_cover.ambr
+++ b/tests/components/tailwind/snapshots/test_cover.ambr
@@ -142,6 +142,6 @@
     'serial_number': None,
     'suggested_area': None,
     'sw_version': '10.10',
-    'via_device_id': <ANY>,
+    'via_device_id': None,
   })
 # ---

--- a/tests/components/tailwind/test_cover.py
+++ b/tests/components/tailwind/test_cover.py
@@ -17,35 +17,43 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 pytestmark = pytest.mark.usefixtures("init_integration")
 
 
+@pytest.mark.parametrize(
+    "entity_id",
+    [
+        "cover.door_1",
+        "cover.door_2",
+    ],
+)
 async def test_cover_entities(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    mock_tailwind: MagicMock,
     snapshot: SnapshotAssertion,
+    entity_id: str,
 ) -> None:
     """Test cover entities provided by the Tailwind integration."""
-    for entity_id in (
-        "cover.door_1",
-        "cover.door_2",
-    ):
-        assert (state := hass.states.get(entity_id))
-        assert state == snapshot(name=entity_id)
+    assert (state := hass.states.get(entity_id))
+    assert state == snapshot
 
-        assert (entity_entry := entity_registry.async_get(state.entity_id))
-        assert entity_entry == snapshot(name=entity_id)
+    assert (entity_entry := entity_registry.async_get(state.entity_id))
+    assert entity_entry == snapshot
 
-        assert entity_entry.device_id
-        assert (device_entry := device_registry.async_get(entity_entry.device_id))
-        assert device_entry == snapshot(name=entity_id)
+    assert entity_entry.device_id
+    assert (device_entry := device_registry.async_get(entity_entry.device_id))
+    assert device_entry == snapshot
 
-    # Test operating the doors
+
+async def test_cover_operations(
+    hass: HomeAssistant,
+    mock_tailwind: MagicMock,
+) -> None:
+    """Test operating the doors."""
     assert len(mock_tailwind.operate.mock_calls) == 0
     await hass.services.async_call(
         COVER_DOMAIN,
         SERVICE_OPEN_COVER,
         {
-            ATTR_ENTITY_ID: state.entity_id,
+            ATTR_ENTITY_ID: "cover.door_1",
         },
         blocking=True,
     )
@@ -58,7 +66,7 @@ async def test_cover_entities(
         COVER_DOMAIN,
         SERVICE_CLOSE_COVER,
         {
-            ATTR_ENTITY_ID: state.entity_id,
+            ATTR_ENTITY_ID: "cover.door_1",
         },
         blocking=True,
     )

--- a/tests/components/tailwind/test_cover.py
+++ b/tests/components/tailwind/test_cover.py
@@ -1,0 +1,68 @@
+"""Tests for cover entities provided by the Tailwind integration."""
+from unittest.mock import ANY, MagicMock
+
+from gotailwind import TailwindDoorOperationCommand
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.cover import (
+    DOMAIN as COVER_DOMAIN,
+    SERVICE_CLOSE_COVER,
+    SERVICE_OPEN_COVER,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+pytestmark = pytest.mark.usefixtures("init_integration")
+
+
+async def test_cover_entities(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    mock_tailwind: MagicMock,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test cover entities provided by the Tailwind integration."""
+    for entity_id in (
+        "cover.door_1",
+        "cover.door_2",
+    ):
+        assert (state := hass.states.get(entity_id))
+        assert state == snapshot(name=entity_id)
+
+        assert (entity_entry := entity_registry.async_get(state.entity_id))
+        assert entity_entry == snapshot(name=entity_id)
+
+        assert entity_entry.device_id
+        assert (device_entry := device_registry.async_get(entity_entry.device_id))
+        assert device_entry == snapshot(name=entity_id)
+
+    # Test operating the doors
+    assert len(mock_tailwind.operate.mock_calls) == 0
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {
+            ATTR_ENTITY_ID: state.entity_id,
+        },
+        blocking=True,
+    )
+
+    mock_tailwind.operate.assert_called_with(
+        door=ANY, operation=TailwindDoorOperationCommand.OPEN
+    )
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_CLOSE_COVER,
+        {
+            ATTR_ENTITY_ID: state.entity_id,
+        },
+        blocking=True,
+    )
+
+    mock_tailwind.operate.assert_called_with(
+        door=ANY, operation=TailwindDoorOperationCommand.CLOSE
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add the thing that this integration is all about: Covers!

![CleanShot 2023-12-19 at 09 53 22](https://github.com/home-assistant/core/assets/195327/452474f9-948c-4edc-bba8-3a3b14f5404f)

![CleanShot 2023-12-19 at 10 51 21@2x](https://github.com/home-assistant/core/assets/195327/e3f9eebd-3e41-49d8-8f8a-c29c307e4f87)

--- 

Tailwind provides garage door controllers that work with most garage door openers and communicates fully locally.

More information: https://gotailwind.com/

The development of this integration will consist of multiple pull requests:

- [x] Add the minimal functional integration (#105926)
- [x] Add zeroconf discovery support (#105949)
- [x] Add re-authentication support in case the local key is changed (#105959)
- [x] Add DHCP discovery support for updating config entries (#105981)
- [x] Add binary sensor platform (#106033)
- [ ] Add switch platform
- [ ] **Add cover platform** (This PR!)
- [x] Add button platform (#105961)
- [x] Add diagnostic platform (#105965)
- [ ] Add error handling to service calls (with translatable errors)
- [ ] [Flip around locked out binary sensor](https://github.com/home-assistant/core/pull/106033#pullrequestreview-1788465515)
- [ ] Bump gotailwind library to latest version
- [ ] General cleanup, as most is in at this point
- [ ] Upgrade integration to platinum level
- [ ] Leverage webhooks to make integration push-based

Big thanks to Tailwind for providing the devices for testing ❤️ 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30410

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
