### PR TITLE
Bump ZHA quirks to 109 and add associated configuration entities

### DIFF
--- a/homeassistant/components/zha/core/cluster_handlers/manufacturerspecific.py
+++ b/homeassistant/components/zha/core/cluster_handlers/manufacturerspecific.py
@@ -147,6 +147,17 @@ class OppleRemote(ClusterHandler):
                 "buzzer": True,
                 "linkage_alarm": True,
             }
+        elif self.cluster.endpoint.model == "lumi.magnet.ac01":
+            self.ZCL_INIT_ATTRS = {
+                "detection_distance": True,
+            }
+        elif self.cluster.endpoint.model == "lumi.switch.acn047":
+            self.ZCL_INIT_ATTRS = {
+                "switch_mode": True,
+                "switch_type": True,
+                "startup_on_off": True,
+                "decoupled_mode": True,
+            }
 
     async def async_initialize_cluster_handler_specific(self, from_cache: bool) -> None:
         """Initialize cluster handler specific."""

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -24,7 +24,7 @@
     "bellows==0.37.4",
     "pyserial==3.5",
     "pyserial-asyncio==0.6",
-    "zha-quirks==0.0.108",
+    "zha-quirks==0.0.109",
     "zigpy-deconz==0.22.3",
     "zigpy==0.60.2",
     "zigpy-xbee==0.20.1",

--- a/homeassistant/components/zha/select.py
+++ b/homeassistant/components/zha/select.py
@@ -7,6 +7,8 @@ import logging
 from typing import TYPE_CHECKING, Any, Self
 
 from zhaquirks.quirk_ids import TUYA_PLUG_MANUFACTURER, TUYA_PLUG_ONOFF
+from zhaquirks.xiaomi.aqara.magnet_ac01 import OppleCluster as MagnetAC01OppleCluster
+from zhaquirks.xiaomi.aqara.switch_acn047 import OppleCluster as T2RelayOppleCluster
 from zigpy import types
 from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.clusters.security import IasWd
@@ -406,6 +408,66 @@ class AqaraApproachDistance(ZCLEnumSelectEntity):
     _attribute_name = "approach_distance"
     _enum = AqaraApproachDistances
     _attr_translation_key: str = "approach_distance"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    cluster_handler_names="opple_cluster", models={"lumi.magnet.ac01"}
+)
+class AqaraMagnetAC01DetectionDistance(ZCLEnumSelectEntity):
+    """Representation of a ZHA detection distance configuration entity."""
+
+    _unique_id_suffix = "detection_distance"
+    _attribute_name = "detection_distance"
+    _enum = MagnetAC01OppleCluster.DetectionDistance
+    _attr_translation_key: str = "detection_distance"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    cluster_handler_names="opple_cluster", models={"lumi.switch.acn047"}
+)
+class AqaraT2RelaySwitchMode(ZCLEnumSelectEntity):
+    """Representation of a ZHA switch mode configuration entity."""
+
+    _unique_id_suffix = "switch_mode"
+    _attribute_name = "switch_mode"
+    _enum = T2RelayOppleCluster.SwitchMode
+    _attr_translation_key: str = "switch_mode"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    cluster_handler_names="opple_cluster", models={"lumi.switch.acn047"}
+)
+class AqaraT2RelaySwitchType(ZCLEnumSelectEntity):
+    """Representation of a ZHA switch type configuration entity."""
+
+    _unique_id_suffix = "switch_type"
+    _attribute_name = "switch_type"
+    _enum = T2RelayOppleCluster.SwitchType
+    _attr_translation_key: str = "switch_type"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    cluster_handler_names="opple_cluster", models={"lumi.switch.acn047"}
+)
+class AqaraT2RelayStartupOnOff(ZCLEnumSelectEntity):
+    """Representation of a ZHA startup on off configuration entity."""
+
+    _unique_id_suffix = "startup_on_off"
+    _attribute_name = "startup_on_off"
+    _enum = T2RelayOppleCluster.StartupOnOff
+    _attr_translation_key: str = "startup_on_off"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    cluster_handler_names="opple_cluster", models={"lumi.switch.acn047"}
+)
+class AqaraT2RelayDecoupledMode(ZCLEnumSelectEntity):
+    """Representation of a ZHA switch decoupled mode configuration entity."""
+
+    _unique_id_suffix = "decoupled_mode"
+    _attribute_name = "decoupled_mode"
+    _enum = T2RelayOppleCluster.DecoupledMode
+    _attr_translation_key: str = "decoupled_mode"
 
 
 class AqaraE1ReverseDirection(types.enum8):

--- a/homeassistant/components/zha/select.py
+++ b/homeassistant/components/zha/select.py
@@ -455,7 +455,7 @@ class AqaraT2RelayStartupOnOff(ZCLEnumSelectEntity):
     _unique_id_suffix = "startup_on_off"
     _attribute_name = "startup_on_off"
     _enum = T2RelayOppleCluster.StartupOnOff
-    _attr_translation_key: str = "startup_on_off"
+    _attr_translation_key: str = "start_up_on_off"
 
 
 @CONFIG_DIAGNOSTIC_MATCH(

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -778,8 +778,17 @@
       "feeding_mode": {
         "name": "Mode"
       },
-      "preset": {
-        "name": "Preset"
+      "detection_distance": {
+        "name": "Detection distance"
+      },
+      "switch_mode": {
+        "name": "Switch mode"
+      },
+      "startup_on_off": {
+        "name": "Startup on off"
+      },
+      "decoupled_mode": {
+        "name": "Decoupled mode"
       }
     },
     "sensor": {

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -784,9 +784,6 @@
       "switch_mode": {
         "name": "Switch mode"
       },
-      "startup_on_off": {
-        "name": "Startup on off"
-      },
       "decoupled_mode": {
         "name": "Decoupled mode"
       }

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -778,6 +778,9 @@
       "feeding_mode": {
         "name": "Mode"
       },
+      "preset": {
+        "name": "Preset"
+      },
       "detection_distance": {
         "name": "Detection distance"
       },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2863,7 +2863,7 @@ zeroconf==0.131.0
 zeversolar==0.3.1
 
 # homeassistant.components.zha
-zha-quirks==0.0.108
+zha-quirks==0.0.109
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2165,7 +2165,7 @@ zeroconf==0.131.0
 zeversolar==0.3.1
 
 # homeassistant.components.zha
-zha-quirks==0.0.108
+zha-quirks==0.0.109
 
 # homeassistant.components.zha
 zigpy-deconz==0.22.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR bumps [ZHA quirks to 109](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.109) and adds config entities for a couple Xiaomi devices included in 109. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
