### PR TITLE
Deprecate deprecated humidifier constants

### DIFF
--- a/homeassistant/components/humidifier/__init__.py
+++ b/homeassistant/components/humidifier/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 from enum import StrEnum
+from functools import partial
 import logging
 from typing import Any, final
 
@@ -22,12 +23,19 @@ from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
     PLATFORM_SCHEMA_BASE,
 )
+from homeassistant.helpers.deprecation import (
+    check_if_deprecated_constant,
+    dir_with_deprecated_constants,
+)
 from homeassistant.helpers.entity import ToggleEntity, ToggleEntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 
 from .const import (  # noqa: F401
+    _DEPRECATED_DEVICE_CLASS_DEHUMIDIFIER,
+    _DEPRECATED_DEVICE_CLASS_HUMIDIFIER,
+    _DEPRECATED_SUPPORT_MODES,
     ATTR_ACTION,
     ATTR_AVAILABLE_MODES,
     ATTR_CURRENT_HUMIDITY,
@@ -36,15 +44,12 @@ from .const import (  # noqa: F401
     ATTR_MIN_HUMIDITY,
     DEFAULT_MAX_HUMIDITY,
     DEFAULT_MIN_HUMIDITY,
-    DEVICE_CLASS_DEHUMIDIFIER,
-    DEVICE_CLASS_HUMIDIFIER,
     DOMAIN,
     MODE_AUTO,
     MODE_AWAY,
     MODE_NORMAL,
     SERVICE_SET_HUMIDITY,
     SERVICE_SET_MODE,
-    SUPPORT_MODES,
     HumidifierAction,
     HumidifierEntityFeature,
 )
@@ -69,6 +74,12 @@ DEVICE_CLASSES_SCHEMA = vol.All(vol.Lower, vol.Coerce(HumidifierDeviceClass))
 # DEVICE_CLASSES below is deprecated as of 2021.12
 # use the HumidifierDeviceClass enum instead.
 DEVICE_CLASSES = [cls.value for cls in HumidifierDeviceClass]
+
+# As we import deprecated constants from the const module, we need to add these two functions
+# otherwise this module will be logged for using deprecated constants and not the custom component
+# Both can be removed if no deprecated constant are in this module anymore
+__getattr__ = partial(check_if_deprecated_constant, module_globals=globals())
+__dir__ = partial(dir_with_deprecated_constants, module_globals=globals())
 
 # mypy: disallow-any-generics
 

--- a/homeassistant/components/humidifier/const.py
+++ b/homeassistant/components/humidifier/const.py
@@ -1,5 +1,13 @@
 """Provides the constants needed for component."""
 from enum import IntFlag, StrEnum
+from functools import partial
+
+from homeassistant.helpers.deprecation import (
+    DeprecatedConstant,
+    DeprecatedConstantEnum,
+    check_if_deprecated_constant,
+    dir_with_deprecated_constants,
+)
 
 MODE_NORMAL = "normal"
 MODE_ECO = "eco"
@@ -35,8 +43,12 @@ DOMAIN = "humidifier"
 
 # DEVICE_CLASS_* below are deprecated as of 2021.12
 # use the HumidifierDeviceClass enum instead.
-DEVICE_CLASS_HUMIDIFIER = "humidifier"
-DEVICE_CLASS_DEHUMIDIFIER = "dehumidifier"
+_DEPRECATED_DEVICE_CLASS_HUMIDIFIER = DeprecatedConstant(
+    "humidifier", "HumidifierDeviceClass.HUMIDIFIER", "2025.1"
+)
+_DEPRECATED_DEVICE_CLASS_DEHUMIDIFIER = DeprecatedConstant(
+    "dehumidifier", "HumidifierDeviceClass.DEHUMIDIFIER", "2025.1"
+)
 
 SERVICE_SET_MODE = "set_mode"
 SERVICE_SET_HUMIDITY = "set_humidity"
@@ -50,4 +62,10 @@ class HumidifierEntityFeature(IntFlag):
 
 # The SUPPORT_MODES constant is deprecated as of Home Assistant 2022.5.
 # Please use the HumidifierEntityFeature enum instead.
-SUPPORT_MODES = 1
+_DEPRECATED_SUPPORT_MODES = DeprecatedConstantEnum(
+    HumidifierEntityFeature.MODES, "2025.1"
+)
+
+# Both can be removed if no deprecated constant are in this module anymore
+__getattr__ = partial(check_if_deprecated_constant, module_globals=globals())
+__dir__ = partial(dir_with_deprecated_constants, module_globals=globals())

--- a/tests/components/humidifier/test_init.py
+++ b/tests/components/humidifier/test_init.py
@@ -1,8 +1,15 @@
 """The tests for the humidifier component."""
+from enum import Enum
+from types import ModuleType
 from unittest.mock import MagicMock
 
+import pytest
+
+from homeassistant.components import humidifier
 from homeassistant.components.humidifier import HumidifierEntity
 from homeassistant.core import HomeAssistant
+
+from tests.common import import_and_test_deprecated_constant_enum
 
 
 class MockHumidifierEntity(HumidifierEntity):
@@ -34,3 +41,28 @@ async def test_sync_turn_off(hass: HomeAssistant) -> None:
     await humidifier.async_turn_off()
 
     assert humidifier.turn_off.called
+
+
+def _create_tuples(enum: Enum, constant_prefix: str) -> list[tuple[Enum, str]]:
+    result = []
+    for enum in enum:
+        result.append((enum, constant_prefix))
+    return result
+
+
+@pytest.mark.parametrize(
+    ("enum", "constant_prefix"),
+    _create_tuples(humidifier.HumidifierEntityFeature, "SUPPORT_")
+    + _create_tuples(humidifier.HumidifierDeviceClass, "DEVICE_CLASS_"),
+)
+@pytest.mark.parametrize(("module"), [humidifier, humidifier.const])
+def test_deprecated_constants(
+    caplog: pytest.LogCaptureFixture,
+    enum: Enum,
+    constant_prefix: str,
+    module: ModuleType,
+) -> None:
+    """Test deprecated constants."""
+    import_and_test_deprecated_constant_enum(
+        caplog, module, enum, constant_prefix, "2025.1"
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA similar to https://github.com/home-assistant/core/pull/105736

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
