### PR TITLE
Revert "Set volume_step in cmus media_player"

### DIFF
--- a/homeassistant/components/cmus/media_player.py
+++ b/homeassistant/components/cmus/media_player.py
@@ -94,7 +94,6 @@ class CmusDevice(MediaPlayerEntity):
         | MediaPlayerEntityFeature.SEEK
         | MediaPlayerEntityFeature.PLAY
     )
-    _attr_volume_step = 5 / 100
 
     def __init__(self, device, name, server):
         """Initialize the CMUS device."""
@@ -153,6 +152,30 @@ class CmusDevice(MediaPlayerEntity):
     def set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         self._remote.cmus.set_volume(int(volume * 100))
+
+    def volume_up(self) -> None:
+        """Set the volume up."""
+        left = self.status["set"].get("vol_left")
+        right = self.status["set"].get("vol_right")
+        if left != right:
+            current_volume = float(left + right) / 2
+        else:
+            current_volume = left
+
+        if current_volume <= 100:
+            self._remote.cmus.set_volume(int(current_volume) + 5)
+
+    def volume_down(self) -> None:
+        """Set the volume down."""
+        left = self.status["set"].get("vol_left")
+        right = self.status["set"].get("vol_right")
+        if left != right:
+            current_volume = float(left + right) / 2
+        else:
+            current_volume = left
+
+        if current_volume <= 100:
+            self._remote.cmus.set_volume(int(current_volume) - 5)
 
     def play_media(
         self, media_type: MediaType | str, media_id: str, **kwargs: Any


### PR DESCRIPTION
Reverts home-assistant/core#105667

There was some additional issues brought up in https://github.com/home-assistant/architecture/discussions/1012 after this PR was merged. This functionality needs to be reverted until they way forward is clear.