### PR TITLE
Add support for attribute caching to the vacuum platform

### DIFF
--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from enum import IntFlag
 from functools import partial
 import logging
-from typing import Any, final
+from typing import TYPE_CHECKING, Any, final
 
 import voluptuous as vol
 
@@ -44,6 +44,11 @@ from homeassistant.loader import (
     async_suggest_report_issue,
     bind_hass,
 )
+
+if TYPE_CHECKING:
+    from functools import cached_property
+else:
+    from homeassistant.backports.functools import cached_property
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -225,7 +230,16 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return await component.async_unload_entry(entry)
 
 
-class _BaseVacuum(Entity):
+BASE_CACHED_PROPERTIES_WITH_ATTR_ = {
+    "supported_features",
+    "battery_level",
+    "battery_icon",
+    "fan_speed",
+    "fan_speed_list",
+}
+
+
+class _BaseVacuum(Entity, cached_properties=BASE_CACHED_PROPERTIES_WITH_ATTR_):
     """Representation of a base vacuum.
 
     Contains common properties and functions for all vacuum devices.
@@ -239,27 +253,27 @@ class _BaseVacuum(Entity):
     _attr_fan_speed_list: list[str]
     _attr_supported_features: VacuumEntityFeature = VacuumEntityFeature(0)
 
-    @property
+    @cached_property
     def supported_features(self) -> VacuumEntityFeature:
         """Flag vacuum cleaner features that are supported."""
         return self._attr_supported_features
 
-    @property
+    @cached_property
     def battery_level(self) -> int | None:
         """Return the battery level of the vacuum cleaner."""
         return self._attr_battery_level
 
-    @property
+    @cached_property
     def battery_icon(self) -> str:
         """Return the battery icon for the vacuum cleaner."""
         return self._attr_battery_icon
 
-    @property
+    @cached_property
     def fan_speed(self) -> str | None:
         """Return the fan speed of the vacuum cleaner."""
         return self._attr_fan_speed
 
-    @property
+    @cached_property
     def fan_speed_list(self) -> list[str]:
         """Get the list of available fan speed steps of the vacuum cleaner."""
         return self._attr_fan_speed_list
@@ -370,7 +384,14 @@ class VacuumEntityDescription(ToggleEntityDescription, frozen_or_thawed=True):
     """A class that describes vacuum entities."""
 
 
-class VacuumEntity(_BaseVacuum, ToggleEntity):
+VACUUM_CACHED_PROPERTIES_WITH_ATTR_ = {
+    "status",
+}
+
+
+class VacuumEntity(
+    _BaseVacuum, ToggleEntity, cached_properties=VACUUM_CACHED_PROPERTIES_WITH_ATTR_
+):
     """Representation of a vacuum cleaner robot."""
 
     @callback
@@ -428,7 +449,7 @@ class VacuumEntity(_BaseVacuum, ToggleEntity):
     entity_description: VacuumEntityDescription
     _attr_status: str | None = None
 
-    @property
+    @cached_property
     def status(self) -> str | None:
         """Return the status of the vacuum cleaner."""
         return self._attr_status
@@ -492,13 +513,20 @@ class StateVacuumEntityDescription(EntityDescription, frozen_or_thawed=True):
     """A class that describes vacuum entities."""
 
 
-class StateVacuumEntity(_BaseVacuum):
+STATE_VACUUM_CACHED_PROPERTIES_WITH_ATTR_ = {
+    "state",
+}
+
+
+class StateVacuumEntity(
+    _BaseVacuum, cached_properties=STATE_VACUUM_CACHED_PROPERTIES_WITH_ATTR_
+):
     """Representation of a vacuum cleaner robot that supports states."""
 
     entity_description: StateVacuumEntityDescription
     _attr_state: str | None = None
 
-    @property
+    @cached_property
     def state(self) -> str | None:
         """Return the state of the vacuum cleaner."""
         return self._attr_state


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for attribute caching to the vacuum platform

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
