### PR TITLE
Prevent toggle from calling stop on covers which do not support it

### DIFF
--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -481,7 +481,7 @@ class CoverEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     def _get_toggle_function(
         self, fns: dict[str, Callable[_P, _R]]
     ) -> Callable[_P, _R]:
-        if CoverEntityFeature.STOP | self.supported_features and (
+        if CoverEntityFeature.STOP in self.supported_features and (
             self.is_closing or self.is_opening
         ):
             return fns["stop"]

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -481,7 +481,7 @@ class CoverEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     def _get_toggle_function(
         self, fns: dict[str, Callable[_P, _R]]
     ) -> Callable[_P, _R]:
-        if CoverEntityFeature.STOP in self.supported_features and (
+        if self.supported_features & CoverEntityFeature.STOP and (
             self.is_closing or self.is_opening
         ):
             return fns["stop"]

--- a/tests/components/cover/test_init.py
+++ b/tests/components/cover/test_init.py
@@ -34,7 +34,8 @@ async def test_services(hass: HomeAssistant, enable_custom_integrations: None) -
     # ent3 = cover with simple tilt functions and no position
     # ent4 = cover with all tilt functions but no position
     # ent5 = cover with all functions
-    ent1, ent2, ent3, ent4, ent5 = platform.ENTITIES
+    # ent6 = cover with only open/close, but also reports opening/closing
+    ent1, ent2, ent3, ent4, ent5, ent6 = platform.ENTITIES
 
     # Test init all covers should be open
     assert is_open(hass, ent1)
@@ -42,6 +43,7 @@ async def test_services(hass: HomeAssistant, enable_custom_integrations: None) -
     assert is_open(hass, ent3)
     assert is_open(hass, ent4)
     assert is_open(hass, ent5)
+    assert is_open(hass, ent6)
 
     # call basic toggle services
     await call_service(hass, SERVICE_TOGGLE, ent1)
@@ -49,13 +51,15 @@ async def test_services(hass: HomeAssistant, enable_custom_integrations: None) -
     await call_service(hass, SERVICE_TOGGLE, ent3)
     await call_service(hass, SERVICE_TOGGLE, ent4)
     await call_service(hass, SERVICE_TOGGLE, ent5)
+    await call_service(hass, SERVICE_TOGGLE, ent6)
 
-    # entities without stop should be closed and with stop should be closing
+    # entities should be either closed or closing, depending on if they report transitional states
     assert is_closed(hass, ent1)
     assert is_closing(hass, ent2)
     assert is_closed(hass, ent3)
     assert is_closed(hass, ent4)
     assert is_closing(hass, ent5)
+    assert is_closing(hass, ent6)
 
     # call basic toggle services and set different cover position states
     await call_service(hass, SERVICE_TOGGLE, ent1)
@@ -65,6 +69,7 @@ async def test_services(hass: HomeAssistant, enable_custom_integrations: None) -
     await call_service(hass, SERVICE_TOGGLE, ent4)
     set_cover_position(ent5, 15)
     await call_service(hass, SERVICE_TOGGLE, ent5)
+    await call_service(hass, SERVICE_TOGGLE, ent6)
 
     # entities should be in correct state depending on the SUPPORT_STOP feature and cover position
     assert is_open(hass, ent1)
@@ -72,6 +77,7 @@ async def test_services(hass: HomeAssistant, enable_custom_integrations: None) -
     assert is_open(hass, ent3)
     assert is_open(hass, ent4)
     assert is_open(hass, ent5)
+    assert is_opening(hass, ent6)
 
     # call basic toggle services
     await call_service(hass, SERVICE_TOGGLE, ent1)
@@ -79,6 +85,7 @@ async def test_services(hass: HomeAssistant, enable_custom_integrations: None) -
     await call_service(hass, SERVICE_TOGGLE, ent3)
     await call_service(hass, SERVICE_TOGGLE, ent4)
     await call_service(hass, SERVICE_TOGGLE, ent5)
+    await call_service(hass, SERVICE_TOGGLE, ent6)
 
     # entities should be in correct state depending on the SUPPORT_STOP feature and cover position
     assert is_closed(hass, ent1)
@@ -86,6 +93,12 @@ async def test_services(hass: HomeAssistant, enable_custom_integrations: None) -
     assert is_closed(hass, ent3)
     assert is_closed(hass, ent4)
     assert is_opening(hass, ent5)
+    assert is_closing(hass, ent6)
+
+    # Without STOP but still reports opening/closing has a 4th possible toggle state
+    set_state(ent6, STATE_CLOSED)
+    await call_service(hass, SERVICE_TOGGLE, ent6)
+    assert is_opening(hass, ent6)
 
 
 def call_service(hass, service, ent):
@@ -98,6 +111,11 @@ def call_service(hass, service, ent):
 def set_cover_position(ent, position) -> None:
     """Set a position value to a cover."""
     ent._values["current_cover_position"] = position
+
+
+def set_state(ent, state) -> None:
+    """Set the state of a cover."""
+    ent._values["state"] = state
 
 
 def is_open(hass, ent):

--- a/tests/testing_config/custom_components/test/cover.py
+++ b/tests/testing_config/custom_components/test/cover.py
@@ -2,6 +2,8 @@
 
 Call init before using it in your tests to ensure clean test data.
 """
+from typing import Any
+
 from homeassistant.components.cover import CoverEntity, CoverEntityFeature
 from homeassistant.const import STATE_CLOSED, STATE_CLOSING, STATE_OPEN, STATE_OPENING
 
@@ -70,6 +72,13 @@ def init(empty=False):
                 | CoverEntityFeature.STOP_TILT
                 | CoverEntityFeature.SET_TILT_POSITION,
             ),
+            MockCover(
+                name="Simple with opening/closing cover",
+                is_on=True,
+                unique_id="unique_opening_closing_cover",
+                supported_features=CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE,
+                reports_opening_closing=True,
+            ),
         ]
     )
 
@@ -84,50 +93,59 @@ async def async_setup_platform(
 class MockCover(MockEntity, CoverEntity):
     """Mock Cover class."""
 
+    def __init__(
+        self, reports_opening_closing: bool | None = None, **values: Any
+    ) -> None:
+        """Initialize a mock cover entity."""
+
+        super().__init__(**values)
+        self._reports_opening_closing = (
+            reports_opening_closing
+            if reports_opening_closing is not None
+            else CoverEntityFeature.STOP in self.supported_features
+        )
+
     @property
     def is_closed(self):
         """Return if the cover is closed or not."""
-        if self.supported_features & CoverEntityFeature.STOP:
-            return self.current_cover_position == 0
+        if "state" in self._values and self._values["state"] == STATE_CLOSED:
+            return True
 
-        if "state" in self._values:
-            return self._values["state"] == STATE_CLOSED
-        return False
+        return self.current_cover_position == 0
 
     @property
     def is_opening(self):
         """Return if the cover is opening or not."""
-        if self.supported_features & CoverEntityFeature.STOP:
-            if "state" in self._values:
-                return self._values["state"] == STATE_OPENING
+        if "state" in self._values:
+            return self._values["state"] == STATE_OPENING
 
         return False
 
     @property
     def is_closing(self):
         """Return if the cover is closing or not."""
-        if self.supported_features & CoverEntityFeature.STOP:
-            if "state" in self._values:
-                return self._values["state"] == STATE_CLOSING
+        if "state" in self._values:
+            return self._values["state"] == STATE_CLOSING
 
         return False
 
     def open_cover(self, **kwargs) -> None:
         """Open cover."""
-        if self.supported_features & CoverEntityFeature.STOP:
+        if self._reports_opening_closing:
             self._values["state"] = STATE_OPENING
         else:
             self._values["state"] = STATE_OPEN
 
     def close_cover(self, **kwargs) -> None:
         """Close cover."""
-        if self.supported_features & CoverEntityFeature.STOP:
+        if self._reports_opening_closing:
             self._values["state"] = STATE_CLOSING
         else:
             self._values["state"] = STATE_CLOSED
 
     def stop_cover(self, **kwargs) -> None:
         """Stop cover."""
+        assert CoverEntityFeature.STOP in self.supported_features
         self._values["state"] = STATE_CLOSED if self.is_closed else STATE_OPEN
 
     @property


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Previously, it was possible for the core `CoverEntity` implementation of `toggle()` to call `stop_cover()`, even when the entity's `supported_features` did not include `CoverEntityFeature.STOP`. (#106791) The [default implementation of `stop_cover()`](https://github.com/home-assistant/core/blob/ce54a1259a2e00bebbfe21596bdba8c20cdbdde5/homeassistant/components/cover/__init__.py#L427) was a no-op, so this ended up just doing nothing.

This could only happen in the case where the entity without `STOP` support still reported an opening/closing transitional state, which is presumably unusual? The `cover` tests and the existing `MockCover` assumed that the two went hand-in-hand, at least. Nonetheless, a search turned up the following integrations where this case appears possible
* `opengarage`
* `smartthings`
* `gogogate2`
* `modbus`
* `linear_garage_door`
* `brunt`
* `tailwind`

I updated the core `CoverEntity` to map `toggle()` while opening/closing to `close_cover()`/`open_cover()`, respectively, when `stop_cover()` is not available. This seems like the most reasonable interpretation of that intent under the circumstances?

I also added support to `MockCover` and the tests for this case.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #106791
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
