### PR TITLE
Add more fine grained control over Matter server commissioning for the Companion apps

### DIFF
--- a/homeassistant/components/matter/api.py
+++ b/homeassistant/components/matter/api.py
@@ -109,7 +109,7 @@ async def websocket_commission(
     {
         vol.Required(TYPE): "matter/commission_on_network",
         vol.Required("pin"): int,
-        vol.Optional("ip"): str,
+        vol.Optional("ip_addr"): str,
     }
 )
 @websocket_api.async_response
@@ -123,7 +123,7 @@ async def websocket_commission_on_network(
 ) -> None:
     """Commission a device already on the network."""
     await matter.matter_client.commission_on_network(
-        msg["pin"], ip_addr=msg.get("ip", None)
+        msg["pin"], ip_addr=msg.get("ip_addr", None)
     )
     connection.send_result(msg[ID])
 

--- a/homeassistant/components/matter/api.py
+++ b/homeassistant/components/matter/api.py
@@ -97,7 +97,9 @@ async def websocket_commission(
     matter: MatterAdapter,
 ) -> None:
     """Add a device to the network and commission the device."""
-    await matter.matter_client.commission_with_code(msg["code"])
+    await matter.matter_client.commission_with_code(
+        msg["code"], network_only=msg.get("network_only", True)
+    )
     connection.send_result(msg[ID])
 
 
@@ -118,7 +120,9 @@ async def websocket_commission_on_network(
     matter: MatterAdapter,
 ) -> None:
     """Commission a device already on the network."""
-    await matter.matter_client.commission_on_network(msg["pin"])
+    await matter.matter_client.commission_on_network(
+        msg["pin"], ip_addr=msg.get("ip", None)
+    )
     connection.send_result(msg[ID])
 
 

--- a/homeassistant/components/matter/api.py
+++ b/homeassistant/components/matter/api.py
@@ -85,6 +85,7 @@ def async_handle_failed_command(
     {
         vol.Required(TYPE): "matter/commission",
         vol.Required("code"): str,
+        vol.Optional("network_only"): bool,
     }
 )
 @websocket_api.async_response
@@ -108,6 +109,7 @@ async def websocket_commission(
     {
         vol.Required(TYPE): "matter/commission_on_network",
         vol.Required("pin"): int,
+        vol.Optional("ip"): str,
     }
 )
 @websocket_api.async_response

--- a/homeassistant/components/matter/manifest.json
+++ b/homeassistant/components/matter/manifest.json
@@ -6,5 +6,5 @@
   "dependencies": ["websocket_api"],
   "documentation": "https://www.home-assistant.io/integrations/matter",
   "iot_class": "local_push",
