### PR TITLE
Add valve support to Amazon Alexa

### DIFF
--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -32,6 +32,7 @@ from homeassistant.components import (
     switch,
     timer,
     vacuum,
+    valve,
     water_heater,
 )
 from homeassistant.const import (
@@ -972,6 +973,31 @@ class VacuumCapabilities(AlexaEntity):
                 self.entity, allow_remote_resume=support_resume
             )
 
+        yield AlexaEndpointHealth(self.hass, self.entity)
+        yield Alexa(self.entity)
+
+
+@ENTITY_ADAPTERS.register(valve.DOMAIN)
+class ValveCapabilities(AlexaEntity):
+    """Class to represent Valve capabilities."""
+
+    def default_display_categories(self) -> list[str]:
+        """Return the display categories for this entity."""
+        return [DisplayCategory.OTHER]
+
+    def interfaces(self) -> Generator[AlexaCapability, None, None]:
+        """Yield the supported interfaces."""
+        supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        if supported & valve.ValveEntityFeature.SET_POSITION:
+            yield AlexaRangeController(
+                self.entity, instance=f"{valve.DOMAIN}.{valve.ATTR_POSITION}"
+            )
+        elif supported & (
+            valve.ValveEntityFeature.CLOSE | valve.ValveEntityFeature.OPEN
+        ):
+            yield AlexaModeController(self.entity, instance=f"{valve.DOMAIN}.state")
+        if supported & valve.ValveEntityFeature.STOP:
+            yield AlexaToggleController(self.entity, instance=f"{valve.DOMAIN}.stop")
         yield AlexaEndpointHealth(self.hass, self.entity)
         yield Alexa(self.entity)
 

--- a/tests/components/alexa/test_capabilities.py
+++ b/tests/components/alexa/test_capabilities.py
@@ -8,6 +8,7 @@ from homeassistant.components.alexa import smart_home
 from homeassistant.components.climate import ATTR_CURRENT_TEMPERATURE, HVACMode
 from homeassistant.components.lock import STATE_JAMMED, STATE_LOCKING, STATE_UNLOCKING
 from homeassistant.components.media_player import MediaPlayerEntityFeature
