### PR TITLE
Add entity name and translations to Netgear LTE

### DIFF
--- a/homeassistant/components/netgear_lte/binary_sensor.py
+++ b/homeassistant/components/netgear_lte/binary_sensor.py
@@ -16,13 +16,16 @@ from .entity import LTEEntity
 BINARY_SENSORS: tuple[BinarySensorEntityDescription, ...] = (
     BinarySensorEntityDescription(
         key="roaming",
+        translation_key="roaming",
     ),
     BinarySensorEntityDescription(
         key="wire_connected",
+        translation_key="wire_connected",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
     ),
     BinarySensorEntityDescription(
         key="mobile_connected",
+        translation_key="mobile_connected",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
     ),
 )

--- a/homeassistant/components/netgear_lte/entity.py
+++ b/homeassistant/components/netgear_lte/entity.py
@@ -13,6 +13,7 @@ from .const import DISPATCHER_NETGEAR_LTE, DOMAIN, MANUFACTURER
 class LTEEntity(Entity):
     """Base LTE entity."""
 
+    _attr_has_entity_name = True
     _attr_should_poll = False
 
     def __init__(
@@ -24,7 +25,6 @@ class LTEEntity(Entity):
         """Initialize a Netgear LTE entity."""
         self.entity_description = description
         self.modem_data = modem_data
-        self._attr_name = f"Netgear LTE {description.key}"
         self._attr_unique_id = f"{description.key}_{modem_data.data.serial_number}"
         self._attr_device_info = DeviceInfo(
             configuration_url=f"http://{config_entry.data[CONF_HOST]}",

--- a/homeassistant/components/netgear_lte/sensor.py
+++ b/homeassistant/components/netgear_lte/sensor.py
@@ -34,39 +34,53 @@ class NetgearLTESensorEntityDescription(SensorEntityDescription):
 SENSORS: tuple[NetgearLTESensorEntityDescription, ...] = (
     NetgearLTESensorEntityDescription(
         key="sms",
+        translation_key="sms",
         native_unit_of_measurement="unread",
         value_fn=lambda modem_data: sum(1 for x in modem_data.data.sms if x.unread),
     ),
     NetgearLTESensorEntityDescription(
         key="sms_total",
+        translation_key="sms_total",
         native_unit_of_measurement="messages",
         value_fn=lambda modem_data: len(modem_data.data.sms),
     ),
     NetgearLTESensorEntityDescription(
         key="usage",
+        translation_key="usage",
         device_class=SensorDeviceClass.DATA_SIZE,
         native_unit_of_measurement=UnitOfInformation.MEBIBYTES,
         value_fn=lambda modem_data: round(modem_data.data.usage / 1024**2, 1),
     ),
     NetgearLTESensorEntityDescription(
         key="radio_quality",
+        translation_key="radio_quality",
         native_unit_of_measurement=PERCENTAGE,
     ),
     NetgearLTESensorEntityDescription(
         key="rx_level",
+        translation_key="rx_level",
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     ),
     NetgearLTESensorEntityDescription(
         key="tx_level",
+        translation_key="tx_level",
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     ),
-    NetgearLTESensorEntityDescription(key="upstream"),
-    NetgearLTESensorEntityDescription(key="connection_text"),
-    NetgearLTESensorEntityDescription(key="connection_type"),
-    NetgearLTESensorEntityDescription(key="current_ps_service_type"),
-    NetgearLTESensorEntityDescription(key="register_network_display"),
-    NetgearLTESensorEntityDescription(key="current_band"),
-    NetgearLTESensorEntityDescription(key="cell_id"),
+    NetgearLTESensorEntityDescription(key="upstream", translation_key="upstream"),
+    NetgearLTESensorEntityDescription(
+        key="connection_text", translation_key="connection_text"
+    ),
+    NetgearLTESensorEntityDescription(
+        key="connection_type", translation_key="connection_type"
+    ),
+    NetgearLTESensorEntityDescription(
+        key="current_ps_service_type", translation_key="service_type"
+    ),
+    NetgearLTESensorEntityDescription(
+        key="register_network_display", translation_key="register_network_display"
+    ),
+    NetgearLTESensorEntityDescription(key="current_band", translation_key="band"),
+    NetgearLTESensorEntityDescription(key="cell_id", translation_key="cell_id"),
 )
 
 

--- a/homeassistant/components/netgear_lte/strings.json
+++ b/homeassistant/components/netgear_lte/strings.json
@@ -116,7 +116,7 @@
         "name": "Rx level"
       },
       "service_type": {
-        "name": "Current PS service type"
+        "name": "Service type"
       },
       "sms": {
         "name": "SMS"

--- a/homeassistant/components/netgear_lte/strings.json
+++ b/homeassistant/components/netgear_lte/strings.json
@@ -80,5 +80,59 @@
         }
       }
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "mobile_connected": {
+        "name": "Mobile connected"
+      },
+      "roaming": {
+        "name": "Roaming"
+      },
+      "wire_connected": {
+        "name": "Wire connected"
+      }
+    },
+    "sensor": {
+      "band": {
+        "name": "Current band"
+      },
+      "cell_id": {
+        "name": "Cell ID"
+      },
+      "connection_text": {
+        "name": "Connection text"
+      },
+      "connection_type": {
+        "name": "Connection type"
+      },
+      "radio_quality": {
+        "name": "Radio quality"
+      },
+      "register_network_display": {
+        "name": "Register network display"
+      },
+      "rx_level": {
+        "name": "Rx level"
+      },
+      "service_type": {
+        "name": "Current PS service type"
+      },
+      "sms": {
+        "name": "SMS"
+      },
+      "sms_total": {
+        "name": "SMS total"
+      },
+      "tx_level": {
+        "name": "Tx level"
+      },
+      "upstream": {
+        "name": "Upstream"
+      },
+      "usage": {
+        "name": "Usage"
+      }
+    }
   }
 }

