### PR TITLE
Move Trunks from Button to Cover in Tessie

### DIFF
--- a/homeassistant/components/tessie/button.py
+++ b/homeassistant/components/tessie/button.py
@@ -9,8 +9,6 @@ from tessie_api import (
     enable_keyless_driving,
     flash_lights,
     honk,
-    open_close_rear_trunk,
-    open_front_trunk,
     trigger_homelink,
     wake,
 )
@@ -48,12 +46,6 @@ DESCRIPTIONS: tuple[TessieButtonEntityDescription, ...] = (
     ),
     TessieButtonEntityDescription(
         key="boombox", func=lambda: boombox, icon="mdi:volume-high"
-    ),
-    TessieButtonEntityDescription(
-        key="frunk", func=lambda: open_front_trunk, icon="mdi:car"
-    ),
-    TessieButtonEntityDescription(
-        key="trunk", func=lambda: open_close_rear_trunk, icon="mdi:car-back"
     ),
 )
 

--- a/homeassistant/components/tessie/const.py
+++ b/homeassistant/components/tessie/const.py
@@ -1,7 +1,7 @@
 """Constants used by Tessie integration."""
 from __future__ import annotations
 
-from enum import StrEnum
+from enum import IntEnum, StrEnum
 
 DOMAIN = "tessie"
 
@@ -48,7 +48,7 @@ class TessieUpdateStatus(StrEnum):
     SCHEDULED = "scheduled"
 
 
-class TessieCoverStates(StrEnum):
+class TessieCoverStates(IntEnum):
     """Tessie Cover states."""
 
     CLOSED = 0

--- a/homeassistant/components/tessie/const.py
+++ b/homeassistant/components/tessie/const.py
@@ -46,3 +46,10 @@ class TessieUpdateStatus(StrEnum):
     INSTALLING = "installing"
     WIFI_WAIT = "downloading_wifi_wait"
     SCHEDULED = "scheduled"
+
+
+class TessieCoverStates(StrEnum):
+    """Tessie Cover states."""
+
+    CLOSED = 0
+    OPEN = 1

--- a/homeassistant/components/tessie/cover.py
+++ b/homeassistant/components/tessie/cover.py
@@ -21,7 +21,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, TessieCoverStates
 from .coordinator import TessieStateUpdateCoordinator
 from .entity import TessieEntity
 
@@ -58,30 +58,30 @@ class TessieWindowEntity(TessieEntity, CoverEntity):
     def is_closed(self) -> bool | None:
         """Return if the cover is closed or not."""
         return (
-            self.get("vehicle_state_fd_window") == 0
-            and self.get("vehicle_state_fp_window") == 0
-            and self.get("vehicle_state_rd_window") == 0
-            and self.get("vehicle_state_rp_window") == 0
+            self.get("vehicle_state_fd_window") == TessieCoverStates.CLOSED
+            and self.get("vehicle_state_fp_window") == TessieCoverStates.CLOSED
+            and self.get("vehicle_state_rd_window") == TessieCoverStates.CLOSED
+            and self.get("vehicle_state_rp_window") == TessieCoverStates.CLOSED
         )
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open windows."""
         await self.run(vent_windows)
         self.set(
-            ("vehicle_state_fd_window", 1),
-            ("vehicle_state_fp_window", 1),
-            ("vehicle_state_rd_window", 1),
-            ("vehicle_state_rp_window", 1),
+            ("vehicle_state_fd_window", TessieCoverStates.OPEN),
+            ("vehicle_state_fp_window", TessieCoverStates.OPEN),
+            ("vehicle_state_rd_window", TessieCoverStates.OPEN),
+            ("vehicle_state_rp_window", TessieCoverStates.OPEN),
         )
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close windows."""
         await self.run(close_windows)
         self.set(
-            ("vehicle_state_fd_window", 0),
-            ("vehicle_state_fp_window", 0),
-            ("vehicle_state_rd_window", 0),
-            ("vehicle_state_rp_window", 0),
+            ("vehicle_state_fd_window", TessieCoverStates.CLOSED),
+            ("vehicle_state_fp_window", TessieCoverStates.CLOSED),
+            ("vehicle_state_rd_window", TessieCoverStates.CLOSED),
+            ("vehicle_state_rp_window", TessieCoverStates.CLOSED),
         )
 
 
