### PR TITLE
Enable strict typing for aruba

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -70,6 +70,7 @@ homeassistant.components.apcupsd.*
 homeassistant.components.apprise.*
 homeassistant.components.aqualogic.*
 homeassistant.components.aranet.*
+homeassistant.components.aruba.*
 homeassistant.components.aseko_pool_live.*
 homeassistant.components.assist_pipeline.*
 homeassistant.components.asuswrt.*

--- a/homeassistant/components/aruba/device_tracker.py
+++ b/homeassistant/components/aruba/device_tracker.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import re
+from typing import Any
 
 import pexpect
 import voluptuous as vol
@@ -44,33 +45,33 @@ def get_scanner(hass: HomeAssistant, config: ConfigType) -> ArubaDeviceScanner |
 class ArubaDeviceScanner(DeviceScanner):
     """Class which queries a Aruba Access Point for connected devices."""
 
-    def __init__(self, config):
+    def __init__(self, config: dict[str, Any]) -> None:
         """Initialize the scanner."""
-        self.host = config[CONF_HOST]
-        self.username = config[CONF_USERNAME]
-        self.password = config[CONF_PASSWORD]
+        self.host: str = config[CONF_HOST]
+        self.username: str = config[CONF_USERNAME]
+        self.password: str = config[CONF_PASSWORD]
 
-        self.last_results = {}
+        self.last_results: dict[str, dict[str, str]] = {}
 
         # Test the router is accessible.
         data = self.get_aruba_data()
         self.success_init = data is not None
 
-    def scan_devices(self):
+    def scan_devices(self) -> list[str]:
         """Scan for new devices and return a list with found device IDs."""
         self._update_info()
-        return [client["mac"] for client in self.last_results]
+        return [client["mac"] for client in self.last_results.values()]
 
-    def get_device_name(self, device):
+    def get_device_name(self, device: str) -> str | None:
         """Return the name of the given device or None if we don't know."""
         if not self.last_results:
             return None
-        for client in self.last_results:
+        for client in self.last_results.values():
             if client["mac"] == device:
                 return client["name"]
         return None
 
-    def _update_info(self):
+    def _update_info(self) -> bool:
         """Ensure the information from the Aruba Access Point is up to date.
 
         Return boolean if scanning successful.
@@ -81,10 +82,10 @@ class ArubaDeviceScanner(DeviceScanner):
         if not (data := self.get_aruba_data()):
             return False
 
-        self.last_results = data.values()
+        self.last_results = data
         return True
 
-    def get_aruba_data(self):
+    def get_aruba_data(self) -> dict[str, dict[str, str]] | None:
         """Retrieve data from Aruba Access Point and return parsed result."""
 
         connect = f"ssh {self.username}@{self.host} -o HostKeyAlgorithms=ssh-rsa"
@@ -103,22 +104,22 @@ class ArubaDeviceScanner(DeviceScanner):
         )
         if query == 1:
             _LOGGER.error("Timeout")
-            return
+            return None
         if query == 2:
             _LOGGER.error("Unexpected response from router")
-            return
+            return None
         if query == 3:
             ssh.sendline("yes")
             ssh.expect("password:")
         elif query == 4:
             _LOGGER.error("Host key changed")
-            return
+            return None
         elif query == 5:
             _LOGGER.error("Connection refused by server")
-            return
+            return None
         elif query == 6:
             _LOGGER.error("Connection timed out")
-            return
+            return None
         ssh.sendline(self.password)
         ssh.expect("#")
         ssh.sendline("show clients")
@@ -126,7 +127,7 @@ class ArubaDeviceScanner(DeviceScanner):
         devices_result = ssh.before.split(b"\r\n")
         ssh.sendline("exit")
 
-        devices = {}
+        devices: dict[str, dict[str, str]] = {}
         for device in devices_result:
             if match := _DEVICES_REGEX.search(device.decode("utf-8")):
                 devices[match.group("ip")] = {

--- a/mypy.ini
+++ b/mypy.ini
@@ -460,6 +460,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.aruba.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.aseko_pool_live.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true


### PR DESCRIPTION
## Proposed change
Improve annotations and enable strict typing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
