### PR TITLE
Fix caldav todo item completed status

### DIFF
--- a/homeassistant/components/caldav/todo.py
+++ b/homeassistant/components/caldav/todo.py
@@ -146,8 +146,9 @@ class WebDavTodoListEntity(TodoListEntity):
         """Update a To-do item."""
         uid: str = cast(str, item.uid)
         try:
-            todo: caldav.Todo = await self.hass.async_add_executor_job(
-                self._calendar.todo_by_uid, uid
+            todo: caldav.Todo = cast(
+                caldav.Todo,
+                await self.hass.async_add_executor_job(self._calendar.todo_by_uid, uid),
             )
         except NotFoundError as err:
             raise HomeAssistantError(f"Could not find To-do item {uid}") from err

--- a/homeassistant/components/caldav/todo.py
+++ b/homeassistant/components/caldav/todo.py
@@ -38,6 +38,7 @@ TODO_STATUS_MAP = {
     "CANCELLED": TodoItemStatus.COMPLETED,
 }
 
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -124,12 +125,11 @@ class WebDavTodoListEntity(TodoListEntity):
         item_data: dict[str, Any] = {}
         if summary := item.summary:
             item_data["summary"] = summary
-        if status := item.status:
-            item_data["status"] = "NEEDS-ACTION"
         if due := item.due:
             item_data["due"] = due
         if description := item.description:
             item_data["description"] = description
+        item_data["status"] = "NEEDS-ACTION"
         try:
             await self.hass.async_add_executor_job(
                 partial(self._calendar.save_todo, **item_data),

--- a/homeassistant/components/caldav/todo.py
+++ b/homeassistant/components/caldav/todo.py
@@ -146,7 +146,7 @@ class WebDavTodoListEntity(TodoListEntity):
         """Update a To-do item."""
         uid: str = cast(str, item.uid)
         try:
-            todo: Todo = await self.hass.async_add_executor_job(
+            todo: caldav.Todo = await self.hass.async_add_executor_job(
                 self._calendar.todo_by_uid, uid
             )
         except NotFoundError as err:

--- a/tests/components/caldav/test_todo.py
+++ b/tests/components/caldav/test_todo.py
@@ -544,7 +544,7 @@ async def test_update_item_failure(
     calendar.todo_by_uid = MagicMock(return_value=item)
     dav_client.put.side_effect = DAVError()
 
-    with pytest.raises(HomeAssistantError, match="CalDAV save error"):
+    with pytest.raises(HomeAssistantError, match="CalDAV completed error"):
         await hass.services.async_call(
             TODO_DOMAIN,
             "update_item",


### PR DESCRIPTION

## Proposed change

Currently, a caldav todo item is marked completed only by changing it's status.
It looks the proper way includes setting the VTODO `COMPLETED` property with the date of completion.
The caldav library actually nicely does that for us through the `complete()` function.

This implements it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/nextcloud/tasks/issues/2428
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
