### PR TITLE
Add state attribute for zigbee group id to ZHA group entities

### DIFF
--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -255,6 +255,7 @@ class ZhaGroupEntity(BaseZhaEntity):
         self._update_group_from_child_delay = DEFAULT_UPDATE_GROUP_FROM_CHILD_DELAY
 
         self._attr_name = self._group.name
+        self._extra_state_attributes.update({"zigbee_group_id": group_id})
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/zha/fan.py
+++ b/homeassistant/components/zha/fan.py
@@ -205,6 +205,14 @@ class FanGroup(BaseFan, ZhaGroupEntity):
         self._preset_mode = None
 
     @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return state attributes from both parents."""
+        attributes = {}
+        attributes.update(super(BaseFan, self).extra_state_attributes)
+        attributes.update(super(ZhaGroupEntity, self).extra_state_attributes)
+        return attributes
+
+    @property
     def percentage(self) -> int | None:
         """Return the current speed percentage."""
         return self._percentage

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -1185,6 +1185,14 @@ class LightGroup(BaseLight, ZhaGroupEntity):
         self._zha_config_enhanced_light_transition = False
         self._attr_color_mode = None
 
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return state attributes from both parents."""
+        attributes = {}
+        attributes.update(super(BaseLight, self).extra_state_attributes)
+        attributes.update(super(ZhaGroupEntity, self).extra_state_attributes)
+        return attributes
+
     # remove this when all ZHA platforms and base entities are updated
     @property
     def available(self) -> bool:

--- a/tests/components/zha/test_fan.py
+++ b/tests/components/zha/test_fan.py
@@ -317,6 +317,9 @@ async def test_zha_group_fan_entity(
 
     entity_id = async_find_group_entity_id(hass, Platform.FAN, zha_group)
     assert hass.states.get(entity_id) is not None
+    assert (
+        hass.states.get(entity_id).attributes["zigbee_group_id"] == zha_group.group_id
+    )
 
     group_fan_cluster = zha_group.endpoint[hvac.Fan.cluster_id]
 

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -506,6 +506,10 @@ async def test_transitions(
 
     group_entity_id = async_find_group_entity_id(hass, Platform.LIGHT, zha_group)
     assert hass.states.get(group_entity_id) is not None
+    assert (
+        hass.states.get(group_entity_id).attributes["zigbee_group_id"]
+        == zha_group.group_id
+    )
 
     assert device_1_entity_id in zha_group.member_entity_ids
     assert device_2_entity_id in zha_group.member_entity_ids


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Nothing is expected to break. A new attribute is added to a zigbee group entities.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I didn't find a way to get an access to a zigbee group id when given an entity of such a group. 
It may be useful when writing a blueprint and allowing an entity choice but at the same time one of the actions
is a service call to a `zha.issue_zigbee_group_command` that requires a group id to call a command for.
This PR adds `zigbee_group_id` attribute to such grouping entities (atm. `LightGroup` and `FanGroup`). 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
