### PR TITLE
WeatherFlow Forecast (REST API)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1588,6 +1588,10 @@ omit =
     homeassistant/components/weatherflow/__init__.py
     homeassistant/components/weatherflow/const.py
     homeassistant/components/weatherflow/sensor.py
+    homeassistant/components/weatherflow_cloud/__init__.py
+    homeassistant/components/weatherflow_cloud/const.py
+    homeassistant/components/weatherflow_cloud/coordinator.py
+    homeassistant/components/weatherflow_cloud/weather.py
     homeassistant/components/webmin/sensor.py
     homeassistant/components/wiffi/__init__.py
     homeassistant/components/wiffi/binary_sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1511,6 +1511,8 @@ build.json @home-assistant/supervisor
 /tests/components/weather/ @home-assistant/core
 /homeassistant/components/weatherflow/ @natekspencer @jeeftor
 /tests/components/weatherflow/ @natekspencer @jeeftor
+/homeassistant/components/weatherflow_cloud/ @jeeftor
+/tests/components/weatherflow_cloud/ @jeeftor
 /homeassistant/components/weatherkit/ @tjhorner
 /tests/components/weatherkit/ @tjhorner
 /homeassistant/components/webhook/ @home-assistant/core

--- a/homeassistant/components/weatherflow_cloud/__init__.py
+++ b/homeassistant/components/weatherflow_cloud/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import CONF_API_TOKEN, Platform
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
@@ -16,7 +16,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     data_coordinator = WeatherFlowCloudDataUpdateCoordinator(
         hass=hass,
-        config_entry=entry,
+        api_token=entry.data[CONF_API_TOKEN],
     )
     await data_coordinator.async_config_entry_first_refresh()
 

--- a/homeassistant/components/weatherflow_cloud/__init__.py
+++ b/homeassistant/components/weatherflow_cloud/__init__.py
@@ -1,0 +1,34 @@
+"""The WeatherflowCloud integration."""
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .coordinator import WeatherFlowCloudDataUpdateCoordinator
+
+PLATFORMS: list[Platform] = [Platform.WEATHER]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up WeatherFlowCloud from a config entry."""
+
+    data_coordinator = WeatherFlowCloudDataUpdateCoordinator(
+        hass=hass,
+        config_entry=entry,
+    )
+    await data_coordinator.async_config_entry_first_refresh()
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = data_coordinator
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/weatherflow_cloud/config_flow.py
+++ b/homeassistant/components/weatherflow_cloud/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for WeatherflowCloud integration."""
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 from aiohttp import ClientResponseError
@@ -14,30 +15,58 @@ from homeassistant.data_entry_flow import FlowResult
 from .const import DOMAIN
 
 
+async def _validate_api_token(api_token: str) -> dict[str, Any]:
+    """Validate the API token."""
+    try:
+        async with WeatherFlowRestAPI(api_token) as api:
+            await api.async_get_stations()
+    except ClientResponseError as err:
+        if err.status == 401:
+            return {"base": "invalid_api_key"}
+        return {"base": "cannot_connect"}
+    return {}
+
+
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for WeatherFlowCloud."""
 
     VERSION = 1
+
+    async def async_step_reauth(self, user_input: Mapping[str, Any]) -> FlowResult:
+        """Handle a flow for reauth."""
+        errors = {}
+
+        if user_input is not None:
+            api_token = user_input[CONF_API_TOKEN]
+            errors = await _validate_api_token(api_token)
+            if not errors:
+                # Update the existing entry and abort
+                existing_entry = self.hass.config_entries.async_get_entry(
+                    self.context["entry_id"]
+                )
+                self.hass.config_entries.async_update_entry(
+                    existing_entry,  # type: ignore[arg-type]
+                    data={CONF_API_TOKEN: api_token},
+                )
+                return self.async_abort(reason="reauth_successful")
+
+        return self.async_show_form(
+            step_id="reauth",
+            data_schema=vol.Schema({vol.Required(CONF_API_TOKEN): str}),
+            errors=errors,
+        )
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle a flow initialized by the user."""
         errors = {}
+
         if user_input is not None:
             self._async_abort_entries_match(user_input)
-
-            # Validate Entry
             api_token = user_input[CONF_API_TOKEN]
