### PR TITLE
Don't make huawei_lte entity classes dataclasses

### DIFF
--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -616,16 +616,17 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     return True
 
 
-@dataclass
 class HuaweiLteBaseEntity(Entity):
     """Huawei LTE entity base class."""
 
-    router: Router
-
-    _available: bool = field(default=True, init=False)
-    _unsub_handlers: list[Callable] = field(default_factory=list, init=False)
-    _attr_has_entity_name: bool = field(default=True, init=False)
+    _available = True
+    _attr_has_entity_name = True
     _attr_should_poll = False
+
+    def __init__(self, router: Router) -> None:
+        """Initialize."""
+        self.router = router
+        self._unsub_handlers: list[Callable] = []
 
     @property
     def _device_unique_id(self) -> str:

--- a/homeassistant/components/huawei_lte/binary_sensor.py
+++ b/homeassistant/components/huawei_lte/binary_sensor.py
@@ -1,7 +1,6 @@
 """Support for Huawei LTE binary sensors."""
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 import logging
 from typing import Any
 
@@ -48,15 +47,14 @@ async def async_setup_entry(
     async_add_entities(entities, True)
 
 
-@dataclass
 class HuaweiLteBaseBinarySensor(HuaweiLteBaseEntityWithDevice, BinarySensorEntity):
     """Huawei LTE binary sensor device base class."""
 
     _attr_entity_registry_enabled_default = False
 
-    key: str = field(init=False)
-    item: str = field(init=False)
-    _raw_state: str | None = field(default=None, init=False)
+    key: str
+    item: str
+    _raw_state: str | None = None
 
     @property
     def _device_unique_id(self) -> str:
@@ -100,17 +98,14 @@ CONNECTION_STATE_ATTRIBUTES = {
 }
 
 
-@dataclass
 class HuaweiLteMobileConnectionBinarySensor(HuaweiLteBaseBinarySensor):
     """Huawei LTE mobile connection binary sensor."""
 
-    _attr_translation_key: str = field(default="mobile_connection", init=False)
+    _attr_translation_key = "mobile_connection"
     _attr_entity_registry_enabled_default = True
 
-    def __post_init__(self) -> None:
-        """Initialize identifiers."""
-        self.key = KEY_MONITORING_STATUS
-        self.item = "ConnectionStatus"
+    key = KEY_MONITORING_STATUS
+    item = "ConnectionStatus"
 
     @property
     def is_on(self) -> bool:
@@ -165,52 +160,40 @@ class HuaweiLteBaseWifiStatusBinarySensor(HuaweiLteBaseBinarySensor):
         return "mdi:wifi" if self.is_on else "mdi:wifi-off"
 
 
-@dataclass
 class HuaweiLteWifiStatusBinarySensor(HuaweiLteBaseWifiStatusBinarySensor):
     """Huawei LTE WiFi status binary sensor."""
 
-    _attr_translation_key: str = field(default="wifi_status", init=False)
+    _attr_translation_key: str = "wifi_status"
 
-    def __post_init__(self) -> None:
-        """Initialize identifiers."""
-        self.key = KEY_MONITORING_STATUS
-        self.item = "WifiStatus"
+    key = KEY_MONITORING_STATUS
+    item = "WifiStatus"
 
 
-@dataclass
 class HuaweiLteWifi24ghzStatusBinarySensor(HuaweiLteBaseWifiStatusBinarySensor):
     """Huawei LTE 2.4GHz WiFi status binary sensor."""
 
-    _attr_translation_key: str = field(default="24ghz_wifi_status", init=False)
+    _attr_translation_key: str = "24ghz_wifi_status"
 
-    def __post_init__(self) -> None:
-        """Initialize identifiers."""
-        self.key = KEY_WLAN_WIFI_FEATURE_SWITCH
-        self.item = "wifi24g_switch_enable"
+    key = KEY_WLAN_WIFI_FEATURE_SWITCH
+    item = "wifi24g_switch_enable"
 
 
-@dataclass
 class HuaweiLteWifi5ghzStatusBinarySensor(HuaweiLteBaseWifiStatusBinarySensor):
     """Huawei LTE 5GHz WiFi status binary sensor."""
 
-    _attr_translation_key: str = field(default="5ghz_wifi_status", init=False)
+    _attr_translation_key: str = "5ghz_wifi_status"
 
-    def __post_init__(self) -> None:
-        """Initialize identifiers."""
-        self.key = KEY_WLAN_WIFI_FEATURE_SWITCH
-        self.item = "wifi5g_enabled"
+    key = KEY_WLAN_WIFI_FEATURE_SWITCH
+    item = "wifi5g_enabled"
 
 
-@dataclass
 class HuaweiLteSmsStorageFullBinarySensor(HuaweiLteBaseBinarySensor):
     """Huawei LTE SMS storage full binary sensor."""
 
-    _attr_translation_key: str = field(default="sms_storage_full", init=False)
+    _attr_translation_key: str = "sms_storage_full"
 
-    def __post_init__(self) -> None:
-        """Initialize identifiers."""
-        self.key = KEY_MONITORING_CHECK_NOTIFICATIONS
-        self.item = "SmsStorageFull"
+    key = KEY_MONITORING_CHECK_NOTIFICATIONS
+    item = "SmsStorageFull"
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/huawei_lte/device_tracker.py
+++ b/homeassistant/components/huawei_lte/device_tracker.py
@@ -1,7 +1,6 @@
 """Support for device tracking of Huawei LTE routers."""
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 import logging
 import re
 from typing import Any, cast
@@ -173,16 +172,18 @@ def _better_snakecase(text: str) -> str:
     return cast(str, snakecase(text))
 
 
-@dataclass
 class HuaweiLteScannerEntity(HuaweiLteBaseEntity, ScannerEntity):
     """Huawei LTE router scanner entity."""
 
-    _mac_address: str
+    _ip_address: str | None = None
+    _is_connected: bool = False
+    _hostname: str | None = None
 
-    _ip_address: str | None = field(default=None, init=False)
-    _is_connected: bool = field(default=False, init=False)
-    _hostname: str | None = field(default=None, init=False)
-    _extra_state_attributes: dict[str, Any] = field(default_factory=dict, init=False)
+    def __init__(self, router: Router, mac_address: str) -> None:
+        """Initialize."""
+        super().__init__(router)
+        self._extra_state_attributes: dict[str, Any] = {}
+        self._mac_address = mac_address
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/huawei_lte/notify.py
+++ b/homeassistant/components/huawei_lte/notify.py
@@ -1,7 +1,6 @@
 """Support for Huawei LTE router notifications."""
 from __future__ import annotations
 
-from dataclasses import dataclass
 import logging
 import time
 from typing import Any
@@ -34,12 +33,13 @@ async def async_get_service(
     return HuaweiLteSmsNotificationService(router, default_targets)
 
 
-@dataclass
 class HuaweiLteSmsNotificationService(BaseNotificationService):
     """Huawei LTE router SMS notification service."""
 
-    router: Router
-    default_targets: list[str]
+    def __init__(self, router: Router, default_targets: list[str]) -> None:
+        """Initialize."""
+        self.router = router
+        self.default_targets = default_targets
 
     def send_message(self, message: str = "", **kwargs: Any) -> None:
         """Send message to target numbers."""

--- a/homeassistant/components/huawei_lte/select.py
+++ b/homeassistant/components/huawei_lte/select.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import partial
 import logging
 
@@ -20,7 +20,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import UNDEFINED
 
-from . import HuaweiLteBaseEntityWithDevice
+from . import HuaweiLteBaseEntityWithDevice, Router
 from .const import DOMAIN, KEY_NET_NET_MODE
 
 _LOGGER = logging.getLogger(__name__)
@@ -80,18 +80,25 @@ async def async_setup_entry(
     async_add_entities(selects, True)
 
 
-@dataclass
 class HuaweiLteSelectEntity(HuaweiLteBaseEntityWithDevice, SelectEntity):
     """Huawei LTE select entity."""
 
     entity_description: HuaweiSelectEntityDescription
-    key: str
-    item: str
+    _raw_state: str | None = None
 
-    _raw_state: str | None = field(default=None, init=False)
+    def __init__(
+        self,
+        router: Router,
+        entity_description: HuaweiSelectEntityDescription,
+        key: str,
+        item: str,
+    ) -> None:
+        """Initialize."""
+        super().__init__(router)
+        self.entity_description = entity_description
+        self.key = key
+        self.item = item
 
-    def __post_init__(self) -> None:
-        """Initialize remaining attributes."""
         name = None
         if self.entity_description.name != UNDEFINED:
             name = self.entity_description.name

--- a/homeassistant/components/huawei_lte/sensor.py
+++ b/homeassistant/components/huawei_lte/sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from bisect import bisect
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
 import re
@@ -29,7 +29,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from . import HuaweiLteBaseEntityWithDevice
+from . import HuaweiLteBaseEntityWithDevice, Router
 from .const import (
     DOMAIN,
     KEY_DEVICE_INFORMATION,
@@ -688,17 +688,26 @@ async def async_setup_entry(
     async_add_entities(sensors, True)
 
 
-@dataclass
 class HuaweiLteSensor(HuaweiLteBaseEntityWithDevice, SensorEntity):
     """Huawei LTE sensor entity."""
 
-    key: str
-    item: str
     entity_description: HuaweiSensorEntityDescription
+    _state: StateType = None
+    _unit: str | None = None
+    _last_reset: datetime | None = None
 
-    _state: StateType = field(default=None, init=False)
-    _unit: str | None = field(default=None, init=False)
-    _last_reset: datetime | None = field(default=None, init=False)
+    def __init__(
+        self,
+        router: Router,
+        key: str,
+        item: str,
+        entity_description: HuaweiSensorEntityDescription,
+    ) -> None:
+        """Initialize."""
+        super().__init__(router)
+        self.key = key
+        self.item = item
+        self.entity_description = entity_description
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to needed data on add."""

--- a/homeassistant/components/huawei_lte/switch.py
+++ b/homeassistant/components/huawei_lte/switch.py
@@ -1,7 +1,6 @@
 """Support for Huawei LTE switches."""
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 import logging
 from typing import Any
 
@@ -43,17 +42,14 @@ async def async_setup_entry(
     async_add_entities(switches, True)
 
 
-@dataclass
 class HuaweiLteBaseSwitch(HuaweiLteBaseEntityWithDevice, SwitchEntity):
     """Huawei LTE switch device base class."""
 
-    key: str = field(init=False)
-    item: str = field(init=False)
+    key: str
+    item: str
 
-    _attr_device_class: SwitchDeviceClass = field(
-        default=SwitchDeviceClass.SWITCH, init=False
-    )
-    _raw_state: str | None = field(default=None, init=False)
+    _attr_device_class: SwitchDeviceClass = SwitchDeviceClass.SWITCH
+    _raw_state: str | None = None
 
     def _turn(self, state: bool) -> None:
         raise NotImplementedError
@@ -88,16 +84,13 @@ class HuaweiLteBaseSwitch(HuaweiLteBaseEntityWithDevice, SwitchEntity):
         self._raw_state = str(value)
 
 
-@dataclass
 class HuaweiLteMobileDataSwitch(HuaweiLteBaseSwitch):
     """Huawei LTE mobile data switch device."""
 
-    _attr_translation_key: str = field(default="mobile_data", init=False)
+    _attr_translation_key: str = "mobile_data"
 
-    def __post_init__(self) -> None:
-        """Initialize identifiers."""
-        self.key = KEY_DIALUP_MOBILE_DATASWITCH
-        self.item = "dataswitch"
+    key = KEY_DIALUP_MOBILE_DATASWITCH
+    item = "dataswitch"
 
     @property
     def _device_unique_id(self) -> str:
@@ -120,16 +113,13 @@ class HuaweiLteMobileDataSwitch(HuaweiLteBaseSwitch):
         return "mdi:signal" if self.is_on else "mdi:signal-off"
 
 
-@dataclass
 class HuaweiLteWifiGuestNetworkSwitch(HuaweiLteBaseSwitch):
     """Huawei LTE WiFi guest network switch device."""
 
-    _attr_translation_key: str = field(default="wifi_guest_network", init=False)
+    _attr_translation_key: str = "wifi_guest_network"
 
-    def __post_init__(self) -> None:
-        """Initialize identifiers."""
-        self.key = KEY_WLAN_WIFI_GUEST_NETWORK_SWITCH
-        self.item = "WifiEnable"
+    key = KEY_WLAN_WIFI_GUEST_NETWORK_SWITCH
+    item = "WifiEnable"
 
     @property
     def _device_unique_id(self) -> str:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make `huawei_lte` regular classes instead of `dataclass`

Making a derived class a dataclass broke with https://github.com/home-assistant/core/pull/100601.
That has since been fixed by annotating the added `__attr_*`-fields, however, `dataclass` does not seem like a good fit for a non-container class such as `Entity`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
