### PR TITLE
Fix freebox pairing in bridge mode

### DIFF
--- a/homeassistant/components/freebox/config_flow.py
+++ b/homeassistant/components/freebox/config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.data_entry_flow import FlowResult
 
 from .const import DOMAIN
-from .router import get_api
+from .router import get_api, get_hosts_list_if_supported
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -69,7 +69,7 @@ class FreeboxFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             # Check permissions
             await fbx.system.get_config()
-            await fbx.lan.get_hosts_list()
+            await get_hosts_list_if_supported(fbx)
 
             # Close connection
             await fbx.close()

--- a/tests/components/freebox/conftest.py
+++ b/tests/components/freebox/conftest.py
@@ -112,3 +112,14 @@ def mock_router_bridge_mode(mock_device_registry_devices, router):
     )
 
     return router
+
+
+@pytest.fixture
+def mock_router_bridge_mode_error(mock_device_registry_devices, router):
+    """Mock a failed connection to Freebox Bridge mode."""
+
+    router().lan.get_hosts_list = AsyncMock(
+        side_effect=HttpRequestError("Request failed (APIResponse: some unknown error)")
+    )
+
+    return router

--- a/tests/components/freebox/test_router.py
+++ b/tests/components/freebox/test_router.py
@@ -1,7 +1,11 @@
 """Tests for the Freebox utility methods."""
 import json
+from unittest.mock import Mock
 
-from homeassistant.components.freebox.router import is_json
+from freebox_api.exceptions import HttpRequestError
+import pytest
+
+from homeassistant.components.freebox.router import get_hosts_list_if_supported, is_json
 
 from .const import DATA_LAN_GET_HOSTS_LIST_MODE_BRIDGE, DATA_WIFI_GET_GLOBAL_CONFIG
 
@@ -20,3 +24,33 @@ async def test_is_json() -> None:
     assert not is_json("")
     assert not is_json("XXX")
     assert not is_json("{XXX}")
+
+
+async def test_get_hosts_list_if_supported(
+    router: Mock,
+) -> None:
+    """In router mode, get_hosts_list is supported and list is filled."""
+    supports_hosts, fbx_devices = await get_hosts_list_if_supported(router())
+    assert supports_hosts is True
+    # List must not be empty; but it's content depends on how many unit tests are executed...
+    assert fbx_devices
+    assert "d633d0c8-958c-43cc-e807-d881b076924b" in str(fbx_devices)
+
+
+async def test_get_hosts_list_if_supported_bridge(
+    router_bridge_mode: Mock,
+) -> None:
+    """In bridge mode, get_hosts_list is NOT supported and list is empty."""
+    supports_hosts, fbx_devices = await get_hosts_list_if_supported(
+        router_bridge_mode()
+    )
+    assert supports_hosts is False
+    assert fbx_devices == []
+
+
+async def test_get_hosts_list_if_supported_bridge_error(
+    mock_router_bridge_mode_error: Mock,
+) -> None:
+    """Other exceptions must be propagated."""
+    with pytest.raises(HttpRequestError):
+        await get_hosts_list_if_supported(mock_router_bridge_mode_error())


### PR DESCRIPTION
Ignore host list API call error as it's not supported in bridge mode.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up of PR #103221, applying the same solution to the pairing step:
host list API call is not supported when the Freebox is configured in bridge mode, so ignore
the error if it's a "nodev" one.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: #50954
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
