### PR TITLE
Index entities by domain for entity services

### DIFF
--- a/homeassistant/components/isy994/services.py
+++ b/homeassistant/components/isy994/services.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import async_get_platforms
 from homeassistant.helpers.service import entity_service_call
 
@@ -120,6 +121,14 @@ SERVICE_SEND_PROGRAM_COMMAND_SCHEMA = vol.All(
 )
 
 
+def async_get_entities(hass: HomeAssistant) -> dict[str, Entity]:
+    """Get entities for a domain."""
+    entities: dict[str, Entity] = {}
+    for platform in async_get_platforms(hass, DOMAIN):
+        entities.update(platform.entities)
+    return entities
+
+
 @callback
 def async_setup_services(hass: HomeAssistant) -> None:  # noqa: C901
     """Create and register services for the ISY integration."""
@@ -159,7 +168,7 @@ def async_setup_services(hass: HomeAssistant) -> None:  # noqa: C901
 
     async def _async_send_raw_node_command(call: ServiceCall) -> None:
         await entity_service_call(
-            hass, async_get_platforms(hass, DOMAIN), "async_send_raw_node_command", call
+            hass, async_get_entities(hass), "async_send_raw_node_command", call
         )
 
     hass.services.async_register(
@@ -171,7 +180,7 @@ def async_setup_services(hass: HomeAssistant) -> None:  # noqa: C901
 
     async def _async_send_node_command(call: ServiceCall) -> None:
         await entity_service_call(
-            hass, async_get_platforms(hass, DOMAIN), "async_send_node_command", call
+            hass, async_get_entities(hass), "async_send_node_command", call
         )
 
     hass.services.async_register(
@@ -183,7 +192,7 @@ def async_setup_services(hass: HomeAssistant) -> None:  # noqa: C901
 
     async def _async_get_zwave_parameter(call: ServiceCall) -> None:
         await entity_service_call(
-            hass, async_get_platforms(hass, DOMAIN), "async_get_zwave_parameter", call
+            hass, async_get_entities(hass), "async_get_zwave_parameter", call
         )
 
     hass.services.async_register(
@@ -195,7 +204,7 @@ def async_setup_services(hass: HomeAssistant) -> None:  # noqa: C901
 
     async def _async_set_zwave_parameter(call: ServiceCall) -> None:
         await entity_service_call(
-            hass, async_get_platforms(hass, DOMAIN), "async_set_zwave_parameter", call
+            hass, async_get_entities(hass), "async_set_zwave_parameter", call
         )
 
     hass.services.async_register(
@@ -207,7 +216,7 @@ def async_setup_services(hass: HomeAssistant) -> None:  # noqa: C901
 
     async def _async_rename_node(call: ServiceCall) -> None:
         await entity_service_call(
-            hass, async_get_platforms(hass, DOMAIN), "async_rename_node", call
+            hass, async_get_entities(hass), "async_rename_node", call
         )
 
     hass.services.async_register(

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -93,11 +93,9 @@ class EntityComponent(Generic[_EntityT]):
         self._platforms: dict[
             str | tuple[str, timedelta | None, str | None], EntityPlatform
         ] = {domain: domain_platform}
-
         self.async_add_entities = domain_platform.async_add_entities
         self.add_entities = domain_platform.add_entities
         self._entities: dict[str, entity.Entity] = domain_platform.domain_entities
-
         hass.data.setdefault(DATA_INSTANCES, {})[domain] = self
 
     @property

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -94,7 +94,9 @@ class EntityComponent(Generic[_EntityT]):
         ] = {domain: self._async_init_entity_platform(domain, None)}
         self.async_add_entities = self._platforms[domain].async_add_entities
         self.add_entities = self._platforms[domain].add_entities
-        self._entities: dict[str, entity.Entity] = self._platforms[domain].entities
+        self._entities: dict[str, entity.Entity] = self._platforms[
+            domain
+        ].domain_entities
 
         hass.data.setdefault(DATA_INSTANCES, {})[domain] = self
 

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -144,10 +144,9 @@ class EntityPlatform:
         # which powers entity_component.add_entities
         self.parallel_updates_created = platform is None
 
-        platforms: list[EntityPlatform] = hass.data.setdefault(
-            DATA_ENTITY_PLATFORM, {}
-        ).setdefault(platform_name, [])
-        platforms.append(self)
+        hass.data.setdefault(DATA_ENTITY_PLATFORM, {}).setdefault(
+            self.platform_name, []
+        ).append(self)
 
         self.domain_entities: dict[str, Entity] = hass.data.setdefault(
             DATA_DOMAIN_ENTITIES, {}

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -55,6 +55,7 @@ SLOW_ADD_MIN_TIMEOUT = 500
 
 PLATFORM_NOT_READY_RETRIES = 10
 DATA_ENTITY_PLATFORM = "entity_platform"
+DATA_DOMAIN_ENTITIES = "domain_entities"
 PLATFORM_NOT_READY_BASE_WAIT_TIME = 30  # seconds
 
 _LOGGER = getLogger(__name__)
@@ -143,9 +144,14 @@ class EntityPlatform:
         # which powers entity_component.add_entities
         self.parallel_updates_created = platform is None
 
-        hass.data.setdefault(DATA_ENTITY_PLATFORM, {}).setdefault(
-            self.platform_name, []
-        ).append(self)
+        platforms: list[EntityPlatform] = hass.data.setdefault(
+            DATA_ENTITY_PLATFORM, {}
+        ).setdefault(platform_name, [])
+        platforms.append(self)
+
+        self.domain_entities: dict[str, Entity] = hass.data.setdefault(
+            DATA_DOMAIN_ENTITIES, {}
+        ).setdefault(domain, {})
 
     def __repr__(self) -> str:
         """Represent an EntityPlatform."""
@@ -734,6 +740,7 @@ class EntityPlatform:
 
         entity_id = entity.entity_id
         self.entities[entity_id] = entity
+        self.domain_entities[entity_id] = entity
 
         if not restored:
             # Reserve the state in the state machine
@@ -746,6 +753,7 @@ class EntityPlatform:
         def remove_entity_cb() -> None:
             """Remove entity from entities dict."""
             self.entities.pop(entity_id)
+            self.domain_entities.pop(entity_id)
 
         entity.async_on_remove(remove_entity_cb)
 
@@ -830,11 +838,7 @@ class EntityPlatform:
             """Handle the service."""
             return await service.entity_service_call(
                 self.hass,
-                [
-                    plf
-                    for plf in self.hass.data[DATA_ENTITY_PLATFORM][self.platform_name]
-                    if plf.domain == self.domain
-                ],
+                self.domain_entities,
                 func,
                 call,
                 required_features,

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -58,7 +58,6 @@ from .typing import ConfigType, TemplateVarsType
 
 if TYPE_CHECKING:
     from .entity import Entity
-    from .entity_platform import EntityPlatform
 
     _EntityT = TypeVar("_EntityT", bound=Entity)
 
@@ -741,7 +740,7 @@ def async_set_service_schema(
 
 def _get_permissible_entity_candidates(
     call: ServiceCall,
-    platforms: Iterable[EntityPlatform],
+    entities: dict[str, Entity],
     entity_perms: None | (Callable[[str, str], bool]),
     target_all_entities: bool,
     all_referenced: set[str] | None,
@@ -754,9 +753,8 @@ def _get_permissible_entity_candidates(
             # is allowed to control.
             return [
                 entity
-                for platform in platforms
-                for entity in platform.entities.values()
-                if entity_perms(entity.entity_id, POLICY_CONTROL)
+                for entity_id, entity in entities.items()
+                if entity_perms(entity_id, POLICY_CONTROL)
             ]
 
         assert all_referenced is not None
@@ -771,29 +769,22 @@ def _get_permissible_entity_candidates(
                 )
 
     elif target_all_entities:
-        return [
-            entity for platform in platforms for entity in platform.entities.values()
-        ]
+        return list(entities.values())
 
     # We have already validated they have permissions to control all_referenced
     # entities so we do not need to check again.
     assert all_referenced is not None
     if single_entity := len(all_referenced) == 1 and list(all_referenced)[0]:
-        for platform in platforms:
-            if (entity := platform.entities.get(single_entity)) is not None:
-                return [entity]
+        if (entity := entities.get(single_entity)) is not None:
+            return [entity]
 
-    return [
-        platform.entities[entity_id]
-        for platform in platforms
-        for entity_id in all_referenced.intersection(platform.entities)
-    ]
+    return [entities[entity_id] for entity_id in all_referenced.intersection(entities)]
 
 
 @bind_hass
 async def entity_service_call(
     hass: HomeAssistant,
-    platforms: Iterable[EntityPlatform],
+    registered_entities: dict[str, Entity],
     func: str | Callable[..., Coroutine[Any, Any, ServiceResponse]],
     call: ServiceCall,
     required_features: Iterable[int] | None = None,
@@ -832,7 +823,7 @@ async def entity_service_call(
     # A list with entities to call the service on.
     entity_candidates = _get_permissible_entity_candidates(
         call,
-        platforms,
+        registered_entities,
         entity_perms,
         target_all_entities,
         all_referenced,

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -773,10 +773,14 @@ def _get_permissible_entity_candidates(
 
     # We have already validated they have permissions to control all_referenced
     # entities so we do not need to check again.
-    assert all_referenced is not None
-    if single_entity := len(all_referenced) == 1 and list(all_referenced)[0]:
-        if (entity := entities.get(single_entity)) is not None:
-            return [entity]
+    if TYPE_CHECKING:
+        assert all_referenced is not None
+    if (
+        len(all_referenced) == 1
+        and (single_entity := list(all_referenced)[0])
+        and (entity := entities.get(single_entity)) is not None
+    ):
+        return [entity]
 
     return [entities[entity_id] for entity_id in all_referenced.intersection(entities)]
 

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -1406,7 +1406,9 @@ def test_resolve_engine(hass: HomeAssistant, setup: str, engine_id: str) -> None
 
     with patch.dict(
         hass.data[tts.DATA_TTS_MANAGER].providers, {}, clear=True
-    ), patch.dict(hass.data[tts.DOMAIN]._platforms, {}, clear=True):
+    ), patch.dict(hass.data[tts.DOMAIN]._platforms, {}, clear=True), patch.dict(
+        hass.data[tts.DOMAIN]._entities, {}, clear=True
+    ):
         assert tts.async_resolve_engine(hass, None) is None
 
     with patch.dict(hass.data[tts.DATA_TTS_MANAGER].providers, {"cloud": object()}):

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -802,7 +802,7 @@ async def test_call_with_required_features(hass: HomeAssistant, mock_entities) -
     test_service_mock = AsyncMock(return_value=None)
     await service.entity_service_call(
         hass,
-        [Mock(entities=mock_entities)],
+        mock_entities,
         test_service_mock,
         ServiceCall("test_domain", "test_service", {"entity_id": "all"}),
         required_features=[SUPPORT_A],
@@ -821,7 +821,7 @@ async def test_call_with_required_features(hass: HomeAssistant, mock_entities) -
     with pytest.raises(exceptions.HomeAssistantError):
         await service.entity_service_call(
             hass,
-            [Mock(entities=mock_entities)],
+            mock_entities,
             test_service_mock,
             ServiceCall(
                 "test_domain", "test_service", {"entity_id": "light.living_room"}
@@ -838,7 +838,7 @@ async def test_call_with_both_required_features(
     test_service_mock = AsyncMock(return_value=None)
     await service.entity_service_call(
         hass,
-        [Mock(entities=mock_entities)],
+        mock_entities,
         test_service_mock,
         ServiceCall("test_domain", "test_service", {"entity_id": "all"}),
         required_features=[SUPPORT_A | SUPPORT_B],
@@ -857,7 +857,7 @@ async def test_call_with_one_of_required_features(
     test_service_mock = AsyncMock(return_value=None)
     await service.entity_service_call(
         hass,
-        [Mock(entities=mock_entities)],
+        mock_entities,
         test_service_mock,
         ServiceCall("test_domain", "test_service", {"entity_id": "all"}),
         required_features=[SUPPORT_A, SUPPORT_C],
@@ -878,7 +878,7 @@ async def test_call_with_sync_func(hass: HomeAssistant, mock_entities) -> None:
     test_service_mock = Mock(return_value=None)
     await service.entity_service_call(
         hass,
-        [Mock(entities=mock_entities)],
+        mock_entities,
         test_service_mock,
         ServiceCall("test_domain", "test_service", {"entity_id": "light.kitchen"}),
     )
@@ -890,7 +890,7 @@ async def test_call_with_sync_attr(hass: HomeAssistant, mock_entities) -> None:
     mock_method = mock_entities["light.kitchen"].sync_method = Mock(return_value=None)
     await service.entity_service_call(
         hass,
-        [Mock(entities=mock_entities)],
+        mock_entities,
         "sync_method",
         ServiceCall(
             "test_domain",
@@ -908,7 +908,7 @@ async def test_call_context_user_not_exist(hass: HomeAssistant) -> None:
     with pytest.raises(exceptions.UnknownUser) as err:
         await service.entity_service_call(
             hass,
-            [],
+            {},
             Mock(),
             ServiceCall(
                 "test_domain",
@@ -935,7 +935,7 @@ async def test_call_context_target_all(
     ):
         await service.entity_service_call(
             hass,
-            [Mock(entities=mock_entities)],
+            mock_entities,
             Mock(),
             ServiceCall(
                 "test_domain",
@@ -963,7 +963,7 @@ async def test_call_context_target_specific(
     ):
         await service.entity_service_call(
             hass,
-            [Mock(entities=mock_entities)],
+            mock_entities,
             Mock(),
             ServiceCall(
                 "test_domain",
@@ -987,7 +987,7 @@ async def test_call_context_target_specific_no_auth(
     ):
         await service.entity_service_call(
             hass,
-            [Mock(entities=mock_entities)],
+            mock_entities,
             Mock(),
             ServiceCall(
                 "test_domain",
@@ -1007,7 +1007,7 @@ async def test_call_no_context_target_all(
     """Check we target all if no user context given."""
     await service.entity_service_call(
         hass,
-        [Mock(entities=mock_entities)],
+        mock_entities,
         Mock(),
         ServiceCall(
             "test_domain", "test_service", data={"entity_id": ENTITY_MATCH_ALL}
@@ -1026,7 +1026,7 @@ async def test_call_no_context_target_specific(
     """Check we can target specified entities."""
     await service.entity_service_call(
         hass,
-        [Mock(entities=mock_entities)],
+        mock_entities,
         Mock(),
         ServiceCall(
             "test_domain",
@@ -1048,7 +1048,7 @@ async def test_call_with_match_all(
     """Check we only target allowed entities if targeting all."""
     await service.entity_service_call(
         hass,
-        [Mock(entities=mock_entities)],
+        mock_entities,
         Mock(),
         ServiceCall("test_domain", "test_service", {"entity_id": "all"}),
     )
@@ -1065,7 +1065,7 @@ async def test_call_with_omit_entity_id(
     """Check service call if we do not pass an entity ID."""
     await service.entity_service_call(
         hass,
-        [Mock(entities=mock_entities)],
+        mock_entities,
         Mock(),
         ServiceCall("test_domain", "test_service"),
     )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The average [time complexity](https://wiki.python.org/moin/TimeComplexity) to lookup entities for entity service calls and the generic entity update service is now O(entities) instead of O(entities*((EntityPlatforms/2)+1)). For the common single entity case the average lookup [time complexity](https://wiki.python.org/moin/TimeComplexity) is now O(1).

I've been trying to solve this for a long time, since it's one of the primary sources of latency controlling lights. Previously couldn't work out a pattern that was a simple change as previous attempts grew to unacceptable sizes. This version is not only significantly smaller than previous iterations, but it also removes complexity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