-  "requirements": ["python-matter-server==5.0.0"]
+  "requirements": ["python-matter-server==5.1.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2193,7 +2193,7 @@ python-kasa[speedups]==0.5.4
 # python-lirc==1.2.3
 
 # homeassistant.components.matter
-python-matter-server==5.0.0
+python-matter-server==5.1.1
 
 # homeassistant.components.xiaomi_miio
 python-miio==0.5.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1650,7 +1650,7 @@ python-juicenet==1.1.0
 python-kasa[speedups]==0.5.4
 
 # homeassistant.components.matter
-python-matter-server==5.0.0
+python-matter-server==5.1.1
 
 # homeassistant.components.xiaomi_miio
 python-miio==0.5.12

--- a/tests/components/matter/fixtures/config_entry_diagnostics_redacted.json
+++ b/tests/components/matter/fixtures/config_entry_diagnostics_redacted.json
@@ -14,7 +14,6 @@
         "node_id": 5,
         "date_commissioned": "2023-01-16T21:07:57.508440",
         "last_interview": "2023-01-16T21:07:57.508448",
-        "last_subscription_attempt": 0,
         "interview_version": 2,
         "attributes": {
           "0/4/0": 128,

--- a/tests/components/matter/fixtures/nodes/device_diagnostics.json
+++ b/tests/components/matter/fixtures/nodes/device_diagnostics.json
@@ -3,7 +3,6 @@
   "date_commissioned": "2023-01-16T21:07:57.508440",
   "last_interview": "2023-01-16T21:07:57.508448",
   "interview_version": 2,
-  "last_subscription_attempt": 0,
   "attributes": {
     "0/4/0": 128,
     "0/4/65532": 1,

--- a/tests/components/matter/test_api.py
+++ b/tests/components/matter/test_api.py
@@ -40,17 +40,13 @@ async def test_commission(
     )
 
     await ws_client.send_json(
-        {
-            ID: 2,
-            TYPE: "matter/commission",
-            "code": "12345678",
-        }
+        {ID: 2, TYPE: "matter/commission", "code": "12345678", "network_only": False}
     )
     msg = await ws_client.receive_json()
 
     assert not msg["success"]
     assert msg["error"]["code"] == "9"
-    matter_client.commission_with_code.assert_called_once_with("12345678", True)
+    matter_client.commission_with_code.assert_called_once_with("12345678", False)
 
 
 # This tests needs to be adjusted to remove lingering tasks
@@ -82,17 +78,13 @@ async def test_commission_on_network(
     )
 
     await ws_client.send_json(
-        {
-            ID: 2,
-            TYPE: "matter/commission_on_network",
-            "pin": 1234,
-        }
+        {ID: 2, TYPE: "matter/commission_on_network", "pin": 1234, "ip": "1.2.3.4"}
     )
     msg = await ws_client.receive_json()
 
     assert not msg["success"]
     assert msg["error"]["code"] == "1"
-    matter_client.commission_on_network.assert_called_once_with(1234, None)
+    matter_client.commission_on_network.assert_called_once_with(1234, "1.2.3.4")
 
 
 # This tests needs to be adjusted to remove lingering tasks

--- a/tests/components/matter/test_api.py
+++ b/tests/components/matter/test_api.py
@@ -32,7 +32,7 @@ async def test_commission(
     msg = await ws_client.receive_json()
 
     assert msg["success"]
-    matter_client.commission_with_code.assert_called_once_with("12345678")
+    matter_client.commission_with_code.assert_called_once_with("12345678", True)
 
     matter_client.commission_with_code.reset_mock()
     matter_client.commission_with_code.side_effect = InvalidCommand(
@@ -50,7 +50,7 @@ async def test_commission(
 
     assert not msg["success"]
     assert msg["error"]["code"] == "9"
-    matter_client.commission_with_code.assert_called_once_with("12345678")
+    matter_client.commission_with_code.assert_called_once_with("12345678", True)
 
 
 # This tests needs to be adjusted to remove lingering tasks
@@ -74,7 +74,7 @@ async def test_commission_on_network(
     msg = await ws_client.receive_json()
 
     assert msg["success"]
-    matter_client.commission_on_network.assert_called_once_with(1234)
+    matter_client.commission_on_network.assert_called_once_with(1234, None)
 
     matter_client.commission_on_network.reset_mock()
     matter_client.commission_on_network.side_effect = NodeCommissionFailed(
@@ -92,7 +92,7 @@ async def test_commission_on_network(
 
     assert not msg["success"]
     assert msg["error"]["code"] == "1"
-    matter_client.commission_on_network.assert_called_once_with(1234)
+    matter_client.commission_on_network.assert_called_once_with(1234, None)
 
 
 # This tests needs to be adjusted to remove lingering tasks

--- a/tests/components/matter/test_api.py
+++ b/tests/components/matter/test_api.py
@@ -78,7 +78,7 @@ async def test_commission_on_network(
     )
 
     await ws_client.send_json(
-        {ID: 2, TYPE: "matter/commission_on_network", "pin": 1234, "ip": "1.2.3.4"}
+        {ID: 2, TYPE: "matter/commission_on_network", "pin": 1234, "ip_addr": "1.2.3.4"}
     )
     msg = await ws_client.receive_json()
 


### PR DESCRIPTION
## Proposed change
Add a few additional options to the websocket commands used for commissioning matter devices that can be leveraged by the (Android) companion app.

- Allows Android app to fix the bug that commisisoning is not working when initiated from the HA app
- Skips bluetooth by default when commissioning

Bumps the matter-server client to version 5.1.1 and depends on schema version 6 to be fully utilized (although backwards compatible).

## Type of change

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