-            try:
-                async with WeatherFlowRestAPI(api_token) as api:
-                    await api.async_get_stations()
-            except ClientResponseError as err:
-                if err.status == 401:
-                    errors["base"] = "invalid_api_key"
-                else:
-                    errors["base"] = "cannot_connect"
-            else:
+            errors = await _validate_api_token(api_token)
+            if not errors:
                 return self.async_create_entry(
                     title="Weatherflow REST",
                     data={CONF_API_TOKEN: api_token},

--- a/homeassistant/components/weatherflow_cloud/config_flow.py
+++ b/homeassistant/components/weatherflow_cloud/config_flow.py
@@ -1,0 +1,61 @@
+"""Config flow for WeatherflowCloud integration."""
+from __future__ import annotations
+
+from typing import Any
+
+from aiohttp import ClientResponseError
+import voluptuous as vol
+from weatherflow4py.api import WeatherFlowRestAPI
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_API_TOKEN
+from homeassistant.data_entry_flow import FlowResult
+
+from .const import DOMAIN
+
+
+async def _async_validate_api_token(api_token) -> bool:
+    """Validate the API token."""
+
+    async with WeatherFlowRestAPI(api_token) as api:
+        await api.async_get_stations()
+
+    return True
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for WeatherFlowCloud."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle a flow initialized by the user."""
+
+        if user_input is None:
+            return await self._show_setup_form(user_input)
+
+        await self.async_set_unique_id(user_input[CONF_API_TOKEN])
+        self._abort_if_unique_id_configured()
+
+        # Validate Entry
+        api_token = user_input[CONF_API_TOKEN]
+        try:
+            await _async_validate_api_token(api_token)
+            return self.async_create_entry(
+                title="Weatherflow REST",
+                data={CONF_API_TOKEN: api_token},
+            )
+        except ClientResponseError as err:
+            if err.status == 401:
+                return await self._show_setup_form({"base": "invalid_api_key"})
+            return await self._show_setup_form({"base": "cannot_connect"})
+
+    async def _show_setup_form(self, errors=None):
+        """Show the setup form to the user."""
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema({vol.Required(CONF_API_TOKEN): str}),
+            errors=errors or {},
+        )

