### PR TITLE
Fix mqtt valve is not resetting opening or closing state

### DIFF
--- a/homeassistant/components/mqtt/valve.py
+++ b/homeassistant/components/mqtt/valve.py
@@ -276,7 +276,8 @@ class MqttValve(MqttEntity, ValveEntity):
             else:
                 percentage_payload = min(max(percentage_payload, 0), 100)
                 self._attr_current_valve_position = percentage_payload
-                if state is None and (percentage_payload in {0, 100}):
+                # Reset closing and opening if the valve is fully opened or fully closed
+                if state is None and percentage_payload in (0, 100):
                     state = RESET_CLOSING_OPENING
                 position_set = True
         if state_payload and state is None and not position_set:

--- a/homeassistant/components/mqtt/valve.py
+++ b/homeassistant/components/mqtt/valve.py
@@ -290,9 +290,7 @@ class MqttValve(MqttEntity, ValveEntity):
             return
         if state is None:
             return
-        self._attr_is_closed = state == STATE_CLOSED
-        self._attr_is_opening = state == STATE_OPENING
-        self._attr_is_closing = state == STATE_CLOSING
+        self._update_state(state)
 
     def _prepare_subscribe_topics(self) -> None:
         """(Re)Subscribe to topics."""

--- a/tests/components/mqtt/test_valve.py
+++ b/tests/components/mqtt/test_valve.py
@@ -301,6 +301,58 @@ async def test_state_via_state_topic_through_position(
                     "state_topic": "state-topic",
                     "command_topic": "command-topic",
                     "reports_position": True,
+                }
+            }
+        }
+    ],
+)
+async def test_opening_closing_state_is_reset(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+) -> None:
+    """Test the controlling state via topic through position.
+
+    Test  a `opening` or `closing` state update is reset correctly after sequential updates.
+    """
+    await mqtt_mock_entry()
+
+    state = hass.states.get("valve.test")
+    assert state.state == STATE_UNKNOWN
+    assert not state.attributes.get(ATTR_ASSUMED_STATE)
+
+    messages = [
+        ('{"position": 0, "state": "opening"}', STATE_OPENING, 0),
+        ('{"position": 50, "state": "opening"}', STATE_OPENING, 50),
+        ('{"position": 60}', STATE_OPENING, 60),
+        ('{"position": 100, "state": "opening"}', STATE_OPENING, 100),
+        ('{"position": 100, "state": null}', STATE_OPEN, 100),
+        ('{"position": 90, "state": "closing"}', STATE_CLOSING, 90),
+        ('{"position": 40}', STATE_CLOSING, 40),
+        ('{"position": 0}', STATE_CLOSED, 0),
+        ('{"position": 10}', STATE_OPEN, 10),
+        ('{"position": 0, "state": "opening"}', STATE_OPENING, 0),
+        ('{"position": 0, "state": "closing"}', STATE_CLOSING, 0),
+        ('{"position": 0}', STATE_CLOSED, 0),
+    ]
+
+    for message, asserted_state, valve_position in messages:
+        async_fire_mqtt_message(hass, "state-topic", message)
+
+        state = hass.states.get("valve.test")
+        assert state.state == asserted_state
+        assert state.attributes.get(ATTR_CURRENT_POSITION) == valve_position
+
+
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            mqtt.DOMAIN: {
+                valve.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "reports_position": True,
                     "position_closed": -128,
                     "position_open": 127,
                 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When an MQTT valve that reports position receives an `opening` or `closing` state this will toggle the entity `is_opening` or `is_closing` state, and with that determine the valve's state.
When a valve is closed or fully open this should be reset, unless the valve is still reporting it is opening or closing. When `opening` or `closing` is received this state update will alway be respected. If no `opening` or `closing` state is added and the position is `0` or `100` any `opening` or `closing` status should be reset.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
