### PR TITLE
Remove IP / mDNS validation in airq integration setup

### DIFF
--- a/homeassistant/components/airq/config_flow.py
+++ b/homeassistant/components/airq/config_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from aioairq import AirQ, InvalidAuth, InvalidInput
+from aioairq import AirQ, InvalidAuth
 from aiohttp.client_exceptions import ClientConnectionError
 import voluptuous as vol
 
@@ -42,44 +42,32 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         session = async_get_clientsession(self.hass)
+        airq = AirQ(user_input[CONF_IP_ADDRESS], user_input[CONF_PASSWORD], session)
         try:
-            airq = AirQ(user_input[CONF_IP_ADDRESS], user_input[CONF_PASSWORD], session)
-        except InvalidInput:
+            await airq.validate()
+        except ClientConnectionError:
             _LOGGER.debug(
-                "%s does not appear to be a valid IP address or mDNS name",
+                (
+                    "Failed to connect to device %s. Check the IP address / device"
+                    " ID as well as whether the device is connected to power and"
+                    " the WiFi"
+                ),
                 user_input[CONF_IP_ADDRESS],
             )
-            errors["base"] = "invalid_input"
+            errors["base"] = "cannot_connect"
+        except InvalidAuth:
+            _LOGGER.debug(
+                "Incorrect password for device %s", user_input[CONF_IP_ADDRESS]
+            )
+            errors["base"] = "invalid_auth"
         else:
-            try:
-                await airq.validate()
-            except ClientConnectionError:
-                _LOGGER.debug(
-                    (
-                        "Failed to connect to device %s. Check the IP address / device"
-                        " ID as well as whether the device is connected to power and"
-                        " the WiFi"
-                    ),
-                    user_input[CONF_IP_ADDRESS],
-                )
-                errors["base"] = "cannot_connect"
-            except InvalidAuth:
-                _LOGGER.debug(
-                    "Incorrect password for device %s", user_input[CONF_IP_ADDRESS]
-                )
-                errors["base"] = "invalid_auth"
-            else:
-                _LOGGER.debug(
-                    "Successfully connected to %s", user_input[CONF_IP_ADDRESS]
-                )
+            _LOGGER.debug("Successfully connected to %s", user_input[CONF_IP_ADDRESS])
 
-                device_info = await airq.fetch_device_info()
-                await self.async_set_unique_id(device_info["id"])
-                self._abort_if_unique_id_configured()
+            device_info = await airq.fetch_device_info()
+            await self.async_set_unique_id(device_info["id"])
+            self._abort_if_unique_id_configured()
 
-                return self.async_create_entry(
-                    title=device_info["name"], data=user_input
-                )
+            return self.async_create_entry(title=device_info["name"], data=user_input)
 
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors

--- a/homeassistant/components/airq/manifest.json
+++ b/homeassistant/components/airq/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["aioairq"],
-  "requirements": ["aioairq==0.3.1"]
+  "requirements": ["aioairq==0.3.2"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -185,7 +185,7 @@ aio-geojson-usgs-earthquakes==0.2
 aio-georss-gdacs==0.8
 
 # homeassistant.components.airq
-aioairq==0.3.1
+aioairq==0.3.2
 
 # homeassistant.components.airzone_cloud
 aioairzone-cloud==0.3.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -164,7 +164,7 @@ aio-geojson-usgs-earthquakes==0.2
 aio-georss-gdacs==0.8
 
 # homeassistant.components.airq
-aioairq==0.3.1
+aioairq==0.3.2
 
 # homeassistant.components.airzone_cloud
 aioairzone-cloud==0.3.6

--- a/tests/components/airq/test_config_flow.py
+++ b/tests/components/airq/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the air-Q config flow."""
 from unittest.mock import patch
 
-from aioairq import DeviceInfo, InvalidAuth, InvalidInput
+from aioairq import DeviceInfo, InvalidAuth
 from aiohttp.client_exceptions import ClientConnectionError
 import pytest
 
@@ -78,21 +78,6 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
 
     assert result2["type"] == FlowResultType.FORM
     assert result2["errors"] == {"base": "cannot_connect"}
-
-
-async def test_form_invalid_input(hass: HomeAssistant) -> None:
-    """Test we handle cannot connect error."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    with patch("aioairq.AirQ.validate", side_effect=InvalidInput):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"], TEST_USER_DATA | {CONF_IP_ADDRESS: "invalid_ip"}
-        )
-
-    assert result2["type"] == FlowResultType.FORM
-    assert result2["errors"] == {"base": "invalid_input"}
 
 
 async def test_duplicate_error(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Original design relied on `aioairq.AirQ.__init__ `checking if the input was a valid IP address or an mDNS of a very specific structure, and raising an `InvalidInput` otherwise.
Now, `aioairq==0.3.2` [removes](https://github.com/CorantGmbH/aioairq/compare/v0.3.1...v0.3.2) said check completely following [a user's request](https://github.com/CorantGmbH/aioairq/issues/2#issuecomment-1855924466) to allow arbitrary host name and DNS entries, which otherwise would not pass the validation (while being perfectly legitimate). In the config flow, `"cannot_connect"` covers the cases of misspelled or erroneous inputs now, which previously were covered by a dedicated `"invalid_input"`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/CorantGmbH/aioairq/issues/2
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
