### PR TITLE
Flip around Tailwind locked out binary sensor

### DIFF
--- a/homeassistant/components/tailwind/binary_sensor.py
+++ b/homeassistant/components/tailwind/binary_sensor.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from gotailwind import TailwindDoor
 
 from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
@@ -32,6 +33,7 @@ DESCRIPTIONS: tuple[TailwindDoorBinarySensorEntityDescription, ...] = (
         key="locked_out",
         translation_key="operational_problem",
         entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=BinarySensorDeviceClass.PROBLEM,
         icon="mdi:garage-alert",
         is_on_fn=lambda door: door.locked_out,
     ),

--- a/homeassistant/components/tailwind/binary_sensor.py
+++ b/homeassistant/components/tailwind/binary_sensor.py
@@ -30,10 +30,10 @@ class TailwindDoorBinarySensorEntityDescription(BinarySensorEntityDescription):
 DESCRIPTIONS: tuple[TailwindDoorBinarySensorEntityDescription, ...] = (
     TailwindDoorBinarySensorEntityDescription(
         key="locked_out",
-        translation_key="operational_status",
+        translation_key="operational_problem",
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:garage-alert",
-        is_on_fn=lambda door: not door.locked_out,
+        is_on_fn=lambda door: door.locked_out,
     ),
 )
 

--- a/homeassistant/components/tailwind/strings.json
+++ b/homeassistant/components/tailwind/strings.json
@@ -47,11 +47,11 @@
   },
   "entity": {
     "binary_sensor": {
-      "operational_status": {
-        "name": "Operational status",
+      "operational_problem": {
+        "name": "Operational problem",
         "state": {
-          "off": "Locked out",
-          "on": "Operational"
+          "off": "Operational",
+          "on": "Locked out"
         }
       }
     },

--- a/tests/components/tailwind/snapshots/test_binary_sensor.ambr
+++ b/tests/components/tailwind/snapshots/test_binary_sensor.ambr
@@ -1,18 +1,18 @@
 # serializer version: 1
-# name: test_number_entities
+# name: test_number_entities[binary_sensor.door_1_operational_problem]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Door 1 Operational status',
+      'friendly_name': 'Door 1 Operational problem',
       'icon': 'mdi:garage-alert',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.door_1_operational_status',
+    'entity_id': 'binary_sensor.door_1_operational_problem',
     'last_changed': <ANY>,
     'last_updated': <ANY>,
-    'state': 'on',
+    'state': 'off',
   })
 # ---
-# name: test_number_entities.1
+# name: test_number_entities[binary_sensor.door_1_operational_problem].1
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -24,7 +24,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.door_1_operational_status',
+    'entity_id': 'binary_sensor.door_1_operational_problem',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -34,160 +34,16 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:garage-alert',
-    'original_name': 'Operational status',
+    'original_name': 'Operational problem',
     'platform': 'tailwind',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'operational_status',
+    'translation_key': 'operational_problem',
     'unique_id': '_3c_e9_e_6d_21_84_-door1-locked_out',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_number_entities.2
-  DeviceRegistryEntrySnapshot({
-    'area_id': None,
-    'config_entries': <ANY>,
-    'configuration_url': None,
-    'connections': set({
-    }),
-    'disabled_by': None,
-    'entry_type': None,
-    'hw_version': None,
-    'id': <ANY>,
-    'identifiers': set({
-      tuple(
-        'tailwind',
-        '_3c_e9_e_6d_21_84_-door1',
-      ),
-    }),
-    'is_new': False,
-    'manufacturer': 'Tailwind',
-    'model': 'iQ3',
-    'name': 'Door 1',
-    'name_by_user': None,
-    'serial_number': None,
-    'suggested_area': None,
-    'sw_version': '10.10',
-    'via_device_id': None,
-  })
-# ---
-# name: test_number_entities.3
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Door 2 Operational status',
-      'icon': 'mdi:garage-alert',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.door_2_operational_status',
-    'last_changed': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'on',
-  })
-# ---
-# name: test_number_entities.4
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'binary_sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.door_2_operational_status',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': 'mdi:garage-alert',
-    'original_name': 'Operational status',
-    'platform': 'tailwind',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': 'operational_status',
-    'unique_id': '_3c_e9_e_6d_21_84_-door2-locked_out',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_number_entities.5
-  DeviceRegistryEntrySnapshot({
-    'area_id': None,
-    'config_entries': <ANY>,
-    'configuration_url': None,
-    'connections': set({
-    }),
-    'disabled_by': None,
-    'entry_type': None,
-    'hw_version': None,
-    'id': <ANY>,
-    'identifiers': set({
-      tuple(
-        'tailwind',
-        '_3c_e9_e_6d_21_84_-door2',
-      ),
-    }),
-    'is_new': False,
-    'manufacturer': 'Tailwind',
-    'model': 'iQ3',
-    'name': 'Door 2',
-    'name_by_user': None,
-    'serial_number': None,
-    'suggested_area': None,
-    'sw_version': '10.10',
-    'via_device_id': None,
-  })
-# ---
-# name: test_number_entities[binary_sensor.door_1_operational_status]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Door 1 Operational status',
-      'icon': 'mdi:garage-alert',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.door_1_operational_status',
-    'last_changed': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'on',
-  })
-# ---
-# name: test_number_entities[binary_sensor.door_1_operational_status].1
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'binary_sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.door_1_operational_status',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': 'mdi:garage-alert',
-    'original_name': 'Operational status',
-    'platform': 'tailwind',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': 'operational_status',
-    'unique_id': '_3c_e9_e_6d_21_84_-door1-locked_out',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_number_entities[binary_sensor.door_1_operational_status].2
+# name: test_number_entities[binary_sensor.door_1_operational_problem].2
   DeviceRegistryEntrySnapshot({
     'area_id': None,
     'config_entries': <ANY>,
@@ -215,20 +71,20 @@
     'via_device_id': <ANY>,
   })
 # ---
