### PR TITLE
Avoid clearing the attr cache in setter when nothing has changed

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -227,6 +227,9 @@ class EntityPlatformState(Enum):
     REMOVED = auto()
 
 
+_SENTINEL = object()
+
+
 class EntityDescription(metaclass=FrozenOrThawed, frozen_or_thawed=True):
     """A class that describes Home Assistant entities."""
 
@@ -346,6 +349,8 @@ class CachedProperties(type):
                 Also invalidates the corresponding cached_property by calling
                 delattr on it.
                 """
+                if getattr(o, private_attr_name, _SENTINEL) == val:
+                    return
                 setattr(o, private_attr_name, val)
                 try:  # noqa: SIM105  suppress is much slower
                     delattr(o, name)

--- a/tests/components/konnected/test_init.py
+++ b/tests/components/konnected/test_init.py
@@ -712,7 +712,7 @@ async def test_state_updates_zone(
     result = await resp.json()
     assert result == {"message": "ok"}
     await hass.async_block_till_done()
-    assert hass.states.get("sensor.temper_temperature").state == "32.0"
+    assert hass.states.get("sensor.temper_temperature").state == "32"
 
     resp = await client.post(
         "/api/konnected/device/112233445566",
@@ -869,7 +869,7 @@ async def test_state_updates_pin(
     result = await resp.json()
     assert result == {"message": "ok"}
     await hass.async_block_till_done()
-    assert hass.states.get("sensor.temper_temperature").state == "32.0"
+    assert hass.states.get("sensor.temper_temperature").state == "32"
 
     resp = await client.post(
         "/api/konnected/device/112233445566",

--- a/tests/components/konnected/test_init.py
+++ b/tests/components/konnected/test_init.py
@@ -706,13 +706,13 @@ async def test_state_updates_zone(
     resp = await client.post(
         "/api/konnected/device/112233445566",
         headers={"Authorization": "Bearer abcdefgh"},
-        json={"zone": "5", "temp": 32, "addr": 1},
+        json={"zone": "5", "temp": 32.0, "addr": 1},
     )
     assert resp.status == HTTPStatus.OK
     result = await resp.json()
     assert result == {"message": "ok"}
     await hass.async_block_till_done()
-    assert hass.states.get("sensor.temper_temperature").state == "32"
+    assert hass.states.get("sensor.temper_temperature").state == "32.0"
 
     resp = await client.post(
         "/api/konnected/device/112233445566",
@@ -863,13 +863,13 @@ async def test_state_updates_pin(
     resp = await client.post(
         "/api/konnected/device/112233445566",
         headers={"Authorization": "Bearer abcdefgh"},
-        json={"pin": "7", "temp": 32, "addr": 1},
+        json={"pin": "7", "temp": 32.0, "addr": 1},
     )
     assert resp.status == HTTPStatus.OK
     result = await resp.json()
     assert result == {"message": "ok"}
     await hass.async_block_till_done()
-    assert hass.states.get("sensor.temper_temperature").state == "32"
+    assert hass.states.get("sensor.temper_temperature").state == "32.0"
 
     resp = await client.post(
         "/api/konnected/device/112233445566",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The setter gets called frequently even though nothing has changed which makes the getter have to recreate the cache. With this change ~96% of the sets are eliminated on my production system which means we get significantly more cache hits.

 
before
![before_setter](https://github.com/home-assistant/core/assets/663432/3c503b93-a2fe-40e3-95af-007985d6adae)

after
![after_setter](https://github.com/home-assistant/core/assets/663432/41ec9921-5f2a-4714-877e-11e0ea05f79f)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