--- a/homeassistant/components/weatherflow_cloud/config_flow.py
+++ b/homeassistant/components/weatherflow_cloud/config_flow.py
@@ -25,9 +25,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle a flow initialized by the user."""
         errors = {}
         if user_input is not None:
-            await self.async_set_unique_id(user_input[CONF_API_TOKEN])
-            self._abort_if_unique_id_configured()
-            self._async_abort_entries_match()
+            self._async_abort_entries_match(user_input)
 
             # Validate Entry
             api_token = user_input[CONF_API_TOKEN]

--- a/homeassistant/components/weatherflow_cloud/config_flow.py
+++ b/homeassistant/components/weatherflow_cloud/config_flow.py
@@ -27,6 +27,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             await self.async_set_unique_id(user_input[CONF_API_TOKEN])
             self._abort_if_unique_id_configured()
+            self._async_abort_entries_match()
 
             # Validate Entry
             api_token = user_input[CONF_API_TOKEN]

--- a/homeassistant/components/weatherflow_cloud/config_flow.py
+++ b/homeassistant/components/weatherflow_cloud/config_flow.py
@@ -41,14 +41,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors = await _validate_api_token(api_token)
             if not errors:
                 # Update the existing entry and abort
-                existing_entry = self.hass.config_entries.async_get_entry(
+                if existing_entry := self.hass.config_entries.async_get_entry(
                     self.context["entry_id"]
-                )
-                self.hass.config_entries.async_update_entry(
-                    existing_entry,  # type: ignore[arg-type]
-                    data={CONF_API_TOKEN: api_token},
-                )
-                return self.async_abort(reason="reauth_successful")
+                ):
+                    return self.async_update_reload_and_abort(
+                        existing_entry,
+                        data={CONF_API_TOKEN: api_token},
+                        reason="reauth_successful",
+                    )
 
         return self.async_show_form(
             step_id="reauth",

--- a/homeassistant/components/weatherflow_cloud/const.py
+++ b/homeassistant/components/weatherflow_cloud/const.py
@@ -2,7 +2,7 @@
 import logging
 
 DOMAIN = "weatherflow_cloud"
-_LOGGER = logging.getLogger(__package__)
+LOGGER = logging.getLogger(__package__)
 
 ATTR_ATTRIBUTION = "Weather data delivered by WeatherFlow"
 MANUFACTURER = "WeatherFlow"

--- a/homeassistant/components/weatherflow_cloud/const.py
+++ b/homeassistant/components/weatherflow_cloud/const.py
@@ -4,5 +4,5 @@ import logging
 DOMAIN = "weatherflow_cloud"
 LOGGER = logging.getLogger(__package__)
 
-ATTR_ATTRIBUTION = "Weather data delivered by WeatherFlow"
+ATTR_ATTRIBUTION = "Weather data delivered by WeatherFlow/Tempest REST Api"
 MANUFACTURER = "WeatherFlow"

--- a/homeassistant/components/weatherflow_cloud/const.py
+++ b/homeassistant/components/weatherflow_cloud/const.py
@@ -1,0 +1,8 @@
+"""Constants for the WeatherflowCloud integration."""
+import logging
+
+DOMAIN = "weatherflow_cloud"
+_LOGGER = logging.getLogger(__package__)
+
+ATTR_ATTRIBUTION = "Weather data delivered by WeatherFlow"
+MANUFACTURER = "WeatherFlow"

--- a/homeassistant/components/weatherflow_cloud/coordinator.py
+++ b/homeassistant/components/weatherflow_cloud/coordinator.py
@@ -18,7 +18,6 @@ class WeatherFlowCloudDataUpdateCoordinator(
 ):
     """Class to manage fetching REST Based WeatherFlow Forecast data."""
 
-    config_entry: ConfigEntry
 
     def __init__(self, hass: HomeAssistant, api_token: str) -> None:
         """Initialize global WeatherFlow forecast data updater."""

--- a/homeassistant/components/weatherflow_cloud/coordinator.py
+++ b/homeassistant/components/weatherflow_cloud/coordinator.py
@@ -1,0 +1,46 @@
+"""Data coordinator for WeatherFlow Cloud Data."""
+from datetime import timedelta
+from random import randrange
+
+from weatherflow4py.api import WeatherFlowRestAPI
+from weatherflow4py.models.unified import WeatherFlowData
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_API_TOKEN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import _LOGGER, DOMAIN
+
+
+class WeatherFlowCloudDataUpdateCoordinator(DataUpdateCoordinator):
+    """Class to manage fetching REST Based WeatherFlow Forecast data."""
+
+    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+        """Initialize global WeatherFlow forecast data updater."""
+
+        # Store local variables
+        self.hass = hass
+        self.config_entry = config_entry
+
+        # Extract API Token
+        api_token = config_entry.data[CONF_API_TOKEN]
+        self.weather_api = WeatherFlowRestAPI(api_token=api_token)
+
+        self.data: dict[int, WeatherFlowData] = {}
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=timedelta(minutes=randrange(25, 35)),
+        )
+
+    async def _async_update_data(self) -> dict[int, WeatherFlowData]:
+        """Fetch data from WeatherFlow Forecast."""
+        try:
+            async with self.weather_api:
+                self.data = await self.weather_api.get_all_data()
+                return self.data
+        except Exception as err:
+            raise UpdateFailed(f"Update failed: {err}") from err

--- a/homeassistant/components/weatherflow_cloud/coordinator.py
+++ b/homeassistant/components/weatherflow_cloud/coordinator.py
@@ -32,7 +32,6 @@ class WeatherFlowCloudDataUpdateCoordinator(
 
     async def _async_update_data(self) -> dict[int, WeatherFlowData]:
         """Fetch data from WeatherFlow Forecast."""
-        LOGGER.debug("Updating Tempest Data")
         try:
             async with self.weather_api:
                 return await self.weather_api.get_all_data()

--- a/homeassistant/components/weatherflow_cloud/coordinator.py
+++ b/homeassistant/components/weatherflow_cloud/coordinator.py
@@ -1,46 +1,45 @@
 """Data coordinator for WeatherFlow Cloud Data."""
 from datetime import timedelta
-from random import randrange
 
+from aiohttp import ClientResponseError
 from weatherflow4py.api import WeatherFlowRestAPI
 from weatherflow4py.models.unified import WeatherFlowData
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_API_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import _LOGGER, DOMAIN
+from .const import DOMAIN, LOGGER
 
 
-class WeatherFlowCloudDataUpdateCoordinator(DataUpdateCoordinator):
+class WeatherFlowCloudDataUpdateCoordinator(
+    DataUpdateCoordinator[dict[int, WeatherFlowData]]
+):
     """Class to manage fetching REST Based WeatherFlow Forecast data."""
 
-    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+    config_entry: ConfigEntry
+
+    def __init__(self, hass: HomeAssistant, api_token: str) -> None:
         """Initialize global WeatherFlow forecast data updater."""
 
         # Store local variables
         self.hass = hass
-        self.config_entry = config_entry
 
         # Extract API Token
-        api_token = config_entry.data[CONF_API_TOKEN]
         self.weather_api = WeatherFlowRestAPI(api_token=api_token)
-
-        self.data: dict[int, WeatherFlowData] = {}
 
         super().__init__(
             hass,
-            _LOGGER,
+            LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(minutes=randrange(25, 35)),
+            update_interval=timedelta(minutes=15),
         )
 
     async def _async_update_data(self) -> dict[int, WeatherFlowData]:
         """Fetch data from WeatherFlow Forecast."""
+        LOGGER.debug("Updating Tempest Data")
         try:
             async with self.weather_api:
-                self.data = await self.weather_api.get_all_data()
-                return self.data
-        except Exception as err:
+                return await self.weather_api.get_all_data()
+        except ClientResponseError as err:
             raise UpdateFailed(f"Update failed: {err}") from err

--- a/homeassistant/components/weatherflow_cloud/coordinator.py
+++ b/homeassistant/components/weatherflow_cloud/coordinator.py
@@ -5,7 +5,6 @@ from aiohttp import ClientResponseError
 from weatherflow4py.api import WeatherFlowRestAPI
 from weatherflow4py.models.unified import WeatherFlowData
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -17,7 +16,6 @@ class WeatherFlowCloudDataUpdateCoordinator(
     DataUpdateCoordinator[dict[int, WeatherFlowData]]
 ):
     """Class to manage fetching REST Based WeatherFlow Forecast data."""
-
 
     def __init__(self, hass: HomeAssistant, api_token: str) -> None:
         """Initialize global WeatherFlow forecast data updater."""

--- a/homeassistant/components/weatherflow_cloud/coordinator.py
+++ b/homeassistant/components/weatherflow_cloud/coordinator.py
@@ -7,6 +7,7 @@ from weatherflow4py.models.unified import WeatherFlowData
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, LOGGER
@@ -36,4 +37,6 @@ class WeatherFlowCloudDataUpdateCoordinator(
             async with self.weather_api:
                 return await self.weather_api.get_all_data()
         except ClientResponseError as err:
+            if err.status == 401:
+                raise ConfigEntryAuthFailed(err) from err
             raise UpdateFailed(f"Update failed: {err}") from err

--- a/homeassistant/components/weatherflow_cloud/coordinator.py
+++ b/homeassistant/components/weatherflow_cloud/coordinator.py
@@ -23,7 +23,7 @@ class WeatherFlowCloudDataUpdateCoordinator(
         """Initialize global WeatherFlow forecast data updater."""
 
         # Store local variables
-        self.hass = hass
+        # self.hass = hass
 
         # Extract API Token
         self.weather_api = WeatherFlowRestAPI(api_token=api_token)

--- a/homeassistant/components/weatherflow_cloud/coordinator.py
+++ b/homeassistant/components/weatherflow_cloud/coordinator.py
@@ -21,11 +21,6 @@ class WeatherFlowCloudDataUpdateCoordinator(
 
     def __init__(self, hass: HomeAssistant, api_token: str) -> None:
         """Initialize global WeatherFlow forecast data updater."""
-
-        # Store local variables
-        # self.hass = hass
-
-        # Extract API Token
         self.weather_api = WeatherFlowRestAPI(api_token=api_token)
 
         super().__init__(

--- a/homeassistant/components/weatherflow_cloud/manifest.json
+++ b/homeassistant/components/weatherflow_cloud/manifest.json
@@ -3,11 +3,7 @@
   "name": "WeatherflowCloud",
   "codeowners": ["@jeeftor"],
   "config_flow": true,
-  "dependencies": [],
   "documentation": "https://www.home-assistant.io/integrations/weatherflow_cloud",
-  "homekit": {},
   "iot_class": "cloud_polling",
-  "requirements": ["weatherflow4py==0.1.10"],
-  "ssdp": [],
-  "zeroconf": []
+  "requirements": ["weatherflow4py==0.1.11"]
 }

--- a/homeassistant/components/weatherflow_cloud/manifest.json
+++ b/homeassistant/components/weatherflow_cloud/manifest.json
@@ -1,0 +1,13 @@
+{
+  "domain": "weatherflow_cloud",
+  "name": "WeatherflowCloud",
+  "codeowners": ["@jeeftor"],
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://www.home-assistant.io/integrations/weatherflow_cloud",
+  "homekit": {},
+  "iot_class": "cloud_polling",
+  "requirements": ["weatherflow4py==0.1.10"],
+  "ssdp": [],
+  "zeroconf": []
+}

--- a/homeassistant/components/weatherflow_cloud/strings.json
+++ b/homeassistant/components/weatherflow_cloud/strings.json
@@ -14,7 +14,7 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "unique_id": "A configuration with this API key has already been configured."
+      "already_configured": "A configuration with this API key has already been configured."
     }
   }
 }

--- a/homeassistant/components/weatherflow_cloud/strings.json
+++ b/homeassistant/components/weatherflow_cloud/strings.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "description": "Set up a WeatherFlow Forecast Station",
+        "title": "WeatherFlow Forecast",
+        "data": {
+          "api_token": "Personal api token"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_api_key": "[%key:common::config_flow::error::invalid_api_key%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "unique_id": "A configuration with this API key has already been configured."
+    }
+  }
+}

--- a/homeassistant/components/weatherflow_cloud/strings.json
+++ b/homeassistant/components/weatherflow_cloud/strings.json
@@ -10,7 +10,7 @@
       "reauth": {
         "description": "Reauthenticate with WeatherFlow",
         "data": {
-          "api_token": "Personal api token"
+          "api_token": "[%key:component::weatherflow_cloud::config::step::user::data::api_token%]"
         }
       }
     },
@@ -20,7 +20,8 @@
     },
 
     "abort": {
-      "already_configured": "A configuration with this API key has already been configured."
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   }
 }

--- a/homeassistant/components/weatherflow_cloud/strings.json
+++ b/homeassistant/components/weatherflow_cloud/strings.json
@@ -11,7 +11,6 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_api_key": "[%key:common::config_flow::error::invalid_api_key%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
       "already_configured": "A configuration with this API key has already been configured."

--- a/homeassistant/components/weatherflow_cloud/strings.json
+++ b/homeassistant/components/weatherflow_cloud/strings.json
@@ -3,7 +3,6 @@
     "step": {
       "user": {
         "description": "Set up a WeatherFlow Forecast Station",
-        "title": "WeatherFlow Forecast",
         "data": {
           "api_token": "Personal api token"
         }

--- a/homeassistant/components/weatherflow_cloud/strings.json
+++ b/homeassistant/components/weatherflow_cloud/strings.json
@@ -6,12 +6,19 @@
         "data": {
           "api_token": "Personal api token"
         }
+      },
+      "reauth": {
+        "description": "Reauthenticate with WeatherFlow",
+        "data": {
+          "api_token": "Personal api token"
+        }
       }
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_api_key": "[%key:common::config_flow::error::invalid_api_key%]",
+      "invalid_api_key": "[%key:common::config_flow::error::invalid_api_key%]"
     },
+
     "abort": {
       "already_configured": "A configuration with this API key has already been configured."
     }

--- a/homeassistant/components/weatherflow_cloud/weather.py
+++ b/homeassistant/components/weatherflow_cloud/weather.py
@@ -67,13 +67,13 @@ class WeatherFlowWeather(
 
         self.station_id = station_id
         self._attr_unique_id = f"weatherflow_forecast_{station_id}"
-        self._attr_name = self.local_data.station.name
+        self._attr_name = None
 
-        outdoor_device = [
-            d for d in self.local_data.station.devices if d.device_type == "ST"
-        ][0]
+        # Obtain info from 1st outdoor device on station
+        outdoor_device = self.local_data.station.outdoor_devices[0]
+
         self._attr_device_info = DeviceInfo(
-            name="Forecast",
+            name=self.local_data.station.name,
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, outdoor_device.serial_number)},
             manufacturer=MANUFACTURER,

--- a/homeassistant/components/weatherflow_cloud/weather.py
+++ b/homeassistant/components/weatherflow_cloud/weather.py
@@ -78,9 +78,6 @@ class WeatherFlowWeather(
             identifiers={(DOMAIN, outdoor_device.serial_number)},
             manufacturer=MANUFACTURER,
             configuration_url=f"https://tempestwx.com/station/{station_id}/grid",
-            serial_number=outdoor_device.serial_number,
-            sw_version=outdoor_device.firmware_revision,
-            hw_version=outdoor_device.hardware_revision,
         )
 
     @property

--- a/homeassistant/components/weatherflow_cloud/weather.py
+++ b/homeassistant/components/weatherflow_cloud/weather.py
@@ -69,13 +69,10 @@ class WeatherFlowWeather(
         self.station_id = station_id
         self._attr_unique_id = f"weatherflow_forecast_{station_id}"
 
-        # Obtain info from 1st outdoor device on station
-        outdoor_device = self.local_data.station.outdoor_devices[0]
-
         self._attr_device_info = DeviceInfo(
             name=self.local_data.station.name,
             entry_type=DeviceEntryType.SERVICE,
-            identifiers={(DOMAIN, outdoor_device.serial_number)},
+            identifiers={(DOMAIN, f"{station_id}")},
             manufacturer=MANUFACTURER,
             configuration_url=f"https://tempestwx.com/station/{station_id}/grid",
         )

--- a/homeassistant/components/weatherflow_cloud/weather.py
+++ b/homeassistant/components/weatherflow_cloud/weather.py
@@ -56,6 +56,7 @@ class WeatherFlowWeather(
     _attr_supported_features = (
         WeatherEntityFeature.FORECAST_DAILY | WeatherEntityFeature.FORECAST_HOURLY
     )
+    _attr_name = None
 
     def __init__(
         self,
@@ -67,7 +68,6 @@ class WeatherFlowWeather(
 
         self.station_id = station_id
         self._attr_unique_id = f"weatherflow_forecast_{station_id}"
-        self._attr_name = None
 
         # Obtain info from 1st outdoor device on station
         outdoor_device = self.local_data.station.outdoor_devices[0]

--- a/homeassistant/components/weatherflow_cloud/weather.py
+++ b/homeassistant/components/weatherflow_cloud/weather.py
@@ -1,0 +1,145 @@
+"""Support for WeatherFlow Forecast weather service."""
+from __future__ import annotations
+
+from weatherflow4py.models.unified import WeatherFlowData
+
+from homeassistant.components.weather import (
+    Forecast,
+    SingleCoordinatorWeatherEntity,
+    WeatherEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    UnitOfPrecipitationDepth,
+    UnitOfPressure,
+    UnitOfSpeed,
+    UnitOfTemperature,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import ATTR_ATTRIBUTION, DOMAIN, MANUFACTURER
+from .coordinator import WeatherFlowCloudDataUpdateCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Add a weather entity from a config_entry."""
+    coordinator: WeatherFlowCloudDataUpdateCoordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]
+
+    async_add_entities(
+        [
+            WeatherFlowWeather(coordinator, station_id=station_id)
+            for station_id, data in coordinator.data.items()
+        ]
+    )
+
+
+class WeatherFlowWeather(
+    SingleCoordinatorWeatherEntity[WeatherFlowCloudDataUpdateCoordinator]
+):
+    """Implementation of a WeatherFlow weather condition."""
+
+    _attr_attribution = ATTR_ATTRIBUTION
+    _attr_has_entity_name = True
+
+    _attr_native_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_native_precipitation_unit = UnitOfPrecipitationDepth.MILLIMETERS
+    _attr_native_pressure_unit = UnitOfPressure.MBAR
+    _attr_native_wind_speed_unit = UnitOfSpeed.METERS_PER_SECOND
+    _attr_supported_features = (
+        WeatherEntityFeature.FORECAST_DAILY | WeatherEntityFeature.FORECAST_HOURLY
+    )
+
+    def __init__(
+        self,
+        coordinator: WeatherFlowCloudDataUpdateCoordinator,
+        station_id: int,
+    ) -> None:
+        """Initialise the platform with a data instance and station."""
+        super().__init__(coordinator)
+
+        self.station_id = station_id
+        self._attr_unique_id = f"weatherflow_forecast_{station_id}"
+        self._attr_name = self.local_data.station.name
+
+        outdoor_device = [
+            d for d in self.local_data.station.devices if d.device_type == "ST"
+        ][0]
+        self._attr_device_info = DeviceInfo(
+            name="Forecast",
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={(DOMAIN, outdoor_device.serial_number)},
+            manufacturer=MANUFACTURER,
+            configuration_url=f"https://tempestwx.com/station/{station_id}/grid",
+            serial_number=outdoor_device.serial_number,
+            sw_version=outdoor_device.firmware_revision,
+            hw_version=outdoor_device.hardware_revision,
+        )
+
+    @property
+    def local_data(self) -> WeatherFlowData:
+        """Return the local weather data object for this station."""
+        return self.coordinator.data[self.station_id]
+
+    @property
+    def condition(self) -> str | None:
+        """Return current condition - required property."""
+        return self.local_data.weather.current_conditions.icon.ha_icon
+
+    @property
+    def native_temperature(self) -> float | None:
+        """Return the temperature."""
+        return self.local_data.weather.current_conditions.air_temperature
+
+    @property
+    def native_pressure(self) -> float | None:
+        """Return the Air Pressure @ Station."""
+        return self.local_data.weather.current_conditions.station_pressure
+
+    #
+    @property
+    def humidity(self) -> float | None:
+        """Return the humidity."""
+        return self.local_data.weather.current_conditions.relative_humidity
+
+    @property
+    def native_wind_speed(self) -> float | None:
+        """Return the wind speed."""
+        return self.local_data.weather.current_conditions.wind_avg
+
+    @property
+    def wind_bearing(self) -> float | str | None:
+        """Return the wind direction."""
+        return self.local_data.weather.current_conditions.wind_direction
+
+    @property
+    def native_wind_gust_speed(self) -> float | None:
+        """Return the wind gust speed in native units."""
+        return self.local_data.weather.current_conditions.wind_gust
+
+    @property
+    def native_dew_point(self) -> float | None:
+        """Return dew point."""
+        return self.local_data.weather.current_conditions.dew_point
+
+    @property
+    def uv_index(self) -> float | None:
+        """Return UV Index."""
+        return self.local_data.weather.current_conditions.uv
+
+    @callback
+    def _async_forecast_daily(self) -> list[Forecast] | None:
+        """Return the daily forecast in native units."""
+        return [x.ha_forecast for x in self.local_data.weather.forecast.daily]
+
+    @callback
+    def _async_forecast_hourly(self) -> list[Forecast] | None:
+        """Return the hourly forecast in native units."""
+        return [x.ha_forecast for x in self.local_data.weather.forecast.hourly]

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -586,6 +586,7 @@ FLOWS = {
         "watttime",
         "waze_travel_time",
         "weatherflow",
+        "weatherflow_cloud",
         "weatherkit",
         "webmin",
         "webostv",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -6663,6 +6663,12 @@
       "config_flow": true,
       "iot_class": "local_push"
     },
