### PR TITLE
Enable strict typing for amberelectric

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -58,6 +58,7 @@ homeassistant.components.alarm_control_panel.*
 homeassistant.components.alert.*
 homeassistant.components.alexa.*
 homeassistant.components.amazon_polly.*
+homeassistant.components.amberelectric.*
 homeassistant.components.ambient_station.*
 homeassistant.components.amcrest.*
 homeassistant.components.ampio.*

--- a/homeassistant/components/amberelectric/binary_sensor.py
+++ b/homeassistant/components/amberelectric/binary_sensor.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import Any
 
 from homeassistant.components.binary_sensor import (
@@ -45,14 +44,14 @@ class AmberPriceGridSensor(
     @property
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
-        return self.coordinator.data["grid"][self.entity_description.key]
+        return self.coordinator.data["grid"][self.entity_description.key]  # type: ignore[no-any-return]
 
 
 class AmberPriceSpikeBinarySensor(AmberPriceGridSensor):
     """Sensor to show single grid binary values."""
 
     @property
-    def icon(self):
+    def icon(self) -> str:
         """Return the sensor icon."""
         status = self.coordinator.data["grid"]["price_spike"]
         return PRICE_SPIKE_ICONS[status]
@@ -60,10 +59,10 @@ class AmberPriceSpikeBinarySensor(AmberPriceGridSensor):
     @property
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
-        return self.coordinator.data["grid"]["price_spike"] == "spike"
+        return self.coordinator.data["grid"]["price_spike"] == "spike"  # type: ignore[no-any-return]
 
     @property
-    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional pieces of information about the price spike."""
 
         spike_status = self.coordinator.data["grid"]["price_spike"]
@@ -80,10 +79,10 @@ async def async_setup_entry(
     """Set up a config entry."""
     coordinator: AmberUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
-    entities: list = []
     price_spike_description = BinarySensorEntityDescription(
         key="price_spike",
         name=f"{entry.title} - Price Spike",
     )
-    entities.append(AmberPriceSpikeBinarySensor(coordinator, price_spike_description))
-    async_add_entities(entities)
+    async_add_entities(
+        [AmberPriceSpikeBinarySensor(coordinator, price_spike_description)]
+    )

--- a/homeassistant/components/amberelectric/config_flow.py
+++ b/homeassistant/components/amberelectric/config_flow.py
@@ -28,10 +28,10 @@ class AmberElectricConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def _fetch_sites(self, token: str) -> list[Site] | None:
         configuration = amberelectric.Configuration(access_token=token)
-        api = amber_api.AmberApi.create(configuration)
+        api: amber_api.AmberApi = amber_api.AmberApi.create(configuration)
 
         try:
-            sites = api.get_sites()
+            sites: list[Site] = api.get_sites()
             if len(sites) == 0:
                 self._errors[CONF_API_TOKEN] = "no_site"
                 return None

--- a/homeassistant/components/amberelectric/coordinator.py
+++ b/homeassistant/components/amberelectric/coordinator.py
@@ -30,19 +30,19 @@ def is_forecast(interval: ActualInterval | CurrentInterval | ForecastInterval) -
 
 def is_general(interval: ActualInterval | CurrentInterval | ForecastInterval) -> bool:
     """Return true if the supplied interval is on the general channel."""
-    return interval.channel_type == ChannelType.GENERAL
+    return interval.channel_type == ChannelType.GENERAL  # type: ignore[no-any-return]
 
 
 def is_controlled_load(
     interval: ActualInterval | CurrentInterval | ForecastInterval,
 ) -> bool:
     """Return true if the supplied interval is on the controlled load channel."""
-    return interval.channel_type == ChannelType.CONTROLLED_LOAD
+    return interval.channel_type == ChannelType.CONTROLLED_LOAD  # type: ignore[no-any-return]
 
 
 def is_feed_in(interval: ActualInterval | CurrentInterval | ForecastInterval) -> bool:
     """Return true if the supplied interval is on the feed in channel."""
-    return interval.channel_type == ChannelType.FEED_IN
+    return interval.channel_type == ChannelType.FEED_IN  # type: ignore[no-any-return]
 
 
 def normalize_descriptor(descriptor: Descriptor) -> str | None:

--- a/homeassistant/components/amberelectric/sensor.py
+++ b/homeassistant/components/amberelectric/sensor.py
@@ -7,7 +7,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import Any
 
 from amberelectric.model.channel import ChannelType
@@ -86,7 +85,7 @@ class AmberPriceSensor(AmberSensor):
         return format_cents_to_dollars(interval.per_kwh)
 
     @property
-    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+    def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return additional pieces of information about the price."""
         interval = self.coordinator.data[self.entity_description.key][self.channel_type]
 
@@ -133,7 +132,7 @@ class AmberForecastSensor(AmberSensor):
         return format_cents_to_dollars(interval.per_kwh)
 
     @property
-    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+    def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return additional pieces of information about the price."""
         intervals = self.coordinator.data[self.entity_description.key].get(
             self.channel_type
@@ -177,7 +176,7 @@ class AmberPriceDescriptorSensor(AmberSensor):
     @property
     def native_value(self) -> str | None:
         """Return the current price descriptor."""
-        return self.coordinator.data[self.entity_description.key][self.channel_type]
+        return self.coordinator.data[self.entity_description.key][self.channel_type]  # type: ignore[no-any-return]
 
 
 class AmberGridSensor(CoordinatorEntity[AmberUpdateCoordinator], SensorEntity):
@@ -199,7 +198,7 @@ class AmberGridSensor(CoordinatorEntity[AmberUpdateCoordinator], SensorEntity):
     @property
     def native_value(self) -> str | None:
         """Return the value of the sensor."""
-        return self.coordinator.data["grid"][self.entity_description.key]
+        return self.coordinator.data["grid"][self.entity_description.key]  # type: ignore[no-any-return]
 
 
 async def async_setup_entry(
@@ -213,7 +212,7 @@ async def async_setup_entry(
     current: dict[str, CurrentInterval] = coordinator.data["current"]
     forecasts: dict[str, list[ForecastInterval]] = coordinator.data["forecasts"]
 
-    entities: list = []
+    entities: list[SensorEntity] = []
     for channel_type in current:
         description = SensorEntityDescription(
             key="current",

--- a/mypy.ini
+++ b/mypy.ini
@@ -340,6 +340,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.amberelectric.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.ambient_station.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true


### PR DESCRIPTION
## Proposed change
Improve annotations and enable strict typing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
