### PR TITLE
Add screenlogic super chlorination support

### DIFF
--- a/homeassistant/components/screenlogic/coordinator.py
+++ b/homeassistant/components/screenlogic/coordinator.py
@@ -48,6 +48,8 @@ async def async_get_connect_info(
 class ScreenlogicDataUpdateCoordinator(DataUpdateCoordinator[None]):
     """Class to manage the data update for the Screenlogic component."""
 
+    super_chlor_entities: dict = {}
+
     def __init__(
         self,
         hass: HomeAssistant,

--- a/homeassistant/components/screenlogic/number.py
+++ b/homeassistant/components/screenlogic/number.py
@@ -2,7 +2,11 @@
 from dataclasses import dataclass
 import logging
 
-from screenlogicpy.const.common import ScreenLogicCommunicationError, ScreenLogicError
+from screenlogicpy.const.common import (
+    UNIT,
+    ScreenLogicCommunicationError,
+    ScreenLogicError,
+)
 from screenlogicpy.const.data import ATTR, DEVICE, GROUP, VALUE
 from screenlogicpy.device_const.system import EQUIPMENT_FLAG
 
@@ -11,6 +15,7 @@ from homeassistant.components.number import (
     NumberEntity,
     NumberEntityDescription,
 )
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
@@ -48,6 +53,14 @@ SUPPORTED_SCG_NUMBERS = [
     ),
 ]
 
+SUPPORTED_SUPER_CHLOR_NUMBERS = [
+    ScreenLogicNumberDescription(
+        data_root=(DEVICE.SCG, GROUP.CONFIGURATION),
+        key="super_chlor_runtime",
+        entity_category=EntityCategory.CONFIG,
+    ),
+]
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -72,6 +85,20 @@ async def async_setup_entry(
         if gateway.get_data(*scg_number_data_path):
             entities.append(ScreenLogicSCGNumber(coordinator, scg_number_description))
 
+    for scg_super_chlor_number_description in SUPPORTED_SUPER_CHLOR_NUMBERS:
+        sup_chlor_number_data_path = (
+            *scg_super_chlor_number_description.data_root,
+            scg_super_chlor_number_description.key,
+        )
+        if EQUIPMENT_FLAG.CHLORINATOR not in gateway.equipment_flags:
+            cleanup_excluded_entity(coordinator, DOMAIN, sup_chlor_number_data_path)
+            continue
+        entities.append(
+            ScreenLogicSuperChlorinationNumber(
+                coordinator, scg_super_chlor_number_description
+            )
+        )
+
     async_add_entities(entities)
 
 
@@ -87,6 +114,10 @@ class ScreenLogicNumber(ScreenLogicEntity, NumberEntity):
     ) -> None:
         """Initialize a ScreenLogic number entity."""
         super().__init__(coordinator, entity_description)
+        if entity_description.enabled_lambda:
+            self._attr_entity_registry_enabled_default = (
+                entity_description.enabled_lambda(coordinator.gateway.equipment_flags)
+            )
 
         self._attr_native_unit_of_measurement = get_ha_unit(
             self.entity_data.get(ATTR.UNIT)
@@ -130,4 +161,56 @@ class ScreenLogicSCGNumber(ScreenLogicNumber):
                 f"Failed to set '{self._data_key}' to {value}: {sle.msg}"
             ) from sle
         _LOGGER.debug("Set '%s' to %s", self._data_key, value)
+        await self._async_refresh()
+
+
+class ScreenLogicSuperChlorinationNumber(ScreenLogicNumber):
+    """Class to represent a ScreenLogic Super Chlorination number."""
+
+    _attr_native_value = 0
+    _attr_native_max_value = 72
+    _attr_native_min_value = 0
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = get_ha_unit(UNIT.HOUR)
+
+    def __init__(
+        self,
+        coordinator: ScreenlogicDataUpdateCoordinator,
+        entity_description: ScreenLogicNumberDescription,
+    ) -> None:
+        """Initialize a ScreenLogic Super Chlorinate Runtime number entity."""
+        super().__init__(coordinator, entity_description)
+        coordinator.super_chlor_entities[DOMAIN] = self
+
+    @property
+    def entity_data(self) -> dict:
+        """The data for this entity."""
+        return {
+            ATTR.NAME: "Super Chlorination Runtime",
+            ATTR.VALUE: self._attr_native_value,
+        }
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the current value."""
+
+        # Current API requires int values for this number.
+        self._attr_native_value = runtime = int(value)
+
+        sc_switch: SwitchEntity | None = self.coordinator.super_chlor_entities.get(
+            SWITCH_DOMAIN
+        )
+        if sc_switch is None or not sc_switch.is_on:
+            _LOGGER.debug(
+                "Not setting %s when 'super_chlorinate' is not on",
+                self._data_key,
+            )
+            return
+
+        try:
+            await self.gateway.async_set_scg_config(super_chlor_timer=runtime)
+        except (ScreenLogicCommunicationError, ScreenLogicError) as sle:
+            raise HomeAssistantError(
+                f"Failed to set '{self._data_key}' to {runtime}: {sle.msg}"
+            ) from sle
+        _LOGGER.debug("Set '%s' to %s", self._data_key, runtime)
         await self._async_refresh()

--- a/homeassistant/components/screenlogic/switch.py
+++ b/homeassistant/components/screenlogic/switch.py
@@ -2,31 +2,62 @@
 from dataclasses import dataclass
 import logging
 
-from screenlogicpy.const.data import ATTR, DEVICE
+from screenlogicpy.const.common import (
+    ON_OFF,
+    ScreenLogicCommunicationError,
+    ScreenLogicError,
+)
+from screenlogicpy.const.data import ATTR, DEVICE, VALUE
 from screenlogicpy.const.msg import CODE
 from screenlogicpy.device_const.circuit import GENERIC_CIRCUIT_NAMES, INTERFACE
+from screenlogicpy.device_const.system import EQUIPMENT_FLAG
 
-from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN, NumberEntity
+from homeassistant.components.switch import (
+    DOMAIN,
+    SwitchEntity,
+    SwitchEntityDescription,
+)
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN as SL_DOMAIN, LIGHT_CIRCUIT_FUNCTIONS
 from .coordinator import ScreenlogicDataUpdateCoordinator
 from .entity import (
     ScreenLogicCircuitEntity,
+    ScreenLogicEntityDescription,
     ScreenLogicPushEntityDescription,
     ScreenLogicSwitchingEntity,
 )
+from .util import cleanup_excluded_entity
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ScreenLogicSwitchDescription(
+    SwitchEntityDescription, ScreenLogicEntityDescription
+):
+    """Describes a ScreenLogic switch entity."""
 
 
 @dataclass(frozen=True)
 class ScreenLogicCircuitSwitchDescription(
     SwitchEntityDescription, ScreenLogicPushEntityDescription
 ):
-    """Describes a ScreenLogic switch entity."""
+    """Describes a ScreenLogic circuit switch entity."""
+
+
+SUPPORTED_SUPER_CHLOR_SWITCHES = [
+    ScreenLogicSwitchDescription(
+        data_root=(DEVICE.SCG,),
+        key=VALUE.SUPER_CHLORINATE,
+        entity_category=EntityCategory.CONFIG,
+    )
+]
 
 
 async def async_setup_entry(
@@ -63,6 +94,20 @@ async def async_setup_entry(
                 ),
             )
         )
+    for scg_super_chlor_switch_description in SUPPORTED_SUPER_CHLOR_SWITCHES:
+        sup_chlor_switch_data_path = (
+            *scg_super_chlor_switch_description.data_root,
+            scg_super_chlor_switch_description.key,
+        )
+        if EQUIPMENT_FLAG.CHLORINATOR not in gateway.equipment_flags:
+            cleanup_excluded_entity(coordinator, DOMAIN, sup_chlor_switch_data_path)
+            continue
+        if gateway.get_data(*sup_chlor_switch_data_path):
+            entities.append(
+                ScreenLogicSuperChlorinateSwitch(
+                    coordinator, scg_super_chlor_switch_description
+                )
+            )
 
     async_add_entities(entities)
 
@@ -71,3 +116,41 @@ class ScreenLogicCircuitSwitch(ScreenLogicCircuitEntity, SwitchEntity):
     """Class to represent a ScreenLogic Switch."""
 
     entity_description: ScreenLogicCircuitSwitchDescription
+
+
+class ScreenLogicSuperChlorinateSwitch(ScreenLogicSwitchingEntity, SwitchEntity):
+    """Class to represent a ScreenLogic Super Chlorination switch."""
+
+    entity_description: ScreenLogicSwitchDescription
+
+    def __init__(
+        self,
+        coordinator: ScreenlogicDataUpdateCoordinator,
+        entity_description: ScreenLogicSwitchDescription,
+    ) -> None:
+        """Initialize a ScreenLogic Super Chlorinate switch entity."""
+        super().__init__(coordinator, entity_description)
+        if entity_description.enabled_lambda:
+            self._attr_entity_registry_enabled_default = (
+                entity_description.enabled_lambda(coordinator.gateway.equipment_flags)
+            )
+        coordinator.super_chlor_entities[DOMAIN] = self
+
+    async def _async_set_state(self, state: ON_OFF) -> None:
+        runtime = None
+        sc_number: NumberEntity | None = self.coordinator.super_chlor_entities.get(
+            NUMBER_DOMAIN
+        )
+        if sc_number is not None and sc_number.native_value is not None:
+            runtime = int(sc_number.native_value)
+
+        try:
+            await self.gateway.async_set_scg_config(
+                super_chlorinate=state.value, super_chlor_timer=runtime
+            )
+        except (ScreenLogicCommunicationError, ScreenLogicError) as sle:
+            raise HomeAssistantError(
+                f"Failed to set '{self._data_key}' to {state.value}: {sle.msg}"
+            ) from sle
+        _LOGGER.debug("Set '%s' to %s", self._data_key, state.value)
+        await self._async_refresh()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds entities (`number`, `switch`) to configure and enable super chlorination.

Notes
- ScreenLogic controller does not accept updates to super chlorination runtime unless super chlorination is active. There is no data in the api that retains a set-but-not-enabled value for super chlorination runtime. Therefore  `ScreenLogicSuperChlorinationNumber` is not linked to api data and does not register an update with the controller unless the `ScreenLogicSuperChlorinateSwitch` is on. 
- Conversely, `ScreenLogicSuperChlorinateSwitch` always pulls the latest value from `ScreenLogicSuperChlorinationNumber` when setting the switch.
- References to the "linked" entities are stored on the coordinator in a known location so entities have direct access to each other.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
