### PR TITLE
Add fan mode support to SmartThings fan entity

### DIFF
--- a/homeassistant/components/smartthings/fan.py
+++ b/homeassistant/components/smartthings/fan.py
@@ -41,18 +41,50 @@ async def async_setup_entry(
 
 def get_capabilities(capabilities: Sequence[str]) -> Sequence[str] | None:
     """Return all capabilities supported if minimum required are present."""
-    supported = [Capability.switch, Capability.fan_speed]
-    # Must have switch and fan_speed
-    if all(capability in capabilities for capability in supported):
-        return supported
-    return None
+
+    # MUST support switch as we need a way to turn it on and off
+    if Capability.switch not in capabilities:
+        return None
+
+    # These are all optional but at least one must be supported
+    optional = [
+        Capability.air_conditioner_fan_mode,
+        Capability.fan_speed,
+    ]
+
+    # If none of the optional capabilities are supported then error
+    if not any(capability in capabilities for capability in optional):
+        return None
+
+    supported = [Capability.switch]
+
+    for capability in optional:
+        if capability in capabilities:
+            supported.append(capability)
+
+    return supported
 
 
 class SmartThingsFan(SmartThingsEntity, FanEntity):
     """Define a SmartThings Fan."""
 
-    _attr_supported_features = FanEntityFeature.SET_SPEED
+    _attr_supported_features = FanEntityFeature(0)
     _attr_speed_count = int_states_in_range(SPEED_RANGE)
+
+    def __init__(self, device):
+        """Init the class."""
+        super().__init__(device)
+        self._attr_supported_features = self._determine_features()
+
+    def _determine_features(self):
+        flags = FanEntityFeature(0)
+
+        if self._device.get_capability(Capability.fan_speed):
+            flags |= FanEntityFeature.SET_SPEED
+        if self._device.get_capability(Capability.air_conditioner_fan_mode):
+            flags |= FanEntityFeature.PRESET_MODE
+
+        return flags
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""
@@ -70,6 +102,16 @@ class SmartThingsFan(SmartThingsEntity, FanEntity):
         # the entity state ahead of receiving the confirming push updates
         self.async_write_ha_state()
 
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set the preset_mode of the fan."""
+        if (FanEntityFeature.PRESET_MODE in self._attr_supported_features) and (
+            self.preset_modes is not None
+        ):
+            if preset_mode in self.preset_modes:
+                await self._device.set_fan_mode(preset_mode, set_status=True)
+
+            self.async_write_ha_state()
+
     async def async_turn_on(
         self,
         percentage: int | None = None,
@@ -77,7 +119,15 @@ class SmartThingsFan(SmartThingsEntity, FanEntity):
         **kwargs: Any,
     ) -> None:
         """Turn the fan on."""
-        await self._async_set_percentage(percentage)
+        if percentage is not None:
+            await self._async_set_percentage(percentage)
+        if preset_mode is not None:
+            await self.async_set_preset_mode(preset_mode)
+        else:
+            await self._device.switch_on(set_status=True)
+        # State is set optimistically in the command above, therefore update
+        # the entity state ahead of receiving the confirming push updates
+        self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the fan off."""
@@ -92,6 +142,33 @@ class SmartThingsFan(SmartThingsEntity, FanEntity):
         return self._device.status.switch
 
     @property
-    def percentage(self) -> int:
+    def percentage(self) -> int | None:
         """Return the current speed percentage."""
-        return ranged_value_to_percentage(SPEED_RANGE, self._device.status.fan_speed)
+        if FanEntityFeature.SET_SPEED in self._attr_supported_features:
+            return ranged_value_to_percentage(
+                SPEED_RANGE, self._device.status.fan_speed
+            )
+
+        return None
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the current preset mode, e.g., auto, smart, interval, favorite.
+
+        Requires FanEntityFeature.SET_SPEED.
+        """
+        if FanEntityFeature.PRESET_MODE in self._attr_supported_features:
+            return self._device.status.fan_mode
+
+        return None
+
+    @property
+    def preset_modes(self) -> list[str] | None:
+        """Return a list of available preset modes.
+
+        Requires FanEntityFeature.SET_SPEED.
+        """
+        if FanEntityFeature.PRESET_MODE in self._attr_supported_features:
+            return self._device.status.supported_ac_fan_modes
+
+        return None

--- a/homeassistant/components/smartthings/fan.py
+++ b/homeassistant/components/smartthings/fan.py
@@ -140,31 +140,20 @@ class SmartThingsFan(SmartThingsEntity, FanEntity):
     @property
     def percentage(self) -> int | None:
         """Return the current speed percentage."""
-        if FanEntityFeature.SET_SPEED in self._attr_supported_features:
-            return ranged_value_to_percentage(
-                SPEED_RANGE, self._device.status.fan_speed
-            )
-
-        return None
+        return ranged_value_to_percentage(SPEED_RANGE, self._device.status.fan_speed)
 
     @property
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., auto, smart, interval, favorite.
 
-        Requires FanEntityFeature.SET_SPEED.
+        Requires FanEntityFeature.PRESET_MODE.
         """
-        if FanEntityFeature.PRESET_MODE in self._attr_supported_features:
-            return self._device.status.fan_mode
-
-        return None
+        return self._device.status.fan_mode
 
     @property
     def preset_modes(self) -> list[str] | None:
         """Return a list of available preset modes.
 
-        Requires FanEntityFeature.SET_SPEED.
+        Requires FanEntityFeature.PRESET_MODE.
         """
-        if FanEntityFeature.PRESET_MODE in self._attr_supported_features:
-            return self._device.status.supported_ac_fan_modes
-
-        return None
+        return self._device.status.supported_ac_fan_modes

--- a/homeassistant/components/smartthings/fan.py
+++ b/homeassistant/components/smartthings/fan.py
@@ -68,7 +68,6 @@ def get_capabilities(capabilities: Sequence[str]) -> Sequence[str] | None:
 class SmartThingsFan(SmartThingsEntity, FanEntity):
     """Define a SmartThings Fan."""
 
-    _attr_supported_features = FanEntityFeature(0)
     _attr_speed_count = int_states_in_range(SPEED_RANGE)
 
     def __init__(self, device):

--- a/homeassistant/components/smartthings/fan.py
+++ b/homeassistant/components/smartthings/fan.py
@@ -103,13 +103,10 @@ class SmartThingsFan(SmartThingsEntity, FanEntity):
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset_mode of the fan."""
-        if (FanEntityFeature.PRESET_MODE in self._attr_supported_features) and (
-            self.preset_modes is not None
-        ):
-            if preset_mode in self.preset_modes:
-                await self._device.set_fan_mode(preset_mode, set_status=True)
+        if self.preset_modes is not None and preset_mode in self.preset_modes:
+            await self._device.set_fan_mode(preset_mode, set_status=True)
 
-            self.async_write_ha_state()
+        self.async_write_ha_state()
 
     async def async_turn_on(
         self,

--- a/homeassistant/components/smartthings/fan.py
+++ b/homeassistant/components/smartthings/fan.py
@@ -119,11 +119,11 @@ class SmartThingsFan(SmartThingsEntity, FanEntity):
         **kwargs: Any,
     ) -> None:
         """Turn the fan on."""
-        if percentage is not None:
+        if FanEntityFeature.SET_SPEED in self._attr_supported_features:
+            # If speed is set in features then turn the fan on with the speed.
             await self._async_set_percentage(percentage)
-        if preset_mode is not None:
-            await self.async_set_preset_mode(preset_mode)
         else:
+            # If speed is not valid then turn on the fan with the
             await self._device.switch_on(set_status=True)
         # State is set optimistically in the command above, therefore update
         # the entity state ahead of receiving the confirming push updates

--- a/homeassistant/components/smartthings/fan.py
+++ b/homeassistant/components/smartthings/fan.py
@@ -103,9 +103,7 @@ class SmartThingsFan(SmartThingsEntity, FanEntity):
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset_mode of the fan."""
-        if self.preset_modes is not None and preset_mode in self.preset_modes:
-            await self._device.set_fan_mode(preset_mode, set_status=True)
-
+        await self._device.set_fan_mode(preset_mode, set_status=True)
         self.async_write_ha_state()
 
     async def async_turn_on(

--- a/tests/components/smartthings/test_fan.py
+++ b/tests/components/smartthings/test_fan.py
@@ -99,7 +99,6 @@ async def test_setup_mode_capability(hass: HomeAssistant, device_factory) -> Non
     state = hass.states.get("fan.fan_1")
     assert state is not None
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == FanEntityFeature.PRESET_MODE
-    assert ATTR_PERCENTAGE not in state.attributes
     assert state.attributes[ATTR_PRESET_MODE] == "high"
     assert state.attributes[ATTR_PRESET_MODES] == ["high", "low", "medium"]
 
@@ -123,8 +122,6 @@ async def test_setup_speed_capability(hass: HomeAssistant, device_factory) -> No
     assert state is not None
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == FanEntityFeature.SET_SPEED
     assert state.attributes[ATTR_PERCENTAGE] == 66
-    assert state.attributes[ATTR_PRESET_MODE] is None
-    assert state.attributes[ATTR_PRESET_MODES] is None
 
 
 async def test_setup_both_capabilities(hass: HomeAssistant, device_factory) -> None:

--- a/tests/components/smartthings/test_fan.py
+++ b/tests/components/smartthings/test_fan.py
@@ -8,6 +8,7 @@ from pysmartthings import Attribute, Capability
 from homeassistant.components.fan import (
     ATTR_PERCENTAGE,
     ATTR_PRESET_MODE,
+    ATTR_PRESET_MODES,
     DOMAIN as FAN_DOMAIN,
     FanEntityFeature,
 )
@@ -78,7 +79,90 @@ async def test_entity_and_device_attributes(
     assert entry.sw_version == "v7.89"
 
 
-async def test_turn_off(hass: HomeAssistant, device_factory) -> None:
+# Setup platform tests with varying capabilities
+async def test_setup_mode_capability(hass: HomeAssistant, device_factory) -> None:
+    """Test setting up a fan with only the mode capability."""
+    # Arrange
+    device = device_factory(
+        "Fan 1",
+        capabilities=[Capability.switch, Capability.air_conditioner_fan_mode],
+        status={
+            Attribute.switch: "off",
+            Attribute.fan_mode: "high",
+            Attribute.supported_ac_fan_modes: ["high", "low", "medium"],
+        },
+    )
+
+    await setup_platform(hass, FAN_DOMAIN, devices=[device])
+
+    # Assert
+    state = hass.states.get("fan.fan_1")
+    assert state is not None
+    assert state.attributes[ATTR_SUPPORTED_FEATURES] == FanEntityFeature.PRESET_MODE
+    assert ATTR_PERCENTAGE not in state.attributes
+    assert state.attributes[ATTR_PRESET_MODE] == "high"
+    assert state.attributes[ATTR_PRESET_MODES] == ["high", "low", "medium"]
+
+
+async def test_setup_speed_capability(hass: HomeAssistant, device_factory) -> None:
+    """Test setting up a fan with only the speed capability."""
+    # Arrange
+    device = device_factory(
+        "Fan 1",
+        capabilities=[Capability.switch, Capability.fan_speed],
+        status={
+            Attribute.switch: "off",
+            Attribute.fan_speed: 2,
+        },
+    )
+
+    await setup_platform(hass, FAN_DOMAIN, devices=[device])
+
+    # Assert
+    state = hass.states.get("fan.fan_1")
+    assert state is not None
+    assert state.attributes[ATTR_SUPPORTED_FEATURES] == FanEntityFeature.SET_SPEED
+    assert state.attributes[ATTR_PERCENTAGE] == 66
+    assert state.attributes[ATTR_PRESET_MODE] is None
+    assert state.attributes[ATTR_PRESET_MODES] is None
+
+
+async def test_setup_both_capabilities(hass: HomeAssistant, device_factory) -> None:
+    """Test setting up a fan with both the mode and speed capability."""
+    # Arrange
+    device = device_factory(
+        "Fan 1",
+        capabilities=[
+            Capability.switch,
+            Capability.fan_speed,
+            Capability.air_conditioner_fan_mode,
+        ],
+        status={
+            Attribute.switch: "off",
+            Attribute.fan_speed: 2,
+            Attribute.fan_mode: "high",
+            Attribute.supported_ac_fan_modes: ["high", "low", "medium"],
+        },
+    )
+
+    await setup_platform(hass, FAN_DOMAIN, devices=[device])
+
+    # Assert
+    state = hass.states.get("fan.fan_1")
+    assert state is not None
+    assert (
+        state.attributes[ATTR_SUPPORTED_FEATURES]
+        == FanEntityFeature.SET_SPEED | FanEntityFeature.PRESET_MODE
+    )
+    assert state.attributes[ATTR_PERCENTAGE] == 66
+    assert state.attributes[ATTR_PRESET_MODE] == "high"
+    assert state.attributes[ATTR_PRESET_MODES] == ["high", "low", "medium"]
+
+
+# Speed Capability Tests
+
+
+async def test_turn_off_speed_capability(hass: HomeAssistant, device_factory) -> None:
     """Test the fan turns of successfully."""
     # Arrange
     device = device_factory(
@@ -97,7 +181,7 @@ async def test_turn_off(hass: HomeAssistant, device_factory) -> None:
     assert state.state == "off"
 
 
-async def test_turn_on(hass: HomeAssistant, device_factory) -> None:
+async def test_turn_on_speed_capability(hass: HomeAssistant, device_factory) -> None:
     """Test the fan turns of successfully."""
     # Arrange
     device = device_factory(
@@ -116,7 +200,9 @@ async def test_turn_on(hass: HomeAssistant, device_factory) -> None:
     assert state.state == "on"
 
 
-async def test_turn_on_with_speed(hass: HomeAssistant, device_factory) -> None:
+async def test_turn_on_with_speed_speed_capability(
+    hass: HomeAssistant, device_factory
+) -> None:
     """Test the fan turns on to the specified speed."""
     # Arrange
     device = device_factory(
@@ -139,7 +225,33 @@ async def test_turn_on_with_speed(hass: HomeAssistant, device_factory) -> None:
     assert state.attributes[ATTR_PERCENTAGE] == 100
 
 
-async def test_set_percentage(hass: HomeAssistant, device_factory) -> None:
+async def test_turn_off_with_speed_speed_capability(
+    hass: HomeAssistant, device_factory
+) -> None:
+    """Test the fan turns off with the speed."""
+    # Arrange
+    device = device_factory(
+        "Fan 1",
+        capabilities=[Capability.switch, Capability.fan_speed],
+        status={Attribute.switch: "on", Attribute.fan_speed: 100},
+    )
+    await setup_platform(hass, FAN_DOMAIN, devices=[device])
+    # Act
+    await hass.services.async_call(
+        "fan",
+        "set_percentage",
+        {ATTR_ENTITY_ID: "fan.fan_1", ATTR_PERCENTAGE: 0},
+        blocking=True,
+    )
+    # Assert
+    state = hass.states.get("fan.fan_1")
+    assert state is not None
+    assert state.state == "off"
+
+
+async def test_set_percentage_speed_capability(
+    hass: HomeAssistant, device_factory
+) -> None:
     """Test setting to specific fan speed."""
     # Arrange
     device = device_factory(
@@ -162,7 +274,9 @@ async def test_set_percentage(hass: HomeAssistant, device_factory) -> None:
     assert state.attributes[ATTR_PERCENTAGE] == 100
 
 
-async def test_update_from_signal(hass: HomeAssistant, device_factory) -> None:
+async def test_update_from_signal_speed_capability(
+    hass: HomeAssistant, device_factory
+) -> None:
     """Test the fan updates when receiving a signal."""
     # Arrange
     device = device_factory(
@@ -197,8 +311,12 @@ async def test_unload_config_entry(hass: HomeAssistant, device_factory) -> None:
     assert hass.states.get("fan.fan_1").state == STATE_UNAVAILABLE
 
 
-async def test_entity_state_preset_modes(hass: HomeAssistant, device_factory) -> None:
-    """Tests the state attributes properly match the fan preset mode."""
+# Preset Mode Tests
+
+
+async def test_turn_off_mode_capability(hass: HomeAssistant, device_factory) -> None:
+    """Test the fan turns of successfully."""
+    # Arrange
     device = device_factory(
         "Fan 1",
         capabilities=[Capability.switch, Capability.air_conditioner_fan_mode],
@@ -209,15 +327,69 @@ async def test_entity_state_preset_modes(hass: HomeAssistant, device_factory) ->
         },
     )
     await setup_platform(hass, FAN_DOMAIN, devices=[device])
-
-    # Dimmer 1
+    # Act
+    await hass.services.async_call(
+        "fan", "turn_off", {"entity_id": "fan.fan_1"}, blocking=True
+    )
+    # Assert
     state = hass.states.get("fan.fan_1")
-    assert state.state == "on"
-    assert state.attributes[ATTR_SUPPORTED_FEATURES] == FanEntityFeature.PRESET_MODE
+    assert state is not None
+    assert state.state == "off"
     assert state.attributes[ATTR_PRESET_MODE] == "high"
 
 
-async def test_set_preset_mode(hass: HomeAssistant, device_factory) -> None:
+async def test_turn_on_mode_capability(hass: HomeAssistant, device_factory) -> None:
+    """Test the fan turns of successfully."""
+    # Arrange
+    device = device_factory(
+        "Fan 1",
+        capabilities=[Capability.switch, Capability.air_conditioner_fan_mode],
+        status={
+            Attribute.switch: "off",
+            Attribute.fan_mode: "high",
+            Attribute.supported_ac_fan_modes: ["high", "low", "medium"],
+        },
+    )
+    await setup_platform(hass, FAN_DOMAIN, devices=[device])
+    # Act
+    await hass.services.async_call(
+        "fan", "turn_on", {ATTR_ENTITY_ID: "fan.fan_1"}, blocking=True
+    )
+    # Assert
+    state = hass.states.get("fan.fan_1")
+    assert state is not None
+    assert state.state == "on"
+    assert state.attributes[ATTR_PRESET_MODE] == "high"
+
+
+async def test_update_from_signal_mode_capability(
+    hass: HomeAssistant, device_factory
+) -> None:
+    """Test the fan updates when receiving a signal."""
+    # Arrange
+    device = device_factory(
+        "Fan 1",
+        capabilities=[Capability.switch, Capability.air_conditioner_fan_mode],
+        status={
+            Attribute.switch: "off",
+            Attribute.fan_mode: "high",
+            Attribute.supported_ac_fan_modes: ["high", "low", "medium"],
+        },
+    )
+    await setup_platform(hass, FAN_DOMAIN, devices=[device])
+    await device.switch_on(True)
+    # Act
+    async_dispatcher_send(hass, SIGNAL_SMARTTHINGS_UPDATE, [device.device_id])
+    # Assert
+    await hass.async_block_till_done()
+    state = hass.states.get("fan.fan_1")
+    assert state is not None
+    assert state.state == "on"
+
+
+async def test_set_preset_mode_mode_capability(
+    hass: HomeAssistant, device_factory
+) -> None:
     """Test setting to specific fan mode."""
     # Arrange
     device = device_factory(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add in the ability for a fan entity to be created on fan speed or on a fan mode. Some functionality is only supported in fan modes such as the Samsung AX90 Air purifier. As per #31230 This has been an issue for upwards of 2 years. I have forked this and made my own custom integration that resolves this as I was led to believe that the integration was stale but I see that @gjohansson-ST had a PR merged for smartthings, so I thought I would give it a go to get the fix into core.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31230
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