-# name: test_number_entities[binary_sensor.door_2_operational_status]
+# name: test_number_entities[binary_sensor.door_2_operational_problem]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Door 2 Operational status',
+      'friendly_name': 'Door 2 Operational problem',
       'icon': 'mdi:garage-alert',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.door_2_operational_status',
+    'entity_id': 'binary_sensor.door_2_operational_problem',
     'last_changed': <ANY>,
     'last_updated': <ANY>,
-    'state': 'on',
+    'state': 'off',
   })
 # ---
-# name: test_number_entities[binary_sensor.door_2_operational_status].1
+# name: test_number_entities[binary_sensor.door_2_operational_problem].1
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -240,7 +96,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.door_2_operational_status',
+    'entity_id': 'binary_sensor.door_2_operational_problem',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -250,16 +106,16 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:garage-alert',
-    'original_name': 'Operational status',
+    'original_name': 'Operational problem',
     'platform': 'tailwind',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'operational_status',
+    'translation_key': 'operational_problem',
     'unique_id': '_3c_e9_e_6d_21_84_-door2-locked_out',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_number_entities[binary_sensor.door_2_operational_status].2
+# name: test_number_entities[binary_sensor.door_2_operational_problem].2
   DeviceRegistryEntrySnapshot({
     'area_id': None,
     'config_entries': <ANY>,

--- a/tests/components/tailwind/snapshots/test_binary_sensor.ambr
+++ b/tests/components/tailwind/snapshots/test_binary_sensor.ambr
@@ -2,6 +2,7 @@
 # name: test_number_entities[binary_sensor.door_1_operational_problem]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_class': 'problem',
       'friendly_name': 'Door 1 Operational problem',
       'icon': 'mdi:garage-alert',
     }),
@@ -32,7 +33,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': None,
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
     'original_icon': 'mdi:garage-alert',
     'original_name': 'Operational problem',
     'platform': 'tailwind',
@@ -74,6 +75,7 @@
 # name: test_number_entities[binary_sensor.door_2_operational_problem]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_class': 'problem',
       'friendly_name': 'Door 2 Operational problem',
       'icon': 'mdi:garage-alert',
     }),
@@ -104,7 +106,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': None,
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
     'original_icon': 'mdi:garage-alert',
     'original_name': 'Operational problem',
     'platform': 'tailwind',

--- a/tests/components/tailwind/test_binary_sensor.py
+++ b/tests/components/tailwind/test_binary_sensor.py
@@ -12,8 +12,8 @@ pytestmark = pytest.mark.usefixtures("init_integration")
 @pytest.mark.parametrize(
     "entity_id",
     [
-        "binary_sensor.door_1_operational_status",
-        "binary_sensor.door_2_operational_status",
+        "binary_sensor.door_1_operational_problem",
+        "binary_sensor.door_2_operational_problem",
     ],
 )
 async def test_number_entities(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

[Flip around locked out binary sensor](https://github.com/home-assistant/core/pull/106033#pullrequestreview-1788465515)

After discussing with @MartinHjelmare, we have changed the name of the sensor slightly, to make the native state of the sensor more clear.

--- 

Tailwind provides garage door controllers that work with most garage door openers and communicates fully locally.

More information: https://gotailwind.com/

The development of this integration will consist of multiple pull requests:

- [x] Add the minimal functional integration (#105926)
- [x] Add zeroconf discovery support (#105949)
- [x] Add re-authentication support in case the local key is changed (#105959)
- [x] Add DHCP discovery support for updating config entries (#105981)
- [x] Add binary sensor platform (#106033)
- [x] Add cover platform (#106042)
- [x] Add button platform (#105961)
- [x] Add diagnostic platform (#105965)
- [ ] Add error handling to service calls (with translatable errors)
- [x] Fix flaky via_device_id tests (#106294)
- [ ] **[Flip around locked out binary sensor](https://github.com/home-assistant/core/pull/106033#pullrequestreview-1788465515)** (This PR!)
- [x] Bump gotailwind library to the latest version (#106054)
- [x] General cleanup, as most is in at this point (#106073)
- [ ] Upgrade integration to platinum level
- [ ] Leverage webhooks to make integration push-based

Big thanks to Tailwind for providing the devices for testing ❤️ 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
