### PR TITLE
Enable strict typing for apache_kafka

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -66,6 +66,7 @@ homeassistant.components.android_ip_webcam.*
 homeassistant.components.androidtv_remote.*
 homeassistant.components.anova.*
 homeassistant.components.anthemav.*
+homeassistant.components.apache_kafka.*
 homeassistant.components.apcupsd.*
 homeassistant.components.apprise.*
 homeassistant.components.aqualogic.*

--- a/homeassistant/components/apache_kafka/__init__.py
+++ b/homeassistant/components/apache_kafka/__init__.py
@@ -1,7 +1,10 @@
 """Support for Apache Kafka."""
+from __future__ import annotations
+
 from datetime import datetime
 import json
 import sys
+from typing import Any, Literal
 
 import voluptuous as vol
 
@@ -15,11 +18,12 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entityfilter import FILTER_SCHEMA
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.entityfilter import FILTER_SCHEMA, EntityFilter
+from homeassistant.helpers.event import EventStateChangedData
+from homeassistant.helpers.typing import ConfigType, EventType
 from homeassistant.util import ssl as ssl_util
 
 if sys.version_info < (3, 12):
@@ -84,11 +88,11 @@ class DateTimeJSONEncoder(json.JSONEncoder):
     Additionally add encoding for datetime objects as isoformat.
     """
 
-    def default(self, o):
+    def default(self, o: Any) -> str:
         """Implement encoding logic."""
         if isinstance(o, datetime):
             return o.isoformat()
-        return super().default(o)
+        return super().default(o)  # type: ignore[no-any-return]
 
 
 class KafkaManager:
@@ -96,15 +100,15 @@ class KafkaManager:
 
     def __init__(
         self,
-        hass,
-        ip_address,
-        port,
-        topic,
-        entities_filter,
-        security_protocol,
-        username,
-        password,
-    ):
+        hass: HomeAssistant,
+        ip_address: str,
+        port: int,
+        topic: str,
+        entities_filter: EntityFilter,
+        security_protocol: Literal["PLAINTEXT", "SASL_SSL"],
+        username: str | None,
+        password: str | None,
+    ) -> None:
         """Initialize."""
         self._encoder = DateTimeJSONEncoder()
         self._entities_filter = entities_filter
@@ -121,30 +125,30 @@ class KafkaManager:
         )
         self._topic = topic
 
-    def _encode_event(self, event):
+    def _encode_event(self, event: EventType[EventStateChangedData]) -> bytes | None:
         """Translate events into a binary JSON payload."""
-        state = event.data.get("new_state")
+        state = event.data["new_state"]
         if (
             state is None
             or state.state in (STATE_UNKNOWN, "", STATE_UNAVAILABLE)
             or not self._entities_filter(state.entity_id)
         ):
-            return
+            return None
 
         return json.dumps(obj=state.as_dict(), default=self._encoder.encode).encode(
             "utf-8"
         )
 
-    async def start(self):
+    async def start(self) -> None:
         """Start the Kafka manager."""
-        self._hass.bus.async_listen(EVENT_STATE_CHANGED, self.write)
+        self._hass.bus.async_listen(EVENT_STATE_CHANGED, self.write)  # type: ignore[arg-type]
         await self._producer.start()
 
-    async def shutdown(self, _):
+    async def shutdown(self, _: Event) -> None:
         """Shut the manager down."""
         await self._producer.stop()
 
-    async def write(self, event):
+    async def write(self, event: EventType[EventStateChangedData]) -> None:
         """Write a binary payload to Kafka."""
         payload = self._encode_event(event)
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -420,6 +420,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.apache_kafka.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.apcupsd.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true


### PR DESCRIPTION
## Proposed change
Improve annotations and enable strict typing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
