### PR TITLE
Revert "Raise HomeAssistantError if event is triggered with invalid event_type"

### DIFF
--- a/homeassistant/components/event/__init__.py
+++ b/homeassistant/components/event/__init__.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any, Self, final
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
     PLATFORM_SCHEMA_BASE,
@@ -155,17 +154,7 @@ class EventEntity(RestoreEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_)
     ) -> None:
         """Process a new event."""
         if event_type not in self.event_types:
-            event_types: str = ", ".join(self.event_types)
-            raise HomeAssistantError(
-                f"Invalid event type {event_type} for {self.entity_id}",
-                translation_key="invalid_event_type",
-                translation_domain=DOMAIN,
-                translation_placeholders={
-                    "event_type": event_type,
-                    "event_types": event_types,
-                    "entity_id": self.entity_id,
-                },
-            )
+            raise ValueError(f"Invalid event type {event_type} for {self.entity_id}")
         self.__last_event_triggered = dt_util.utcnow()
         self.__last_event_type = event_type
         self.__last_event_attributes = event_attributes

--- a/homeassistant/components/event/strings.json
+++ b/homeassistant/components/event/strings.json
@@ -21,10 +21,5 @@
     "motion": {
       "name": "Motion"
     }
-  },
-  "exceptions": {
-    "invalid_event_type": {
-      "message": "Invalid event type {event_type} for {entity_id}, valid types are: {event_types}."
-    }
   }
 }

--- a/homeassistant/components/mqtt/event.py
+++ b/homeassistant/components/mqtt/event.py
@@ -16,7 +16,6 @@ from homeassistant.components.event import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME, CONF_VALUE_TEMPLATE
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
@@ -175,7 +174,7 @@ class MqttEvent(MqttEntity, EventEntity):
                 return
             try:
                 self._trigger_event(event_type, event_attributes)
-            except HomeAssistantError:
+            except ValueError:
                 _LOGGER.warning(
                     "Invalid event type %s for %s received on topic %s, payload %s",
                     event_type,

--- a/tests/components/event/test_init.py
+++ b/tests/components/event/test_init.py
@@ -16,7 +16,6 @@ from homeassistant.components.event import (
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.const import CONF_PLATFORM, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, State
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import STORAGE_KEY as RESTORE_STATE_KEY
 from homeassistant.setup import async_setup_component
@@ -91,8 +90,7 @@ async def test_event() -> None:
 
     # Test triggering an unknown event
     with pytest.raises(
-        HomeAssistantError,
-        match="^Invalid event type unknown_event for event.doorbell$",
+        ValueError, match="^Invalid event type unknown_event for event.doorbell$"
     ):
         event._trigger_event("unknown_event")
 


### PR DESCRIPTION
Reverts home-assistant/core#106357

See comment from @MartinHjelmare in <https://github.com/home-assistant/core/pull/106357#pullrequestreview-1796870050>