### PR TITLE
Update habluetooth to 2.0.0

### DIFF
--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -303,7 +303,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     adapters = await manager.async_get_bluetooth_adapters()
     details = adapters[adapter]
     slots: int = details.get(ADAPTER_CONNECTION_SLOTS) or DEFAULT_CONNECTION_SLOTS
-    entry.async_on_unload(async_register_scanner(hass, scanner, True, slots))
+    entry.async_on_unload(async_register_scanner(hass, scanner, connection_slots=slots))
     await async_update_device(hass, entry, adapter, details)
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = scanner
     entry.async_on_unload(entry.add_update_listener(async_update_listener))

--- a/homeassistant/components/bluetooth/api.py
+++ b/homeassistant/components/bluetooth/api.py
@@ -181,13 +181,10 @@ def async_rediscover_address(hass: HomeAssistant, address: str) -> None:
 def async_register_scanner(
     hass: HomeAssistant,
     scanner: BaseHaScanner,
-    connectable: bool,
     connection_slots: int | None = None,
 ) -> CALLBACK_TYPE:
     """Register a BleakScanner."""
-    return _get_manager(hass).async_register_scanner(
-        scanner, connectable, connection_slots
-    )
+    return _get_manager(hass).async_register_scanner(scanner, connection_slots)
 
 
 @hass_callback

--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -220,7 +220,6 @@ class HomeAssistantBluetoothManager(BluetoothManager):
     def async_register_scanner(
         self,
         scanner: BaseHaScanner,
-        connectable: bool,
         connection_slots: int | None = None,
     ) -> CALLBACK_TYPE:
         """Register a scanner."""
@@ -228,7 +227,5 @@ class HomeAssistantBluetoothManager(BluetoothManager):
             if history := self.storage.async_get_advertisement_history(scanner.source):
                 scanner.restore_discovered_devices(history)
 
-        unregister = super().async_register_scanner(
-            scanner, connectable, connection_slots
-        )
+        unregister = super().async_register_scanner(scanner, connection_slots)
         return partial(self._async_unregister_scanner, scanner, unregister)

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -20,6 +20,6 @@
     "bluetooth-auto-recovery==1.2.3",
     "bluetooth-data-tools==1.18.0",
     "dbus-fast==2.21.0",
-    "habluetooth==1.0.0"
+    "habluetooth==2.0.0"
   ]
 }

