### PR TITLE
Deprecate deprecated device tracker constants

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -1,8 +1,14 @@
 """Provide functionality to keep track of devices."""
 from __future__ import annotations
 
+from functools import partial
+
 from homeassistant.const import ATTR_GPS_ACCURACY, STATE_HOME  # noqa: F401
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.deprecation import (
+    check_if_deprecated_constant,
+    dir_with_deprecated_constants,
+)
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 
@@ -13,6 +19,10 @@ from .config_entry import (  # noqa: F401
     async_unload_entry,
 )
 from .const import (  # noqa: F401
+    _DEPRECATED_SOURCE_TYPE_BLUETOOTH,
+    _DEPRECATED_SOURCE_TYPE_BLUETOOTH_LE,
+    _DEPRECATED_SOURCE_TYPE_GPS,
+    _DEPRECATED_SOURCE_TYPE_ROUTER,
     ATTR_ATTRIBUTES,
     ATTR_BATTERY,
     ATTR_DEV_ID,
@@ -32,10 +42,6 @@ from .const import (  # noqa: F401
     DOMAIN,
     ENTITY_ID_FORMAT,
     SCAN_INTERVAL,
-    SOURCE_TYPE_BLUETOOTH,
-    SOURCE_TYPE_BLUETOOTH_LE,
-    SOURCE_TYPE_GPS,
-    SOURCE_TYPE_ROUTER,
     SourceType,
 )
 from .legacy import (  # noqa: F401
@@ -50,6 +56,12 @@ from .legacy import (  # noqa: F401
     async_setup_integration as async_setup_legacy_integration,
     see,
 )
+
+# As we import deprecated constants from the const module, we need to add these two functions
+# otherwise this module will be logged for using deprecated constants and not the custom component
+# Both can be removed if no deprecated constant are in this module anymore
+__getattr__ = partial(check_if_deprecated_constant, module_globals=globals())
+__dir__ = partial(dir_with_deprecated_constants, module_globals=globals())
 
 
 @bind_hass

--- a/homeassistant/components/device_tracker/const.py
+++ b/homeassistant/components/device_tracker/const.py
@@ -3,8 +3,15 @@ from __future__ import annotations
 
 from datetime import timedelta
 from enum import StrEnum
+from functools import partial
 import logging
 from typing import Final
+
+from homeassistant.helpers.deprecation import (
+    DeprecatedConstantEnum,
+    check_if_deprecated_constant,
+    dir_with_deprecated_constants,
+)
 
 LOGGER: Final = logging.getLogger(__package__)
 
@@ -13,13 +20,6 @@ ENTITY_ID_FORMAT: Final = DOMAIN + ".{}"
 
 PLATFORM_TYPE_LEGACY: Final = "legacy"
 PLATFORM_TYPE_ENTITY: Final = "entity_platform"
-
-# SOURCE_TYPE_* below are deprecated as of 2022.9
-# use the SourceType enum instead.
-SOURCE_TYPE_GPS: Final = "gps"
-SOURCE_TYPE_ROUTER: Final = "router"
-SOURCE_TYPE_BLUETOOTH: Final = "bluetooth"
-SOURCE_TYPE_BLUETOOTH_LE: Final = "bluetooth_le"
 
 
 class SourceType(StrEnum):
@@ -30,6 +30,23 @@ class SourceType(StrEnum):
     BLUETOOTH = "bluetooth"
     BLUETOOTH_LE = "bluetooth_le"
 
+
+# SOURCE_TYPE_* below are deprecated as of 2022.9
+# use the SourceType enum instead.
+_DEPRECATED_SOURCE_TYPE_GPS: Final = DeprecatedConstantEnum(SourceType.GPS, "2025.1")
+_DEPRECATED_SOURCE_TYPE_ROUTER: Final = DeprecatedConstantEnum(
+    SourceType.ROUTER, "2025.1"
+)
+_DEPRECATED_SOURCE_TYPE_BLUETOOTH: Final = DeprecatedConstantEnum(
+    SourceType.BLUETOOTH, "2025.1"
+)
+_DEPRECATED_SOURCE_TYPE_BLUETOOTH_LE: Final = DeprecatedConstantEnum(
+    SourceType.BLUETOOTH_LE, "2025.1"
+)
+
+# Both can be removed if no deprecated constant are in this module anymore
+__getattr__ = partial(check_if_deprecated_constant, module_globals=globals())
+__dir__ = partial(dir_with_deprecated_constants, module_globals=globals())
 
 CONF_SCAN_INTERVAL: Final = "interval_seconds"
 SCAN_INTERVAL: Final = timedelta(seconds=12)

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 import json
 import logging
 import os
+from types import ModuleType
 from unittest.mock import Mock, call, patch
 
 import pytest
@@ -33,6 +34,7 @@ from . import common
 from tests.common import (
     assert_setup_component,
     async_fire_time_changed,
+    import_and_test_deprecated_constant_enum,
     mock_registry,
     mock_restore_cache,
     patch_yaml_files,
@@ -680,4 +682,20 @@ def test_see_schema_allowing_ios_calls() -> None:
             "gps_accuracy": 300,
             "hostname": "beer",
         }
+    )
+
+
+@pytest.mark.parametrize(("enum"), list(SourceType))
+@pytest.mark.parametrize(
+    "module",
+    [device_tracker, device_tracker.const],
+)
+def test_deprecated_constants(
+    caplog: pytest.LogCaptureFixture,
+    enum: SourceType,
+    module: ModuleType,
+) -> None:
+    """Test deprecated constants."""
+    import_and_test_deprecated_constant_enum(
+        caplog, module, enum, "SOURCE_TYPE_", "2025.1"
     )

--- a/tests/testing_config/custom_components/test/device_tracker.py
+++ b/tests/testing_config/custom_components/test/device_tracker.py
@@ -2,7 +2,7 @@
 
 from homeassistant.components.device_tracker import DeviceScanner
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
-from homeassistant.components.device_tracker.const import SOURCE_TYPE_ROUTER
+from homeassistant.components.device_tracker.const import SourceType
 
 
 async def async_get_scanner(hass, config):
@@ -23,7 +23,7 @@ class MockScannerEntity(ScannerEntity):
     @property
     def source_type(self):
         """Return the source type, eg gps or router, of the device."""
-        return SOURCE_TYPE_ROUTER
+        return SourceType.ROUTER
 
     @property
     def battery_level(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA similar to https://github.com/home-assistant/core/pull/105736

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
