### PR TITLE
Fix flaky Tailwind tests by fixing via_device

### DIFF
--- a/homeassistant/components/tailwind/__init__.py
+++ b/homeassistant/components/tailwind/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 from .const import DOMAIN
 from .coordinator import TailwindDataUpdateCoordinator
@@ -17,6 +18,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+
+    # Register the Tailwind device, since other entities will have it as a parent.
+    # This prevents a child device being created before the parent ending up
+    # with a missing via_device.
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, coordinator.data.device_id)},
+        connections={(dr.CONNECTION_NETWORK_MAC, coordinator.data.mac_address)},
+        manufacturer="Tailwind",
+        model=coordinator.data.product,
+        sw_version=coordinator.data.firmware_version,
+    )
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True

--- a/homeassistant/components/tailwind/entity.py
+++ b/homeassistant/components/tailwind/entity.py
@@ -1,7 +1,7 @@
 """Base entity for the Tailwind integration."""
 from __future__ import annotations
 
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -25,10 +25,6 @@ class TailwindEntity(CoordinatorEntity[TailwindDataUpdateCoordinator]):
         self._attr_unique_id = f"{coordinator.data.device_id}-{entity_description.key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.data.device_id)},
-            connections={(CONNECTION_NETWORK_MAC, coordinator.data.mac_address)},
-            manufacturer="Tailwind",
-            model=coordinator.data.product,
-            sw_version=coordinator.data.firmware_version,
         )
 
 

--- a/tests/components/tailwind/snapshots/test_binary_sensor.ambr
+++ b/tests/components/tailwind/snapshots/test_binary_sensor.ambr
@@ -212,7 +212,7 @@
     'serial_number': None,
     'suggested_area': None,
     'sw_version': '10.10',
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_number_entities[binary_sensor.door_2_operational_status]
@@ -284,6 +284,6 @@
     'serial_number': None,
     'suggested_area': None,
     'sw_version': '10.10',
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---

--- a/tests/components/tailwind/snapshots/test_cover.ambr
+++ b/tests/components/tailwind/snapshots/test_cover.ambr
@@ -69,7 +69,7 @@
     'serial_number': None,
     'suggested_area': None,
     'sw_version': '10.10',
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_cover_entities[cover.door_2]
@@ -142,6 +142,6 @@
     'serial_number': None,
     'suggested_area': None,
     'sw_version': '10.10',
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

As reported by @edenhaus on Discord, sometimes the Tailwind tests fail snapshot comparison caused by the `via_device_id`.

```
FAILED tests/components/tailwind/test_binary_sensor.py::test_number_entities[binary_sensor.door_1_operational_status] - AssertionError: assert [- snapshot] == [+ received]
    DeviceRegistryEntrySnapshot({
     ...
      'sw_version': '10.10',
  -   'via_device_id': None,
  +   'via_device_id': <ANY>,
    })
```

This is caused by the wonderful world of async 😬 Sometimes, the child entities & devices are ready before the parent they are referencing, making them parentless.

This PR pre-created the parent device, preventing this from happening.

--- 

Tailwind provides garage door controllers that work with most garage door openers and communicates fully locally.

More information: https://gotailwind.com/

The development of this integration will consist of multiple pull requests:

- [x] Add the minimal functional integration (#105926)
- [x] Add zeroconf discovery support (#105949)
- [x] Add re-authentication support in case the local key is changed (#105959)
- [x] Add DHCP discovery support for updating config entries (#105981)
- [x] Add binary sensor platform (#106033)
- [x] Add cover platform (#106042)
- [x] Add button platform (#105961)
- [x] Add diagnostic platform (#105965)
- [ ] Add error handling to service calls (with translatable errors)
- [ ] **Fix flaky via_device_id tests** (This PR!)
- [ ] [Flip around locked out binary sensor](https://github.com/home-assistant/core/pull/106033#pullrequestreview-1788465515)
- [ ] Bump gotailwind library to the latest version (#106054)
- [x] General cleanup, as most is in at this point (#106073)
- [ ] Upgrade integration to platinum level
- [ ] Leverage webhooks to make integration push-based

Big thanks to Tailwind for providing the devices for testing ❤️ 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