+    "weatherflow_cloud": {
+      "name": "WeatherflowCloud",
+      "integration_type": "hub",
+      "config_flow": true,
+      "iot_class": "cloud_polling"
+    },
     "webhook": {
       "name": "Webhook",
       "integration_type": "hub",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2838,6 +2838,9 @@ watchdog==2.3.1
 # homeassistant.components.waterfurnace
 waterfurnace==1.1.0
 
+# homeassistant.components.weatherflow_cloud
+weatherflow4py==0.1.10
+
 # homeassistant.components.webmin
 webmin-xmlrpc==0.0.1
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2839,7 +2839,7 @@ watchdog==2.3.1
 waterfurnace==1.1.0
 
 # homeassistant.components.weatherflow_cloud
-weatherflow4py==0.1.10
+weatherflow4py==0.1.11
 
 # homeassistant.components.webmin
 webmin-xmlrpc==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2174,7 +2174,7 @@ wallbox==0.6.0
 watchdog==2.3.1
 
 # homeassistant.components.weatherflow_cloud
-weatherflow4py==0.1.10
+weatherflow4py==0.1.11
 
 # homeassistant.components.webmin
 webmin-xmlrpc==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2173,6 +2173,9 @@ wallbox==0.6.0
 # homeassistant.components.folder_watcher
 watchdog==2.3.1
 
+# homeassistant.components.weatherflow_cloud
+weatherflow4py==0.1.10
+
 # homeassistant.components.webmin
 webmin-xmlrpc==0.0.1
 

--- a/tests/components/weatherflow_cloud/__init__.py
+++ b/tests/components/weatherflow_cloud/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the WeatherflowCloud integration."""

--- a/tests/components/weatherflow_cloud/conftest.py
+++ b/tests/components/weatherflow_cloud/conftest.py
@@ -17,10 +17,38 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_get_stations_combined() -> Generator[AsyncMock, None, None]:
+def mock_get_stations() -> Generator[AsyncMock, None, None]:
+    """Mock get_stations with a sequence of responses."""
+    side_effects = [
+        True,
+    ]
+
+    with patch(
+        "weatherflow4py.api.WeatherFlowRestAPI.async_get_stations",
+        side_effect=side_effects,
+    ) as mock_get_stations:
+        yield mock_get_stations
+
+
+@pytest.fixture
+def mock_get_stations_500_error() -> Generator[AsyncMock, None, None]:
     """Mock get_stations with a sequence of responses."""
     side_effects = [
         ClientResponseError(Mock(), (), status=500),
+        True,
+    ]
+
+    with patch(
+        "weatherflow4py.api.WeatherFlowRestAPI.async_get_stations",
+        side_effect=side_effects,
+    ) as mock_get_stations:
+        yield mock_get_stations
+
+
+@pytest.fixture
+def mock_get_stations_401_error() -> Generator[AsyncMock, None, None]:
+    """Mock get_stations with a sequence of responses."""
+    side_effects = [
         ClientResponseError(Mock(), (), status=401),
         True,
     ]

--- a/tests/components/weatherflow_cloud/conftest.py
+++ b/tests/components/weatherflow_cloud/conftest.py
@@ -1,0 +1,32 @@
+"""Common fixtures for the WeatherflowCloud tests."""
+from collections.abc import Generator
+from unittest.mock import AsyncMock, Mock, patch
+
+from aiohttp import ClientResponseError
+import pytest
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.weatherflow_cloud.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_get_stations_combined() -> Generator[AsyncMock, None, None]:
+    """Mock get_stations with a sequence of responses."""
+    side_effects = [
+        ClientResponseError(Mock(), (), status=500),
+        ClientResponseError(Mock(), (), status=401),
+        True,
+    ]
+
+    with patch(
+        "weatherflow4py.api.WeatherFlowRestAPI.async_get_stations",
+        side_effect=side_effects,
+    ) as mock_get_stations:
+        yield mock_get_stations

--- a/tests/components/weatherflow_cloud/conftest.py
+++ b/tests/components/weatherflow_cloud/conftest.py
@@ -48,10 +48,7 @@ def mock_get_stations_500_error() -> Generator[AsyncMock, None, None]:
 @pytest.fixture
 def mock_get_stations_401_error() -> Generator[AsyncMock, None, None]:
     """Mock get_stations with a sequence of responses."""
-    side_effects = [
-        ClientResponseError(Mock(), (), status=401),
-        True,
-    ]
+    side_effects = [ClientResponseError(Mock(), (), status=401), True, True, True]
 
     with patch(
         "weatherflow4py.api.WeatherFlowRestAPI.async_get_stations",

--- a/tests/components/weatherflow_cloud/test_config_flow.py
+++ b/tests/components/weatherflow_cloud/test_config_flow.py
@@ -1,0 +1,44 @@
+"""Test the WeatherflowCloud config flow."""
+
+from homeassistant import config_entries
+from homeassistant.components.weatherflow_cloud.const import DOMAIN
+from homeassistant.const import CONF_API_TOKEN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+
+async def test_config_2(hass: HomeAssistant, mock_get_stations_combined) -> None:
+    """Test the config flow (which is very simple now)."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {}
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_API_TOKEN: "string",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_API_TOKEN: "string",
+        },
+    )
+    await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_api_key"}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_API_TOKEN: "string",
+        },
+    )
+    await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.CREATE_ENTRY

