### PR TITLE
Add valve platform for Shelly Gas Valve

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -63,6 +63,7 @@ BLOCK_PLATFORMS: Final = [
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.UPDATE,
+    Platform.VALVE,
 ]
 BLOCK_SLEEPING_PLATFORMS: Final = [
     Platform.BINARY_SENSOR,

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -163,7 +163,7 @@
     },
     "deprecated_valve_switch": {
       "title": "The switch entity for Shelly Gas Valve is deprecated",
-      "description": "The switch entity for Shelly Gas Valve is deprecated, a valve entity is available and should be used going forward."
+      "description": "The switch entity for Shelly Gas Valve is deprecated. A valve entity {entity} is available and should be used going forward. For this new valve entity you need to use {service} service."
     },
     "deprecated_valve_switch_entity": {
       "title": "Deprecated switch entity for Shelly Gas Valve detected in {info}",

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -160,6 +160,14 @@
     "push_update_failure": {
       "title": "Shelly device {device_name} push update failure",
       "description": "Home Assistant is not receiving push updates from the Shelly device {device_name} with IP address {ip_address}. Check the CoIoT configuration in the web panel of the device and your network configuration."
+    },
+    "deprecated_valve_switch": {
+      "title": "The switch entity for Shelly Gas Valve is deprecated",
+      "description": "The switch entity for Shelly Gas Valve is deprecated, a valve entity is available and should be used going forward."
+    },
+    "deprecated_valve_switch_entity": {
+      "title": "Deprecated switch entity for Shelly Gas Valve detected in {info}",
+      "description": "Your Shelly Gas Valve entity `{entity}` is being used in `{info}`. A valve entity is available and should be used going forward.\n\nPlease adjust `{info}` to fix this issue."
     }
   }
 }

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -42,6 +42,7 @@ class BlockSwitchDescription(BlockEntityDescription, SwitchEntityDescription):
     """Class to describe a BLOCK switch."""
 
 
+# This entity description is deprecated and will be removed in Home Assistant 2024.7.0.
 GAS_VALVE_SWITCH = BlockSwitchDescription(
     key="valve|valve",
     name="Valve",
@@ -145,7 +146,10 @@ def async_setup_rpc_entry(
 
 
 class BlockValveSwitch(ShellyBlockAttributeEntity, SwitchEntity):
-    """Entity that controls a Gas Valve on Block based Shelly devices."""
+    """Entity that controls a Gas Valve on Block based Shelly devices.
+
+    This class is deprecated and will be removed in Home Assistant 2024.7.0.
+    """
 
     entity_description: BlockSwitchDescription
 
@@ -179,7 +183,7 @@ class BlockValveSwitch(ShellyBlockAttributeEntity, SwitchEntity):
             self.hass,
             DOMAIN,
             "deprecated_valve_switch",
-            breaks_in_ha_version="2024.6.0",
+            breaks_in_ha_version="2024.7.0",
             is_fixable=False,
             severity=IssueSeverity.WARNING,
             translation_key="deprecated_valve_switche",
@@ -193,7 +197,7 @@ class BlockValveSwitch(ShellyBlockAttributeEntity, SwitchEntity):
             self.hass,
             DOMAIN,
             "deprecated_valve_switch",
-            breaks_in_ha_version="2024.6.0",
+            breaks_in_ha_version="2024.7.0",
             is_fixable=False,
             severity=IssueSeverity.WARNING,
             translation_key="deprecated_valve_switche",
@@ -212,7 +216,7 @@ class BlockValveSwitch(ShellyBlockAttributeEntity, SwitchEntity):
                 self.hass,
                 DOMAIN,
                 f"deprecated_valve_{self.entity_id}_{item}",
-                breaks_in_ha_version="2024.6.0",
+                breaks_in_ha_version="2024.7.0",
                 is_fixable=False,
                 severity=IssueSeverity.WARNING,
                 translation_key="deprecated_valve_switch_entity",

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -14,6 +14,7 @@ from homeassistant.components.switch import (
     SwitchEntity,
     SwitchEntityDescription,
 )
+from homeassistant.components.valve import DOMAIN as VALVE_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -187,6 +188,10 @@ class BlockValveSwitch(ShellyBlockAttributeEntity, SwitchEntity):
             is_fixable=True,
             severity=IssueSeverity.WARNING,
             translation_key="deprecated_valve_switch",
+            translation_placeholders={
+                "entity": f"{VALVE_DOMAIN}.{cast(str, self.name).lower().replace(' ', '_')}",
+                "service": f"{VALVE_DOMAIN}.open_valve",
+            },
         )
         self.control_result = await self.set_state(go="open")
         self.async_write_ha_state()
@@ -201,6 +206,10 @@ class BlockValveSwitch(ShellyBlockAttributeEntity, SwitchEntity):
             is_fixable=True,
             severity=IssueSeverity.WARNING,
             translation_key="deprecated_valve_switche",
+            translation_placeholders={
+                "entity": f"{VALVE_DOMAIN}.{cast(str, self.name).lower().replace(' ', '_')}",
+                "service": f"{VALVE_DOMAIN}.close_valve",
+            },
         )
         self.control_result = await self.set_state(go="close")
         self.async_write_ha_state()

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -184,7 +184,7 @@ class BlockValveSwitch(ShellyBlockAttributeEntity, SwitchEntity):
             DOMAIN,
             "deprecated_valve_switch",
             breaks_in_ha_version="2024.7.0",
