### PR TITLE
Improve mikrotik error handling

### DIFF
--- a/homeassistant/components/mikrotik/hub.py
+++ b/homeassistant/components/mikrotik/hub.py
@@ -235,14 +235,11 @@ class MikrotikData:
             # we still have to raise CannotConnect to fail the update.
             raise CannotConnect from api_error
         except librouteros.exceptions.ProtocolError as api_error:
+            emsg = "Mikrotik %s failed to retrieve data. cmd=[%s] Error: %s"
             if discover and "no such command prefix" in str(api_error):
+                _LOGGER.debug(emsg, self._host, cmd, api_error)
                 return []
-            _LOGGER.warning(
-                "Mikrotik %s failed to retrieve data. cmd=[%s] Error: %s",
-                self._host,
-                cmd,
-                api_error,
-            )
+            _LOGGER.warning(emsg, self._host, cmd, api_error)
             return []
 
 

--- a/homeassistant/components/mikrotik/hub.py
+++ b/homeassistant/components/mikrotik/hub.py
@@ -91,7 +91,7 @@ class MikrotikData:
     def get_info(self, param: str) -> str:
         """Return device model name."""
         cmd = IDENTITY if param == NAME else INFO
-        if data := self.command(cmd=MIKROTIK_SERVICES[cmd], discover=(cmd == INFO)):
+        if data := self.command(MIKROTIK_SERVICES[cmd], suppress_errors=(cmd == INFO)):
             return str(data[0].get(param))
         return ""
 
@@ -102,16 +102,16 @@ class MikrotikData:
         self.firmware = self.get_info(ATTR_FIRMWARE)
         self.serial_number = self.get_info(ATTR_SERIAL_NUMBER)
         self.support_capsman = bool(
-            self.command(cmd=MIKROTIK_SERVICES[IS_CAPSMAN], discover=True)
+            self.command(MIKROTIK_SERVICES[IS_CAPSMAN], suppress_errors=True)
         )
         self.support_wireless = bool(
-            self.command(cmd=MIKROTIK_SERVICES[IS_WIRELESS], discover=True)
+            self.command(MIKROTIK_SERVICES[IS_WIRELESS], suppress_errors=True)
         )
         self.support_wifiwave2 = bool(
-            self.command(cmd=MIKROTIK_SERVICES[IS_WIFIWAVE2], discover=True)
+            self.command(MIKROTIK_SERVICES[IS_WIFIWAVE2], suppress_errors=True)
         )
         self.support_wifi = bool(
-            self.command(cmd=MIKROTIK_SERVICES[IS_WIFI], discover=True)
+            self.command(MIKROTIK_SERVICES[IS_WIFI], suppress_errors=True)
         )
 
     def get_list_from_interface(self, interface: str) -> dict[str, dict[str, Any]]:
@@ -216,7 +216,7 @@ class MikrotikData:
         self,
         cmd: str,
         params: dict[str, Any] | None = None,
-        discover: bool = False,
+        suppress_errors: bool = False,
     ) -> list[dict[str, Any]]:
         """Retrieve data from Mikrotik API."""
         _LOGGER.debug("Running command %s", cmd)
@@ -236,7 +236,7 @@ class MikrotikData:
             raise CannotConnect from api_error
         except librouteros.exceptions.ProtocolError as api_error:
             emsg = "Mikrotik %s failed to retrieve data. cmd=[%s] Error: %s"
-            if discover and "no such command prefix" in str(api_error):
+            if suppress_errors and "no such command prefix" in str(api_error):
                 _LOGGER.debug(emsg, self._host, cmd, api_error)
                 return []
             _LOGGER.warning(emsg, self._host, cmd, api_error)

--- a/tests/components/mikrotik/__init__.py
+++ b/tests/components/mikrotik/__init__.py
@@ -176,7 +176,10 @@ async def setup_mikrotik_entry(hass: HomeAssistant, **kwargs: Any) -> None:
     wifiwave2_data: list[dict[str, Any]] = kwargs.get("wifiwave2_data", WIFIWAVE2_DATA)
 
     def mock_command(
-        self, cmd: str, params: dict[str, Any] | None = None, discover: bool = False
+        self,
+        cmd: str,
+        params: dict[str, Any] | None = None,
+        suppress_errors: bool = False,
     ) -> Any:
         if cmd == mikrotik.const.MIKROTIK_SERVICES[mikrotik.const.IS_WIRELESS]:
             return support_wireless

--- a/tests/components/mikrotik/__init__.py
+++ b/tests/components/mikrotik/__init__.py
@@ -175,7 +175,9 @@ async def setup_mikrotik_entry(hass: HomeAssistant, **kwargs: Any) -> None:
     wireless_data: list[dict[str, Any]] = kwargs.get("wireless_data", WIRELESS_DATA)
     wifiwave2_data: list[dict[str, Any]] = kwargs.get("wifiwave2_data", WIFIWAVE2_DATA)
 
-    def mock_command(self, cmd: str, params: dict[str, Any] | None = None) -> Any:
+    def mock_command(
+        self, cmd: str, params: dict[str, Any] | None = None, discover: bool = False
+    ) -> Any:
         if cmd == mikrotik.const.MIKROTIK_SERVICES[mikrotik.const.IS_WIRELESS]:
             return support_wireless
         if cmd == mikrotik.const.MIKROTIK_SERVICES[mikrotik.const.IS_WIFIWAVE2]:

--- a/tests/components/mikrotik/test_device_tracker.py
+++ b/tests/components/mikrotik/test_device_tracker.py
@@ -52,7 +52,9 @@ def mock_device_registry_devices(hass: HomeAssistant) -> None:
         )
 
 
-def mock_command(self, cmd: str, params: dict[str, Any] | None = None) -> Any:
+def mock_command(
+    self, cmd: str, params: dict[str, Any] | None = None, discover: bool = False
+) -> Any:
     """Mock the Mikrotik command method."""
     if cmd == mikrotik.const.MIKROTIK_SERVICES[mikrotik.const.IS_WIRELESS]:
         return True

--- a/tests/components/mikrotik/test_device_tracker.py
+++ b/tests/components/mikrotik/test_device_tracker.py
@@ -53,7 +53,7 @@ def mock_device_registry_devices(hass: HomeAssistant) -> None:
 
 
 def mock_command(
-    self, cmd: str, params: dict[str, Any] | None = None, discover: bool = False
+    self, cmd: str, params: dict[str, Any] | None = None, suppress_errors: bool = False
 ) -> Any:
     """Mock the Mikrotik command method."""
     if cmd == mikrotik.const.MIKROTIK_SERVICES[mikrotik.const.IS_WIRELESS]:


### PR DESCRIPTION
## Proposed change
Improves the error handling of the mikrotik integration, so expected warnings in the discovery phase are now on debug level.
Fixes #92168

## Type of change
- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #92168

## Checklist
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