--- a/homeassistant/components/esphome/bluetooth.py
+++ b/homeassistant/components/esphome/bluetooth.py
@@ -38,7 +38,7 @@ async def async_connect_scanner(
     return partial(
         _async_unload,
         [
-            async_register_scanner(hass, scanner, scanner.connectable),
+            async_register_scanner(hass, scanner),
             scanner.async_setup(),
         ],
     )

--- a/homeassistant/components/ruuvi_gateway/bluetooth.py
+++ b/homeassistant/components/ruuvi_gateway/bluetooth.py
@@ -84,7 +84,7 @@ def async_connect_scanner(
         coordinator=coordinator,
     )
     unload_callbacks = [
-        async_register_scanner(hass, scanner, connectable=False),
+        async_register_scanner(hass, scanner),
         scanner.async_setup(),
         scanner.start_polling(),
     ]

--- a/homeassistant/components/shelly/bluetooth/__init__.py
+++ b/homeassistant/components/shelly/bluetooth/__init__.py
@@ -43,7 +43,7 @@ async def async_connect_scanner(
     )
     scanner = ShellyBLEScanner(source, entry.title, connector, False)
     unload_callbacks = [
-        async_register_scanner(hass, scanner, False),
+        async_register_scanner(hass, scanner),
         scanner.async_setup(),
         coordinator.async_subscribe_events(scanner.async_on_event),
     ]

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -23,7 +23,7 @@ dbus-fast==2.21.0
 fnv-hash-fast==0.5.0
 ha-av==10.1.1
 ha-ffmpeg==3.1.0
-habluetooth==1.0.0
+habluetooth==2.0.0
 hass-nabucasa==0.75.1
 hassil==1.5.1
 home-assistant-bluetooth==1.11.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -989,7 +989,7 @@ ha-philipsjs==3.1.1
 habitipy==0.2.0
 
 # homeassistant.components.bluetooth
-habluetooth==1.0.0
+habluetooth==2.0.0
 
 # homeassistant.components.cloud
 hass-nabucasa==0.75.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -788,7 +788,7 @@ ha-philipsjs==3.1.1
 habitipy==0.2.0
 
 # homeassistant.components.bluetooth
-habluetooth==1.0.0
+habluetooth==2.0.0
 
 # homeassistant.components.cloud
 hass-nabucasa==0.75.1

--- a/tests/components/bluetooth/test_advertisement_tracker.py
+++ b/tests/components/bluetooth/test_advertisement_tracker.py
@@ -346,7 +346,7 @@ async def test_advertisment_interval_longer_than_adapter_stack_timeout_adapter_c
     switchbot_device_went_unavailable = False
 
     scanner = FakeScanner("new", "fake_adapter")
-    cancel_scanner = async_register_scanner(hass, scanner, False)
+    cancel_scanner = async_register_scanner(hass, scanner)
 
     @callback
     def _switchbot_device_unavailable_callback(_address: str) -> None:

--- a/tests/components/bluetooth/test_api.py
+++ b/tests/components/bluetooth/test_api.py
@@ -28,7 +28,7 @@ async def test_scanner_by_source(hass: HomeAssistant, enable_bluetooth: None) ->
     """Test we can get a scanner by source."""
 
     hci2_scanner = FakeScanner("hci2", "hci2")
-    cancel_hci2 = bluetooth.async_register_scanner(hass, hci2_scanner, True)
+    cancel_hci2 = bluetooth.async_register_scanner(hass, hci2_scanner)
 
     assert async_scanner_by_source(hass, "hci2") is hci2_scanner
     cancel_hci2()
@@ -74,9 +74,9 @@ async def test_async_scanner_devices_by_address_connectable(
     connector = (
         HaBluetoothConnector(MockBleakClient, "mock_bleak_client", lambda: False),
     )
-    scanner = FakeInjectableScanner("esp32", "esp32", connector, False)
+    scanner = FakeInjectableScanner("esp32", "esp32", connector, True)
     unsetup = scanner.async_setup()
-    cancel = manager.async_register_scanner(scanner, True)
+    cancel = manager.async_register_scanner(scanner)
     switchbot_device = generate_ble_device(
         "44:44:33:11:23:45",
         "wohand",
@@ -141,7 +141,7 @@ async def test_async_scanner_devices_by_address_non_connectable(
         HaBluetoothConnector(MockBleakClient, "mock_bleak_client", lambda: False),
     )
     scanner = FakeStaticScanner("esp32", "esp32", connector)
-    cancel = manager.async_register_scanner(scanner, False)
+    cancel = manager.async_register_scanner(scanner)
 
     assert scanner.discovered_devices_and_advertisement_data == {
         switchbot_device.address: (switchbot_device, switchbot_device_adv)

--- a/tests/components/bluetooth/test_base_scanner.py
+++ b/tests/components/bluetooth/test_base_scanner.py
@@ -116,7 +116,7 @@ async def test_remote_scanner(
     )
     scanner = FakeScanner("esp32", "esp32", connector, True)
     unsetup = scanner.async_setup()
-    cancel = manager.async_register_scanner(scanner, True)
+    cancel = manager.async_register_scanner(scanner)
 
     scanner.inject_advertisement(switchbot_device, switchbot_device_adv)
 
@@ -182,7 +182,7 @@ async def test_remote_scanner_expires_connectable(
     )
     scanner = FakeScanner("esp32", "esp32", connector, True)
     unsetup = scanner.async_setup()
-    cancel = manager.async_register_scanner(scanner, True)
+    cancel = manager.async_register_scanner(scanner)
 
     start_time_monotonic = time.monotonic()
     scanner.inject_advertisement(switchbot_device, switchbot_device_adv)
@@ -234,9 +234,9 @@ async def test_remote_scanner_expires_non_connectable(
     connector = (
         HaBluetoothConnector(MockBleakClient, "mock_bleak_client", lambda: False),
     )
-    scanner = FakeScanner("esp32", "esp32", connector, False)
+    scanner = FakeScanner("esp32", "esp32", connector, True)
     unsetup = scanner.async_setup()
-    cancel = manager.async_register_scanner(scanner, True)
+    cancel = manager.async_register_scanner(scanner)
 
     start_time_monotonic = time.monotonic()
     scanner.inject_advertisement(switchbot_device, switchbot_device_adv)
@@ -308,9 +308,9 @@ async def test_base_scanner_connecting_behavior(
     connector = (
         HaBluetoothConnector(MockBleakClient, "mock_bleak_client", lambda: False),
     )
-    scanner = FakeScanner("esp32", "esp32", connector, False)
+    scanner = FakeScanner("esp32", "esp32", connector, True)
     unsetup = scanner.async_setup()
-    cancel = manager.async_register_scanner(scanner, True)
+    cancel = manager.async_register_scanner(scanner)
 
     with scanner.connecting():
         assert scanner.scanning is False
@@ -366,7 +366,7 @@ async def test_restore_history_remote_adapter(
         True,
     )
     unsetup = scanner.async_setup()
-    cancel = _get_manager().async_register_scanner(scanner, True)
+    cancel = _get_manager().async_register_scanner(scanner)
 
     assert "EB:0B:36:35:6F:A4" in scanner.discovered_devices_and_advertisement_data
     assert "E3:A5:63:3E:5E:23" not in scanner.discovered_devices_and_advertisement_data
@@ -380,7 +380,7 @@ async def test_restore_history_remote_adapter(
         True,
     )
     unsetup = scanner.async_setup()
-    cancel = _get_manager().async_register_scanner(scanner, True)
+    cancel = _get_manager().async_register_scanner(scanner)
     assert "EB:0B:36:35:6F:A4" in scanner.discovered_devices_and_advertisement_data
     assert "E3:A5:63:3E:5E:23" not in scanner.discovered_devices_and_advertisement_data
 
@@ -410,9 +410,9 @@ async def test_device_with_ten_minute_advertising_interval(
     connector = (
         HaBluetoothConnector(MockBleakClient, "mock_bleak_client", lambda: False),
     )
-    scanner = FakeScanner("esp32", "esp32", connector, False)
+    scanner = FakeScanner("esp32", "esp32", connector, True)
     unsetup = scanner.async_setup()
-    cancel = manager.async_register_scanner(scanner, True)
+    cancel = manager.async_register_scanner(scanner)
 
     monotonic_now = time.monotonic()
     new_time = monotonic_now
@@ -501,9 +501,9 @@ async def test_scanner_stops_responding(
     connector = (
         HaBluetoothConnector(MockBleakClient, "mock_bleak_client", lambda: False),
     )
-    scanner = FakeScanner("esp32", "esp32", connector, False)
+    scanner = FakeScanner("esp32", "esp32", connector, True)
     unsetup = scanner.async_setup()
-    cancel = manager.async_register_scanner(scanner, True)
+    cancel = manager.async_register_scanner(scanner)
 
     start_time_monotonic = time.monotonic()
 

--- a/tests/components/bluetooth/test_diagnostics.py
+++ b/tests/components/bluetooth/test_diagnostics.py
@@ -457,9 +457,9 @@ async def test_diagnostics_remote_adapter(
         connector = (
             HaBluetoothConnector(MockBleakClient, "mock_bleak_client", lambda: False),
         )
-        scanner = FakeScanner("esp32", "esp32", connector, False)
+        scanner = FakeScanner("esp32", "esp32", connector, True)
         unsetup = scanner.async_setup()
-        cancel = manager.async_register_scanner(scanner, True)
+        cancel = manager.async_register_scanner(scanner)
 
         scanner.inject_advertisement(switchbot_device, switchbot_adv)
         inject_advertisement(hass, switchbot_device, switchbot_adv)
@@ -511,7 +511,7 @@ async def test_diagnostics_remote_adapter(
                             -127,
                             [],
                         ],
-                        "connectable": False,
+                        "connectable": True,
                         "device": {
                             "__type": "<class 'bleak.backends.device.BLEDevice'>",
                             "repr": "BLEDevice(44:44:33:11:23:45, wohand)",
@@ -537,7 +537,7 @@ async def test_diagnostics_remote_adapter(
                             [],
                             -127,
                             -127,
-                            [[]],
+                            [],
                         ],
                         "connectable": True,
                         "device": {
@@ -551,7 +551,7 @@ async def test_diagnostics_remote_adapter(
                         "rssi": -127,
                         "service_data": {},
                         "service_uuids": [],
-                        "source": "local",
+                        "source": "esp32",
                         "time": ANY,
                     }
                 ],
@@ -595,7 +595,7 @@ async def test_diagnostics_remote_adapter(
                         "type": "FakeHaScanner",
                     },
                     {
-                        "connectable": False,
+                        "connectable": True,
                         "discovered_device_timestamps": {"44:44:33:11:23:45": ANY},
                         "discovered_devices_and_advertisement_data": [
                             {

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -2816,7 +2816,7 @@ async def test_scanner_count_connectable(
 ) -> None:
     """Test getting the connectable scanner count."""
     scanner = FakeScanner("any", "any")
-    cancel = bluetooth.async_register_scanner(hass, scanner, False)
+    cancel = bluetooth.async_register_scanner(hass, scanner)
     assert bluetooth.async_scanner_count(hass, connectable=True) == 1
     cancel()
 
@@ -2824,7 +2824,7 @@ async def test_scanner_count_connectable(
 async def test_scanner_count(hass: HomeAssistant, enable_bluetooth: None) -> None:
     """Test getting the connectable and non-connectable scanner count."""
     scanner = FakeScanner("any", "any")
-    cancel = bluetooth.async_register_scanner(hass, scanner, False)
+    cancel = bluetooth.async_register_scanner(hass, scanner)
     assert bluetooth.async_scanner_count(hass, connectable=False) == 2
     cancel()
 

--- a/tests/components/bluetooth/test_manager.py
+++ b/tests/components/bluetooth/test_manager.py
@@ -55,7 +55,7 @@ from tests.common import async_fire_time_changed, load_fixture
 def register_hci0_scanner(hass: HomeAssistant) -> Generator[None, None, None]:
     """Register an hci0 scanner."""
     hci0_scanner = FakeScanner("hci0", "hci0")
-    cancel = bluetooth.async_register_scanner(hass, hci0_scanner, True)
+    cancel = bluetooth.async_register_scanner(hass, hci0_scanner)
     yield
     cancel()
 
@@ -64,7 +64,7 @@ def register_hci0_scanner(hass: HomeAssistant) -> Generator[None, None, None]:
 def register_hci1_scanner(hass: HomeAssistant) -> Generator[None, None, None]:
     """Register an hci1 scanner."""
     hci1_scanner = FakeScanner("hci1", "hci1")
-    cancel = bluetooth.async_register_scanner(hass, hci1_scanner, True)
+    cancel = bluetooth.async_register_scanner(hass, hci1_scanner)
     yield
     cancel()
 
@@ -559,9 +559,7 @@ async def test_switching_adapters_when_one_goes_away(
     hass: HomeAssistant, enable_bluetooth: None, register_hci0_scanner: None
 ) -> None:
     """Test switching adapters when one goes away."""
-    cancel_hci2 = bluetooth.async_register_scanner(
-        hass, FakeScanner("hci2", "hci2"), True
-    )
+    cancel_hci2 = bluetooth.async_register_scanner(hass, FakeScanner("hci2", "hci2"))
 
     address = "44:44:33:11:23:45"
 
@@ -611,7 +609,7 @@ async def test_switching_adapters_when_one_stop_scanning(
 ) -> None:
     """Test switching adapters when stops scanning."""
     hci2_scanner = FakeScanner("hci2", "hci2")
-    cancel_hci2 = bluetooth.async_register_scanner(hass, hci2_scanner, True)
+    cancel_hci2 = bluetooth.async_register_scanner(hass, hci2_scanner)
 
     address = "44:44:33:11:23:45"
 
@@ -730,7 +728,7 @@ async def test_goes_unavailable_connectable_only_and_recovers(
     )
     unsetup_connectable_scanner = connectable_scanner.async_setup()
     cancel_connectable_scanner = _get_manager().async_register_scanner(
-        connectable_scanner, True
+        connectable_scanner
     )
     connectable_scanner.inject_advertisement(
         switchbot_device_connectable, switchbot_device_adv
@@ -752,7 +750,7 @@ async def test_goes_unavailable_connectable_only_and_recovers(
     )
     unsetup_not_connectable_scanner = not_connectable_scanner.async_setup()
     cancel_not_connectable_scanner = _get_manager().async_register_scanner(
-        not_connectable_scanner, False
+        not_connectable_scanner
     )
     not_connectable_scanner.inject_advertisement(
         switchbot_device_non_connectable, switchbot_device_adv
@@ -801,7 +799,7 @@ async def test_goes_unavailable_connectable_only_and_recovers(
     )
     unsetup_connectable_scanner_2 = connectable_scanner_2.async_setup()
     cancel_connectable_scanner_2 = _get_manager().async_register_scanner(
-        connectable_scanner, True
+        connectable_scanner
     )
     connectable_scanner_2.inject_advertisement(
         switchbot_device_connectable, switchbot_device_adv
@@ -902,7 +900,7 @@ async def test_goes_unavailable_dismisses_discovery_and_makes_discoverable(
     )
     unsetup_connectable_scanner = non_connectable_scanner.async_setup()
     cancel_connectable_scanner = _get_manager().async_register_scanner(
-        non_connectable_scanner, True
+        non_connectable_scanner
     )
     with patch.object(hass.config_entries.flow, "async_init") as mock_config_flow:
         non_connectable_scanner.inject_advertisement(
@@ -914,7 +912,7 @@ async def test_goes_unavailable_dismisses_discovery_and_makes_discoverable(
     assert mock_config_flow.mock_calls[0][1][0] == "switchbot"
 
     assert async_ble_device_from_address(hass, "44:44:33:11:23:45", False) is not None
-    assert async_scanner_count(hass, connectable=True) == 1
+    assert async_scanner_count(hass, connectable=False) == 1
     assert len(callbacks) == 1
 
     assert (

--- a/tests/components/bluetooth/test_models.py
+++ b/tests/components/bluetooth/test_models.py
@@ -107,7 +107,8 @@ async def test_wrapped_bleak_client_local_adapter_only(
         "00:00:00:00:00:01",
         "hci0",
     )
-    cancel = manager.async_register_scanner(scanner, True)
+    scanner.connectable = True
+    cancel = manager.async_register_scanner(scanner)
     inject_advertisement_with_source(
         hass, switchbot_device, switchbot_adv, "00:00:00:00:00:01"
     )
@@ -187,7 +188,7 @@ async def test_wrapped_bleak_client_set_disconnected_callback_after_connected(
         connector,
         True,
     )
-    cancel = manager.async_register_scanner(scanner, True)
+    cancel = manager.async_register_scanner(scanner)
     inject_advertisement_with_source(
         hass, switchbot_device, switchbot_adv, "00:00:00:00:00:01"
     )
@@ -291,7 +292,7 @@ async def test_ble_device_with_proxy_client_out_of_connections(
 
     connector = HaBluetoothConnector(MockBleakClient, "esp32", lambda: False)
     scanner = FakeScanner("esp32", "esp32", connector, True)
-    cancel = manager.async_register_scanner(scanner, True)
+    cancel = manager.async_register_scanner(scanner)
     inject_advertisement_with_source(
         hass, switchbot_proxy_device_no_connection_slot, switchbot_adv, "esp32"
     )
@@ -356,7 +357,7 @@ async def test_ble_device_with_proxy_clear_cache(
 
     connector = HaBluetoothConnector(MockBleakClient, "esp32", lambda: True)
     scanner = FakeScanner("esp32", "esp32", connector, True)
-    cancel = manager.async_register_scanner(scanner, True)
+    cancel = manager.async_register_scanner(scanner)
     inject_advertisement_with_source(
         hass, switchbot_proxy_device_with_connection_slot, switchbot_adv, "esp32"
     )
@@ -466,7 +467,7 @@ async def test_ble_device_with_proxy_client_out_of_connections_uses_best_availab
         connector,
         True,
     )
-    cancel = manager.async_register_scanner(scanner, True)
+    cancel = manager.async_register_scanner(scanner)
     assert manager.async_discovered_devices(True) == [
         switchbot_proxy_device_no_connection_slot
     ]
@@ -578,7 +579,7 @@ async def test_ble_device_with_proxy_client_out_of_connections_uses_best_availab
         connector,
         True,
     )
-    cancel = manager.async_register_scanner(scanner, True)
+    cancel = manager.async_register_scanner(scanner)
     assert manager.async_discovered_devices(True) == [
         switchbot_proxy_device_no_connection_slot
     ]

--- a/tests/components/bluetooth/test_wrappers.py
+++ b/tests/components/bluetooth/test_wrappers.py
@@ -187,8 +187,8 @@ def _generate_scanners_with_fake_devices(hass):
     for device, adv_data in hci1_device_advs.values():
         scanner_hci1.inject_advertisement(device, adv_data)
 
-    cancel_hci0 = manager.async_register_scanner(scanner_hci0, True, 2)
-    cancel_hci1 = manager.async_register_scanner(scanner_hci1, True, 1)
+    cancel_hci0 = manager.async_register_scanner(scanner_hci0, connection_slots=2)
+    cancel_hci1 = manager.async_register_scanner(scanner_hci1, connection_slots=1)
 
     return hci0_device_advs, cancel_hci0, cancel_hci1
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

changelog: https://github.com/Bluetooth-Devices/habluetooth/compare/v1.0.0...v2.0.0


There is a technically breaking change to `async_register_scanner` which makes it unnecessary to pass connectable. 

The scanner itself knows if its connectable or not, and having to pass it lead to bugs because there could be a disagreement between the values. 

As `habluetooth` is only used in dev, its unlikely this change is breaking because it would have been quite difficult to create a custom component with a scanner before. I updated the dev docs in https://github.com/home-assistant/developers.home-assistant/pull/2021 but I think a blog post would be noise because its likely only used inside of core at the moment.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
