### PR TITLE
Revert "Set volume_step in clementine media_player"

### DIFF
--- a/homeassistant/components/clementine/media_player.py
+++ b/homeassistant/components/clementine/media_player.py
@@ -65,7 +65,6 @@ class ClementineDevice(MediaPlayerEntity):
         | MediaPlayerEntityFeature.SELECT_SOURCE
         | MediaPlayerEntityFeature.PLAY
     )
-    _attr_volume_step = 4 / 100
 
     def __init__(self, client, name):
         """Initialize the Clementine device."""
@@ -123,6 +122,16 @@ class ClementineDevice(MediaPlayerEntity):
             return (image, "image/png")
 
         return None, None
+
+    def volume_up(self) -> None:
+        """Volume up the media player."""
+        newvolume = min(self._client.volume + 4, 100)
+        self._client.set_volume(newvolume)
+
+    def volume_down(self) -> None:
+        """Volume down media player."""
+        newvolume = max(self._client.volume - 4, 0)
+        self._client.set_volume(newvolume)
 
     def mute_volume(self, mute: bool) -> None:
         """Send mute command."""


### PR DESCRIPTION
Reverts home-assistant/core#105666

There was some additional issues brought up in https://github.com/home-assistant/architecture/discussions/1012 after this PR was merged. This functionality needs to be reverted until they way forward is clear.