### PR TITLE
Bump reolink_aio to 0.8.5

### DIFF
--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -18,5 +18,5 @@
   "documentation": "https://www.home-assistant.io/integrations/reolink",
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
-  "requirements": ["reolink-aio==0.8.4"]
+  "requirements": ["reolink-aio==0.8.5"]
 }

--- a/homeassistant/components/reolink/media_source.py
+++ b/homeassistant/components/reolink/media_source.py
@@ -19,6 +19,8 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
+from reolink_aio.enums import VodRequestType
+
 from . import ReolinkData
 from .const import DOMAIN
 
@@ -56,7 +58,12 @@ class ReolinkVODMediaSource(MediaSource):
         channel = int(channel_str)
 
         host = self.data[config_entry_id].host
-        mime_type, url = await host.api.get_vod_source(channel, filename, stream_res)
+
+        vod_type = VodRequestType.RTMP
+        if host.api.is_nvr:
+            vod_type = VodRequestType.FLV
+
+        mime_type, url = await host.api.get_vod_source(channel, filename, stream_res, vod_type)
         if _LOGGER.isEnabledFor(logging.DEBUG):
             url_log = f"{url.split('&user=')[0]}&user=xxxxx&password=xxxxx"
             _LOGGER.debug(

--- a/homeassistant/components/reolink/media_source.py
+++ b/homeassistant/components/reolink/media_source.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import datetime as dt
 import logging
 
+from reolink_aio.enums import VodRequestType
+
 from homeassistant.components.camera import DOMAIN as CAM_DOMAIN, DynamicStreamSettings
 from homeassistant.components.media_player import MediaClass, MediaType
 from homeassistant.components.media_source.error import Unresolvable
@@ -18,8 +20,6 @@ from homeassistant.components.stream import create_stream
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-
-from reolink_aio.enums import VodRequestType
 
 from . import ReolinkData
 from .const import DOMAIN
@@ -63,7 +63,9 @@ class ReolinkVODMediaSource(MediaSource):
         if host.api.is_nvr:
             vod_type = VodRequestType.FLV
 
-        mime_type, url = await host.api.get_vod_source(channel, filename, stream_res, vod_type)
+        mime_type, url = await host.api.get_vod_source(
+            channel, filename, stream_res, vod_type
+        )
         if _LOGGER.isEnabledFor(logging.DEBUG):
             url_log = f"{url.split('&user=')[0]}&user=xxxxx&password=xxxxx"
             _LOGGER.debug(

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2379,7 +2379,7 @@ renault-api==0.2.1
 renson-endura-delta==1.7.1
 
 # homeassistant.components.reolink
-reolink-aio==0.8.4
+reolink-aio==0.8.5
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1798,7 +1798,7 @@ renault-api==0.2.1
 renson-endura-delta==1.7.1
 
 # homeassistant.components.reolink
-reolink-aio==0.8.4
+reolink-aio==0.8.5
 
 # homeassistant.components.rflink
 rflink==0.0.65


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump reolink_aio to 0.8.5:
**Additions:**
- [Add RTMP, FLV and PLAYBACK get_vod_source options](https://github.com/starkillerOG/reolink_aio/commit/bb67959bdae7e6e01a6e2e79bfec36f109040794)

**Bug fixes:**
- [Check RTSP urls with DESCRIBE request](https://github.com/starkillerOG/reolink_aio/commit/9f32a606356948480677675c1021cc2fd7cf1e81)

**Notes:**
- get_vod_source will now return the FLV url by default instead of the RTMP url for seperate cams, NVRs were always returning the FLV url.

**Full Changelog**: https://github.com/starkillerOG/reolink_aio/compare/0.8.4...0.8.5

The changes to media_source.py are just restoring the current behaviour of default RTMP url for seperate cams and FLV for NVRs.
Future PR will utilize the new posibility to select diffrent protocols for playback.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/106331
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
