### PR TITLE
Bump ZHA dependencies

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,15 +21,15 @@
     "universal_silabs_flasher"
   ],
   "requirements": [
-    "bellows==0.37.3",
+    "bellows==0.37.4",
     "pyserial==3.5",
     "pyserial-asyncio==0.6",
-    "zha-quirks==0.0.107",
-    "zigpy-deconz==0.22.2",
-    "zigpy==0.60.1",
+    "zha-quirks==0.0.108",
+    "zigpy-deconz==0.22.3",
+    "zigpy==0.60.2",
     "zigpy-xbee==0.20.1",
     "zigpy-zigate==0.12.0",
-    "zigpy-znp==0.12.0",
+    "zigpy-znp==0.12.1",
     "universal-silabs-flasher==0.0.15",
     "pyserial-asyncio-fast==0.11"
   ],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -526,7 +526,7 @@ beautifulsoup4==4.12.2
 # beewi-smartclim==0.0.10
 
 # homeassistant.components.zha
-bellows==0.37.3
+bellows==0.37.4
 
 # homeassistant.components.bmw_connected_drive
 bimmer-connected[china]==0.14.6
@@ -2843,7 +2843,7 @@ zeroconf==0.131.0
 zeversolar==0.3.1
 
 # homeassistant.components.zha
-zha-quirks==0.0.107
+zha-quirks==0.0.108
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.9
@@ -2852,7 +2852,7 @@ zhong-hong-hvac==1.0.9
 ziggo-mediabox-xl==1.1.0
 
 # homeassistant.components.zha
-zigpy-deconz==0.22.2
+zigpy-deconz==0.22.3
 
 # homeassistant.components.zha
 zigpy-xbee==0.20.1
@@ -2861,10 +2861,10 @@ zigpy-xbee==0.20.1
 zigpy-zigate==0.12.0
 
 # homeassistant.components.zha
-zigpy-znp==0.12.0
+zigpy-znp==0.12.1
 
 # homeassistant.components.zha
-zigpy==0.60.1
+zigpy==0.60.2
 
 # homeassistant.components.zoneminder
 zm-py==0.5.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -448,7 +448,7 @@ base36==0.1.1
 beautifulsoup4==4.12.2
 
 # homeassistant.components.zha
-bellows==0.37.3
+bellows==0.37.4
 
 # homeassistant.components.bmw_connected_drive
 bimmer-connected[china]==0.14.6
@@ -2141,10 +2141,10 @@ zeroconf==0.131.0
 zeversolar==0.3.1
 
 # homeassistant.components.zha
-zha-quirks==0.0.107
+zha-quirks==0.0.108
 
 # homeassistant.components.zha
-zigpy-deconz==0.22.2
+zigpy-deconz==0.22.3
 
 # homeassistant.components.zha
 zigpy-xbee==0.20.1
@@ -2153,10 +2153,10 @@ zigpy-xbee==0.20.1
 zigpy-zigate==0.12.0
 
 # homeassistant.components.zha
-zigpy-znp==0.12.0
+zigpy-znp==0.12.1
 
 # homeassistant.components.zha
-zigpy==0.60.1
+zigpy==0.60.2
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.54.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bumps ZHA dependencies:

- bellows to [0.37.4](https://github.com/zigpy/bellows/releases/tag/0.37.4)
- zha-quirks to [0.0.108](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.108)
- zigpy-deconz to [0.22.3](https://github.com/zigpy/zigpy-deconz/releases/tag/0.22.3)
- zigpy to [0.60.2](https://github.com/zigpy/zigpy/releases/tag/0.60.2)
- zigpy-znp to [0.12.1](https://github.com/zigpy/zigpy-znp/releases/tag/v0.12.1)

Radio libraries were previously affected by watchdog issues this release, causing repeated resets. This PR incorporates a change to zigpy that prioritizes watchdog counter writes, fixing issues preventing Conbee II/III radios from working reliably, in addition to similar issues with some Silicon Labs coordinators. I've also bumped the quirks version, as it corrects a regression with Aqara switches.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #105593
- This PR is related to issue: #105445, #105705, #105506, #105734, #106220, #106403
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
