### PR TITLE
Fix yolink entity descriptions

### DIFF
--- a/homeassistant/components/yolink/sensor.py
+++ b/homeassistant/components/yolink/sensor.py
@@ -48,21 +48,13 @@ from .coordinator import YoLinkCoordinator
 from .entity import YoLinkEntity
 
 
-@dataclass(frozen=True)
-class YoLinkSensorEntityDescriptionMixin:
-    """Mixin for device type."""
-
-    exists_fn: Callable[[YoLinkDevice], bool] = lambda _: True
-
-
-@dataclass(frozen=True)
-class YoLinkSensorEntityDescription(
-    YoLinkSensorEntityDescriptionMixin, SensorEntityDescription
-):
+@dataclass(frozen=True, kw_only=True)
+class YoLinkSensorEntityDescription(SensorEntityDescription):
     """YoLink SensorEntityDescription."""
 
-    value: Callable = lambda state: state
+    exists_fn: Callable[[YoLinkDevice], bool] = lambda _: True
     should_update_entity: Callable = lambda state: True
+    value: Callable = lambda state: state
 
 
 SENSOR_DEVICE_TYPE = [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix yolink entity descriptions

I'm not able to test this live. However, the `dataclass` creation fails by just importing:
```
$ python3
>>> from homeassistant.components.yolink import sensor
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/erik/development/home-assistant_fork/homeassistant/components/yolink/sensor.py", line 58, in <module>
    @dataclass(frozen=True)
     ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/erik/.pyenv/versions/3.11.5/lib/python3.11/dataclasses.py", line 1224, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/erik/.pyenv/versions/3.11.5/lib/python3.11/dataclasses.py", line 1031, in _process_class
    _init_fn(all_init_fields,
  File "/home/erik/.pyenv/versions/3.11.5/lib/python3.11/dataclasses.py", line 549, in _init_fn
    raise TypeError(f'non-default argument {f.name!r} '
TypeError: non-default argument 'key' follows default argument
```

With the fix in this PR, the dataclass creation works fine.

The problem is that the mixin has a field with a default value. Mixin classes are normally added to `EntityDescription` subclasses to make it possible to add fields *without* default values.

`yolink` is the only integration in core I could find which has such a mixin.

It's possible to make the yolink pattern work by relying on dataclass inheritance if a parent adds a field with a default value.

However, relying on dataclass inheritance means it's no longer possible to create mutable dataclasses, so I'm not sure there's any benefit; any custom integration relying on the same pattern would still break unless the author change to frozen entity descriptions and we might break additional custom integrations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/106617
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
