### PR TITLE
Move prusalink migration to async_migrate_entry and use a minor version bump

### DIFF
--- a/homeassistant/components/prusalink/__init__.py
+++ b/homeassistant/components/prusalink/__init__.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -29,73 +30,24 @@ from homeassistant.helpers.update_coordinator import (
     UpdateFailed,
 )
 
+from .config_flow import ConfigFlow
 from .const import DOMAIN
 
 PLATFORMS: list[Platform] = [Platform.BUTTON, Platform.CAMERA, Platform.SENSOR]
 _LOGGER = logging.getLogger(__name__)
 
 
-async def _migrate_to_version_2(
-    hass: HomeAssistant, entry: ConfigEntry
-) -> PrusaLink | None:
-    """Migrate to Version 2."""
-    _LOGGER.debug("Migrating entry to version 2")
-
-    data = dict(entry.data)
-    # "maker" is currently hardcoded in the firmware
-    # https://github.com/prusa3d/Prusa-Firmware-Buddy/blob/bfb0ffc745ee6546e7efdba618d0e7c0f4c909cd/lib/WUI/wui_api.h#L19
-    data = {
-        **entry.data,
-        CONF_USERNAME: "maker",
-        CONF_PASSWORD: entry.data[CONF_API_KEY],
-    }
-    data.pop(CONF_API_KEY)
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up PrusaLink from a config entry."""
+    if entry.version == 1 and entry.minor_version < 2:
+        raise ConfigEntryError("Please upgrade your printer's firmware.")
 
     api = PrusaLink(
         async_get_clientsession(hass),
-        data[CONF_HOST],
-        data[CONF_USERNAME],
-        data[CONF_PASSWORD],
+        entry.data[CONF_HOST],
+        entry.data[CONF_USERNAME],
+        entry.data[CONF_PASSWORD],
     )
-    try:
-        await api.get_info()
-    except InvalidAuth:
-        # We are unable to reach the new API which usually means
-        # that the user is running an outdated firmware version
-        ir.async_create_issue(
-            hass,
-            DOMAIN,
-            "firmware_5_1_required",
-            is_fixable=False,
-            severity=ir.IssueSeverity.ERROR,
-            translation_key="firmware_5_1_required",
-            translation_placeholders={
-                "entry_title": entry.title,
-                "prusa_mini_firmware_update": "https://help.prusa3d.com/article/firmware-updating-mini-mini_124784",
-                "prusa_mk4_xl_firmware_update": "https://help.prusa3d.com/article/how-to-update-firmware-mk4-xl_453086",
-            },
-        )
-        return None
-
-    entry.version = 2
-    hass.config_entries.async_update_entry(entry, data=data)
-    _LOGGER.info("Migrated config entry to version %d", entry.version)
-    return api
-
-
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up PrusaLink from a config entry."""
-    if entry.version == 1:
-        if (api := await _migrate_to_version_2(hass, entry)) is None:
-            return False
-        ir.async_delete_issue(hass, DOMAIN, "firmware_5_1_required")
-    else:
-        api = PrusaLink(
-            async_get_clientsession(hass),
-            entry.data[CONF_HOST],
-            entry.data[CONF_USERNAME],
-            entry.data[CONF_PASSWORD],
-        )
 
     coordinators = {
         "legacy_status": LegacyStatusCoordinator(hass, api),
@@ -112,9 +64,58 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate old entry."""
-    # Version 1->2 migration are handled in async_setup_entry.
+    if config_entry.version > ConfigFlow.VERSION:
+        # This means the user has downgraded from a future version
+        return False
+
+    new_data = dict(config_entry.data)
+    if config_entry.version == 1:
+        if config_entry.minor_version < 2:
+            # Add username and password
+            # "maker" is currently hardcoded in the firmware
+            # https://github.com/prusa3d/Prusa-Firmware-Buddy/blob/bfb0ffc745ee6546e7efdba618d0e7c0f4c909cd/lib/WUI/wui_api.h#L19
+            username = "maker"
+            password = config_entry.data[CONF_API_KEY]
+
+            api = PrusaLink(
+                async_get_clientsession(hass),
+                config_entry.data[CONF_HOST],
+                username,
+                password,
+            )
+            try:
+                await api.get_info()
+            except InvalidAuth:
+                # We are unable to reach the new API which usually means
+                # that the user is running an outdated firmware version
+                ir.async_create_issue(
+                    hass,
+                    DOMAIN,
+                    "firmware_5_1_required",
+                    is_fixable=False,
+                    severity=ir.IssueSeverity.ERROR,
+                    translation_key="firmware_5_1_required",
+                    translation_placeholders={
+                        "entry_title": config_entry.title,
+                        "prusa_mini_firmware_update": "https://help.prusa3d.com/article/firmware-updating-mini-mini_124784",
+                        "prusa_mk4_xl_firmware_update": "https://help.prusa3d.com/article/how-to-update-firmware-mk4-xl_453086",
+                    },
+                )
+                # There is a check in the async_setup_entry to prevent the setup if minor_version < 2
+                # Currently we can't go out of a migration here without restart and returning here True
+                # with the setup check is a nice workaround
+                return True
+
+            new_data[CONF_USERNAME] = username
+            new_data[CONF_PASSWORD] = password
+
+        ir.async_delete_issue(hass, DOMAIN, "firmware_5_1_required")
+        config_entry.minor_version = 2
+
+        hass.config_entries.async_update_entry(config_entry, data=new_data)
+
     return True
 
 

--- a/homeassistant/components/prusalink/__init__.py
+++ b/homeassistant/components/prusalink/__init__.py
@@ -104,8 +104,9 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                     },
                 )
                 # There is a check in the async_setup_entry to prevent the setup if minor_version < 2
-                # Currently we can't go out of a migration here without restart and returning here True
-                # with the setup check is a nice workaround
+                # Currently we can't reload the config entry
+                # if the migration returns False.
+                # Return True here to workaround that.
                 return True
 
             new_data[CONF_USERNAME] = username

--- a/homeassistant/components/prusalink/config_flow.py
+++ b/homeassistant/components/prusalink/config_flow.py
@@ -66,7 +66,8 @@ async def validate_input(hass: HomeAssistant, data: dict[str, str]) -> dict[str,
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for PrusaLink."""
 
-    VERSION = 2
+    VERSION = 1
+    MINOR_VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/tests/components/prusalink/conftest.py
+++ b/tests/components/prusalink/conftest.py
@@ -14,7 +14,8 @@ def mock_config_entry(hass):
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={"host": "http://example.com", "username": "dummy", "password": "dummypw"},
-        version=2,
+        version=1,
+        minor_version=2,
     )
     entry.add_to_hass(hass)
     return entry

