### PR TITLE
Avoid unnecessary domain dataclass in Discovergy

### DIFF
--- a/homeassistant/components/discovergy/__init__.py
+++ b/homeassistant/components/discovergy/__init__.py
@@ -1,12 +1,9 @@
 """The Discovergy integration."""
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 from pydiscovergy import Discovergy
 from pydiscovergy.authentication import BasicAuth
 import pydiscovergy.error as discovergyError
-from pydiscovergy.models import Meter
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, Platform
@@ -20,35 +17,21 @@ from .coordinator import DiscovergyUpdateCoordinator
 PLATFORMS = [Platform.SENSOR]
 
 
-@dataclass
-class DiscovergyData:
-    """Discovergy data class to share meters and api client."""
-
-    api_client: Discovergy
-    meters: list[Meter]
-    coordinators: dict[str, DiscovergyUpdateCoordinator]
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Discovergy from a config entry."""
-    hass.data.setdefault(DOMAIN, {})
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = []
 
-    # init discovergy data class
-    discovergy_data = DiscovergyData(
-        api_client=Discovergy(
-            email=entry.data[CONF_EMAIL],
-            password=entry.data[CONF_PASSWORD],
-            httpx_client=get_async_client(hass),
-            authentication=BasicAuth(),
-        ),
-        meters=[],
-        coordinators={},
+    client = Discovergy(
+        email=entry.data[CONF_EMAIL],
+        password=entry.data[CONF_PASSWORD],
+        httpx_client=get_async_client(hass),
+        authentication=BasicAuth(),
     )
 
     try:
         # try to get meters from api to check if credentials are still valid and for later use
         # if no exception is raised everything is fine to go
-        discovergy_data.meters = await discovergy_data.api_client.meters()
+        meters = await client.meters()
     except discovergyError.InvalidLogin as err:
         raise ConfigEntryAuthFailed("Invalid email or password") from err
     except Exception as err:
@@ -57,19 +40,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ) from err
 
     # Init coordinators for meters
-    for meter in discovergy_data.meters:
+    for meter in meters:
         # Create coordinator for meter, set config entry and fetch initial data,
         # so we have data when entities are added
         coordinator = DiscovergyUpdateCoordinator(
             hass=hass,
             meter=meter,
-            discovergy_client=discovergy_data.api_client,
+            discovergy_client=client,
         )
         await coordinator.async_config_entry_first_refresh()
+        hass.data[DOMAIN][entry.entry_id].append(coordinator)
 
-        discovergy_data.coordinators[meter.meter_id] = coordinator
-
-    hass.data[DOMAIN][entry.entry_id] = discovergy_data
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))

--- a/homeassistant/components/discovergy/__init__.py
+++ b/homeassistant/components/discovergy/__init__.py
@@ -19,7 +19,7 @@ PLATFORMS = [Platform.SENSOR]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Discovergy from a config entry."""
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = []
+    hass.data.setdefault(DOMAIN, {})
 
     client = Discovergy(
         email=entry.data[CONF_EMAIL],
@@ -40,6 +40,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ) from err
 
     # Init coordinators for meters
+    coordinators = []
     for meter in meters:
         # Create coordinator for meter, set config entry and fetch initial data,
         # so we have data when entities are added
@@ -49,8 +50,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             discovergy_client=client,
         )
         await coordinator.async_config_entry_first_refresh()
-        hass.data[DOMAIN][entry.entry_id].append(coordinator)
+        coordinators.append(coordinator)
 
+    hass.data[DOMAIN][entry.entry_id] = coordinators
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))

--- a/homeassistant/components/discovergy/diagnostics.py
+++ b/homeassistant/components/discovergy/diagnostics.py
@@ -8,12 +8,11 @@ from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from . import DiscovergyData
 from .const import DOMAIN
