### PR TITLE
Fix holiday HA language not supported

### DIFF
--- a/homeassistant/components/holiday/config_flow.py
+++ b/homeassistant/components/holiday/config_flow.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from babel import Locale
+from babel import Locale, UnknownLocaleError
 from holidays import list_supported_countries
 import voluptuous as vol
 
@@ -46,7 +46,12 @@ class HolidayConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             self._async_abort_entries_match({CONF_COUNTRY: user_input[CONF_COUNTRY]})
 
-            locale = Locale(self.hass.config.language)
+            try:
+                locale = Locale(self.hass.config.language)
+            except UnknownLocaleError:
+                # Default to (US) English if language not recognized by babel
+                # Mainly an issue with English flavors such as "en-GB"
+                locale = Locale("en")
             title = locale.territories[selected_country]
             return self.async_create_entry(title=title, data=user_input)
 
@@ -81,7 +86,12 @@ class HolidayConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 }
             )
 
-            locale = Locale(self.hass.config.language)
+            try:
+                locale = Locale(self.hass.config.language)
+            except UnknownLocaleError:
+                # Default to (US) English if language not recognized by babel
+                # Mainly an issue with English flavors such as "en-GB"
+                locale = Locale("en")
             province_str = f", {province}" if province else ""
             name = f"{locale.territories[country]}{province_str}"
 

--- a/tests/components/holiday/test_config_flow.py
+++ b/tests/components/holiday/test_config_flow.py
@@ -126,3 +126,22 @@ async def test_single_combination_country_province(hass: HomeAssistant) -> None:
     )
     assert result_de_step2["type"] == FlowResultType.ABORT
     assert result_de_step2["reason"] == "already_configured"
+
+
+async def test_form_babel_unresolved_language(hass: HomeAssistant) -> None:
+    """Test the config flow if using not babel supported language."""
+    hass.config.language = "en-GB"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_COUNTRY: "SE",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result2["title"] == "Sweden"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Package `babel` does not support all flavors of language so we default to English
Mainly an issue with English flavors such as `en-GB`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #106552
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
