### PR TITLE
Update aioairzone-cloud to v0.3.7

### DIFF
--- a/homeassistant/components/airzone_cloud/manifest.json
+++ b/homeassistant/components/airzone_cloud/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/airzone_cloud",
   "iot_class": "cloud_polling",
   "loggers": ["aioairzone_cloud"],
-  "requirements": ["aioairzone-cloud==0.3.6"]
+  "requirements": ["aioairzone-cloud==0.3.7"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -188,7 +188,7 @@ aio-georss-gdacs==0.8
 aioairq==0.3.2
 
 # homeassistant.components.airzone_cloud
-aioairzone-cloud==0.3.6
+aioairzone-cloud==0.3.7
 
 # homeassistant.components.airzone
 aioairzone==0.7.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -167,7 +167,7 @@ aio-georss-gdacs==0.8
 aioairq==0.3.2
 
 # homeassistant.components.airzone_cloud
-aioairzone-cloud==0.3.6
+aioairzone-cloud==0.3.7
 
 # homeassistant.components.airzone
 aioairzone==0.7.2

--- a/tests/components/airzone_cloud/snapshots/test_diagnostics.ambr
+++ b/tests/components/airzone_cloud/snapshots/test_diagnostics.ambr
@@ -324,6 +324,12 @@
       }),
       'systems': dict({
         'system1': dict({
+          'aq-index': 1,
+          'aq-pm-1': 3,
+          'aq-pm-10': 3,
+          'aq-pm-2.5': 4,
+          'aq-present': True,
+          'aq-status': 'good',
           'available': True,
           'errors': list([
             dict({
@@ -398,6 +404,19 @@
         'zone1': dict({
           'action': 1,
           'active': True,
+          'aq-active': False,
+          'aq-index': 1,
+          'aq-mode-conf': 'auto',
+          'aq-mode-values': list([
+            'off',
+            'on',
+            'auto',
+          ]),
+          'aq-pm-1': 3,
+          'aq-pm-10': 3,
+          'aq-pm-2.5': 4,
+          'aq-present': True,
+          'aq-status': 'good',
           'available': True,
           'humidity': 30,
           'id': 'zone1',
@@ -445,6 +464,19 @@
         'zone2': dict({
           'action': 6,
           'active': False,
+          'aq-active': False,
+          'aq-index': 1,
+          'aq-mode-conf': 'auto',
+          'aq-mode-values': list([
+            'off',
+            'on',
+            'auto',
+          ]),
+          'aq-pm-1': 3,
+          'aq-pm-10': 3,
+          'aq-pm-2.5': 4,
+          'aq-present': True,
+          'aq-status': 'good',
           'available': True,
           'humidity': 24,
           'id': 'zone2',

--- a/tests/components/airzone_cloud/util.py
+++ b/tests/components/airzone_cloud/util.py
@@ -6,6 +6,14 @@ from unittest.mock import patch
 from aioairzone_cloud.common import OperationMode
 from aioairzone_cloud.const import (
     API_ACTIVE,
+    API_AQ_ACTIVE,
+    API_AQ_MODE_CONF,
+    API_AQ_MODE_VALUES,
+    API_AQ_PM_1,
+    API_AQ_PM_2P5,
+    API_AQ_PM_10,
+    API_AQ_PRESENT,
+    API_AQ_QUALITY,
     API_AZ_AIDOO,
     API_AZ_AIDOO_PRO,
     API_AZ_SYSTEM,
@@ -291,6 +299,12 @@ def mock_get_device_status(device: Device) -> dict[str, Any]:
         }
     if device.get_id() == "system1":
         return {
+            API_AQ_MODE_VALUES: ["off", "on", "auto"],
+            API_AQ_PM_1: 3,
+            API_AQ_PM_2P5: 4,
+            API_AQ_PM_10: 3,
+            API_AQ_PRESENT: True,
+            API_AQ_QUALITY: "good",
             API_ERRORS: [
                 {
                     API_OLD_ID: "error-id",
@@ -310,6 +324,14 @@ def mock_get_device_status(device: Device) -> dict[str, Any]:
     if device.get_id() == "zone1":
         return {
             API_ACTIVE: True,
+            API_AQ_ACTIVE: False,
+            API_AQ_MODE_CONF: "auto",
+            API_AQ_MODE_VALUES: ["off", "on", "auto"],
+            API_AQ_PM_1: 3,
+            API_AQ_PM_2P5: 4,
+            API_AQ_PM_10: 3,
+            API_AQ_PRESENT: True,
+            API_AQ_QUALITY: "good",
             API_HUMIDITY: 30,
             API_MODE: OperationMode.COOLING.value,
             API_MODE_AVAIL: [
@@ -346,6 +368,14 @@ def mock_get_device_status(device: Device) -> dict[str, Any]:
     if device.get_id() == "zone2":
         return {
             API_ACTIVE: False,
+            API_AQ_ACTIVE: False,
+            API_AQ_MODE_CONF: "auto",
+            API_AQ_MODE_VALUES: ["off", "on", "auto"],
+            API_AQ_PM_1: 3,
+            API_AQ_PM_2P5: 4,
+            API_AQ_PM_10: 3,
+            API_AQ_PRESENT: True,
+            API_AQ_QUALITY: "good",
             API_HUMIDITY: 24,
             API_MODE: OperationMode.COOLING.value,
             API_MODE_AVAIL: [],


### PR DESCRIPTION
## Proposed change
Update aioairzone-cloud to [v0.3.7](https://github.com/Noltari/aioairzone-cloud/compare/0.3.6...0.3.7).
Adds new Air Quality sensors support.

Releases:
- https://github.com/Noltari/aioairzone-cloud/releases/tag/0.3.7

Git compare: https://github.com/Noltari/aioairzone-cloud/compare/0.3.6...0.3.7

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