--- a/tests/components/weatherflow_cloud/test_config_flow.py
+++ b/tests/components/weatherflow_cloud/test_config_flow.py
@@ -1,13 +1,36 @@
 """Test the WeatherflowCloud config flow."""
 
+
 from homeassistant import config_entries
 from homeassistant.components.weatherflow_cloud.const import DOMAIN
 from homeassistant.const import CONF_API_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
+from tests.common import MockConfigEntry
 
-async def test_config_2(hass: HomeAssistant, mock_get_stations_combined) -> None:
+
+async def test_config(hass: HomeAssistant, mock_get_stations) -> None:
+    """Test the config flow for the ideal case."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {}
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_API_TOKEN: "string",
+        },
+    )
+
+    await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+
+
+async def test_config_cannot_connect(
+    hass: HomeAssistant, mock_get_stations_500_error
+) -> None:
     """Test the config flow (which is very simple now)."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -31,9 +54,28 @@ async def test_config_2(hass: HomeAssistant, mock_get_stations_combined) -> None
         },
     )
     await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+
+
+async def test_config_bad_api_key(
+    hass: HomeAssistant, mock_get_stations_401_error
+) -> None:
+    """Test the config flow (which is very simple now)."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {}
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_API_TOKEN: "string",
+        },
+    )
+    await hass.async_block_till_done()
+
     assert result["type"] == FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_api_key"}
-
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
@@ -42,3 +84,28 @@ async def test_config_2(hass: HomeAssistant, mock_get_stations_combined) -> None
     )
     await hass.async_block_till_done()
     assert result["type"] == FlowResultType.CREATE_ENTRY
+
+
+async def test_config_flow_abort(hass: HomeAssistant, mock_get_stations) -> None:
+    """Test an abort case."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_API_TOKEN: "same_same",
+        },
+    )
+    entry.add_to_hass(hass)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_API_TOKEN: "same_same",
+        },
+    )
+    await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/components/weatherflow_cloud/test_config_flow.py
+++ b/tests/components/weatherflow_cloud/test_config_flow.py
@@ -65,8 +65,8 @@ async def test_config_errors(
     hass: HomeAssistant, request, expected_error, mock_fixture, mock_get_stations
 ) -> None:
     """Test the config flow for various error scenarios."""
