### PR TITLE
Skip logging deprecated constant if the calling integration couldn't be indentified

### DIFF
--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -161,6 +161,7 @@ def _print_deprecation_warning(
         description,
         verb,
         breaks_in_ha_version,
+        log_when_no_integration_is_found=True,
     )
 
 
@@ -172,7 +173,7 @@ def _print_deprecation_warning_internal(
     verb: str,
     breaks_in_ha_version: str | None,
     *,
-    log_when_no_integration_is_found: bool = True,
+    log_when_no_integration_is_found: bool,
 ) -> None:
     logger = logging.getLogger(module_name)
     if breaks_in_ha_version:

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -171,6 +171,8 @@ def _print_deprecation_warning_internal(
     description: str,
     verb: str,
     breaks_in_ha_version: str | None,
+    *,
+    log_when_no_integration_is_found: bool = True,
 ) -> None:
     logger = logging.getLogger(module_name)
     if breaks_in_ha_version:
@@ -180,13 +182,14 @@ def _print_deprecation_warning_internal(
     try:
         integration_frame = get_integration_frame()
     except MissingIntegrationFrame:
-        logger.warning(
-            "%s is a deprecated %s%s. Use %s instead",
-            obj_name,
-            description,
-            breaks_in,
-            replacement,
-        )
+        if log_when_no_integration_is_found:
+            logger.warning(
+                "%s is a deprecated %s%s. Use %s instead",
+                obj_name,
+                description,
+                breaks_in,
+                replacement,
+            )
     else:
         if integration_frame.custom_integration:
             hass: HomeAssistant | None = None
@@ -280,6 +283,7 @@ def check_if_deprecated_constant(name: str, module_globals: dict[str, Any]) -> A
         "constant",
         "used",
         breaks_in_ha_version,
+        log_when_no_integration_is_found=False,
     )
     return value
 

--- a/tests/helpers/test_deprecation.py
+++ b/tests/helpers/test_deprecation.py
@@ -366,7 +366,7 @@ def test_check_if_deprecated_constant_integration_not_found(
     assert (
         module_name,
         logging.WARNING,
-        f"TEST_CONSTANT wis a deprecated constant{extra_msg}",
+        f"TEST_CONSTANT is a deprecated constant{extra_msg}",
     ) not in caplog.record_tuples
 
 

--- a/tests/helpers/test_deprecation.py
+++ b/tests/helpers/test_deprecation.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.deprecation import (
     dir_with_deprecated_constants,
     get_deprecated,
 )
+from homeassistant.helpers.frame import MissingIntegrationFrame
 
 from tests.common import MockModule, mock_integration
 
@@ -322,6 +323,51 @@ def test_check_if_deprecated_constant(
         logging.WARNING,
         f"TEST_CONSTANT was used from hue, this is a deprecated constant{extra_msg}{extra_extra_msg}",
     ) in caplog.record_tuples
+
+
+@pytest.mark.parametrize(
+    ("deprecated_constant", "extra_msg"),
+    [
+        (
+            DeprecatedConstant("value", "NEW_CONSTANT", None),
+            ". Use NEW_CONSTANT instead",
+        ),
+        (
+            DeprecatedConstant(1, "NEW_CONSTANT", "2099.1"),
+            " which will be removed in HA Core 2099.1. Use NEW_CONSTANT instead",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    ("module_name"),
+    [
+        "homeassistant.components.hue.light",  # builtin integration
+        "config.custom_components.hue.light",  # custom component integration
+    ],
+)
+def test_check_if_deprecated_constant_integration_not_found(
+    caplog: pytest.LogCaptureFixture,
+    deprecated_constant: DeprecatedConstant | DeprecatedConstantEnum,
+    extra_msg: str,
+    module_name: str,
+) -> None:
+    """Test check_if_deprecated_constant."""
+    module_globals = {
+        "__name__": module_name,
+        "_DEPRECATED_TEST_CONSTANT": deprecated_constant,
+    }
+
+    with patch(
+        "homeassistant.helpers.frame.extract_stack", side_effect=MissingIntegrationFrame
+    ):
+        value = check_if_deprecated_constant("TEST_CONSTANT", module_globals)
+        assert value == deprecated_constant.value
+
+    assert (
+        module_name,
+        logging.WARNING,
+        f"TEST_CONSTANT wis a deprecated constant{extra_msg}",
+    ) not in caplog.record_tuples
 
 
 def test_test_check_if_deprecated_constant_invalid(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

It points out that `freezegun` loops over all module attributes and creates a lot of false positives during testing:

```
WARNING:homeassistant.components.binary_sensor:DEVICE_CLASS_UPDATE is a deprecated constant which will be removed in HA Core 2025.1. Use BinarySensorDeviceClass.UPDATE instead
ERROR:homeassistant.helpers.frame:<FrameSummary file /home/development/home-assistant_fork/homeassistant/helpers/frame.py, line 43 in get_integration_frame>
ERROR:homeassistant.helpers.frame:<FrameSummary file /home/development/home-assistant_fork/homeassistant/helpers/deprecation.py, line 181 in _print_deprecation_warning_internal>
ERROR:homeassistant.helpers.frame:<FrameSummary file /home/development/home-assistant_fork/homeassistant/helpers/deprecation.py, line 276 in check_if_deprecated_constant>
ERROR:homeassistant.helpers.frame:<FrameSummary file /home/development/home-assistant_fork/.venv/lib/python3.11/site-packages/freezegun/api.py, line 98 in _get_module_attributes>
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
