### PR TITLE
Fix MQTT retained event messages should be discarded

### DIFF
--- a/homeassistant/components/mqtt/event.py
+++ b/homeassistant/components/mqtt/event.py
@@ -122,6 +122,13 @@ class MqttEvent(MqttEntity, EventEntity):
         @log_messages(self.hass, self.entity_id)
         def message_received(msg: ReceiveMessage) -> None:
             """Handle new MQTT messages."""
+            if msg.retain:
+                _LOGGER.debug(
+                    "Ignoring event trigger from replayed retained payload '%s' on topic %s",
+                    msg.payload,
+                    msg.topic,
+                )
+                return
             event_attributes: dict[str, Any] = {}
             event_type: str
             payload = self._template(msg.payload, PayloadSentinel.DEFAULT)

--- a/homeassistant/components/mqtt/event.py
+++ b/homeassistant/components/mqtt/event.py
@@ -35,7 +35,6 @@ from .mixins import (
     MQTT_ENTITY_COMMON_SCHEMA,
     MqttEntity,
     async_setup_entity_entry_helper,
-    write_state_on_attr_change,
 )
 from .models import (
     MqttValueTemplate,
@@ -43,6 +42,7 @@ from .models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
+from .util import get_mqtt_data
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -120,7 +120,6 @@ class MqttEvent(MqttEntity, EventEntity):
 
         @callback
         @log_messages(self.hass, self.entity_id)
-        @write_state_on_attr_change(self, {"state"})
         def message_received(msg: ReceiveMessage) -> None:
             """Handle new MQTT messages."""
             event_attributes: dict[str, Any] = {}
@@ -183,6 +182,8 @@ class MqttEvent(MqttEntity, EventEntity):
                     payload,
                 )
                 return
+            mqtt_data = get_mqtt_data(self.hass)
+            mqtt_data.state_write_requests.write_state_request(self)
 
         topics["state_topic"] = {
             "topic": self._config[CONF_STATE_TOPIC],

--- a/tests/components/mqtt/test_event.py
+++ b/tests/components/mqtt/test_event.py
@@ -108,6 +108,48 @@ async def test_multiple_events_are_all_updating_the_state(
         assert len(mock_async_ha_write_state.mock_calls) == 2
 
 
+@pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
+async def test_handling_retained_event_payloads(
+    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+) -> None:
+    """Test if event messages with a retained flag are ignored."""
+    await mqtt_mock_entry()
+    with patch(
+        "homeassistant.components.mqtt.mixins.MqttEntity.async_write_ha_state"
+    ) as mock_async_ha_write_state:
+        async_fire_mqtt_message(
+            hass,
+            "test-topic",
+            '{"event_type": "press", "duration": "short" }',
+            retain=True,
+        )
+        assert len(mock_async_ha_write_state.mock_calls) == 0
+
+        async_fire_mqtt_message(
+            hass,
+            "test-topic",
+            '{"event_type": "press", "duration": "short" }',
+            retain=False,
+        )
+        assert len(mock_async_ha_write_state.mock_calls) == 1
+
+        async_fire_mqtt_message(
+            hass,
+            "test-topic",
+            '{"event_type": "press", "duration": "short" }',
+            retain=True,
+        )
+        assert len(mock_async_ha_write_state.mock_calls) == 1
+
+        async_fire_mqtt_message(
+            hass,
+            "test-topic",
+            '{"event_type": "press", "duration": "short" }',
+            retain=False,
+        )
+        assert len(mock_async_ha_write_state.mock_calls) == 2
+
+
 @pytest.mark.freeze_time("2023-08-01 00:00:00+00:00")
 @pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
 @pytest.mark.parametrize(

--- a/tests/components/mqtt/test_event.py
+++ b/tests/components/mqtt/test_event.py
@@ -90,6 +90,26 @@ async def test_setting_event_value_via_mqtt_message(
 
 @pytest.mark.freeze_time("2023-08-01 00:00:00+00:00")
 @pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
+async def test_multiple_events_are_all_updating_the_state(
+    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+) -> None:
+    """Test all events are respected and trigger a state write."""
+    await mqtt_mock_entry()
+    with patch(
+        "homeassistant.components.mqtt.mixins.MqttEntity.async_write_ha_state"
+    ) as mock_async_ha_write_state:
+        async_fire_mqtt_message(
+            hass, "test-topic", '{"event_type": "press", "duration": "short" }'
+        )
+        assert len(mock_async_ha_write_state.mock_calls) == 1
+        async_fire_mqtt_message(
+            hass, "test-topic", '{"event_type": "press", "duration": "short" }'
+        )
+        assert len(mock_async_ha_write_state.mock_calls) == 2
+
+
+@pytest.mark.freeze_time("2023-08-01 00:00:00+00:00")
+@pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
 @pytest.mark.parametrize(
     ("message", "log"),
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As an MQTT event should only be triggered on live messages. Replayed retained messages should be ignored. Further an `mqtt` event message should always be processed. The state should not be checked as it could be 2 messages are received at once.
This PR changes the behavior in processing replayed messages, but I believe it was never intended these messages should be processed and trigger an event. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: #106388 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30508 Note added on discarding replayed messages.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
