### PR TITLE
Use correct state for emulated_hue covers

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -74,6 +74,7 @@ from homeassistant.util.network import is_local
 from .config import Config
 
 _LOGGER = logging.getLogger(__name__)
+_OFF_STATES: dict[str, str] = {cover.DOMAIN: STATE_CLOSED}
 
 # How long to wait for a state change to happen
 STATE_CHANGE_WAIT_TIMEOUT = 5.0
@@ -730,13 +731,6 @@ def _build_entity_state_dict(entity: State) -> dict[str, Any]:
     return data
 
 
-def _hass_to_hue_state(entity: State) -> bool:
-    if entity.domain == cover.DOMAIN:
-        return entity.state != STATE_CLOSED
-
-    return entity.state != STATE_OFF
-
-
 def _clamp_values(data: dict[str, Any]) -> None:
     """Clamp brightness, hue, saturation, and color temp to valid values."""
     for key, v_min, v_max in (
@@ -897,6 +891,11 @@ def hue_brightness_to_hass(value: int) -> int:
 def hass_to_hue_brightness(value: int) -> int:
     """Convert hass brightness 0..255 to hue 1..254 scale."""
     return max(1, round((value / 255) * HUE_API_STATE_BRI_MAX))
+
+
+def _hass_to_hue_state(entity: State) -> bool:
+    """Convert hass entity states to simple True/False on/off state for Hue."""
+    return entity.state != _OFF_STATES.get(entity.domain, STATE_OFF)
 
 
 async def wait_for_state_change_or_timeout(

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -1019,6 +1019,12 @@ async def test_set_position_cover(hass_hue, hue_client) -> None:
     cover_test = hass_hue.states.get(cover_id)
     assert cover_test.state == "closed"
 
+    cover_json = await perform_get_light_state(
+        hue_client, "cover.living_room_window", HTTPStatus.OK
+    )
+    assert cover_json["state"][HUE_API_STATE_ON] is False
+    assert cover_json["state"][HUE_API_STATE_BRI] == 1
+
     level = 20
     brightness = round(level / 100 * 254)
 
@@ -1095,6 +1101,7 @@ async def test_put_light_state_fan(hass_hue, hue_client) -> None:
         fan_json = await perform_get_light_state(
             hue_client, "fan.living_room_fan", HTTPStatus.OK
         )
+        assert fan_json["state"][HUE_API_STATE_ON] is True
         assert round(fan_json["state"][HUE_API_STATE_BRI] * 100 / 254) == 33
 
     await perform_put_light_state(
@@ -1112,6 +1119,7 @@ async def test_put_light_state_fan(hass_hue, hue_client) -> None:
         fan_json = await perform_get_light_state(
             hue_client, "fan.living_room_fan", HTTPStatus.OK
         )
+        assert fan_json["state"][HUE_API_STATE_ON] is True
         assert (
             round(fan_json["state"][HUE_API_STATE_BRI] * 100 / 254) == 66
         )  # small rounding error in inverse operation
@@ -1132,7 +1140,26 @@ async def test_put_light_state_fan(hass_hue, hue_client) -> None:
         fan_json = await perform_get_light_state(
             hue_client, "fan.living_room_fan", HTTPStatus.OK
         )
+        assert fan_json["state"][HUE_API_STATE_ON] is True
         assert round(fan_json["state"][HUE_API_STATE_BRI] * 100 / 254) == 100
+
+    await perform_put_light_state(
+        hass_hue,
+        hue_client,
+        "fan.living_room_fan",
+        False,
+        brightness=0,
+    )
+    assert (
+        hass_hue.states.get("fan.living_room_fan").attributes[fan.ATTR_PERCENTAGE] == 0
+    )
+    with patch.object(hue_api, "STATE_CACHED_TIMEOUT", 0.000001):
+        await asyncio.sleep(0.000001)
+        fan_json = await perform_get_light_state(
+            hue_client, "fan.living_room_fan", HTTPStatus.OK
+        )
+        assert fan_json["state"][HUE_API_STATE_ON] is False
+        assert fan_json["state"][HUE_API_STATE_BRI] == 1
 
 
 async def test_put_with_form_urlencoded_content_type(hass_hue, hue_client) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Expose closed covers as "off" via emulated_hue


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #106505

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
