### PR TITLE
Allow clearing To-do list item extended fields

### DIFF
--- a/homeassistant/components/google_tasks/todo.py
+++ b/homeassistant/components/google_tasks/todo.py
@@ -29,18 +29,20 @@ TODO_STATUS_MAP = {
 TODO_STATUS_MAP_INV = {v: k for k, v in TODO_STATUS_MAP.items()}
 
 
-def _convert_todo_item(item: TodoItem) -> dict[str, str]:
+def _convert_todo_item(item: TodoItem) -> dict[str, str | None]:
     """Convert TodoItem dataclass items to dictionary of attributes the tasks API."""
-    result: dict[str, str] = {}
-    if item.summary is not None:
-        result["title"] = item.summary
+    result: dict[str, str | None] = {}
+    result["title"] = item.summary
     if item.status is not None:
         result["status"] = TODO_STATUS_MAP_INV[item.status]
+    else:
+        result["status"] = TodoItemStatus.NEEDS_ACTION
     if (due := item.due) is not None:
         # due API field is a timestamp string, but with only date resolution
         result["due"] = dt_util.start_of_local_day(due).isoformat()
-    if (description := item.description) is not None:
-        result["notes"] = description
+    else:
+        result["due"] = None
+    result["notes"] = item.description
     return result
 
 

--- a/homeassistant/components/local_todo/todo.py
+++ b/homeassistant/components/local_todo/todo.py
@@ -1,13 +1,9 @@
 """A Local To-do todo platform."""
 
-from collections.abc import Iterable
-import dataclasses
 import logging
-from typing import Any
 
 from ical.calendar import Calendar
 from ical.calendar_stream import IcsCalendarStream
-from ical.exceptions import CalendarParseError
 from ical.store import TodoStore
 from ical.todo import Todo, TodoStatus
 
@@ -59,26 +55,18 @@ async def async_setup_entry(
     async_add_entities([entity], True)
 
 
-def _todo_dict_factory(obj: Iterable[tuple[str, Any]]) -> dict[str, str]:
-    """Convert TodoItem dataclass items to dictionary of attributes for ical consumption."""
-    result: dict[str, str] = {}
-    for name, value in obj:
-        if value is None:
-            continue
-        if name == "status":
-            result[name] = ICS_TODO_STATUS_MAP_INV[value]
-        else:
-            result[name] = value
-    return result
-
-
 def _convert_item(item: TodoItem) -> Todo:
     """Convert a HomeAssistant TodoItem to an ical Todo."""
-    try:
-        return Todo(**dataclasses.asdict(item, dict_factory=_todo_dict_factory))
-    except CalendarParseError as err:
-        _LOGGER.debug("Error parsing todo input fields: %s (%s)", item, err)
-        raise HomeAssistantError("Error parsing todo input fields") from err
+    todo = Todo()
+    if item.uid:
+        todo.uid = item.uid
+    if item.summary:
+        todo.summary = item.summary
+    if item.status:
+        todo.status = ICS_TODO_STATUS_MAP_INV[item.status]
+    todo.due = item.due
+    todo.description = item.description
+    return todo
 
 
 class LocalTodoListEntity(TodoListEntity):

--- a/homeassistant/components/shopping_list/todo.py
+++ b/homeassistant/components/shopping_list/todo.py
@@ -1,6 +1,6 @@
 """A shopping list todo platform."""
 
-from typing import Any, cast
+from typing import cast
 
 from homeassistant.components.todo import (
     TodoItem,
@@ -55,11 +55,10 @@ class ShoppingTodoListEntity(TodoListEntity):
 
     async def async_update_todo_item(self, item: TodoItem) -> None:
         """Update an item to the To-do list."""
-        data: dict[str, Any] = {}
-        if item.summary:
-            data["name"] = item.summary
-        if item.status:
-            data["complete"] = item.status == TodoItemStatus.COMPLETED
+        data = {
+            "name": item.summary,
+            "complete": item.status == TodoItemStatus.COMPLETED,
+        }
         try:
             await self._data.async_update(item.uid, data)
         except NoMatchingShoppingListItem as err:

--- a/homeassistant/components/todo/__init__.py
+++ b/homeassistant/components/todo/__init__.py
@@ -68,19 +68,19 @@ class TodoItemFieldDescription:
 TODO_ITEM_FIELDS = [
     TodoItemFieldDescription(
         service_field=ATTR_DUE_DATE,
-        validation=cv.date,
+        validation=vol.Any(cv.date, None),
         todo_item_field=ATTR_DUE,
         required_feature=TodoListEntityFeature.SET_DUE_DATE_ON_ITEM,
     ),
     TodoItemFieldDescription(
         service_field=ATTR_DUE_DATETIME,
-        validation=vol.All(cv.datetime, dt_util.as_local),
+        validation=vol.Any(vol.All(cv.datetime, dt_util.as_local), None),
         todo_item_field=ATTR_DUE,
         required_feature=TodoListEntityFeature.SET_DUE_DATETIME_ON_ITEM,
     ),
     TodoItemFieldDescription(
         service_field=ATTR_DESCRIPTION,
-        validation=cv.string,
+        validation=vol.Any(cv.string, None),
         todo_item_field=ATTR_DESCRIPTION,
         required_feature=TodoListEntityFeature.SET_DESCRIPTION_ON_ITEM,
     ),
@@ -474,18 +474,22 @@ async def _async_update_todo_item(entity: TodoListEntity, call: ServiceCall) -> 
 
     _validate_supported_features(entity.supported_features, call.data)
 
-    await entity.async_update_todo_item(
-        item=TodoItem(
-            uid=found.uid,
-            summary=call.data.get("rename"),
-            status=call.data.get("status"),
-            **{
-                desc.todo_item_field: call.data[desc.service_field]
-                for desc in TODO_ITEM_FIELDS
-                if desc.service_field in call.data
-            },
-        )
+    # Perform a partial update on the existing entity based on the fields
+    # present in the update. This allows explicitly clearing any of the
+    # extended fields present and set to None.
+    updated_data = dataclasses.asdict(found)
+    if summary := call.data.get("rename"):
+        updated_data["summary"] = summary
+    if status := call.data.get("status"):
+        updated_data["status"] = status
+    updated_data.update(
+        {
+            desc.todo_item_field: call.data[desc.service_field]
+            for desc in TODO_ITEM_FIELDS
+            if desc.service_field in call.data
+        }
     )
+    await entity.async_update_todo_item(item=TodoItem(**updated_data))
 
 
 async def _async_remove_todo_items(entity: TodoListEntity, call: ServiceCall) -> None:

--- a/homeassistant/components/todoist/todo.py
+++ b/homeassistant/components/todoist/todo.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import datetime
-import logging
 from typing import Any, cast
 
 from homeassistant.components.todo import (
@@ -19,8 +18,6 @@ from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 from .coordinator import TodoistCoordinator
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -49,7 +46,6 @@ def _task_api_data(item: TodoItem) -> dict[str, Any]:
             item_data["due_date"] = due.isoformat()
     else:
         item_data["due_string"] = "no date"
-    _LOGGER.debug("item=%s", item_data)
     return item_data
 
 

--- a/homeassistant/components/todoist/todo.py
+++ b/homeassistant/components/todoist/todo.py
@@ -45,6 +45,8 @@ def _task_api_data(item: TodoItem) -> dict[str, Any]:
         else:
             item_data["due_date"] = due.isoformat()
     else:
+        # Special flag "no date" clears the due date/datetime.
+        # See https://developer.todoist.com/rest/v2/#update-a-task for more.
         item_data["due_string"] = "no date"
     return item_data
 

--- a/tests/components/caldav/test_todo.py
+++ b/tests/components/caldav/test_todo.py
@@ -69,6 +69,19 @@ STATUS:NEEDS-ACTION
 END:VTODO
 END:VCALENDAR"""
 
+TODO_ALL_FIELDS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//E-Corp.//CalDAV Client//EN
+BEGIN:VTODO
+UID:2
+DTSTAMP:20171125T000000Z
+SUMMARY:Cheese
+DESCRIPTION:Any kind will do
+STATUS:NEEDS-ACTION
+DUE:20171126
+END:VTODO
+END:VCALENDAR"""
+
 
 @pytest.fixture
 def platforms() -> list[Platform]:
@@ -130,6 +143,18 @@ async def mock_add_to_hass(
 ) -> None:
     """Fixture to add the ConfigEntry."""
     config_entry.add_to_hass(hass)
+
+
+IGNORE_COMPONENTS = ["BEGIN", "END", "DTSTAMP", "PRODID", "UID", "VERSION"]
+
+
+def compact_ics(ics: str) -> list[str]:
+    """Pull out parts of the rfc5545 content useful for assertions in tests."""
+    return [
+        line
+        for line in ics.split("\n")
+        if line and not any(filter(line.startswith, IGNORE_COMPONENTS))
+    ]
 
 
 @pytest.mark.parametrize(
@@ -292,45 +317,148 @@ async def test_add_item_failure(
     [
         (
             {"rename": "Swiss Cheese"},
-            ["SUMMARY:Swiss Cheese", "STATUS:NEEDS-ACTION"],
+            [
+                "DESCRIPTION:Any kind will do",
+                "DUE;VALUE=DATE:20171126",
+                "STATUS:NEEDS-ACTION",
+                "SUMMARY:Swiss Cheese",
+            ],
             "1",
-            {**RESULT_ITEM, "summary": "Swiss Cheese"},
+            {
+                "uid": "2",
+                "summary": "Swiss Cheese",
+                "status": "needs_action",
+                "description": "Any kind will do",
+                "due": "2017-11-26",
+            },
         ),
         (
             {"status": "needs_action"},
-            ["SUMMARY:Cheese", "STATUS:NEEDS-ACTION"],
+            [
+                "DESCRIPTION:Any kind will do",
+                "DUE;VALUE=DATE:20171126",
+                "STATUS:NEEDS-ACTION",
+                "SUMMARY:Cheese",
+            ],
             "1",
-            RESULT_ITEM,
+            {
+                "uid": "2",
+                "summary": "Cheese",
+                "status": "needs_action",
+                "description": "Any kind will do",
+                "due": "2017-11-26",
+            },
         ),
         (
             {"status": "completed"},
-            ["SUMMARY:Cheese", "STATUS:COMPLETED"],
+            [
+                "DESCRIPTION:Any kind will do",
+                "DUE;VALUE=DATE:20171126",
+                "STATUS:COMPLETED",
+                "SUMMARY:Cheese",
+            ],
             "0",
-            {**RESULT_ITEM, "status": "completed"},
+            {
+                "uid": "2",
+                "summary": "Cheese",
+                "status": "completed",
+                "description": "Any kind will do",
+                "due": "2017-11-26",
+            },
         ),
         (
             {"rename": "Swiss Cheese", "status": "needs_action"},
-            ["SUMMARY:Swiss Cheese", "STATUS:NEEDS-ACTION"],
+            [
+                "DESCRIPTION:Any kind will do",
+                "DUE;VALUE=DATE:20171126",
+                "STATUS:NEEDS-ACTION",
+                "SUMMARY:Swiss Cheese",
+            ],
             "1",
-            {**RESULT_ITEM, "summary": "Swiss Cheese"},
+            {
+                "uid": "2",
+                "summary": "Swiss Cheese",
+                "status": "needs_action",
+                "description": "Any kind will do",
+                "due": "2017-11-26",
+            },
         ),
         (
             {"due_date": "2023-11-18"},
-            ["SUMMARY:Cheese", "DUE;VALUE=DATE:20231118"],
+            [
+                "DESCRIPTION:Any kind will do",
+                "DUE;VALUE=DATE:20231118",
+                "STATUS:NEEDS-ACTION",
+                "SUMMARY:Cheese",
+            ],
             "1",
-            {**RESULT_ITEM, "due": "2023-11-18"},
+            {
+                "uid": "2",
+                "summary": "Cheese",
+                "status": "needs_action",
+                "description": "Any kind will do",
+                "due": "2023-11-18",
+            },
         ),
         (
             {"due_datetime": "2023-11-18T08:30:00-06:00"},
-            ["SUMMARY:Cheese", "DUE;TZID=America/Regina:20231118T083000"],
+            [
+                "DESCRIPTION:Any kind will do",
+                "DUE;TZID=America/Regina:20231118T083000",
+                "STATUS:NEEDS-ACTION",
+                "SUMMARY:Cheese",
+            ],
             "1",
-            {**RESULT_ITEM, "due": "2023-11-18T08:30:00-06:00"},
+            {
+                "uid": "2",
+                "summary": "Cheese",
+                "status": "needs_action",
+                "description": "Any kind will do",
+                "due": "2023-11-18T08:30:00-06:00",
+            },
+        ),
+        (
+            {"due_datetime": None},
+            [
+                "DESCRIPTION:Any kind will do",
+                "STATUS:NEEDS-ACTION",
+                "SUMMARY:Cheese",
+            ],
+            "1",
+            {
+                "uid": "2",
+                "summary": "Cheese",
+                "status": "needs_action",
+                "description": "Any kind will do",
+            },
         ),
         (
             {"description": "Make sure to get Swiss"},
-            ["SUMMARY:Cheese", "DESCRIPTION:Make sure to get Swiss"],
+            [
+                "DESCRIPTION:Make sure to get Swiss",
+                "DUE;VALUE=DATE:20171126",
+                "STATUS:NEEDS-ACTION",
+                "SUMMARY:Cheese",
+            ],
             "1",
-            {**RESULT_ITEM, "description": "Make sure to get Swiss"},
+            {
+                "uid": "2",
+                "summary": "Cheese",
+                "status": "needs_action",
+                "due": "2017-11-26",
+                "description": "Make sure to get Swiss",
+            },
+        ),
+        (
+            {"description": None},
+            ["DUE;VALUE=DATE:20171126", "STATUS:NEEDS-ACTION", "SUMMARY:Cheese"],
+            "1",
+            {
+                "uid": "2",
+                "summary": "Cheese",
+                "status": "needs_action",
+                "due": "2017-11-26",
+            },
         ),
     ],
     ids=[
@@ -340,7 +468,9 @@ async def test_add_item_failure(
         "rename_status",
         "due_date",
         "due_datetime",
+        "clear_due_date",
         "description",
+        "clear_description",
     ],
 )
 async def test_update_item(
@@ -355,7 +485,7 @@ async def test_update_item(
 ) -> None:
     """Test updating an item on the list."""
 
-    item = Todo(dav_client, None, TODO_NEEDS_ACTION, calendar, "2")
+    item = Todo(dav_client, None, TODO_ALL_FIELDS, calendar, "2")
     calendar.search = MagicMock(return_value=[item])
 
     await config_entry.async_setup(hass)
@@ -381,8 +511,7 @@ async def test_update_item(
 
     assert dav_client.put.call_args
     ics = dav_client.put.call_args.args[1]
-    for expected in expected_ics:
-        assert expected in ics
+    assert compact_ics(ics) == expected_ics
 
     state = hass.states.get(TEST_ENTITY)
     assert state

--- a/tests/components/google_tasks/snapshots/test_todo.ambr
+++ b/tests/components/google_tasks/snapshots/test_todo.ambr
@@ -6,7 +6,7 @@
   )
 # ---
 # name: test_create_todo_list_item[description].1
-  '{"title": "Soda", "status": "needsAction", "notes": "6-pack"}'
+  '{"title": "Soda", "status": "needsAction", "due": null, "notes": "6-pack"}'
 # ---
 # name: test_create_todo_list_item[due]
   tuple(
@@ -15,7 +15,7 @@
   )
 # ---
 # name: test_create_todo_list_item[due].1
-  '{"title": "Soda", "status": "needsAction", "due": "2023-11-18T00:00:00-08:00"}'
+  '{"title": "Soda", "status": "needsAction", "due": "2023-11-18T00:00:00-08:00", "notes": null}'
 # ---
 # name: test_create_todo_list_item[summary]
   tuple(
@@ -24,7 +24,7 @@
   )
 # ---
 # name: test_create_todo_list_item[summary].1
-  '{"title": "Soda", "status": "needsAction"}'
+  '{"title": "Soda", "status": "needsAction", "due": null, "notes": null}'
 # ---
 # name: test_delete_todo_list_item[_handler]
   tuple(
@@ -56,6 +56,24 @@
     }),
   ])
 # ---
+# name: test_partial_update[clear_description]
+  tuple(
+    'https://tasks.googleapis.com/tasks/v1/lists/task-list-id-1/tasks/some-task-id?alt=json',
+    'PATCH',
+  )
+# ---
+# name: test_partial_update[clear_description].1
+  '{"title": "Water", "status": "needsAction", "due": null, "notes": null}'
+# ---
+# name: test_partial_update[clear_due_date]
+  tuple(
+    'https://tasks.googleapis.com/tasks/v1/lists/task-list-id-1/tasks/some-task-id?alt=json',
+    'PATCH',
+  )
+# ---
+# name: test_partial_update[clear_due_date].1
+  '{"title": "Water", "status": "needsAction", "due": null, "notes": null}'
+# ---
 # name: test_partial_update[description]
   tuple(
     'https://tasks.googleapis.com/tasks/v1/lists/task-list-id-1/tasks/some-task-id?alt=json',
@@ -63,7 +81,7 @@
   )
 # ---
 # name: test_partial_update[description].1
-  '{"notes": "6-pack"}'
+  '{"title": "Water", "status": "needsAction", "due": null, "notes": "At least one gallon"}'
 # ---
 # name: test_partial_update[due_date]
   tuple(
@@ -72,7 +90,16 @@
   )
 # ---
 # name: test_partial_update[due_date].1
-  '{"due": "2023-11-18T00:00:00-08:00"}'
+  '{"title": "Water", "status": "needsAction", "due": "2023-11-18T00:00:00-08:00", "notes": null}'
+# ---
+# name: test_partial_update[empty_description]
+  tuple(
+    'https://tasks.googleapis.com/tasks/v1/lists/task-list-id-1/tasks/some-task-id?alt=json',
+    'PATCH',
+  )
+# ---
+# name: test_partial_update[empty_description].1
+  '{"title": "Water", "status": "needsAction", "due": null, "notes": ""}'
 # ---
 # name: test_partial_update[rename]
   tuple(
@@ -81,7 +108,7 @@
   )
 # ---
 # name: test_partial_update[rename].1
-  '{"title": "Soda"}'
+  '{"title": "Soda", "status": "needsAction", "due": null, "notes": null}'
 # ---
 # name: test_partial_update_status[api_responses0]
   tuple(
@@ -90,7 +117,7 @@
   )
 # ---
 # name: test_partial_update_status[api_responses0].1
-  '{"status": "needsAction"}'
+  '{"title": "Water", "status": "needsAction", "due": null, "notes": null}'
 # ---
 # name: test_update_todo_list_item[api_responses0]
   tuple(
@@ -99,5 +126,5 @@
   )
 # ---
 # name: test_update_todo_list_item[api_responses0].1
-  '{"title": "Soda", "status": "completed"}'
+  '{"title": "Soda", "status": "completed", "due": null, "notes": null}'
 # ---

--- a/tests/components/google_tasks/test_todo.py
+++ b/tests/components/google_tasks/test_todo.py
@@ -48,6 +48,7 @@ LIST_TASKS_RESPONSE_WATER = {
             "id": "some-task-id",
             "title": "Water",
             "status": "needsAction",
+            "description": "Any size is ok",
             "position": "00000000000000000001",
         },
     ],
@@ -493,9 +494,19 @@ async def test_update_todo_list_item_error(
     [
         (UPDATE_API_RESPONSES, {"rename": "Soda"}),
         (UPDATE_API_RESPONSES, {"due_date": "2023-11-18"}),
-        (UPDATE_API_RESPONSES, {"description": "6-pack"}),
+        (UPDATE_API_RESPONSES, {"due_date": None}),
+        (UPDATE_API_RESPONSES, {"description": "At least one gallon"}),
+        (UPDATE_API_RESPONSES, {"description": ""}),
+        (UPDATE_API_RESPONSES, {"description": None}),
     ],
-    ids=("rename", "due_date", "description"),
+    ids=(
+        "rename",
+        "due_date",
+        "clear_due_date",
+        "description",
+        "empty_description",
+        "clear_description",
+    ),
 )
 async def test_partial_update(
     hass: HomeAssistant,

--- a/tests/components/local_todo/test_todo.py
+++ b/tests/components/local_todo/test_todo.py
@@ -65,16 +65,27 @@ def set_time_zone(hass: HomeAssistant) -> None:
     hass.config.set_time_zone("America/Regina")
 
 
+EXPECTED_ADD_ITEM = {
+    "status": "needs_action",
+    "summary": "replace batteries",
+}
+
+
 @pytest.mark.parametrize(
     ("item_data", "expected_item_data"),
     [
-        ({}, {}),
-        ({"due_date": "2023-11-17"}, {"due": "2023-11-17"}),
+        ({}, EXPECTED_ADD_ITEM),
+        ({"due_date": "2023-11-17"}, {**EXPECTED_ADD_ITEM, "due": "2023-11-17"}),
         (
             {"due_datetime": "2023-11-17T11:30:00+00:00"},
-            {"due": "2023-11-17T05:30:00-06:00"},
+            {**EXPECTED_ADD_ITEM, "due": "2023-11-17T05:30:00-06:00"},
         ),
-        ({"description": "Additional detail"}, {"description": "Additional detail"}),
+        (
+            {"description": "Additional detail"},
+            {**EXPECTED_ADD_ITEM, "description": "Additional detail"},
+        ),
+        ({"description": ""}, {**EXPECTED_ADD_ITEM, "description": ""}),
+        ({"description": None}, EXPECTED_ADD_ITEM),
     ],
 )
 async def test_add_item(
@@ -101,11 +112,10 @@ async def test_add_item(
 
     items = await ws_get_items()
     assert len(items) == 1
-    assert items[0]["summary"] == "replace batteries"
-    assert items[0]["status"] == "needs_action"
-    for k, v in expected_item_data.items():
-        assert items[0][k] == v
-    assert "uid" in items[0]
+    item_data = items[0]
+    assert "uid" in item_data
+    del item_data["uid"]
+    assert item_data == expected_item_data
 
     state = hass.states.get(TEST_ENTITY)
     assert state
@@ -207,19 +217,29 @@ async def test_bulk_remove(
     assert state.state == "0"
 
 
+EXPECTED_UPDATE_ITEM = {
+    "status": "needs_action",
+    "summary": "soda",
+}
+
+
 @pytest.mark.parametrize(
     ("item_data", "expected_item_data", "expected_state"),
     [
-        ({"status": "completed"}, {"status": "completed"}, "0"),
-        ({"due_date": "2023-11-17"}, {"due": "2023-11-17"}, "1"),
+        ({"status": "completed"}, {**EXPECTED_UPDATE_ITEM, "status": "completed"}, "0"),
+        (
+            {"due_date": "2023-11-17"},
+            {**EXPECTED_UPDATE_ITEM, "due": "2023-11-17"},
+            "1",
+        ),
         (
             {"due_datetime": "2023-11-17T11:30:00+00:00"},
-            {"due": "2023-11-17T05:30:00-06:00"},
+            {**EXPECTED_UPDATE_ITEM, "due": "2023-11-17T05:30:00-06:00"},
             "1",
         ),
         (
             {"description": "Additional detail"},
-            {"description": "Additional detail"},
+            {**EXPECTED_UPDATE_ITEM, "description": "Additional detail"},
             "1",
         ),
     ],
@@ -246,6 +266,7 @@ async def test_update_item(
     # Fetch item
     items = await ws_get_items()
     assert len(items) == 1
+
     item = items[0]
     assert item["summary"] == "soda"
     assert item["status"] == "needs_action"
@@ -254,7 +275,7 @@ async def test_update_item(
     assert state
     assert state.state == "1"
 
-    # Mark item completed
+    # Update item
     await hass.services.async_call(
         TODO_DOMAIN,
         "update_item",
@@ -268,12 +289,128 @@ async def test_update_item(
     assert len(items) == 1
     item = items[0]
     assert item["summary"] == "soda"
-    for k, v in expected_item_data.items():
-        assert items[0][k] == v
+    assert "uid" in item
+    del item["uid"]
+    assert item == expected_item_data
 
     state = hass.states.get(TEST_ENTITY)
     assert state
     assert state.state == expected_state
+
+
+@pytest.mark.parametrize(
+    ("item_data", "expected_item_data"),
+    [
+        (
+            {"status": "completed"},
+            {
+                "summary": "soda",
+                "status": "completed",
+                "description": "Additional detail",
+                "due": "2024-01-01",
+            },
+        ),
+        (
+            {"due_date": "2024-01-02"},
+            {
+                "summary": "soda",
+                "status": "needs_action",
+                "description": "Additional detail",
+                "due": "2024-01-02",
+            },
+        ),
+        (
+            {"due_date": None},
+            {
+                "summary": "soda",
+                "status": "needs_action",
+                "description": "Additional detail",
+            },
+        ),
+        (
+            {"due_datetime": "2024-01-01 10:30:00"},
+            {
+                "summary": "soda",
+                "status": "needs_action",
+                "description": "Additional detail",
+                "due": "2024-01-01T10:30:00-06:00",
+            },
+        ),
+        (
+            {"due_datetime": None},
+            {
+                "summary": "soda",
+                "status": "needs_action",
+                "description": "Additional detail",
+            },
+        ),
+        (
+            {"description": "updated description"},
+            {
+                "summary": "soda",
+                "status": "needs_action",
+                "due": "2024-01-01",
+                "description": "updated description",
+            },
+        ),
+        (
+            {"description": None},
+            {"summary": "soda", "status": "needs_action", "due": "2024-01-01"},
+        ),
+    ],
+    ids=[
+        "status",
+        "due_date",
+        "clear_due_date",
+        "due_datetime",
+        "clear_due_datetime",
+        "description",
+        "clear_description",
+    ],
+)
+async def test_update_existing_field(
+    hass: HomeAssistant,
+    setup_integration: None,
+    ws_get_items: Callable[[], Awaitable[dict[str, str]]],
+    item_data: dict[str, Any],
+    expected_item_data: dict[str, Any],
+) -> None:
+    """Test updating a todo item."""
+
+    # Create new item
+    await hass.services.async_call(
+        TODO_DOMAIN,
+        "add_item",
+        {"item": "soda", "description": "Additional detail", "due_date": "2024-01-01"},
+        target={"entity_id": TEST_ENTITY},
+        blocking=True,
+    )
+
+    # Fetch item
+    items = await ws_get_items()
+    assert len(items) == 1
+
+    item = items[0]
+    assert item["summary"] == "soda"
+    assert item["status"] == "needs_action"
+
+    # Perform update
+    await hass.services.async_call(
+        TODO_DOMAIN,
+        "update_item",
+        {"item": item["uid"], **item_data},
+        target={"entity_id": TEST_ENTITY},
+        blocking=True,
+    )
+
+    # Verify item is updated
+    items = await ws_get_items()
+    assert len(items) == 1
+    item = items[0]
+    assert item["summary"] == "soda"
+    assert "uid" in item
+    del item["uid"]
+    assert item == expected_item_data
 
 
 async def test_rename(

--- a/tests/components/todo/test_init.py
+++ b/tests/components/todo/test_init.py
@@ -146,15 +146,19 @@ async def create_mock_platform(
     return config_entry
 
 
+@pytest.fixture(name="test_entity_items")
+def mock_test_entity_items() -> list[TodoItem]:
+    """Fixture that creates the items returned by the test entity."""
+    return [
+        TodoItem(summary="Item #1", uid="1", status=TodoItemStatus.NEEDS_ACTION),
+        TodoItem(summary="Item #2", uid="2", status=TodoItemStatus.COMPLETED),
+    ]
+
+
 @pytest.fixture(name="test_entity")
-def mock_test_entity() -> TodoListEntity:
+def mock_test_entity(test_entity_items: list[TodoItem]) -> TodoListEntity:
     """Fixture that creates a test TodoList entity with mock service calls."""
-    entity1 = MockTodoListEntity(
-        [
-            TodoItem(summary="Item #1", uid="1", status=TodoItemStatus.NEEDS_ACTION),
-            TodoItem(summary="Item #2", uid="2", status=TodoItemStatus.COMPLETED),
-        ]
-    )
+    entity1 = MockTodoListEntity(test_entity_items)
     entity1.entity_id = "todo.entity1"
     entity1._attr_supported_features = (
         TodoListEntityFeature.CREATE_TODO_ITEM
@@ -504,7 +508,7 @@ async def test_update_todo_item_service_by_id_status_only(
     item = args.kwargs.get("item")
     assert item
     assert item.uid == "1"
-    assert item.summary is None
+    assert item.summary == "Item #1"
     assert item.status == TodoItemStatus.COMPLETED
 
 
@@ -530,7 +534,7 @@ async def test_update_todo_item_service_by_id_rename(
     assert item
     assert item.uid == "1"
     assert item.summary == "Updated item"
-    assert item.status is None
+    assert item.status == TodoItemStatus.NEEDS_ACTION
 
 
 async def test_update_todo_item_service_raises(
@@ -607,7 +611,7 @@ async def test_update_todo_item_service_by_summary_only_status(
     assert item
     assert item.uid == "1"
     assert item.summary == "Something else"
-    assert item.status is None
+    assert item.status == TodoItemStatus.NEEDS_ACTION
 
 
 async def test_update_todo_item_service_by_summary_not_found(
@@ -693,20 +697,32 @@ async def test_update_todo_item_field_unsupported(
         (
             TodoListEntityFeature.SET_DUE_DATE_ON_ITEM,
             {"due_date": "2023-11-13"},
-            TodoItem(uid="1", due=datetime.date(2023, 11, 13)),
+            TodoItem(
+                uid="1",
+                summary="Item #1",
+                status=TodoItemStatus.NEEDS_ACTION,
+                due=datetime.date(2023, 11, 13),
+            ),
         ),
         (
             TodoListEntityFeature.SET_DUE_DATETIME_ON_ITEM,
             {"due_datetime": f"2023-11-13T17:00:00{TEST_OFFSET}"},
             TodoItem(
                 uid="1",
+                summary="Item #1",
+                status=TodoItemStatus.NEEDS_ACTION,
                 due=datetime.datetime(2023, 11, 13, 17, 0, 0, tzinfo=TEST_TIMEZONE),
             ),
         ),
         (
             TodoListEntityFeature.SET_DESCRIPTION_ON_ITEM,
             {"description": "Submit revised draft"},
-            TodoItem(uid="1", description="Submit revised draft"),
+            TodoItem(
+                uid="1",
+                summary="Item #1",
+                status=TodoItemStatus.NEEDS_ACTION,
+                description="Submit revised draft",
+            ),
         ),
     ),
 )
@@ -720,6 +736,96 @@ async def test_update_todo_item_extended_fields(
     """Test updating an item in a To-do list."""
 
     test_entity._attr_supported_features |= supported_entity_feature
+    await create_mock_platform(hass, [test_entity])
+
+    await hass.services.async_call(
+        DOMAIN,
+        "update_item",
+        {"item": "1", **update_data},
+        target={"entity_id": "todo.entity1"},
+        blocking=True,
+    )
+
+    args = test_entity.async_update_todo_item.call_args
+    assert args
+    item = args.kwargs.get("item")
+    assert item == expected_update
+
+
+@pytest.mark.parametrize(
+    ("test_entity_items", "update_data", "expected_update"),
+    (
+        (
+            [TodoItem(uid="1", summary="Summary", description="description")],
+            {"description": "Submit revised draft"},
+            TodoItem(uid="1", summary="Summary", description="Submit revised draft"),
+        ),
+        (
+            [TodoItem(uid="1", summary="Summary", description="description")],
+            {"description": ""},
+            TodoItem(uid="1", summary="Summary", description=""),
+        ),
+        (
+            [TodoItem(uid="1", summary="Summary", description="description")],
+            {"description": None},
+            TodoItem(uid="1", summary="Summary"),
+        ),
+        (
+            [TodoItem(uid="1", summary="Summary", due=datetime.date(2024, 1, 1))],
+            {"due_date": datetime.date(2024, 1, 2)},
+            TodoItem(uid="1", summary="Summary", due=datetime.date(2024, 1, 2)),
+        ),
+        (
+            [TodoItem(uid="1", summary="Summary", due=datetime.date(2024, 1, 1))],
+            {"due_date": None},
+            TodoItem(uid="1", summary="Summary"),
+        ),
+        (
+            [TodoItem(uid="1", summary="Summary", due=datetime.date(2024, 1, 1))],
+            {"due_datetime": datetime.datetime(2024, 1, 1, 10, 0, 0)},
+            TodoItem(
+                uid="1",
+                summary="Summary",
+                due=datetime.datetime(
+                    2024, 1, 1, 10, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="America/Regina")
+                ),
+            ),
+        ),
+        (
+            [
+                TodoItem(
+                    uid="1",
+                    summary="Summary",
+                    due=datetime.datetime(2024, 1, 1, 10, 0, 0),
+                )
+            ],
+            {"due_datetime": None},
+            TodoItem(uid="1", summary="Summary"),
+        ),
+    ),
+    ids=[
+        "overwrite_description",
+        "overwrite_empty_description",
+        "clear_description",
+        "overwrite_due_date",
+        "clear_due_date",
+        "overwrite_due_date_with_time",
+        "clear_due_date_time",
+    ],
+)
+async def test_update_todo_item_extended_fields_overwrite_existing_values(
+    hass: HomeAssistant,
+    test_entity: TodoListEntity,
+    update_data: dict[str, Any],
+    expected_update: TodoItem,
+) -> None:
+    """Test updating an item in a To-do list."""
+
+    test_entity._attr_supported_features |= (
+        TodoListEntityFeature.SET_DESCRIPTION_ON_ITEM
+        | TodoListEntityFeature.SET_DUE_DATE_ON_ITEM
+        | TodoListEntityFeature.SET_DUE_DATETIME_ON_ITEM
+    )
     await create_mock_platform(hass, [test_entity])
 
     await hass.services.async_call(

--- a/tests/components/todoist/test_todo.py
+++ b/tests/components/todoist/test_todo.py
@@ -80,7 +80,7 @@ async def test_todo_item_state(
             [],
             {},
             [make_api_task(id="task-id-1", content="Soda", is_completed=False)],
-            {"content": "Soda"},
+            {"content": "Soda", "due_string": "no date", "description": ""},
             {"uid": "task-id-1", "summary": "Soda", "status": "needs_action"},
         ),
         (
@@ -94,7 +94,7 @@ async def test_todo_item_state(
                     due=Due(is_recurring=False, date="2023-11-18", string="today"),
                 )
             ],
-            {"due": {"date": "2023-11-18"}},
+            {"description": "", "due_date": "2023-11-18"},
             {
                 "uid": "task-id-1",
                 "summary": "Soda",
@@ -119,7 +119,8 @@ async def test_todo_item_state(
                 )
             ],
             {
-                "due": {"date": "2023-11-18", "datetime": "2023-11-18T06:30:00-06:00"},
+                "description": "",
+                "due_datetime": "2023-11-18T06:30:00-06:00",
             },
             {
                 "uid": "task-id-1",
@@ -139,7 +140,7 @@ async def test_todo_item_state(
                     is_completed=False,
                 )
             ],
-            {"description": "6-pack"},
+            {"description": "6-pack", "due_string": "no date"},
             {
                 "uid": "task-id-1",
                 "summary": "Soda",
@@ -264,11 +265,35 @@ async def test_update_todo_item_status(
     ("tasks", "update_data", "tasks_after_update", "update_kwargs", "expected_item"),
     [
         (
-            [make_api_task(id="task-id-1", content="Soda", is_completed=False)],
+            [
+                make_api_task(
+                    id="task-id-1",
+                    content="Soda",
+                    is_completed=False,
+                    description="desc",
+                )
+            ],
             {"rename": "Milk"},
-            [make_api_task(id="task-id-1", content="Milk", is_completed=False)],
-            {"task_id": "task-id-1", "content": "Milk"},
-            {"uid": "task-id-1", "summary": "Milk", "status": "needs_action"},
+            [
+                make_api_task(
+                    id="task-id-1",
+                    content="Milk",
+                    is_completed=False,
+                    description="desc",
+                )
+            ],
+            {
+                "task_id": "task-id-1",
+                "content": "Milk",
+                "description": "desc",
+                "due_string": "no date",
+            },
+            {
+                "uid": "task-id-1",
+                "summary": "Milk",
+                "status": "needs_action",
+                "description": "desc",
+            },
         ),
         (
             [make_api_task(id="task-id-1", content="Soda", is_completed=False)],
@@ -281,7 +306,12 @@ async def test_update_todo_item_status(
                     due=Due(is_recurring=False, date="2023-11-18", string="today"),
                 )
             ],
-            {"task_id": "task-id-1", "due": {"date": "2023-11-18"}},
+            {
+                "task_id": "task-id-1",
+                "content": "Soda",
+                "due_date": "2023-11-18",
+                "description": "",
+            },
             {
                 "uid": "task-id-1",
                 "summary": "Soda",
@@ -307,7 +337,9 @@ async def test_update_todo_item_status(
             ],
             {
                 "task_id": "task-id-1",
-                "due": {"date": "2023-11-18", "datetime": "2023-11-18T06:30:00-06:00"},
+                "content": "Soda",
+                "due_datetime": "2023-11-18T06:30:00-06:00",
+                "description": "",
             },
             {
                 "uid": "task-id-1",
@@ -327,7 +359,12 @@ async def test_update_todo_item_status(
                     is_completed=False,
                 )
             ],
-            {"task_id": "task-id-1", "description": "6-pack"},
+            {
+                "task_id": "task-id-1",
+                "content": "Soda",
+                "description": "6-pack",
+                "due_string": "no date",
+            },
             {
                 "uid": "task-id-1",
                 "summary": "Soda",
@@ -335,8 +372,38 @@ async def test_update_todo_item_status(
                 "description": "6-pack",
             },
         ),
+        (
+            [
+                make_api_task(
+                    id="task-id-1",
+                    content="Soda",
+                    description="6-pack",
+                    is_completed=False,
+                )
+            ],
+            {"description": None},
+            [
+                make_api_task(
+                    id="task-id-1",
+                    content="Soda",
+                    is_completed=False,
+                    description="",
+                )
+            ],
+            {
+                "task_id": "task-id-1",
+                "content": "Soda",
+                "description": "",
+                "due_string": "no date",
+            },
+            {
+                "uid": "task-id-1",
+                "summary": "Soda",
+                "status": "needs_action",
+            },
+        ),
     ],
-    ids=["rename", "due_date", "due_datetime", "description"],
+    ids=["rename", "due_date", "due_datetime", "description", "clear_description"],
 )
 async def test_update_todo_items(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow clearing To-do list item extended fields. This is needed based on feedback from https://github.com/home-assistant/frontend/pull/19107 that the current API won't let the frontend clear the extended fields.

This changes the partial update semantics. Service calls for the extended due date and description fields can be set to `None` which will overwrite the existing values. The integrations then have to translate a `TodoItem` with `None` values to overwrite those extended fields to clear them.

This updates all the integrations that support extended fields with the new semantics:
- Local todo item supports overwriting fields that are explicitly set
- Google tasks supports setting `None` fields on create and update. We're using `PATCH` so we only clobber extended fields home assistant knows about
- Todoist update API date/due date fields support a string with a value of `no date` to indicate the dates should be cleared. It needs some special handling for status since it will now always be present.
- Caldav create and update were separated given the update semantics are too complicated to keep together

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2022

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
