### PR TITLE
Add error handling to Tailwind service methods

### DIFF
--- a/homeassistant/components/tailwind/button.py
+++ b/homeassistant/components/tailwind/button.py
@@ -5,7 +5,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
-from gotailwind import Tailwind
+from gotailwind import Tailwind, TailwindError
 
 from homeassistant.components.button import (
     ButtonDeviceClass,
@@ -15,6 +15,7 @@ from homeassistant.components.button import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -62,4 +63,11 @@ class TailwindButtonEntity(TailwindEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Trigger button press on the Tailwind device."""
-        await self.entity_description.press_fn(self.coordinator.tailwind)
+        try:
+            await self.entity_description.press_fn(self.coordinator.tailwind)
+        except TailwindError as exc:
+            raise HomeAssistantError(
+                str(exc),
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+            ) from exc

--- a/homeassistant/components/tailwind/cover.py
+++ b/homeassistant/components/tailwind/cover.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from gotailwind import TailwindDoorOperationCommand, TailwindDoorState
+from gotailwind import (
+    TailwindDoorDisabledError,
+    TailwindDoorLockedOutError,
+    TailwindDoorOperationCommand,
+    TailwindDoorState,
+    TailwindError,
+)
 
 from homeassistant.components.cover import (
     CoverDeviceClass,
@@ -12,6 +18,7 @@ from homeassistant.components.cover import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -56,11 +63,31 @@ class TailwindDoorCoverEntity(TailwindDoorEntity, CoverEntity):
         """
         self._attr_is_opening = True
         self.async_write_ha_state()
-        await self.coordinator.tailwind.operate(
-            door=self.coordinator.data.doors[self.door_id],
-            operation=TailwindDoorOperationCommand.OPEN,
-        )
-        self._attr_is_opening = False
+        try:
+            await self.coordinator.tailwind.operate(
+                door=self.coordinator.data.doors[self.door_id],
+                operation=TailwindDoorOperationCommand.OPEN,
+            )
+        except TailwindDoorDisabledError as exc:
+            raise HomeAssistantError(
+                str(exc),
+                translation_domain=DOMAIN,
+                translation_key="door_disabled",
+            ) from exc
+        except TailwindDoorLockedOutError as exc:
+            raise HomeAssistantError(
+                str(exc),
+                translation_domain=DOMAIN,
+                translation_key="door_locked_out",
+            ) from exc
+        except TailwindError as exc:
+            raise HomeAssistantError(
+                str(exc),
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+            ) from exc
+        finally:
+            self._attr_is_opening = False
         await self.coordinator.async_request_refresh()
 
     async def async_close_cover(self, **kwargs: Any) -> None:
@@ -71,9 +98,28 @@ class TailwindDoorCoverEntity(TailwindDoorEntity, CoverEntity):
         """
         self._attr_is_closing = True
         self.async_write_ha_state()
-        await self.coordinator.tailwind.operate(
-            door=self.coordinator.data.doors[self.door_id],
-            operation=TailwindDoorOperationCommand.CLOSE,
-        )
+        try:
+            await self.coordinator.tailwind.operate(
+                door=self.coordinator.data.doors[self.door_id],
+                operation=TailwindDoorOperationCommand.CLOSE,
+            )
+        except TailwindDoorDisabledError as exc:
+            raise HomeAssistantError(
+                str(exc),
+                translation_domain=DOMAIN,
+                translation_key="door_disabled",
+            ) from exc
+        except TailwindDoorLockedOutError as exc:
+            raise HomeAssistantError(
+                str(exc),
+                translation_domain=DOMAIN,
+                translation_key="door_locked_out",
+            ) from exc
+        except TailwindError as exc:
+            raise HomeAssistantError(
+                str(exc),
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+            ) from exc
         self._attr_is_closing = False
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/tailwind/strings.json
+++ b/homeassistant/components/tailwind/strings.json
@@ -60,5 +60,16 @@
         "name": "Status LED brightness"
       }
     }
+  },
+  "exceptions": {
+    "communication_error": {
+      "message": "An error occurred while communicating with the Tailwind device."
+    },
+    "door_disabled": {
+      "message": "The door is disabled and cannot be operated."
+    },
+    "door_locked_out": {
+      "message": "The door is locked out and cannot be operated."
+    }
   }
 }

--- a/tests/components/tailwind/test_button.py
+++ b/tests/components/tailwind/test_button.py
@@ -1,12 +1,15 @@
 """Tests for button entities provided by the Tailwind integration."""
 from unittest.mock import MagicMock
 
+from gotailwind import TailwindError
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.components.tailwind.const import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 pytestmark = [
@@ -46,3 +49,17 @@ async def test_number_entities(
 
     assert (state := hass.states.get(state.entity_id))
     assert state.state == "2023-12-17T15:25:00+00:00"
+
+    # Test error handling
+    mock_tailwind.identify.side_effect = TailwindError("Some error")
+
+    with pytest.raises(HomeAssistantError, match="Some error") as excinfo:
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: state.entity_id},
+            blocking=True,
+        )
+
+    assert excinfo.value.translation_domain == DOMAIN
+    assert excinfo.value.translation_key == "communication_error"

--- a/tests/components/tailwind/test_cover.py
+++ b/tests/components/tailwind/test_cover.py
@@ -1,7 +1,12 @@
 """Tests for cover entities provided by the Tailwind integration."""
 from unittest.mock import ANY, MagicMock
 
-from gotailwind import TailwindDoorOperationCommand
+from gotailwind import (
+    TailwindDoorDisabledError,
+    TailwindDoorLockedOutError,
+    TailwindDoorOperationCommand,
+    TailwindError,
+)
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -10,8 +15,10 @@ from homeassistant.components.cover import (
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
 )
+from homeassistant.components.tailwind.const import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 pytestmark = pytest.mark.usefixtures("init_integration")
@@ -74,3 +81,90 @@ async def test_cover_operations(
     mock_tailwind.operate.assert_called_with(
         door=ANY, operation=TailwindDoorOperationCommand.CLOSE
     )
+
+    # Test door disabled error handling
+    mock_tailwind.operate.side_effect = TailwindDoorDisabledError("Door disabled")
+
+    with pytest.raises(HomeAssistantError, match="Door disabled") as excinfo:
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_OPEN_COVER,
+            {
+                ATTR_ENTITY_ID: "cover.door_1",
+            },
+            blocking=True,
+        )
+
+    assert excinfo.value.translation_domain == DOMAIN
+    assert excinfo.value.translation_key == "door_disabled"
+
+    with pytest.raises(HomeAssistantError, match="Door disabled") as excinfo:
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_CLOSE_COVER,
+            {
+                ATTR_ENTITY_ID: "cover.door_1",
+            },
+            blocking=True,
+        )
+
+    assert excinfo.value.translation_domain == DOMAIN
+    assert excinfo.value.translation_key == "door_disabled"
+
+    # Test door locked out error handling
+    mock_tailwind.operate.side_effect = TailwindDoorLockedOutError("Door locked out")
+
+    with pytest.raises(HomeAssistantError, match="Door locked out") as excinfo:
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_OPEN_COVER,
+            {
+                ATTR_ENTITY_ID: "cover.door_1",
+            },
+            blocking=True,
+        )
+
+    assert excinfo.value.translation_domain == DOMAIN
+    assert excinfo.value.translation_key == "door_locked_out"
+
+    with pytest.raises(HomeAssistantError, match="Door locked out") as excinfo:
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_CLOSE_COVER,
+            {
+                ATTR_ENTITY_ID: "cover.door_1",
+            },
+            blocking=True,
+        )
+
+    assert excinfo.value.translation_domain == DOMAIN
+    assert excinfo.value.translation_key == "door_locked_out"
+
+    # Test door error handling
+    mock_tailwind.operate.side_effect = TailwindError("Some error")
+
+    with pytest.raises(HomeAssistantError, match="Some error") as excinfo:
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_OPEN_COVER,
+            {
+                ATTR_ENTITY_ID: "cover.door_1",
+            },
+            blocking=True,
+        )
+
+    assert excinfo.value.translation_domain == DOMAIN
+    assert excinfo.value.translation_key == "communication_error"
+
+    with pytest.raises(HomeAssistantError, match="Some error") as excinfo:
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_CLOSE_COVER,
+            {
+                ATTR_ENTITY_ID: "cover.door_1",
+            },
+            blocking=True,
+        )
+
+    assert excinfo.value.translation_domain == DOMAIN
+    assert excinfo.value.translation_key == "communication_error"

--- a/tests/components/tailwind/test_number.py
+++ b/tests/components/tailwind/test_number.py
@@ -1,13 +1,16 @@
 """Tests for number entities provided by the Tailwind integration."""
 from unittest.mock import MagicMock
 
+from gotailwind import TailwindError
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components import number
 from homeassistant.components.number import ATTR_VALUE, SERVICE_SET_VALUE
+from homeassistant.components.tailwind.const import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 pytestmark = pytest.mark.usefixtures("init_integration")
@@ -44,3 +47,20 @@ async def test_number_entities(
 
     assert len(mock_tailwind.status_led.mock_calls) == 1
     mock_tailwind.status_led.assert_called_with(brightness=42)
+
+    # Test error handling
+    mock_tailwind.status_led.side_effect = TailwindError("Some error")
+
+    with pytest.raises(HomeAssistantError, match="Some error") as excinfo:
+        await hass.services.async_call(
+            number.DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: state.entity_id,
+                ATTR_VALUE: 42,
+            },
+            blocking=True,
+        )
+
+    assert excinfo.value.translation_domain == DOMAIN
+    assert excinfo.value.translation_key == "communication_error"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds error handling to all methods that do operations for service calls.

--- 

Tailwind provides garage door controllers that work with most garage door openers and communicates fully locally.

More information: https://gotailwind.com/

The development of this integration will consist of multiple pull requests:

- [x] Add the minimal functional integration (#105926)
- [x] Add zeroconf discovery support (#105949)
- [x] Add re-authentication support in case the local key is changed (#105959)
- [x] Add DHCP discovery support for updating config entries (#105981)
- [x] Add binary sensor platform (#106033)
- [x] Add cover platform (#106042)
- [x] Add button platform (#105961)
- [x] Add diagnostic platform (#105965)
- [ ] **Add error handling to service calls (with translatable errors)** (This PR!)
- [x] Fix flaky via_device_id tests (#106294)
- [x] [Flip around locked out binary sensor](https://github.com/home-assistant/core/pull/106033#pullrequestreview-1788465515) (#106457)
- [x] Bump gotailwind library to the latest version (#106054)
- [x] General cleanup, as most is in at this point (#106073)
- [ ] Upgrade integration to platinum level
- [ ] Leverage webhooks to make integration push-based

Big thanks to Tailwind for providing the devices for testing ❤️ 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