-            is_fixable=False,
+            is_fixable=True,
             severity=IssueSeverity.WARNING,
             translation_key="deprecated_valve_switch",
         )
@@ -198,7 +198,7 @@ class BlockValveSwitch(ShellyBlockAttributeEntity, SwitchEntity):
             DOMAIN,
             "deprecated_valve_switch",
             breaks_in_ha_version="2024.7.0",
-            is_fixable=False,
+            is_fixable=True,
             severity=IssueSeverity.WARNING,
             translation_key="deprecated_valve_switche",
         )
@@ -217,7 +217,7 @@ class BlockValveSwitch(ShellyBlockAttributeEntity, SwitchEntity):
                 DOMAIN,
                 f"deprecated_valve_{self.entity_id}_{item}",
                 breaks_in_ha_version="2024.7.0",
-                is_fixable=False,
+                is_fixable=True,
                 severity=IssueSeverity.WARNING,
                 translation_key="deprecated_valve_switch_entity",
                 translation_placeholders={

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -19,7 +19,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 
-from .const import DOMAIN, GAS_VALVE_OPEN_STATES, LOGGER, MODEL_WALL_DISPLAY
+from .const import DOMAIN, GAS_VALVE_OPEN_STATES, MODEL_WALL_DISPLAY
 from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator, get_entry_data
 from .entity import (
     BlockEntityDescription,
@@ -208,7 +208,6 @@ class BlockValveSwitch(ShellyBlockAttributeEntity, SwitchEntity):
         entity_automations = automations_with_entity(self.hass, self.entity_id)
         entity_scripts = scripts_with_entity(self.hass, self.entity_id)
         for item in entity_automations + entity_scripts:
-            LOGGER.warning(f"deprecated_valve_{self.entity_id}_{item}")
             async_create_issue(
                 self.hass,
                 DOMAIN,

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -40,6 +40,7 @@ GAS_VALVE_SWITCH = BlockSwitchDescription(
     name="Valve",
     available=lambda block: block.valve not in ("failure", "checking"),
     removal_condition=lambda _, block: block.valve in ("not_connected", "unknown"),
+    entity_registry_enabled_default=False,
 )
 
 

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -186,7 +186,7 @@ class BlockValveSwitch(ShellyBlockAttributeEntity, SwitchEntity):
             breaks_in_ha_version="2024.7.0",
             is_fixable=False,
             severity=IssueSeverity.WARNING,
-            translation_key="deprecated_valve_switche",
+            translation_key="deprecated_valve_switch",
         )
         self.control_result = await self.set_state(go="open")
         self.async_write_ha_state()

--- a/homeassistant/components/shelly/valve.py
+++ b/homeassistant/components/shelly/valve.py
@@ -85,14 +85,7 @@ class BlockShellyValve(ShellyBlockAttributeEntity, ValveEntity):
         """Initialize block valve."""
         super().__init__(coordinator, block, attribute, description)
         self.control_result: dict[str, Any] | None = None
-
-    @property
-    def is_closed(self) -> bool:
-        """Return if the valve is closed or not."""
-        if self.control_result:
-            return self.control_result["state"] == "closed"
-
-        return self.attribute_value == "closed"
+        self._attr_is_closed = bool(self.attribute_value == "closed")
 
     @property
     def is_closing(self) -> bool:
@@ -124,4 +117,5 @@ class BlockShellyValve(ShellyBlockAttributeEntity, ValveEntity):
     def _update_callback(self) -> None:
         """When device updates, clear control result that overrides state."""
         self.control_result = None
+        self._attr_is_closed = bool(self.attribute_value == "closed")
         super()._update_callback()

--- a/homeassistant/components/shelly/valve.py
+++ b/homeassistant/components/shelly/valve.py
@@ -1,0 +1,121 @@
+"""Valve for Shelly."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from aioshelly.block_device import Block
+from aioshelly.const import BLOCK_GENERATIONS, MODEL_GAS
+
+from homeassistant.components.valve import (
+    ValveDeviceClass,
+    ValveEntity,
+    ValveEntityDescription,
+    ValveEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .coordinator import ShellyBlockCoordinator, get_entry_data
+from .entity import (
+    BlockEntityDescription,
+    ShellyBlockEntity,
+    async_setup_block_attribute_entities,
+)
+from .utils import get_device_entry_gen
+
+
+@dataclass(frozen=True)
+class BlockValveDescription(BlockEntityDescription, ValveEntityDescription):
+    """Class to describe a BLOCK valve."""
+
+
+GAS_VALVE = BlockValveDescription(
+    key="valve|valve",
+    name="Valve",
+    available=lambda block: block.valve not in ("failure", "checking"),
+    removal_condition=lambda _, block: block.valve in ("not_connected", "unknown"),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up valves for device."""
+    if get_device_entry_gen(config_entry) in BLOCK_GENERATIONS:
+        return async_setup_block_entry(hass, config_entry, async_add_entities)
+
+
+@callback
+def async_setup_block_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up valve for device."""
+    coordinator = get_entry_data(hass)[config_entry.entry_id].block
+    assert coordinator and coordinator.device.blocks
+
+    if coordinator.model == MODEL_GAS:
+        async_setup_block_attribute_entities(
+            hass,
+            async_add_entities,
+            coordinator,
+            {("valve", "valve"): GAS_VALVE},
+            BlockShellyValve,
+        )
+
+
+class BlockShellyValve(ShellyBlockEntity, ValveEntity):
+    """Entity that controls a valve on block based Shelly devices."""
+
+    _attr_device_class = ValveDeviceClass.GAS
+    _attr_supported_features = ValveEntityFeature.OPEN | ValveEntityFeature.CLOSE
+
+    def __init__(self, coordinator: ShellyBlockCoordinator, block: Block) -> None:
+        """Initialize block valve."""
+        super().__init__(coordinator, block)
+        self.control_result: dict[str, Any] | None = None
+
+    @property
+    def is_closed(self) -> bool:
+        """Return if the valve is closed or not."""
+        if self.control_result:
+            return self.control_result["state"] == "closed"
+
+        return self.attribute_value == "closed"
+
+    @property
+    def is_closing(self) -> bool:
+        """Return if the valve is closing."""
+        if self.control_result:
+            return self.control_result["state"] == "closing"
+
+        return self.attribute_value == "closing"
+
+    @property
+    def is_opening(self) -> bool:
+        """Return if the valve is opening."""
+        if self.control_result:
+            return self.control_result["state"] == "opening"
+
+        return self.attribute_value == "opening"
+
+    async def async_open_valve(self, **kwargs: Any) -> None:
+        """Open valve."""
+        self.control_result = await self.set_state(go="open")
+        self.async_write_ha_state()
+
+    async def async_close_valve(self, **kwargs: Any) -> None:
+        """Close valve."""
+        self.control_result = await self.set_state(go="close")
+        self.async_write_ha_state()
+
+    @callback
+    def _update_callback(self) -> None:
+        """When device updates, clear control result that overrides state."""
+        self.control_result = None
+        super()._update_callback()

--- a/homeassistant/components/shelly/valve.py
+++ b/homeassistant/components/shelly/valve.py
@@ -26,7 +26,7 @@ from .entity import (
 from .utils import get_device_entry_gen
 
 
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class BlockValveDescription(BlockEntityDescription, ValveEntityDescription):
     """Class to describe a BLOCK valve."""
 
@@ -46,7 +46,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up valves for device."""
     if get_device_entry_gen(config_entry) in BLOCK_GENERATIONS:
-        return async_setup_block_entry(hass, config_entry, async_add_entities)
+        async_setup_block_entry(hass, config_entry, async_add_entities)
 
 
 @callback

--- a/homeassistant/components/shelly/valve.py
+++ b/homeassistant/components/shelly/valve.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .coordinator import ShellyBlockCoordinator, get_entry_data
 from .entity import (
     BlockEntityDescription,
-    ShellyBlockEntity,
+    ShellyBlockAttributeEntity,
     async_setup_block_attribute_entities,
 )
 from .utils import get_device_entry_gen
@@ -69,15 +69,21 @@ def async_setup_block_entry(
         )
 
 
-class BlockShellyValve(ShellyBlockEntity, ValveEntity):
+class BlockShellyValve(ShellyBlockAttributeEntity, ValveEntity):
     """Entity that controls a valve on block based Shelly devices."""
 
     _attr_device_class = ValveDeviceClass.GAS
     _attr_supported_features = ValveEntityFeature.OPEN | ValveEntityFeature.CLOSE
 
-    def __init__(self, coordinator: ShellyBlockCoordinator, block: Block) -> None:
+    def __init__(
+        self,
+        coordinator: ShellyBlockCoordinator,
+        block: Block,
+        attribute: str,
+        description: BlockValveDescription,
+    ) -> None:
         """Initialize block valve."""
-        super().__init__(coordinator, block)
+        super().__init__(coordinator, block, attribute, description)
         self.control_result: dict[str, Any] | None = None
 
     @property

--- a/homeassistant/components/shelly/valve.py
+++ b/homeassistant/components/shelly/valve.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 from aioshelly.block_device import Block
 from aioshelly.const import BLOCK_GENERATIONS, MODEL_GAS
@@ -72,6 +72,7 @@ def async_setup_block_entry(
 class BlockShellyValve(ShellyBlockAttributeEntity, ValveEntity):
     """Entity that controls a valve on block based Shelly devices."""
 
+    entity_description: BlockValveDescription
     _attr_device_class = ValveDeviceClass.GAS
     _attr_supported_features = ValveEntityFeature.OPEN | ValveEntityFeature.CLOSE
 
@@ -91,7 +92,7 @@ class BlockShellyValve(ShellyBlockAttributeEntity, ValveEntity):
     def is_closing(self) -> bool:
         """Return if the valve is closing."""
         if self.control_result:
-            return self.control_result["state"] == "closing"
+            return cast(bool, self.control_result["state"] == "closing")
 
         return self.attribute_value == "closing"
 
@@ -99,7 +100,7 @@ class BlockShellyValve(ShellyBlockAttributeEntity, ValveEntity):
     def is_opening(self) -> bool:
         """Return if the valve is opening."""
         if self.control_result:
-            return self.control_result["state"] == "opening"
+            return cast(bool, self.control_result["state"] == "opening")
 
         return self.attribute_value == "opening"
 

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -251,7 +251,6 @@ async def test_block_device_gas_valve(
     )
     registry = er.async_get(hass)
     await init_integration(hass, 1, MODEL_GAS)
-    entity_id = "switch.test_name_valve"
 
     entry = registry.async_get(entity_id)
     assert entry

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -238,6 +238,12 @@ async def test_block_device_gas_valve(
     hass: HomeAssistant, mock_block_device, monkeypatch
 ) -> None:
     """Test block device Shelly Gas with Valve addon."""
+    entity_id = register_entity(
+        hass,
+        SWITCH_DOMAIN,
+        "test_name_valve",
+        "valve_0-valve",
+    )
     registry = er.async_get(hass)
     await init_integration(hass, 1, MODEL_GAS)
     entity_id = "switch.test_name_valve"

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -6,7 +6,10 @@ from aioshelly.const import MODEL_GAS
 from aioshelly.exceptions import DeviceConnectionError, InvalidAuthError, RpcCallError
 import pytest
 
+from homeassistant.components import automation, script
+from homeassistant.components.automation import automations_with_entity
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.components.script import scripts_with_entity
 from homeassistant.components.shelly.const import DOMAIN, MODEL_WALL_DISPLAY
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
@@ -21,6 +24,8 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
+import homeassistant.helpers.issue_registry as ir
+from homeassistant.setup import async_setup_component
 
 from . import init_integration, register_entity
 
@@ -322,3 +327,63 @@ async def test_wall_display_relay_mode(
 
     # the climate entity should be removed
     assert hass.states.get(entity_id) is None
+
+
+async def test_create_issue_valve_switch(
+    hass: HomeAssistant,
+    mock_block_device,
+    entity_registry_enabled_by_default: None,
+    monkeypatch,
+) -> None:
+    """Test we create an issue when an automation or script is using a deprecated entity."""
+    monkeypatch.setitem(mock_block_device.status, "cloud", {"connected": False})
+    entity_id = register_entity(
+        hass,
+        SWITCH_DOMAIN,
+        "test_name_valve",
+        "valve_0-valve",
+    )
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "alias": "test",
+                "trigger": {"platform": "state", "entity_id": entity_id},
+                "action": {"service": "switch.turn_on", "entity_id": entity_id},
+            }
+        },
+    )
+    assert await async_setup_component(
+        hass,
+        script.DOMAIN,
+        {
+            script.DOMAIN: {
+                "test": {
+                    "sequence": [
+                        {
+                            "service": "switch.turn_on",
+                            "data": {"entity_id": entity_id},
+                        },
+                    ],
+                }
+            }
+        },
+    )
+
+    await init_integration(hass, 1, MODEL_GAS)
+
+    assert automations_with_entity(hass, entity_id)[0] == "automation.test"
+    assert scripts_with_entity(hass, entity_id)[0] == "script.test"
+    issue_registry: ir.IssueRegistry = ir.async_get(hass)
+
+    assert issue_registry.async_get_issue(DOMAIN, "deprecated_valve_switch")
+    assert issue_registry.async_get_issue(
+        DOMAIN, "deprecated_valve_switch.test_name_valve_automation.test"
+    )
+    assert issue_registry.async_get_issue(
+        DOMAIN, "deprecated_valve_switch.test_name_valve_script.test"
+    )
+
+    assert len(issue_registry.issues) == 3

--- a/tests/components/shelly/test_valve.py
+++ b/tests/components/shelly/test_valve.py
@@ -1,0 +1,72 @@
+"""Tests for Shelly valve platform."""
+from aioshelly.const import MODEL_GAS
+
+from homeassistant.components.valve import DOMAIN as VALVE_DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_CLOSE_VALVE,
+    SERVICE_OPEN_VALVE,
+    STATE_CLOSED,
+    STATE_CLOSING,
+    STATE_OPEN,
+    STATE_OPENING,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import init_integration
+
+GAS_VALVE_BLOCK_ID = 6
+
+
+async def test_block_device_gas_valve(
+    hass: HomeAssistant, mock_block_device, monkeypatch
+) -> None:
+    """Test block device Shelly Gas with Valve addon."""
+    registry = er.async_get(hass)
+    await init_integration(hass, 1, MODEL_GAS)
+    entity_id = "valve.test_name_valve"
+
+    entry = registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-valve_0-valve"
+
+    assert hass.states.get(entity_id).state == STATE_CLOSED
+
+    await hass.services.async_call(
+        VALVE_DOMAIN,
+        SERVICE_OPEN_VALVE,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_OPENING
+
+    monkeypatch.setattr(mock_block_device.blocks[GAS_VALVE_BLOCK_ID], "valve", "opened")
+    mock_block_device.mock_update()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_OPEN
+
+    await hass.services.async_call(
+        VALVE_DOMAIN,
+        SERVICE_CLOSE_VALVE,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_CLOSING
+
+    monkeypatch.setattr(mock_block_device.blocks[GAS_VALVE_BLOCK_ID], "valve", "closed")
+    mock_block_device.mock_update()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_CLOSED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The switch entity for Shelly Gas Valve is now deprecated and will be removed in a future version of Home Assistant. The valve entity is available and should be used going forward. Please adjust any automations or scripts.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the valve platform for Shelly integration. Until now, the switch platform for the valve was used, the switch entity is marked as deprecated and will be removed in HA 2024.7.

I don't have the Valve addon for Shelly Gas so I couldn't test the change with a real device.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30430

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
