### PR TITLE
Add subwoofer crossover support to Sonos Amp devices

### DIFF
--- a/homeassistant/components/sonos/number.py
+++ b/homeassistant/components/sonos/number.py
@@ -21,6 +21,7 @@ LEVEL_TYPES = {
     "bass": (-10, 10),
     "balance": (-100, 100),
     "treble": (-10, 10),
+    "sub_crossover": (50, 110),
     "sub_gain": (-15, 15),
     "surround_level": (-15, 15),
     "music_surround_level": (-15, 15),

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -154,6 +154,7 @@ class SonosSpeaker:
         self.dialog_level: bool | None = None
         self.night_mode: bool | None = None
         self.sub_enabled: bool | None = None
+        self.sub_crossover: int | None = None
         self.sub_gain: int | None = None
         self.surround_enabled: bool | None = None
         self.surround_mode: bool | None = None
@@ -561,6 +562,7 @@ class SonosSpeaker:
             "audio_delay",
             "bass",
             "treble",
+            "sub_crossover",
             "sub_gain",
             "surround_level",
             "music_surround_level",

--- a/homeassistant/components/sonos/strings.json
+++ b/homeassistant/components/sonos/strings.json
@@ -36,6 +36,9 @@
       "treble": {
         "name": "Treble"
       },
+      "sub_crossover": {
+        "name": "Sub crossover frequency"
+      },
       "sub_gain": {
         "name": "Sub gain"
       },

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -110,7 +110,6 @@ class MockSoCo(MagicMock):
 
     uid = "RINCON_test"
     play_mode = "NORMAL"
-    audio_delay = 2
     mute = False
     night_mode = True
     dialog_level = True

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -109,6 +109,7 @@ class MockSoCo(MagicMock):
     """Mock the Soco Object."""
 
     audio_delay = 2
+    sub_crossover = None  # Default to None for non-Amp devices
     sub_gain = 5
 
     @property

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -108,9 +108,27 @@ def config_entry_fixture():
 class MockSoCo(MagicMock):
     """Mock the Soco Object."""
 
+    uid = "RINCON_test"
+    play_mode = "NORMAL"
     audio_delay = 2
+    mute = False
+    night_mode = True
+    dialog_level = True
+    loudness = True
+    volume = 19
+    audio_delay = 2
+    balance = (61, 100)
+    bass = 1
+    treble = -1
+    mic_enabled = False
     sub_crossover = None  # Default to None for non-Amp devices
+    sub_enabled = False
     sub_gain = 5
+    surround_enabled = True
+    surround_mode = True
+    surround_level = 3
+    music_surround_level = 4
+    soundbar_audio_input_format = "Dolby 5.1"
 
     @property
     def visible_zones(self):
@@ -144,10 +162,7 @@ class SoCoMockFactory:
         mock_soco.mock_add_spec(SoCo)
         mock_soco.ip_address = ip_address
         if ip_address != "192.168.42.2":
-            mock_soco.uid = f"RINCON_test_{ip_address}"
-        else:
-            mock_soco.uid = "RINCON_test"
-        mock_soco.play_mode = "NORMAL"
+            mock_soco.uid += f"_{ip_address}"
         mock_soco.music_library = self.music_library
         mock_soco.get_current_track_info.return_value = self.current_track_info
         mock_soco.music_source_from_uri = SoCo.music_source_from_uri
@@ -162,23 +177,6 @@ class SoCoMockFactory:
         mock_soco.contentDirectory = SonosMockService("ContentDirectory", ip_address)
         mock_soco.deviceProperties = SonosMockService("DeviceProperties", ip_address)
         mock_soco.alarmClock = self.alarm_clock
-        mock_soco.mute = False
-        mock_soco.night_mode = True
-        mock_soco.dialog_level = True
-        mock_soco.loudness = True
-        mock_soco.volume = 19
-        mock_soco.audio_delay = 2
-        mock_soco.balance = (61, 100)
-        mock_soco.bass = 1
-        mock_soco.treble = -1
-        mock_soco.mic_enabled = False
-        mock_soco.sub_enabled = False
-        mock_soco.sub_gain = 5
-        mock_soco.surround_enabled = True
-        mock_soco.surround_mode = True
-        mock_soco.surround_level = 3
-        mock_soco.music_surround_level = 4
-        mock_soco.soundbar_audio_input_format = "Dolby 5.1"
         mock_soco.get_battery_info.return_value = self.battery_info
         mock_soco.all_zones = {mock_soco}
         mock_soco.group.coordinator = mock_soco

--- a/tests/components/sonos/test_number.py
+++ b/tests/components/sonos/test_number.py
@@ -6,6 +6,8 @@ from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
+CROSSOVER_ENTITY = "number.zone_a_sub_crossover_frequency"
+
 
 async def test_number_entities(
     hass: HomeAssistant, async_autosetup_sonos, soco, entity_registry: er.EntityRegistry
@@ -62,3 +64,32 @@ async def test_number_entities(
             blocking=True,
         )
         mock_sub_gain.assert_called_once_with(-8)
+
+    # sub_crossover is only available on Sonos Amp devices, see test_amp_number_entities
+    assert CROSSOVER_ENTITY not in entity_registry.entities
+
+
+async def test_amp_number_entities(
+    hass: HomeAssistant, async_setup_sonos, soco, entity_registry: er.EntityRegistry
+) -> None:
+    """Test the sub_crossover feature only available on Sonos Amp devices.
+
+    The sub_crossover value will be None on all other device types.
+    """
+    with patch.object(soco, "sub_crossover", 50):
+        await async_setup_sonos()
+
+    sub_crossover_number = entity_registry.entities[CROSSOVER_ENTITY]
+    sub_crossover_state = hass.states.get(sub_crossover_number.entity_id)
+    assert sub_crossover_state.state == "50"
+
+    with patch.object(
+        type(soco), "sub_crossover", new_callable=PropertyMock
+    ) as mock_sub_crossover:
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: sub_crossover_number.entity_id, "value": 110},
+            blocking=True,
+        )
+        mock_sub_crossover.assert_called_once_with(110)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds support for subwoofer crossover frequency controls on Sonos Amp devices.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30474

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