-    mock_get_stations = request.getfixturevalue(mock_fixture)
-    with mock_get_stations:
+    mock_get_stations_bad = request.getfixturevalue(mock_fixture)
+    with mock_get_stations_bad:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
@@ -81,6 +81,15 @@ async def test_config_errors(
 
         assert result["type"] == FlowResultType.FORM
         assert result["errors"] == {"base": expected_error}
+
+    with mock_get_stations:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_API_TOKEN: "string"},
+        )
+        await hass.async_block_till_done()
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
 
 
 async def test_reauth(hass: HomeAssistant, mock_get_stations_401_error) -> None:
@@ -108,3 +117,4 @@ async def test_reauth(hass: HomeAssistant, mock_get_stations_401_error) -> None:
     )
 
     assert result["reason"] == "reauth_successful"
+    assert result["type"] == FlowResultType.ABORT

--- a/tests/components/weatherflow_cloud/test_config_flow.py
+++ b/tests/components/weatherflow_cloud/test_config_flow.py
@@ -1,5 +1,5 @@
 """Test the WeatherflowCloud config flow."""
-
+import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.weatherflow_cloud.const import DOMAIN
@@ -28,64 +28,6 @@ async def test_config(hass: HomeAssistant, mock_get_stations) -> None:
     assert result["type"] == FlowResultType.CREATE_ENTRY
 
 