+from .coordinator import DiscovergyUpdateCoordinator
 
 TO_REDACT_METER = {
     "serial_number",
-    "full_serial_number",
     "location",
     "full_serial_number",
     "printed_full_serial_number",
@@ -27,15 +26,16 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
     flattened_meter: list[dict] = []
     last_readings: dict[str, dict] = {}
-    data: DiscovergyData = hass.data[DOMAIN][entry.entry_id]
+    coordinators: list[DiscovergyUpdateCoordinator] = hass.data[DOMAIN][entry.entry_id]
 
-    for meter in data.meters:
+    for coordinator in coordinators:
         # make a dict of meter data and redact some data
-        flattened_meter.append(async_redact_data(asdict(meter), TO_REDACT_METER))
+        flattened_meter.append(
+            async_redact_data(asdict(coordinator.meter), TO_REDACT_METER)
+        )
 
         # get last reading for meter and make a dict of it
-        coordinator = data.coordinators[meter.meter_id]
-        last_readings[meter.meter_id] = asdict(coordinator.data)
+        last_readings[coordinator.meter.meter_id] = asdict(coordinator.data)
 
     return {
         "meters": flattened_meter,

--- a/homeassistant/components/discovergy/sensor.py
+++ b/homeassistant/components/discovergy/sensor.py
@@ -205,17 +205,16 @@ class DiscovergySensor(CoordinatorEntity[DiscovergyUpdateCoordinator], SensorEnt
         super().__init__(coordinator)
 
         self.data_key = data_key
-
         self.entity_description = description
-        self._attr_unique_id = f"{coordinator.meter.full_serial_number}-{data_key}"
+
+        meter = coordinator.meter
+        self._attr_unique_id = f"{meter.full_serial_number}-{data_key}"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, coordinator.meter.meter_id)},
-            name=f"{coordinator.meter.measurement_type.capitalize()} "
-            f"{coordinator.meter.location.street} "
-            f"{coordinator.meter.location.street_number}",
-            model=coordinator.meter.type,
+            identifiers={(DOMAIN, meter.meter_id)},
+            name=f"{meter.measurement_type.capitalize()} {meter.location.street} {meter.location.street_number}",
+            model=meter.type,
             manufacturer=MANUFACTURER,
-            serial_number=coordinator.meter.full_serial_number,
+            serial_number=meter.full_serial_number,
         )
 
     @property

--- a/homeassistant/components/discovergy/sensor.py
+++ b/homeassistant/components/discovergy/sensor.py
@@ -3,7 +3,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 
-from pydiscovergy.models import Meter, Reading
+from pydiscovergy.models import Reading
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -24,8 +24,8 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import DiscovergyData, DiscovergyUpdateCoordinator
 from .const import DOMAIN, MANUFACTURER
+from .coordinator import DiscovergyUpdateCoordinator
 
 
 def _get_and_scale(reading: Reading, key: str, scale: int) -> datetime | float | None:
@@ -165,21 +165,20 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the Discovergy sensors."""
-    data: DiscovergyData = hass.data[DOMAIN][entry.entry_id]
+    coordinators: list[DiscovergyUpdateCoordinator] = hass.data[DOMAIN][entry.entry_id]
 
     entities: list[DiscovergySensor] = []
-    for meter in data.meters:
+    for coordinator in coordinators:
         sensors: tuple[DiscovergySensorEntityDescription, ...] = ()
-        coordinator: DiscovergyUpdateCoordinator = data.coordinators[meter.meter_id]
 
         # select sensor descriptions based on meter type and combine with additional sensors
-        if meter.measurement_type == "ELECTRICITY":
+        if coordinator.meter.measurement_type == "ELECTRICITY":
             sensors = ELECTRICITY_SENSORS + ADDITIONAL_SENSORS
-        elif meter.measurement_type == "GAS":
+        elif coordinator.meter.measurement_type == "GAS":
             sensors = GAS_SENSORS + ADDITIONAL_SENSORS
 
         entities.extend(
-            DiscovergySensor(value_key, description, meter, coordinator)
+            DiscovergySensor(value_key, description, coordinator)
             for description in sensors
             for value_key in {description.key, *description.alternative_keys}
             if description.value_fn(coordinator.data, value_key, description.scale)
@@ -200,7 +199,6 @@ class DiscovergySensor(CoordinatorEntity[DiscovergyUpdateCoordinator], SensorEnt
         self,
         data_key: str,
         description: DiscovergySensorEntityDescription,
-        meter: Meter,
         coordinator: DiscovergyUpdateCoordinator,
     ) -> None:
         """Initialize the sensor."""
@@ -209,13 +207,15 @@ class DiscovergySensor(CoordinatorEntity[DiscovergyUpdateCoordinator], SensorEnt
         self.data_key = data_key
 
         self.entity_description = description
-        self._attr_unique_id = f"{meter.full_serial_number}-{data_key}"
+        self._attr_unique_id = f"{coordinator.meter.full_serial_number}-{data_key}"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, meter.meter_id)},
-            name=f"{meter.measurement_type.capitalize()} {meter.location.street} {meter.location.street_number}",
-            model=meter.type,
+            identifiers={(DOMAIN, coordinator.meter.meter_id)},
+            name=f"{coordinator.meter.measurement_type.capitalize()} "
+            f"{coordinator.meter.location.street} "
+            f"{coordinator.meter.location.street_number}",
+            model=coordinator.meter.type,
             manufacturer=MANUFACTURER,
-            serial_number=meter.full_serial_number,
+            serial_number=coordinator.meter.full_serial_number,
         )
 
     @property


### PR DESCRIPTION
## Proposed change
Avoid the unnecessary of an domain dataclass in Discovergy as we already have the necessary `meter` in the update coordinator, this way don't need to pass it via `hass.data`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