@@ -124,12 +124,12 @@ class TessieFrontTrunkEntity(TessieEntity, CoverEntity):
     @property
     def is_closed(self) -> bool | None:
         """Return if the cover is closed or not."""
-        return self._value == 0
+        return self._value == TessieCoverStates.CLOSED
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open front trunk."""
         await self.run(open_front_trunk)
-        self.set((self.key, 1))
+        self.set((self.key, TessieCoverStates.OPEN))
 
 
 class TessieRearTrunkEntity(TessieEntity, CoverEntity):
@@ -145,16 +145,16 @@ class TessieRearTrunkEntity(TessieEntity, CoverEntity):
     @property
     def is_closed(self) -> bool | None:
         """Return if the cover is closed or not."""
-        return self._value == 0
+        return self._value == TessieCoverStates.CLOSED
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open rear trunk."""
-        if self._value == 0:
+        if self._value == TessieCoverStates.CLOSED:
             await self.run(open_close_rear_trunk)
-            self.set((self.key, 1))
+            self.set((self.key, TessieCoverStates.OPEN))
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close rear trunk."""
-        if self._value == 1:
+        if self._value == TessieCoverStates.OPEN:
             await self.run(open_close_rear_trunk)
-            self.set((self.key, 0))
+            self.set((self.key, TessieCoverStates.CLOSED))

--- a/homeassistant/components/tessie/strings.json
+++ b/homeassistant/components/tessie/strings.json
@@ -123,7 +123,9 @@
       },
       "charge_state_charge_port_door_open": {
         "name": "Charge port door"
-      }
+      },
+      "vehicle_state_ft": { "name": "Frunk" },
+      "vehicle_state_rt": { "name": "Trunk" }
     },
     "select": {
       "climate_state_seat_heater_left": {
@@ -255,9 +257,7 @@
       "honk": { "name": "Honk horn" },
       "trigger_homelink": { "name": "Homelink" },
       "enable_keyless_driving": { "name": "Keyless driving" },
-      "boombox": { "name": "Play fart" },
-      "frunk": { "name": "Open frunk" },
-      "trunk": { "name": "Open/Close trunk" }
+      "boombox": { "name": "Play fart" }
     },
     "switch": {
       "charge_state_charge_enable_request": {

--- a/tests/components/tessie/snapshots/test_cover.ambr
+++ b/tests/components/tessie/snapshots/test_cover.ambr
@@ -1,0 +1,97 @@
+# serializer version: 1
+# name: test_covers[cover.test_charge_port_door-homeassistant.components.tessie.cover.open_unlock_charge_port-homeassistant.components.tessie.cover.close_charge_port][cover.test_charge_port_door]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Test Charge port door',
+      'supported_features': <CoverEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_charge_port_door',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---
+# name: test_covers[cover.test_charge_port_door-open_unlock_charge_port-close_charge_port][cover.test_charge_port_door]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Test Charge port door',
+      'supported_features': <CoverEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_charge_port_door',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---
+# name: test_covers[cover.test_front_trunk-homeassistant.components.tessie.cover.open_front_trunk-False][cover.test_front_trunk]
+  None
+# ---
+# name: test_covers[cover.test_front_trunk-open_front_trunk-False][cover.test_front_trunk]
+  None
+# ---
+# name: test_covers[cover.test_frunk-open_front_trunk-False][cover.test_frunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Test Frunk',
+      'supported_features': <CoverEntityFeature: 1>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_frunk',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'closed',
+  })
+# ---
+# name: test_covers[cover.test_rear_trunk-homeassistant.components.tessie.cover.open_close_rear_trunk-homeassistant.components.tessie.cover.open_close_rear_trunk][cover.test_rear_trunk]
+  None
+# ---
+# name: test_covers[cover.test_rear_trunk-open_close_rear_trunk-open_close_rear_trunk][cover.test_rear_trunk]
+  None
+# ---
+# name: test_covers[cover.test_trunk-open_close_rear_trunk-open_close_rear_trunk][cover.test_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Test Trunk',
+      'supported_features': <CoverEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_trunk',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'closed',
+  })
+# ---
+# name: test_covers[cover.test_vent_windows-homeassistant.components.tessie.cover.vent_windows-homeassistant.components.tessie.cover.close_windows][cover.test_vent_windows]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Test Vent windows',
+      'supported_features': <CoverEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_vent_windows',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'closed',
+  })
+# ---
+# name: test_covers[cover.test_vent_windows-vent_windows-close_windows][cover.test_vent_windows]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Test Vent windows',
+      'supported_features': <CoverEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_vent_windows',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'closed',
+  })
+# ---

--- a/tests/components/tessie/snapshots/test_cover.ambr
+++ b/tests/components/tessie/snapshots/test_cover.ambr
@@ -1,18 +1,4 @@
 # serializer version: 1
-# name: test_covers[cover.test_charge_port_door-homeassistant.components.tessie.cover.open_unlock_charge_port-homeassistant.components.tessie.cover.close_charge_port][cover.test_charge_port_door]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Test Charge port door',
-      'supported_features': <CoverEntityFeature: 3>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'cover.test_charge_port_door',
-    'last_changed': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'open',
-  })
-# ---
 # name: test_covers[cover.test_charge_port_door-open_unlock_charge_port-close_charge_port][cover.test_charge_port_door]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -26,12 +12,6 @@
     'last_updated': <ANY>,
     'state': 'open',
   })
-# ---
-# name: test_covers[cover.test_front_trunk-homeassistant.components.tessie.cover.open_front_trunk-False][cover.test_front_trunk]
-  None
-# ---
-# name: test_covers[cover.test_front_trunk-open_front_trunk-False][cover.test_front_trunk]
-  None
 # ---
 # name: test_covers[cover.test_frunk-open_front_trunk-False][cover.test_frunk]
   StateSnapshot({
@@ -47,12 +27,6 @@
     'state': 'closed',
   })
 # ---
-# name: test_covers[cover.test_rear_trunk-homeassistant.components.tessie.cover.open_close_rear_trunk-homeassistant.components.tessie.cover.open_close_rear_trunk][cover.test_rear_trunk]
-  None
-# ---
-# name: test_covers[cover.test_rear_trunk-open_close_rear_trunk-open_close_rear_trunk][cover.test_rear_trunk]
-  None
-# ---
 # name: test_covers[cover.test_trunk-open_close_rear_trunk-open_close_rear_trunk][cover.test_trunk]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -62,20 +36,6 @@
     }),
     'context': <ANY>,
     'entity_id': 'cover.test_trunk',
-    'last_changed': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'closed',
-  })
-# ---
-# name: test_covers[cover.test_vent_windows-homeassistant.components.tessie.cover.vent_windows-homeassistant.components.tessie.cover.close_windows][cover.test_vent_windows]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'Test Vent windows',
-      'supported_features': <CoverEntityFeature: 3>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'cover.test_vent_windows',
     'last_changed': <ANY>,
     'last_updated': <ANY>,
     'state': 'closed',

--- a/tests/components/tessie/test_cover.py
+++ b/tests/components/tessie/test_cover.py
@@ -2,6 +2,7 @@
 from unittest.mock import patch
 
 import pytest
+from syrupy import SnapshotAssertion
 
 from homeassistant.components.cover import (
     DOMAIN as COVER_DOMAIN,
@@ -17,78 +18,57 @@ from homeassistant.exceptions import HomeAssistantError
 from .common import ERROR_UNKNOWN, TEST_RESPONSE, setup_platform
 
 
-async def test_window(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    ("entity_id", "openfunc", "closefunc"),
+    [
+        ("cover.test_vent_windows", "vent_windows", "close_windows"),
+        ("cover.test_charge_port_door", "open_unlock_charge_port", "close_charge_port"),
+        ("cover.test_frunk", "open_front_trunk", False),
+        ("cover.test_trunk", "open_close_rear_trunk", "open_close_rear_trunk"),
+    ],
+)
+async def test_covers(
+    hass: HomeAssistant,
+    entity_id: str,
+    openfunc: str,
+    closefunc: str,
+    snapshot: SnapshotAssertion,
+) -> None:
     """Tests that the window cover entity is correct."""
 
     await setup_platform(hass)
 
-    entity_id = "cover.test_vent_windows"
-    assert hass.states.get(entity_id).state == STATE_CLOSED
+    assert hass.states.get(entity_id) == snapshot(name=entity_id)
 
     # Test open windows
-    with patch(
-        "homeassistant.components.tessie.cover.vent_windows",
-        return_value=TEST_RESPONSE,
-    ) as mock_set:
-        await hass.services.async_call(
-            COVER_DOMAIN,
-            SERVICE_OPEN_COVER,
-            {ATTR_ENTITY_ID: [entity_id]},
-            blocking=True,
-        )
-        mock_set.assert_called_once()
-    assert hass.states.get(entity_id).state == STATE_OPEN
+    if openfunc:
+        with patch(
+            f"homeassistant.components.tessie.cover.{openfunc}",
+            return_value=TEST_RESPONSE,
+        ) as mock_open:
+            await hass.services.async_call(
+                COVER_DOMAIN,
+                SERVICE_OPEN_COVER,
+                {ATTR_ENTITY_ID: [entity_id]},
+                blocking=True,
+            )
+            mock_open.assert_called_once()
+        assert hass.states.get(entity_id).state == STATE_OPEN
 
     # Test close windows
-    with patch(
-        "homeassistant.components.tessie.cover.close_windows",
-        return_value=TEST_RESPONSE,
-    ) as mock_set:
-        await hass.services.async_call(
-            COVER_DOMAIN,
-            SERVICE_CLOSE_COVER,
-            {ATTR_ENTITY_ID: [entity_id]},
-            blocking=True,
-        )
-        mock_set.assert_called_once()
-    assert hass.states.get(entity_id).state == STATE_CLOSED
-
-
-async def test_charge_port(hass: HomeAssistant) -> None:
-    """Tests that the charge port cover entity is correct."""
-
-    await setup_platform(hass)
-
-    entity_id = "cover.test_charge_port_door"
-    assert hass.states.get(entity_id).state == STATE_OPEN
-
-    # Test close charge port
-    with patch(
-        "homeassistant.components.tessie.cover.close_charge_port",
-        return_value=TEST_RESPONSE,
-    ) as mock_set:
-        await hass.services.async_call(
-            COVER_DOMAIN,
-            SERVICE_CLOSE_COVER,
-            {ATTR_ENTITY_ID: [entity_id]},
-            blocking=True,
-        )
-        mock_set.assert_called_once()
-    assert hass.states.get(entity_id).state == STATE_CLOSED
-
-    # Test open charge port
-    with patch(
-        "homeassistant.components.tessie.cover.open_unlock_charge_port",
-        return_value=TEST_RESPONSE,
-    ) as mock_set:
-        await hass.services.async_call(
-            COVER_DOMAIN,
-            SERVICE_OPEN_COVER,
-            {ATTR_ENTITY_ID: [entity_id]},
-            blocking=True,
-        )
-        mock_set.assert_called_once()
-    assert hass.states.get(entity_id).state == STATE_OPEN
+    if closefunc:
+        with patch(
+            f"homeassistant.components.tessie.cover.{closefunc}",
+            return_value=TEST_RESPONSE,
+        ) as mock_close:
+            await hass.services.async_call(
+                COVER_DOMAIN,
+                SERVICE_CLOSE_COVER,
+                {ATTR_ENTITY_ID: [entity_id]},
+                blocking=True,
+            )
+            mock_close.assert_called_once()
+        assert hass.states.get(entity_id).state == STATE_CLOSED
 
 
 async def test_errors(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I found the Front and Rear Trunk states, so they can be real covers now instead of stateless buttons.

This PR removes the buttons and adds 2 new covers with tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30513

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
