### PR TITLE
Revert "Set volume_step in monoprice media_player"

### DIFF
--- a/homeassistant/components/monoprice/media_player.py
+++ b/homeassistant/components/monoprice/media_player.py
@@ -127,7 +127,6 @@ class MonopriceZone(MediaPlayerEntity):
     )
     _attr_has_entity_name = True
     _attr_name = None
-    _attr_volume_step = 1 / MAX_VOLUME
 
     def __init__(self, monoprice, sources, namespace, zone_id):
         """Initialize new zone."""
@@ -211,3 +210,17 @@ class MonopriceZone(MediaPlayerEntity):
     def set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         self._monoprice.set_volume(self._zone_id, round(volume * MAX_VOLUME))
+
+    def volume_up(self) -> None:
+        """Volume up the media player."""
+        if self.volume_level is None:
+            return
+        volume = round(self.volume_level * MAX_VOLUME)
+        self._monoprice.set_volume(self._zone_id, min(volume + 1, MAX_VOLUME))
+
+    def volume_down(self) -> None:
+        """Volume down media player."""
+        if self.volume_level is None:
+            return
+        volume = round(self.volume_level * MAX_VOLUME)
+        self._monoprice.set_volume(self._zone_id, max(volume - 1, 0))


### PR DESCRIPTION
Reverts home-assistant/core#105670

There was some additional issues brought up in https://github.com/home-assistant/architecture/discussions/1012 after this PR was merged. This functionality needs to be reverted until they way forward is clear.