--- a/tests/components/prusalink/test_init.py
+++ b/tests/components/prusalink/test_init.py
@@ -14,11 +14,12 @@ from homeassistant.util.dt import utcnow
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
+pytestmark = pytest.mark.usefixtures("mock_api")
+
 
 async def test_unloading(
     hass: HomeAssistant,
     mock_config_entry: ConfigEntry,
-    mock_api,
 ) -> None:
     """Test unloading prusalink."""
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
@@ -35,7 +36,7 @@ async def test_unloading(
 
 @pytest.mark.parametrize("exception", [InvalidAuth, PrusaLinkError])
 async def test_failed_update(
-    hass: HomeAssistant, mock_config_entry: ConfigEntry, mock_api, exception
+    hass: HomeAssistant, mock_config_entry: ConfigEntry, exception
 ) -> None:
     """Test failed update marks prusalink unavailable."""
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
@@ -62,15 +63,16 @@ async def test_failed_update(
 
 
 async def test_migration_1_2(
-    hass: HomeAssistant, issue_registry: ir.IssueRegistry, mock_api
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
 ) -> None:
     """Test migrating from version 1 to 2."""
+    data = {
+        CONF_HOST: "http://prusaxl.local",
+        CONF_API_KEY: "api-key",
+    }
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={
-            CONF_HOST: "http://prusaxl.local",
-            CONF_API_KEY: "api-key",
-        },
+        data=data,
         version=1,
     )
     entry.add_to_hass(hass)
@@ -83,7 +85,7 @@ async def test_migration_1_2(
     # Ensure that we have username, password after migration
     assert len(config_entries) == 1
     assert config_entries[0].data == {
-        CONF_HOST: "http://prusaxl.local",
+        **data,
         CONF_USERNAME: "maker",
         CONF_PASSWORD: "api-key",
     }
@@ -91,10 +93,10 @@ async def test_migration_1_2(
     assert len(issue_registry.issues) == 0
 
 
-async def test_outdated_firmware_migration_1_2(
-    hass: HomeAssistant, issue_registry: ir.IssueRegistry, mock_api
+async def test_migration_from_1_1_to_1_2_outdated_firmware(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
 ) -> None:
-    """Test migrating from version 1 to 2."""
+    """Test migrating from version 1.1 to 1.2."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -107,14 +109,14 @@ async def test_outdated_firmware_migration_1_2(
 
     with patch(
         "pyprusalink.PrusaLink.get_info",
-        side_effect=InvalidAuth,
+        side_effect=InvalidAuth,  # Simulate firmware update required
     ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
     assert entry.state == ConfigEntryState.SETUP_ERROR
-    # Make sure that we don't have thrown the issues
-    assert len(issue_registry.issues) == 1
+    assert entry.minor_version == 1
+    assert (DOMAIN, "firmware_5_1_required") in issue_registry.issues
 
     # Reloading the integration with a working API (e.g. User updated firmware)
     await hass.config_entries.async_reload(entry.entry_id)
@@ -122,4 +124,5 @@ async def test_outdated_firmware_migration_1_2(
 
     # Integration should be running now, the issue should be gone
     assert entry.state == ConfigEntryState.LOADED
-    assert len(issue_registry.issues) == 0
+    assert entry.minor_version == 2
+    assert (DOMAIN, "firmware_5_1_required") not in issue_registry.issues

--- a/tests/components/prusalink/test_init.py
+++ b/tests/components/prusalink/test_init.py
@@ -62,7 +62,7 @@ async def test_failed_update(
         assert state.state == "unavailable"
 
 
-async def test_migration_1_2(
+async def test_migration_from_1_1_to_1_2(
     hass: HomeAssistant, issue_registry: ir.IssueRegistry
 ) -> None:
     """Test migrating from version 1 to 2."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There was a misunderstanding on my part as we shouldn't allow config entry migrations outside `async_migrate_entry`, which I suggested in #103396. This PR fix this wrong suggestion.
Implementing @MartinHjelmare suggestion to use only a minor version and leave the `api_key`. It doesn't hurt us and a user can downgrade if he needs to.

CC: @Skaronator

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
