### PR TITLE
Handle AttributeError in ViCare integration

### DIFF
--- a/homeassistant/components/vicare/utils.py
+++ b/homeassistant/components/vicare/utils.py
@@ -21,13 +21,12 @@ def is_supported(
     try:
         entity_description.value_getter(vicare_device)
         _LOGGER.debug("Found entity %s", name)
+        return True
     except PyViCareNotSupportedFeatureError:
-        _LOGGER.info("Feature not supported %s", name)
-        return False
+        _LOGGER.debug("Feature not supported %s", name)
     except AttributeError as error:
         _LOGGER.debug("Attribute Error %s: %s", name, error)
-        return False
-    return True
+    return False
 
 
 def get_burners(device: PyViCareDevice) -> list[PyViCareHeatingDeviceComponent]:
@@ -36,6 +35,8 @@ def get_burners(device: PyViCareDevice) -> list[PyViCareHeatingDeviceComponent]:
         return device.burners
     except PyViCareNotSupportedFeatureError:
         _LOGGER.debug("No burners found")
+    except AttributeError as error:
+        _LOGGER.debug("Attribute Error burners: %s", error)
     return []
 
 
@@ -45,6 +46,8 @@ def get_circuits(device: PyViCareDevice) -> list[PyViCareHeatingDeviceComponent]
         return device.circuits
     except PyViCareNotSupportedFeatureError:
         _LOGGER.debug("No circuits found")
+    except AttributeError as error:
+        _LOGGER.debug("Attribute Error circuits: %s", error)
     return []
 
 
@@ -54,4 +57,6 @@ def get_compressors(device: PyViCareDevice) -> list[PyViCareHeatingDeviceCompone
         return device.compressors
     except PyViCareNotSupportedFeatureError:
         _LOGGER.debug("No compressors found")
+    except AttributeError as error:
+        _LOGGER.debug("Attribute Error compressors: %s", error)
     return []

--- a/homeassistant/components/vicare/utils.py
+++ b/homeassistant/components/vicare/utils.py
@@ -25,7 +25,7 @@ def is_supported(
     except PyViCareNotSupportedFeatureError:
         _LOGGER.debug("Feature not supported %s", name)
     except AttributeError as error:
-        _LOGGER.debug("Attribute Error %s: %s", name, error)
+        _LOGGER.debug("Feature not supported %s: %s", name, error)
     return False
 
 
@@ -36,7 +36,7 @@ def get_burners(device: PyViCareDevice) -> list[PyViCareHeatingDeviceComponent]:
     except PyViCareNotSupportedFeatureError:
         _LOGGER.debug("No burners found")
     except AttributeError as error:
-        _LOGGER.debug("Attribute Error burners: %s", error)
+        _LOGGER.debug("No burners found: %s", error)
     return []
 
 
@@ -47,7 +47,7 @@ def get_circuits(device: PyViCareDevice) -> list[PyViCareHeatingDeviceComponent]
     except PyViCareNotSupportedFeatureError:
         _LOGGER.debug("No circuits found")
     except AttributeError as error:
-        _LOGGER.debug("Attribute Error circuits: %s", error)
+        _LOGGER.debug("No circuits found: %s", error)
     return []
 
 
@@ -58,5 +58,5 @@ def get_compressors(device: PyViCareDevice) -> list[PyViCareHeatingDeviceCompone
     except PyViCareNotSupportedFeatureError:
         _LOGGER.debug("No compressors found")
     except AttributeError as error:
-        _LOGGER.debug("Attribute Error compressors: %s", error)
+        _LOGGER.debug("No compressors found: %s", error)
     return []


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When accessing `circuits`, `burners` or `compressors` on Gateway, Ventilation or ElectricalEnergySystem devices there is no `PyViCareNotSupportedFeatureError` raised but an `AttributeError`.

Also reduced the visibility for *unsupported features* messages from *info* to *debug*. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #106368
- This PR is related to issue: https://github.com/home-assistant/core/pull/106467
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