+from homeassistant.components.valve import ValveEntityFeature
 from homeassistant.components.water_heater import (
     ATTR_OPERATION_LIST,
     ATTR_OPERATION_MODE,
@@ -651,6 +652,143 @@ async def test_report_cover_range_value(hass: HomeAssistant) -> None:
 
     properties = await reported_properties(hass, "cover.closed")
     properties.assert_equal("Alexa.RangeController", "rangeValue", 0)
+
+
+async def test_report_valve_range_value(hass: HomeAssistant) -> None:
+    """Test RangeController reports valve position correctly."""
+    all_valve_features = (
+        ValveEntityFeature.OPEN
+        | ValveEntityFeature.CLOSE
+        | ValveEntityFeature.STOP
+        | ValveEntityFeature.SET_POSITION
+    )
+    hass.states.async_set(
+        "valve.fully_open",
+        "open",
+        {
+            "friendly_name": "Fully open valve",
+            "current_position": 100,
+            "supported_features": all_valve_features,
+        },
+    )
+    hass.states.async_set(
+        "valve.half_open",
+        "open",
+        {
+            "friendly_name": "Half open valve",
+            "current_position": 50,
+            "supported_features": all_valve_features,
+        },
+    )
+    hass.states.async_set(
+        "valve.closed",
+        "closed",
+        {
+            "friendly_name": "Closed valve",
+            "current_position": 0,
+            "supported_features": all_valve_features,
+        },
+    )
+
+    properties = await reported_properties(hass, "valve.fully_open")
+    properties.assert_equal("Alexa.RangeController", "rangeValue", 100)
+
+    properties = await reported_properties(hass, "valve.half_open")
+    properties.assert_equal("Alexa.RangeController", "rangeValue", 50)
+
+    properties = await reported_properties(hass, "valve.closed")
+    properties.assert_equal("Alexa.RangeController", "rangeValue", 0)
+
+
+@pytest.mark.parametrize(
+    (
+        "supported_features",
+        "has_mode_controller",
+        "has_range_controller",
+        "has_toggle_controller",
+    ),
+    [
+        (ValveEntityFeature(0), False, False, False),
+        (
+            ValveEntityFeature.OPEN
+            | ValveEntityFeature.CLOSE
+            | ValveEntityFeature.STOP,
+            True,
+            False,
+            True,
+        ),
+        (
+            ValveEntityFeature.OPEN,
+            True,
+            False,
+            False,
+        ),
+        (
+            ValveEntityFeature.CLOSE,
+            True,
+            False,
+            False,
+        ),
+        (
+            ValveEntityFeature.STOP,
+            False,
+            False,
+            True,
+        ),
+        (
+            ValveEntityFeature.SET_POSITION,
+            False,
+            True,
+            False,
+        ),
+        (
+            ValveEntityFeature.STOP | ValveEntityFeature.SET_POSITION,
+            False,
+            True,
+            True,
+        ),
+        (
+            ValveEntityFeature.OPEN
+            | ValveEntityFeature.CLOSE
+            | ValveEntityFeature.SET_POSITION,
+            False,
+            True,
+            False,
+        ),
+    ],
+)
+async def test_report_valve_controllers(
+    hass: HomeAssistant,
+    supported_features: ValveEntityFeature,
+    has_mode_controller: bool,
+    has_range_controller: bool,
+    has_toggle_controller: bool,
+) -> None:
+    """Test valve controllers are reported correctly."""
+    hass.states.async_set(
+        "valve.custom",
+        "opening",
+        {
+            "friendly_name": "Custom valve",
+            "current_position": 0,
+            "supported_features": supported_features,
+        },
+    )
+
+    properties = await reported_properties(hass, "valve.custom")
+
+    if has_mode_controller:
+        properties.assert_equal("Alexa.ModeController", "mode", "state.opening")
+    else:
+        properties.assert_not_has_property("Alexa.ModeController", "mode")
+    if has_range_controller:
+        properties.assert_equal("Alexa.RangeController", "rangeValue", 0)
+    else:
+        properties.assert_not_has_property("Alexa.RangeController", "rangeValue")
+    if has_toggle_controller:
+        properties.assert_equal("Alexa.ToggleController", "toggleState", "OFF")
+    else:
+        properties.assert_not_has_property("Alexa.ToggleController", "toggleState")
 
 
 async def test_report_climate_state(hass: HomeAssistant) -> None:

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -9,8 +9,14 @@ import homeassistant.components.camera as camera
 from homeassistant.components.cover import CoverDeviceClass, CoverEntityFeature
 from homeassistant.components.media_player import MediaPlayerEntityFeature
 from homeassistant.components.vacuum import VacuumEntityFeature
+from homeassistant.components.valve import SERVICE_STOP_VALVE, ValveEntityFeature
 from homeassistant.config import async_process_ha_core_config
-from homeassistant.const import STATE_UNKNOWN, UnitOfTemperature
+from homeassistant.const import (
+    SERVICE_CLOSE_VALVE,
+    SERVICE_OPEN_VALVE,
+    STATE_UNKNOWN,
+    UnitOfTemperature,
+)
 from homeassistant.core import Context, Event, HomeAssistant
 from homeassistant.helpers import entityfilter
 from homeassistant.setup import async_setup_component
@@ -156,7 +162,7 @@ def assert_endpoint_capabilities(endpoint, *interfaces):
     capabilities = endpoint["capabilities"]
     supported = {feature["interface"] for feature in capabilities}
 
-    assert supported == set(interfaces)
+    assert supported == {interface for interface in interfaces if interface is not None}
     return capabilities
 
 
@@ -2069,6 +2075,216 @@ async def test_cover_position(
     assert properties["value"] == position
 
 
+@pytest.mark.parametrize(
+    (
+        "position",
+        "position_attr_in_service_call",
+        "supported_features",
+        "service_call",
+        "has_toggle_controller",
+    ),
+    [
+        (
+            30,
+            30,
+            ValveEntityFeature.SET_POSITION
+            | ValveEntityFeature.OPEN
+            | ValveEntityFeature.CLOSE
+            | ValveEntityFeature.STOP,
+            "valve.set_valve_position",
+            True,
+        ),
+        (
+            0,
+            None,
+            ValveEntityFeature.SET_POSITION
+            | ValveEntityFeature.OPEN
+            | ValveEntityFeature.CLOSE,
+            "valve.close_valve",
+            False,
+        ),
+        (
+            99,
+            99,
+            ValveEntityFeature.SET_POSITION
+            | ValveEntityFeature.OPEN
+            | ValveEntityFeature.CLOSE,
+            "valve.set_valve_position",
+            False,
+        ),
+        (
+            100,
+            None,
+            ValveEntityFeature.SET_POSITION
+            | ValveEntityFeature.OPEN
+            | ValveEntityFeature.CLOSE,
+            "valve.open_valve",
+            False,
+        ),
+        (
+            0,
+            0,
+            ValveEntityFeature.SET_POSITION,
+            "valve.set_valve_position",
+            False,
+        ),
+        (
+            60,
+            60,
+            ValveEntityFeature.SET_POSITION,
+            "valve.set_valve_position",
+            False,
+        ),
+        (
+            60,
+            60,
+            ValveEntityFeature.SET_POSITION | ValveEntityFeature.STOP,
+            "valve.set_valve_position",
+            True,
+        ),
+        (
+            100,
+            100,
+            ValveEntityFeature.SET_POSITION,
+            "valve.set_valve_position",
+            False,
+        ),
+        (
+            0,
+            0,
+            ValveEntityFeature.SET_POSITION | ValveEntityFeature.OPEN,
+            "valve.set_valve_position",
+            False,
+        ),
+        (
+            100,
+            100,
+            ValveEntityFeature.SET_POSITION | ValveEntityFeature.CLOSE,
+            "valve.set_valve_position",
+            False,
+        ),
+    ],
+    ids=[
+        "position_30_open_close_stop",
+        "position_0_open_close",
+        "position_99_open_close",
+        "position_100_open_close",
+        "position_0_no_open_close",
+        "position_60_no_open_close",
+        "position_60_stop_no_open_close",
+        "position_100_no_open_close",
+        "position_0_no_close",
+        "position_100_no_open",
+    ],
+)
+async def test_valve_position(
+    hass: HomeAssistant,
+    position: int,
+    position_attr_in_service_call: int | None,
+    supported_features: CoverEntityFeature,
+    service_call: str,
+    has_toggle_controller: bool,
+) -> None:
+    """Test cover discovery and position using rangeController."""
+    device = (
+        "valve.test_range",
+        "open",
+        {
+            "friendly_name": "Test valve range",
+            "device_class": "water",
+            "supported_features": supported_features,
+            "position": position,
+        },
+    )
+    appliance = await discovery_test(device, hass)
+
+    assert appliance["endpointId"] == "valve#test_range"
+    assert appliance["displayCategories"][0] == "OTHER"
+    assert appliance["friendlyName"] == "Test valve range"
+
+    capabilities = assert_endpoint_capabilities(
+        appliance,
+        "Alexa.RangeController",
+        "Alexa.EndpointHealth",
+        "Alexa.ToggleController" if has_toggle_controller else None,
+        "Alexa",
+    )
+
+    range_capability = get_capability(capabilities, "Alexa.RangeController")
+    assert range_capability is not None
+    assert range_capability["instance"] == "valve.position"
+
+    properties = range_capability["properties"]
+    assert properties["nonControllable"] is False
+    assert {"name": "rangeValue"} in properties["supported"]
+
+    capability_resources = range_capability["capabilityResources"]
+    assert capability_resources is not None
+    assert {
+        "@type": "text",
+        "value": {"text": "Opening", "locale": "en-US"},
+    } in capability_resources["friendlyNames"]
+
+    assert {
+        "@type": "asset",
+        "value": {"assetId": "Alexa.Setting.Opening"},
+    } in capability_resources["friendlyNames"]
+
+    configuration = range_capability["configuration"]
+    assert configuration is not None
+    assert configuration["unitOfMeasure"] == "Alexa.Unit.Percent"
+
+    supported_range = configuration["supportedRange"]
+    assert supported_range["minimumValue"] == 0
+    assert supported_range["maximumValue"] == 100
+    assert supported_range["precision"] == 1
+
+    # Assert for Position Semantics
+    position_semantics = range_capability["semantics"]
+    assert position_semantics is not None
+
+    position_action_mappings = position_semantics["actionMappings"]
+    assert position_action_mappings is not None
+    assert {
+        "@type": "ActionsToDirective",
+        "actions": ["Alexa.Actions.Close"],
+        "directive": {"name": "SetRangeValue", "payload": {"rangeValue": 0}},
+    } in position_action_mappings
+    assert {
+        "@type": "ActionsToDirective",
+        "actions": ["Alexa.Actions.Open"],
+        "directive": {"name": "SetRangeValue", "payload": {"rangeValue": 100}},
+    } in position_action_mappings
+
+    position_state_mappings = position_semantics["stateMappings"]
+    assert position_state_mappings is not None
+    assert {
+        "@type": "StatesToValue",
+        "states": ["Alexa.States.Closed"],
+        "value": 0,
+    } in position_state_mappings
+    assert {
+        "@type": "StatesToRange",
+        "states": ["Alexa.States.Open"],
+        "range": {"minimumValue": 1, "maximumValue": 100},
+    } in position_state_mappings
+
+    call, msg = await assert_request_calls_service(
+        "Alexa.RangeController",
+        "SetRangeValue",
+        "valve#test_range",
+        service_call,
+        hass,
+        payload={"rangeValue": position},
+        instance="valve.position",
+    )
+    assert call.data.get("position") == position_attr_in_service_call
+    properties = msg["context"]["properties"][0]
+    assert properties["name"] == "rangeValue"
+    assert properties["namespace"] == "Alexa.RangeController"
+    assert properties["value"] == position
+
+
 async def test_cover_position_range(
     hass: HomeAssistant,
 ) -> None:
@@ -2184,6 +2400,208 @@ async def test_cover_position_range(
         "position",
         instance="cover.position",
     )
+
+
+async def test_valve_position_range(
+    hass: HomeAssistant,
+) -> None:
+    """Test valve discovery and position range using rangeController.
+
+    Also tests an invalid valve position being handled correctly.
+    """
+
+    device = (
+        "valve.test_range",
+        "open",
+        {
+            "friendly_name": "Test valve range",
+            "device_class": "water",
+            "supported_features": 15,
+            "position": 30,
+        },
+    )
+    appliance = await discovery_test(device, hass)
+
+    assert appliance["endpointId"] == "valve#test_range"
+    assert appliance["displayCategories"][0] == "OTHER"
+    assert appliance["friendlyName"] == "Test valve range"
+
+    capabilities = assert_endpoint_capabilities(
+        appliance,
+        "Alexa.RangeController",
+        "Alexa.EndpointHealth",
+        "Alexa.ToggleController",
+        "Alexa",
+    )
+
+    range_capability = get_capability(capabilities, "Alexa.RangeController")
+    assert range_capability is not None
+    assert range_capability["instance"] == "valve.position"
+
+    properties = range_capability["properties"]
+    assert properties["nonControllable"] is False
+    assert {"name": "rangeValue"} in properties["supported"]
+
+    capability_resources = range_capability["capabilityResources"]
+    assert capability_resources is not None
+    assert {
+        "@type": "text",
+        "value": {"text": "Opening", "locale": "en-US"},
+    } in capability_resources["friendlyNames"]
+
+    assert {
+        "@type": "asset",
+        "value": {"assetId": "Alexa.Setting.Opening"},
+    } in capability_resources["friendlyNames"]
+
+    configuration = range_capability["configuration"]
+    assert configuration is not None
+    assert configuration["unitOfMeasure"] == "Alexa.Unit.Percent"
+
+    supported_range = configuration["supportedRange"]
+    assert supported_range["minimumValue"] == 0
+    assert supported_range["maximumValue"] == 100
+    assert supported_range["precision"] == 1
+
+    # Assert for Position Semantics
+    position_semantics = range_capability["semantics"]
+    assert position_semantics is not None
+
+    position_action_mappings = position_semantics["actionMappings"]
+    assert position_action_mappings is not None
+    assert {
+        "@type": "ActionsToDirective",
+        "actions": ["Alexa.Actions.Close"],
+        "directive": {"name": "SetRangeValue", "payload": {"rangeValue": 0}},
+    } in position_action_mappings
+    assert {
+        "@type": "ActionsToDirective",
+        "actions": ["Alexa.Actions.Open"],
+        "directive": {"name": "SetRangeValue", "payload": {"rangeValue": 100}},
+    } in position_action_mappings
+
+    position_state_mappings = position_semantics["stateMappings"]
+    assert position_state_mappings is not None
+    assert {
+        "@type": "StatesToValue",
+        "states": ["Alexa.States.Closed"],
+        "value": 0,
+    } in position_state_mappings
+    assert {
+        "@type": "StatesToRange",
+        "states": ["Alexa.States.Open"],
+        "range": {"minimumValue": 1, "maximumValue": 100},
+    } in position_state_mappings
+
+    call, msg = await assert_request_calls_service(
+        "Alexa.RangeController",
+        "AdjustRangeValue",
+        "valve#test_range",
+        "valve.open_valve",
+        hass,
+        payload={"rangeValueDelta": 101, "rangeValueDeltaDefault": False},
+        instance="valve.position",
+    )
+    properties = msg["context"]["properties"][0]
+    assert properties["name"] == "rangeValue"
+    assert properties["namespace"] == "Alexa.RangeController"
+    assert properties["value"] == 100
+    assert call.service == SERVICE_OPEN_VALVE
+
+    call, msg = await assert_request_calls_service(
+        "Alexa.RangeController",
+        "AdjustRangeValue",
+        "valve#test_range",
+        "valve.close_valve",
+        hass,
+        payload={"rangeValueDelta": -99, "rangeValueDeltaDefault": False},
+        instance="valve.position",
+    )
+    properties = msg["context"]["properties"][0]
+    assert properties["name"] == "rangeValue"
+    assert properties["namespace"] == "Alexa.RangeController"
+    assert properties["value"] == 0
+    assert call.service == SERVICE_CLOSE_VALVE
+
+    await assert_range_changes(
+        hass,
+        [(25, -5, False), (35, 5, False), (50, 1, True), (10, -1, True)],
+        "Alexa.RangeController",
+        "AdjustRangeValue",
+        "valve#test_range",
+        "valve.set_valve_position",
+        "position",
+        instance="valve.position",
+    )
+
+
+@pytest.mark.parametrize(
+    ("supported_features", "state_controller"),
+    [
+        (
+            ValveEntityFeature.SET_POSITION | ValveEntityFeature.STOP,
+            "Alexa.RangeController",
+        ),
+        (
+            ValveEntityFeature.OPEN
+            | ValveEntityFeature.CLOSE
+            | ValveEntityFeature.STOP,
+            "Alexa.ModeController",
+        ),
+    ],
+)
+async def test_stop_valve(
+    hass: HomeAssistant, supported_features: ValveEntityFeature, state_controller: str
+) -> None:
+    """Test stop valve ToggleController."""
+    device = (
+        "valve.test",
+        "opening",
+        {
+            "friendly_name": "Test valve",
+            "supported_features": supported_features,
+            "current_position": 30,
+        },
+    )
+    appliance = await discovery_test(device, hass)
+
+    assert appliance["endpointId"] == "valve#test"
+    assert appliance["displayCategories"][0] == "OTHER"
+    assert appliance["friendlyName"] == "Test valve"
+    capabilities = assert_endpoint_capabilities(
+        appliance,
+        state_controller,
+        "Alexa.ToggleController",
+        "Alexa.EndpointHealth",
+        "Alexa",
+    )
+
+    toggle_capability = get_capability(capabilities, "Alexa.ToggleController")
+    assert toggle_capability is not None
+    assert toggle_capability["instance"] == "valve.stop"
+
+    properties = toggle_capability["properties"]
+    assert properties["nonControllable"] is False
+    assert {"name": "toggleState"} in properties["supported"]
+
+    capability_resources = toggle_capability["capabilityResources"]
+    assert capability_resources is not None
+    assert {
+        "@type": "text",
+        "value": {"text": "Stop", "locale": "en-US"},
+    } in capability_resources["friendlyNames"]
+
+    call, _ = await assert_request_calls_service(
+        "Alexa.ToggleController",
+        "TurnOn",
+        "valve#test",
+        "valve.stop_valve",
+        hass,
+        payload={},
+        instance="valve.stop",
+    )
+    assert call.data["entity_id"] == "valve.test"
+    assert call.service == SERVICE_STOP_VALVE
 
 
 async def assert_percentage_changes(
@@ -3665,6 +4083,137 @@ async def test_cover_position_mode(hass: HomeAssistant) -> None:
     assert properties["name"] == "mode"
     assert properties["namespace"] == "Alexa.ModeController"
     assert properties["value"] == "position.custom"
+
+
+async def test_valve_position_mode(hass: HomeAssistant) -> None:
+    """Test valve discovery and position using modeController."""
+    device = (
+        "valve.test_mode",
+        "open",
+        {
+            "friendly_name": "Test valve mode",
+            "device_class": "water",
+            "supported_features": ValveEntityFeature.OPEN
+            | ValveEntityFeature.CLOSE
+            | ValveEntityFeature.STOP,
+        },
+    )
+    appliance = await discovery_test(device, hass)
+
+    assert appliance["endpointId"] == "valve#test_mode"
+    assert appliance["displayCategories"][0] == "OTHER"
+    assert appliance["friendlyName"] == "Test valve mode"
+
+    capabilities = assert_endpoint_capabilities(
+        appliance,
+        "Alexa.ModeController",
+        "Alexa.EndpointHealth",
+        "Alexa.ToggleController",
+        "Alexa",
+    )
+
+    mode_capability = get_capability(capabilities, "Alexa.ModeController")
+    assert mode_capability is not None
+    assert mode_capability["instance"] == "valve.state"
+
+    properties = mode_capability["properties"]
+    assert properties["nonControllable"] is False
+    assert {"name": "mode"} in properties["supported"]
+
+    capability_resources = mode_capability["capabilityResources"]
+    assert capability_resources is not None
+    assert {
+        "@type": "text",
+        "value": {"text": "Preset", "locale": "en-US"},
+    } in capability_resources["friendlyNames"]
+
+    assert {
+        "@type": "asset",
+        "value": {"assetId": "Alexa.Setting.Preset"},
+    } in capability_resources["friendlyNames"]
+
+    configuration = mode_capability["configuration"]
+    assert configuration is not None
+    assert configuration["ordered"] is False
+
+    supported_modes = configuration["supportedModes"]
+    assert supported_modes is not None
+    assert {
+        "value": "state.open",
+        "modeResources": {
+            "friendlyNames": [
+                {"@type": "text", "value": {"text": "Open", "locale": "en-US"}},
+                {"@type": "asset", "value": {"assetId": "Alexa.Setting.Preset"}},
+            ]
+        },
+    } in supported_modes
+    assert {
+        "value": "state.closed",
+        "modeResources": {
+            "friendlyNames": [
+                {"@type": "text", "value": {"text": "Closed", "locale": "en-US"}},
+                {"@type": "asset", "value": {"assetId": "Alexa.Setting.Preset"}},
+            ]
+        },
+    } in supported_modes
+
+    # Assert for Position Semantics
+    position_semantics = mode_capability["semantics"]
+    assert position_semantics is not None
+
+    position_action_mappings = position_semantics["actionMappings"]
+    assert position_action_mappings is not None
+    assert {
+        "@type": "ActionsToDirective",
+        "actions": ["Alexa.Actions.Close"],
+        "directive": {"name": "SetMode", "payload": {"mode": "state.closed"}},
+    } in position_action_mappings
+    assert {
+        "@type": "ActionsToDirective",
+        "actions": ["Alexa.Actions.Open"],
+        "directive": {"name": "SetMode", "payload": {"mode": "state.open"}},
+    } in position_action_mappings
+
+    position_state_mappings = position_semantics["stateMappings"]
+    assert position_state_mappings is not None
+    assert {
+        "@type": "StatesToValue",
+        "states": ["Alexa.States.Closed"],
+        "value": "state.closed",
+    } in position_state_mappings
+    assert {
+        "@type": "StatesToValue",
+        "states": ["Alexa.States.Open"],
+        "value": "state.open",
+    } in position_state_mappings
+
+    _, msg = await assert_request_calls_service(
+        "Alexa.ModeController",
+        "SetMode",
+        "valve#test_mode",
+        "valve.close_valve",
+        hass,
+        payload={"mode": "state.closed"},
+        instance="valve.state",
+    )
+    properties = msg["context"]["properties"][0]
+    assert properties["name"] == "mode"
+    assert properties["namespace"] == "Alexa.ModeController"
+    assert properties["value"] == "state.closed"
+
+    _, msg = await assert_request_calls_service(
+        "Alexa.ModeController",
+        "SetMode",
+        "valve#test_mode",
+        "valve.open_valve",
+        hass,
+        payload={"mode": "state.open"},
+        instance="valve.state",
+    )
+    properties = msg["context"]["properties"][0]
+    assert properties["name"] == "mode"
+    assert properties["namespace"] == "Alexa.ModeController"
+    assert properties["value"] == "state.open"
 
 
 async def test_image_processing(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add valve support to Amazon Alexa.

#### Screenshots

State based valeve and vale that reports a position with stop feature:

<img src="https://github.com/home-assistant/core/assets/7188918/0469ffc6-cf17-4a60-9a5e-792fe9e49f44" width="30%" height="30%"> <img src="https://github.com/home-assistant/core/assets/7188918/b308c60b-dcb5-417e-a4ff-7ea73e12412a" width="30%" height="30%">

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30414

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