--- a/tests/components/netgear_lte/test_binary_sensor.py
+++ b/tests/components/netgear_lte/test_binary_sensor.py
@@ -9,11 +9,11 @@ from homeassistant.core import HomeAssistant
 @pytest.mark.usefixtures("setup_integration", "entity_registry_enabled_by_default")
 async def test_binary_sensors(hass: HomeAssistant) -> None:
     """Test for successfully setting up the Netgear LTE binary sensor platform."""
-    state = hass.states.get("binary_sensor.netgear_lte_mobile_connected")
+    state = hass.states.get("binary_sensor.netgear_lm1200_mobile_connected")
     assert state.state == STATE_ON
     assert state.attributes[ATTR_DEVICE_CLASS] == BinarySensorDeviceClass.CONNECTIVITY
-    state = hass.states.get("binary_sensor.netgear_lte_wire_connected")
+    state = hass.states.get("binary_sensor.netgear_lm1200_wire_connected")
     assert state.state == STATE_OFF
     assert state.attributes[ATTR_DEVICE_CLASS] == BinarySensorDeviceClass.CONNECTIVITY
-    state = hass.states.get("binary_sensor.netgear_lte_roaming")
+    state = hass.states.get("binary_sensor.netgear_lm1200_roaming")
     assert state.state == STATE_OFF

--- a/tests/components/netgear_lte/test_sensor.py
+++ b/tests/components/netgear_lte/test_sensor.py
@@ -15,42 +15,42 @@ from homeassistant.core import HomeAssistant
 @pytest.mark.usefixtures("setup_integration", "entity_registry_enabled_by_default")
 async def test_sensors(hass: HomeAssistant) -> None:
     """Test for successfully setting up the Netgear LTE sensor platform."""
-    state = hass.states.get("sensor.netgear_lte_cell_id")
+    state = hass.states.get("sensor.netgear_lm1200_cell_id")
     assert state.state == "12345678"
-    state = hass.states.get("sensor.netgear_lte_connection_text")
+    state = hass.states.get("sensor.netgear_lm1200_connection_text")
     assert state.state == "4G"
-    state = hass.states.get("sensor.netgear_lte_connection_type")
+    state = hass.states.get("sensor.netgear_lm1200_connection_type")
     assert state.state == "IPv4AndIPv6"
-    state = hass.states.get("sensor.netgear_lte_current_band")
+    state = hass.states.get("sensor.netgear_lm1200_current_band")
     assert state.state == "LTE B4"
-    state = hass.states.get("sensor.netgear_lte_current_ps_service_type")
+    state = hass.states.get("sensor.netgear_lm1200_current_ps_service_type")
     assert state.state == "LTE"
-    state = hass.states.get("sensor.netgear_lte_radio_quality")
+    state = hass.states.get("sensor.netgear_lm1200_radio_quality")
     assert state.state == "52"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
-    state = hass.states.get("sensor.netgear_lte_register_network_display")
+    state = hass.states.get("sensor.netgear_lm1200_register_network_display")
     assert state.state == "T-Mobile"
-    state = hass.states.get("sensor.netgear_lte_rx_level")
+    state = hass.states.get("sensor.netgear_lm1200_rx_level")
     assert state.state == "-113"
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == SIGNAL_STRENGTH_DECIBELS_MILLIWATT
     )
-    state = hass.states.get("sensor.netgear_lte_sms")
+    state = hass.states.get("sensor.netgear_lm1200_sms")
     assert state.state == "1"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "unread"
-    state = hass.states.get("sensor.netgear_lte_sms_total")
+    state = hass.states.get("sensor.netgear_lm1200_sms_total")
     assert state.state == "1"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "messages"
-    state = hass.states.get("sensor.netgear_lte_tx_level")
+    state = hass.states.get("sensor.netgear_lm1200_tx_level")
     assert state.state == "4"
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == SIGNAL_STRENGTH_DECIBELS_MILLIWATT
     )
-    state = hass.states.get("sensor.netgear_lte_upstream")
+    state = hass.states.get("sensor.netgear_lm1200_upstream")
     assert state.state == "LTE"
-    state = hass.states.get("sensor.netgear_lte_usage")
+    state = hass.states.get("sensor.netgear_lm1200_usage")
     assert state.state == "40.5"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfInformation.MEBIBYTES
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.DATA_SIZE

--- a/tests/components/netgear_lte/test_sensor.py
+++ b/tests/components/netgear_lte/test_sensor.py
@@ -23,7 +23,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert state.state == "IPv4AndIPv6"
     state = hass.states.get("sensor.netgear_lm1200_current_band")
     assert state.state == "LTE B4"
-    state = hass.states.get("sensor.netgear_lm1200_current_ps_service_type")
+    state = hass.states.get("sensor.netgear_lm1200_service_type")
     assert state.state == "LTE"
     state = hass.states.get("sensor.netgear_lm1200_radio_quality")
     assert state.state == "52"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add entity name and translations to Netgear LTE

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
