### PR TITLE
Add Sound Mode selection in soundpal components

### DIFF
--- a/homeassistant/components/songpal/media_player.py
+++ b/homeassistant/components/songpal/media_player.py
@@ -11,9 +11,11 @@ from songpal import (
     ContentChange,
     Device,
     PowerChange,
+    SettingChange,
     SongpalException,
     VolumeChange,
 )
+from songpal.containers import Setting
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
@@ -99,6 +101,7 @@ class SongpalEntity(MediaPlayerEntity):
         | MediaPlayerEntityFeature.VOLUME_STEP
         | MediaPlayerEntityFeature.VOLUME_MUTE
         | MediaPlayerEntityFeature.SELECT_SOURCE
+        | MediaPlayerEntityFeature.SELECT_SOUND_MODE
         | MediaPlayerEntityFeature.TURN_ON
         | MediaPlayerEntityFeature.TURN_OFF
     )
@@ -124,6 +127,8 @@ class SongpalEntity(MediaPlayerEntity):
 
         self._active_source = None
         self._sources = {}
+        self._active_sound_mode = None
+        self._sound_modes = {}
 
     async def async_added_to_hass(self) -> None:
         """Run when entity is added to hass."""
@@ -132,6 +137,28 @@ class SongpalEntity(MediaPlayerEntity):
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""
         await self._dev.stop_listen_notifications()
+
+    async def _get_sound_modes_info(self):
+        """Get available sound modes and the active one."""
+        settings = await self._dev.get_sound_settings("soundField")
+        if isinstance(settings, Setting):
+            settings = [settings]
+
+        sound_modes = {}
+        active_sound_mode = None
+        for setting in settings:
+            cur = setting.currentValue
+            for opt in setting.candidate:
+                if not opt.isAvailable:
+                    continue
+                if opt.value == cur:
+                    active_sound_mode = opt.value
+                sound_modes[opt.value] = opt
+
+        _LOGGER.debug("Got sound modes: %s", sound_modes)
+        _LOGGER.debug("Active sound mode: %s", active_sound_mode)
+
+        return active_sound_mode, sound_modes
 
     async def async_activate_websocket(self):
         """Activate websocket for listening if wanted."""
@@ -151,6 +178,16 @@ class SongpalEntity(MediaPlayerEntity):
                 self.async_write_ha_state()
             else:
                 _LOGGER.debug("Got non-handled content change: %s", content)
+
+        async def _setting_changed(setting: SettingChange):
+            _LOGGER.debug("Setting changed: %s", setting)
+
+            if setting.target == "soundField":
+                self._active_sound_mode = setting.currentValue
+                _LOGGER.debug("New active sound mode: %s", self._active_sound_mode)
+                self.async_write_ha_state()
+            else:
+                _LOGGER.debug("Got non-handled setting change: %s", setting)
 
         async def _power_changed(power: PowerChange):
             _LOGGER.debug("Power changed: %s", power)
@@ -192,6 +229,7 @@ class SongpalEntity(MediaPlayerEntity):
         self._dev.on_notification(VolumeChange, _volume_changed)
         self._dev.on_notification(ContentChange, _source_changed)
         self._dev.on_notification(PowerChange, _power_changed)
+        self._dev.on_notification(SettingChange, _setting_changed)
         self._dev.on_notification(ConnectChange, _try_reconnect)
 
         async def handle_stop(event):
@@ -271,6 +309,11 @@ class SongpalEntity(MediaPlayerEntity):
 
             _LOGGER.debug("Active source: %s", self._active_source)
 
+            (
+                self._active_sound_mode,
+                self._sound_modes,
+            ) = await self._get_sound_modes_info()
+
             self._attr_available = True
 
         except SongpalException as ex:
@@ -291,6 +334,27 @@ class SongpalEntity(MediaPlayerEntity):
         """Return list of available sources."""
         return [src.title for src in self._sources.values()]
 
+    async def async_select_sound_mode(self, sound_mode: str) -> None:
+        """Select sound mode."""
+        for mode in self._sound_modes.values():
+            if mode.title == sound_mode:
+                await self._dev.set_sound_settings("soundField", mode.value)
+                return
+
+        _LOGGER.error("Unable to find sound mode: %s", sound_mode)
+
+    @property
+    def sound_mode_list(self) -> list[str] | None:
+        """Return list of available sound modes.
+
+        When active mode is None it means that sound mode is unavailable on the sound bar.
+        Can be due to incompatible sound bar or the sound bar is in a mode that does not
+        support sound mode changes.
+        """
+        if not self._active_sound_mode:
+            return None
+        return [sound_mode.title for sound_mode in self._sound_modes.values()]
+
     @property
     def state(self) -> MediaPlayerState:
         """Return current state."""
@@ -303,6 +367,12 @@ class SongpalEntity(MediaPlayerEntity):
         """Return currently active source."""
         # Avoid a KeyError when _active_source is not (yet) populated
         return getattr(self._active_source, "title", None)
+
+    @property
+    def sound_mode(self) -> str | None:
+        """Return currently active sound_mode."""
+        active_sound_mode = self._sound_modes.get(self._active_sound_mode)
+        return active_sound_mode.title if active_sound_mode else None
 
     @property
     def volume_level(self):

--- a/tests/components/songpal/__init__.py
+++ b/tests/components/songpal/__init__.py
@@ -85,6 +85,24 @@ def _create_mocked_device(throw_exception=False, wired_mac=MAC, wireless_mac=Non
     input2.active = True
     type(mocked_device).get_inputs = AsyncMock(return_value=[input1, input2])
 
+    sound_mode1 = MagicMock()
+    sound_mode1.title = "Sound Mode 1"
+    sound_mode1.value = "sound_mode1"
+    sound_mode1.isAvailable = True
+    sound_mode2 = MagicMock()
+    sound_mode2.title = "Sound Mode 2"
+    sound_mode2.value = "sound_mode2"
+    sound_mode2.isAvailable = True
+    sound_mode3 = MagicMock()
+    sound_mode3.title = "Sound Mode 3"
+    sound_mode3.value = "sound_mode3"
+    sound_mode3.isAvailable = False
+
+    soundField = MagicMock()
+    soundField.currentValue = "sound_mode2"
+    soundField.candidate = [sound_mode1, sound_mode2, sound_mode3]
+    type(mocked_device).get_sound_settings = AsyncMock(return_value=[soundField])
+
     type(mocked_device).set_power = AsyncMock()
     type(mocked_device).set_sound_settings = AsyncMock()
     type(mocked_device).listen_notifications = AsyncMock()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It allows songpal component to deal with Sound Mode.
Sound Mode is part of the MediaPlayerEntity and was implemented in the soundpal python library.
So just a little modification to handle it in the songpal hass component.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