-async def test_config_cannot_connect(
-    hass: HomeAssistant, mock_get_stations_500_error
-) -> None:
-    """Test the config flow (which is very simple now)."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    assert result["type"] == FlowResultType.FORM
-    assert result["errors"] == {}
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            CONF_API_TOKEN: "string",
-        },
-    )
-    await hass.async_block_till_done()
-
-    assert result["type"] == FlowResultType.FORM
-    assert result["errors"] == {"base": "cannot_connect"}
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            CONF_API_TOKEN: "string",
-        },
-    )
-    await hass.async_block_till_done()
-    assert result["type"] == FlowResultType.CREATE_ENTRY
-
-
-async def test_config_bad_api_key(
-    hass: HomeAssistant, mock_get_stations_401_error
-) -> None:
-    """Test the config flow (which is very simple now)."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    assert result["type"] == FlowResultType.FORM
-    assert result["errors"] == {}
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            CONF_API_TOKEN: "string",
-        },
-    )
-    await hass.async_block_till_done()
-
-    assert result["type"] == FlowResultType.FORM
-    assert result["errors"] == {"base": "invalid_api_key"}
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            CONF_API_TOKEN: "string",
-        },
-    )
-    await hass.async_block_till_done()
-    assert result["type"] == FlowResultType.CREATE_ENTRY
-
-
 async def test_config_flow_abort(hass: HomeAssistant, mock_get_stations) -> None:
     """Test an abort case."""
 
