### PR TITLE
Revert "Set volume_step in frontier_silicon media_player"

### DIFF
--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -152,9 +152,6 @@ class AFSAPIDevice(MediaPlayerEntity):
         if not self._max_volume:
             self._max_volume = int(await afsapi.get_volume_steps() or 1) - 1
 
-        if self._max_volume:
-            self._attr_volume_step = 1 / self._max_volume
-
         if self._attr_state != MediaPlayerState.OFF:
             info_name = await afsapi.get_play_name()
             info_text = await afsapi.get_play_text()
@@ -242,6 +239,18 @@ class AFSAPIDevice(MediaPlayerEntity):
         await self.fs_device.set_mute(mute)
 
     # volume
+    async def async_volume_up(self) -> None:
+        """Send volume up command."""
+        volume = await self.fs_device.get_volume()
+        volume = int(volume or 0) + 1
+        await self.fs_device.set_volume(min(volume, self._max_volume))
+
+    async def async_volume_down(self) -> None:
+        """Send volume down command."""
+        volume = await self.fs_device.get_volume()
+        volume = int(volume or 0) - 1
+        await self.fs_device.set_volume(max(volume, 0))
+
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume command."""
         if self._max_volume:  # Can't do anything sensible if not set


### PR DESCRIPTION
Reverts home-assistant/core#105953

There was some additional issues brought up in https://github.com/home-assistant/architecture/discussions/1012 after this PR was merged. This functionality needs to be reverted until they way forward is clear.