### PR TITLE
Deprecate deprecated siren constants

### DIFF
--- a/homeassistant/components/siren/__init__.py
+++ b/homeassistant/components/siren/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from functools import partial
 import logging
 from typing import Any, TypedDict, cast, final
 
@@ -15,21 +16,25 @@ from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
     PLATFORM_SCHEMA_BASE,
 )
+from homeassistant.helpers.deprecation import (
+    check_if_deprecated_constant,
+    dir_with_deprecated_constants,
+)
 from homeassistant.helpers.entity import ToggleEntity, ToggleEntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (  # noqa: F401
+    _DEPRECATED_SUPPORT_DURATION,
+    _DEPRECATED_SUPPORT_TONES,
+    _DEPRECATED_SUPPORT_TURN_OFF,
+    _DEPRECATED_SUPPORT_TURN_ON,
+    _DEPRECATED_SUPPORT_VOLUME_SET,
     ATTR_AVAILABLE_TONES,
     ATTR_DURATION,
     ATTR_TONE,
     ATTR_VOLUME_LEVEL,
     DOMAIN,
-    SUPPORT_DURATION,
-    SUPPORT_TONES,
-    SUPPORT_TURN_OFF,
-    SUPPORT_TURN_ON,
-    SUPPORT_VOLUME_SET,
     SirenEntityFeature,
 )
 
@@ -42,6 +47,12 @@ TURN_ON_SCHEMA = {
     vol.Optional(ATTR_DURATION): cv.positive_int,
     vol.Optional(ATTR_VOLUME_LEVEL): cv.small_float,
 }
+
+# As we import deprecated constants from the const module, we need to add these two functions
+# otherwise this module will be logged for using deprecated constants and not the custom component
+# Both can be removed if no deprecated constant are in this module anymore
+__getattr__ = partial(check_if_deprecated_constant, module_globals=globals())
+__dir__ = partial(dir_with_deprecated_constants, module_globals=globals())
 
 
 class SirenTurnOnServiceParameters(TypedDict, total=False):

--- a/homeassistant/components/siren/const.py
+++ b/homeassistant/components/siren/const.py
@@ -1,7 +1,14 @@
 """Constants for the siren component."""
 
 from enum import IntFlag
+from functools import partial
 from typing import Final
+
+from homeassistant.helpers.deprecation import (
+    DeprecatedConstantEnum,
+    check_if_deprecated_constant,
+    dir_with_deprecated_constants,
+)
 
 DOMAIN: Final = "siren"
 
@@ -24,8 +31,22 @@ class SirenEntityFeature(IntFlag):
 
 # These constants are deprecated as of Home Assistant 2022.5
 # Please use the SirenEntityFeature enum instead.
-SUPPORT_TURN_ON: Final = 1
-SUPPORT_TURN_OFF: Final = 2
-SUPPORT_TONES: Final = 4
-SUPPORT_VOLUME_SET: Final = 8
-SUPPORT_DURATION: Final = 16
+_DEPRECATED_SUPPORT_TURN_ON: Final = DeprecatedConstantEnum(
+    SirenEntityFeature.TURN_ON, "2025.1"
+)
+_DEPRECATED_SUPPORT_TURN_OFF: Final = DeprecatedConstantEnum(
+    SirenEntityFeature.TURN_OFF, "2025.1"
+)
+_DEPRECATED_SUPPORT_TONES: Final = DeprecatedConstantEnum(
+    SirenEntityFeature.TONES, "2025.1"
+)
+_DEPRECATED_SUPPORT_VOLUME_SET: Final = DeprecatedConstantEnum(
+    SirenEntityFeature.VOLUME_SET, "2025.1"
+)
+_DEPRECATED_SUPPORT_DURATION: Final = DeprecatedConstantEnum(
+    SirenEntityFeature.DURATION, "2025.1"
+)
+
+# Both can be removed if no deprecated constant are in this module anymore
+__getattr__ = partial(check_if_deprecated_constant, module_globals=globals())
+__dir__ = partial(dir_with_deprecated_constants, module_globals=globals())

--- a/tests/components/siren/test_init.py
+++ b/tests/components/siren/test_init.py
@@ -1,8 +1,10 @@
 """The tests for the siren component."""
+from types import ModuleType
 from unittest.mock import MagicMock
 
 import pytest
 
+from homeassistant.components import siren
 from homeassistant.components.siren import (
     SirenEntity,
     SirenEntityDescription,
@@ -10,6 +12,8 @@ from homeassistant.components.siren import (
 )
 from homeassistant.components.siren.const import SirenEntityFeature
 from homeassistant.core import HomeAssistant
+
+from tests.common import import_and_test_deprecated_constant_enum
 
 
 class MockSirenEntity(SirenEntity):
@@ -104,3 +108,14 @@ async def test_missing_tones_dict(hass: HomeAssistant) -> None:
     siren.hass = hass
     with pytest.raises(ValueError):
         process_turn_on_params(siren, {"tone": 3})
+
+
+@pytest.mark.parametrize(("enum"), list(SirenEntityFeature))
+@pytest.mark.parametrize(("module"), [siren, siren.const])
+def test_deprecated_constants(
+    caplog: pytest.LogCaptureFixture,
+    enum: SirenEntityFeature,
+    module: ModuleType,
+) -> None:
+    """Test deprecated constants."""
+    import_and_test_deprecated_constant_enum(caplog, module, enum, "SUPPORT_", "2025.1")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA similar to https://github.com/home-assistant/core/pull/105736

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
