### PR TITLE
Remove hardcoded bits from LiteJet integration

### DIFF
--- a/homeassistant/components/litejet/diagnostics.py
+++ b/homeassistant/components/litejet/diagnostics.py
@@ -15,6 +15,7 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for LiteJet config entry."""
     system: LiteJet = hass.data[DOMAIN]
     return {
+        "model": system.model_name,
         "loads": list(system.loads()),
         "button_switches": list(system.button_switches()),
         "scenes": list(system.scenes()),

--- a/homeassistant/components/litejet/scene.py
+++ b/homeassistant/components/litejet/scene.py
@@ -51,7 +51,7 @@ class LiteJetScene(Scene):
             identifiers={(DOMAIN, f"{entry_id}_mcp")},
             name="LiteJet",
             manufacturer="Centralite",
-            model="CL24",
+            model=system.model_name,
         )
 
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/litejet/switch.py
+++ b/homeassistant/components/litejet/switch.py
@@ -49,10 +49,10 @@ class LiteJetSwitch(SwitchEntity):
         self._attr_name = name
 
         # Keypad #1 has switches 1-6, #2 has 7-12, ...
-        keypad_number = int((i - 1) / 6) + 1
+        keypad_number = system.get_switch_keypad_number(i)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{entry_id}_keypad_{keypad_number}")},
-            name=f"Keypad #{keypad_number}",
+            name=system.get_switch_keypad_name(i),
             manufacturer="Centralite",
             via_device=(DOMAIN, f"{entry_id}_mcp"),
         )

--- a/tests/components/litejet/conftest.py
+++ b/tests/components/litejet/conftest.py
@@ -1,6 +1,6 @@
 """Fixtures for LiteJet testing."""
 from datetime import timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -20,6 +20,12 @@ def mock_litejet():
 
         async def get_switch_name(number):
             return f"Mock Switch #{number}"
+
+        def get_switch_keypad_number(number):
+            return number + 100
+
+        def get_switch_keypad_name(number):
+            return f"Mock Keypad #{number + 100}"
 
         mock_lj = mock_pylitejet.return_value
 
@@ -65,6 +71,8 @@ def mock_litejet():
         mock_lj.get_switch_name = AsyncMock(side_effect=get_switch_name)
         mock_lj.press_switch = AsyncMock()
         mock_lj.release_switch = AsyncMock()
+        mock_lj.get_switch_keypad_number = Mock(side_effect=get_switch_keypad_number)
+        mock_lj.get_switch_keypad_name = Mock(side_effect=get_switch_keypad_name)
 
         mock_lj.scenes.return_value = range(1, 3)
         mock_lj.get_scene_name = AsyncMock(side_effect=get_scene_name)
@@ -74,6 +82,7 @@ def mock_litejet():
         mock_lj.start_time = dt_util.utcnow()
         mock_lj.last_delta = timedelta(0)
         mock_lj.connected = True
+        mock_lj.model_name = "MockJet"
 
         def connected_changed(connected: bool, reason: str) -> None:
             mock_lj.connected = connected

--- a/tests/components/litejet/test_diagnostics.py
+++ b/tests/components/litejet/test_diagnostics.py
@@ -17,6 +17,7 @@ async def test_diagnostics(
     diag = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
 
     assert diag == {
+        "model": "MockJet",
         "loads": [1, 2],
         "button_switches": [1, 2],
         "scenes": [1, 2],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use new features of pylitejet v0.6.x to move hardcoded bits from the integration into the Python module:
* Use model_name property instead of hardcoded model name. (Minor change: "CL24" -> "LiteJet"; "CL24" (which was wrong) -> "LiteJet 48")
* Use get_switch_keypad_number method instead of hardcoded formula. (Unchanged.)
* Use get_switch_keypad_name method instead of hardcoded formula. (Unchanged.)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