@@ -109,3 +51,32 @@ async def test_config_flow_abort(hass: HomeAssistant, mock_get_stations) -> None
     await hass.async_block_till_done()
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+@pytest.mark.parametrize(
+    "mock_fixture, expected_error",  # noqa: PT006
+    [
+        ("mock_get_stations_500_error", "cannot_connect"),
+        ("mock_get_stations_401_error", "invalid_api_key"),
+    ],
+)
+async def test_config_errors(
+    hass: HomeAssistant, request, expected_error, mock_fixture, mock_get_stations
+) -> None:
+    """Test the config flow for various error scenarios."""
+    mock_get_stations = request.getfixturevalue(mock_fixture)
+    with mock_get_stations:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["errors"] == {}
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_API_TOKEN: "string"},
+        )
+        await hass.async_block_till_done()
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["errors"] == {"base": expected_error}


### PR DESCRIPTION
## Proposed change

<img width="584" alt="image" src="https://github.com/home-assistant/core/assets/6491743/51f04cc6-c62e-4f12-9322-fc8b62ab54c2">


I wrote the `weatherflow`  integration which is a **local** only integration that receives weather data via UDP. Tempest Weatherflow also provides a Cloud/REST API. Initially my plan was to port over the HACS module written by @briis - however - in realized my life would just be simpler to write a new backing library [weatherflow4py](https://github.com/jeeftor/weatherflow4py) 

Additionally - in discussions with @joostlek - we determined the best approach was to keep things as simple as possible - so following this path is how I ended up with a very simple backing library and config flow (we just store a single token).

### Hybrid vs Separate Integrations

I had a discussion with @joostlek about whether I should create a separate integration or extend the existing integration. I started down the path of extending the existing integration but the overall approach to these two integrations is different enough I think it serves to have it as a separate integration. One is entirely udp based while this one is entirely http based. I could also anticipate some users would want to run both at the same time



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30550

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
