### PR TITLE
Improve dispatcher typing

### DIFF
--- a/homeassistant/components/cast/const.py
+++ b/homeassistant/components/cast/const.py
@@ -1,4 +1,15 @@
 """Consts for Cast integration."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pychromecast.controllers.homeassistant import HomeAssistantController
+
+from homeassistant.helpers.dispatcher import SignalType
+
+if TYPE_CHECKING:
+    from .helpers import ChromecastInfo
+
 
 DOMAIN = "cast"
 
@@ -14,14 +25,16 @@ CAST_BROWSER_KEY = "cast_browser"
 
 # Dispatcher signal fired with a ChromecastInfo every time we discover a new
 # Chromecast or receive it through configuration
-SIGNAL_CAST_DISCOVERED = "cast_discovered"
+SIGNAL_CAST_DISCOVERED: SignalType[ChromecastInfo] = SignalType("cast_discovered")
 
 # Dispatcher signal fired with a ChromecastInfo every time a Chromecast is
 # removed
-SIGNAL_CAST_REMOVED = "cast_removed"
+SIGNAL_CAST_REMOVED: SignalType[ChromecastInfo] = SignalType("cast_removed")
 
 # Dispatcher signal fired when a Chromecast should show a Home Assistant Cast view.
-SIGNAL_HASS_CAST_SHOW_VIEW = "cast_show_view"
+SIGNAL_HASS_CAST_SHOW_VIEW: SignalType[
+    HomeAssistantController, str, str, str | None
+] = SignalType("cast_show_view")
 
 CONF_IGNORE_CEC = "ignore_cec"
 CONF_KNOWN_HOSTS = "known_hosts"

--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -25,6 +25,7 @@ from homeassistant.helpers import config_validation as cv, entityfilter
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import (
+    SignalType,
     async_dispatcher_connect,
     async_dispatcher_send,
 )
@@ -68,7 +69,9 @@ PLATFORMS = [Platform.BINARY_SENSOR, Platform.STT]
 SERVICE_REMOTE_CONNECT = "remote_connect"
 SERVICE_REMOTE_DISCONNECT = "remote_disconnect"
 
-SIGNAL_CLOUD_CONNECTION_STATE = "CLOUD_CONNECTION_STATE"
+SIGNAL_CLOUD_CONNECTION_STATE: SignalType[CloudConnectionState] = SignalType(
+    "CLOUD_CONNECTION_STATE"
+)
 
 STARTUP_REPAIR_DELAY = 1  # 1 hour
 

--- a/homeassistant/components/cloud/const.py
+++ b/homeassistant/components/cloud/const.py
@@ -1,4 +1,10 @@
 """Constants for the cloud component."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.helpers.dispatcher import SignalType
+
 DOMAIN = "cloud"
 DATA_PLATFORMS_SETUP = "cloud_platforms_setup"
 REQUEST_TIMEOUT = 10
@@ -64,6 +70,6 @@ CONF_SERVICEHANDLERS_SERVER = "servicehandlers_server"
 MODE_DEV = "development"
 MODE_PROD = "production"
 
-DISPATCHER_REMOTE_UPDATE = "cloud_remote_update"
+DISPATCHER_REMOTE_UPDATE: SignalType[Any] = SignalType("cloud_remote_update")
 
 STT_ENTITY_UNIQUE_ID = "cloud-speech-to-text"

--- a/homeassistant/helpers/dispatcher.py
+++ b/homeassistant/helpers/dispatcher.py
@@ -153,7 +153,7 @@ def dispatcher_send(hass: HomeAssistant, signal: str, *args: Any) -> None:
     ...
 
 
-@bind_hass
+@bind_hass  # type: ignore[misc]
 def dispatcher_send(hass: HomeAssistant, signal: str, *args: Any) -> None:
     """Send signal and data."""
     hass.loop.call_soon_threadsafe(async_dispatcher_send, hass, signal, *args)
@@ -171,7 +171,7 @@ def _format_err(signal: str, target: Callable[..., Any], *args: Any) -> str:
     ...
 
 
-def _format_err(signal: str, target: Callable[..., Any], *args: Any) -> str:
+def _format_err(signal: str, target: Callable[..., Any], *args: Any) -> str:  # type: ignore[misc]
     """Format error message."""
     return "Exception in {} when dispatching '{}': {}".format(
         # Functions wrapped in partial do not have a __name__
@@ -221,7 +221,7 @@ def async_dispatcher_send(hass: HomeAssistant, signal: str, *args: Any) -> None:
     ...
 
 
-@callback
+@callback  # type: ignore[misc]
 @bind_hass
 def async_dispatcher_send(hass: HomeAssistant, signal: str, *args: Any) -> None:
     """Send signal and data.

--- a/homeassistant/helpers/dispatcher.py
+++ b/homeassistant/helpers/dispatcher.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
 from functools import partial
 import logging
 from typing import Any, Generic, TypeVarTuple, overload
@@ -17,14 +18,17 @@ _LOGGER = logging.getLogger(__name__)
 DATA_DISPATCHER = "dispatcher"
 
 
-class SignalType(str, Generic[*_Ts]):
+@dataclass(frozen=True)
+class SignalType(Generic[*_Ts]):
     """Generic string class for signal to improve typing."""
+
+    name: str
 
 
 _DispatcherDataType = dict[
-    str,
+    SignalType[*_Ts] | str,
     dict[
-        Callable[..., Any],
+        Callable[[*_Ts], Any] | Callable[..., Any],
         HassJob[..., None | Coroutine[Any, Any, None]] | None,
     ],
 ]
@@ -46,9 +50,11 @@ def dispatcher_connect(
     ...
 
 
-@bind_hass
+@bind_hass  # type: ignore[misc]  # workaround; exclude typing of 2 overload in func def
 def dispatcher_connect(
-    hass: HomeAssistant, signal: str, target: Callable[..., None]
+    hass: HomeAssistant,
+    signal: SignalType[*_Ts],
+    target: Callable[[*_Ts], None],
 ) -> Callable[[], None]:
     """Connect a callable function to a signal."""
     async_unsub = run_callback_threadsafe(
@@ -62,27 +68,11 @@ def dispatcher_connect(
     return remove_dispatcher
 
 
-@overload
 @callback
 def _async_remove_dispatcher(
-    dispatchers: _DispatcherDataType,
-    signal: SignalType[*_Ts],
-    target: Callable[[*_Ts], Any],
-) -> None:
-    ...
-
-
-@overload
-@callback
-def _async_remove_dispatcher(
-    dispatchers: _DispatcherDataType, signal: str, target: Callable[..., Any]
-) -> None:
-    ...
-
-
-@callback
-def _async_remove_dispatcher(
-    dispatchers: _DispatcherDataType, signal: str, target: Callable[..., Any]
+    dispatchers: _DispatcherDataType[*_Ts],
+    signal: SignalType[*_Ts] | str,
+    target: Callable[[*_Ts], Any] | Callable[..., Any],
 ) -> None:
     """Remove signal listener."""
     try:
@@ -119,7 +109,9 @@ def async_dispatcher_connect(
 @callback
 @bind_hass
 def async_dispatcher_connect(
-    hass: HomeAssistant, signal: str, target: Callable[..., Any]
+    hass: HomeAssistant,
+    signal: SignalType[*_Ts] | str,
+    target: Callable[[*_Ts], Any] | Callable[..., Any],
 ) -> Callable[[], None]:
     """Connect a callable function to a signal.
 
@@ -128,7 +120,7 @@ def async_dispatcher_connect(
     if DATA_DISPATCHER not in hass.data:
         hass.data[DATA_DISPATCHER] = {}
 
-    dispatchers: _DispatcherDataType = hass.data[DATA_DISPATCHER]
+    dispatchers: _DispatcherDataType[*_Ts] = hass.data[DATA_DISPATCHER]
 
     if signal not in dispatchers:
         dispatchers[signal] = {}
@@ -153,25 +145,17 @@ def dispatcher_send(hass: HomeAssistant, signal: str, *args: Any) -> None:
     ...
 
 
-@bind_hass  # type: ignore[misc]
-def dispatcher_send(hass: HomeAssistant, signal: str, *args: Any) -> None:
+@bind_hass  # type: ignore[misc]  # workaround; exclude typing of 2 overload in func def
+def dispatcher_send(hass: HomeAssistant, signal: SignalType[*_Ts], *args: *_Ts) -> None:
     """Send signal and data."""
     hass.loop.call_soon_threadsafe(async_dispatcher_send, hass, signal, *args)
 
 
-@overload
 def _format_err(
-    signal: SignalType[*_Ts], target: Callable[[*_Ts], Any], *args: *_Ts
+    signal: SignalType[*_Ts] | str,
+    target: Callable[[*_Ts], Any] | Callable[..., Any],
+    *args: Any,
 ) -> str:
-    ...
-
-
-@overload
-def _format_err(signal: str, target: Callable[..., Any], *args: Any) -> str:
-    ...
-
-
-def _format_err(signal: str, target: Callable[..., Any], *args: Any) -> str:  # type: ignore[misc]
     """Format error message."""
     return "Exception in {} when dispatching '{}': {}".format(
         # Functions wrapped in partial do not have a __name__
@@ -181,22 +165,8 @@ def _format_err(signal: str, target: Callable[..., Any], *args: Any) -> str:  # 
     )
 
 
-@overload
 def _generate_job(
-    signal: SignalType[*_Ts], target: Callable[[*_Ts], Any]
-) -> HassJob[..., None | Coroutine[Any, Any, None]]:
-    ...
-
-
-@overload
-def _generate_job(
-    signal: str, target: Callable[..., Any]
-) -> HassJob[..., None | Coroutine[Any, Any, None]]:
-    ...
-
-
-def _generate_job(
-    signal: str, target: Callable[..., Any]
+    signal: SignalType[*_Ts] | str, target: Callable[[*_Ts], Any] | Callable[..., Any]
 ) -> HassJob[..., None | Coroutine[Any, Any, None]]:
     """Generate a HassJob for a signal and target."""
     return HassJob(
@@ -221,16 +191,18 @@ def async_dispatcher_send(hass: HomeAssistant, signal: str, *args: Any) -> None:
     ...
 
 
-@callback  # type: ignore[misc]
+@callback
 @bind_hass
-def async_dispatcher_send(hass: HomeAssistant, signal: str, *args: Any) -> None:
+def async_dispatcher_send(
+    hass: HomeAssistant, signal: SignalType[*_Ts] | str, *args: *_Ts
+) -> None:
     """Send signal and data.
 
     This method must be run in the event loop.
     """
     if (maybe_dispatchers := hass.data.get(DATA_DISPATCHER)) is None:
         return
-    dispatchers: _DispatcherDataType = maybe_dispatchers
+    dispatchers: _DispatcherDataType[*_Ts] = maybe_dispatchers
     if (target_list := dispatchers.get(signal)) is None:
         return
 

--- a/homeassistant/helpers/dispatcher.py
+++ b/homeassistant/helpers/dispatcher.py
@@ -24,6 +24,20 @@ class SignalType(Generic[*_Ts]):
 
     name: str
 
+    def __hash__(self) -> int:
+        """Return hash of name."""
+
+        return hash(self.name)
+
+    def __eq__(self, other: Any) -> bool:
+        """Check equality for dict keys to be compatible with str."""
+
+        if isinstance(other, str):
+            return self.name == other
+        if isinstance(other, SignalType):
+            return self.name == other.name
+        return False
+
 
 _DispatcherDataType = dict[
     SignalType[*_Ts] | str,

--- a/tests/helpers/test_dispatcher.py
+++ b/tests/helpers/test_dispatcher.py
@@ -50,6 +50,12 @@ async def test_signal_type(hass: HomeAssistant) -> None:
 
     assert calls == [("Hello", 2), ("World", 3)]
 
+    # Test compatibility with string keys
+    async_dispatcher_send(hass, "test", "x", 4)
+    await hass.async_block_till_done()
+
+    assert calls == [("Hello", 2), ("World", 3), ("x", 4)]
+
 
 async def test_simple_function_unsub(hass: HomeAssistant) -> None:
     """Test simple function (executor) and unsub."""

--- a/tests/helpers/test_dispatcher.py
+++ b/tests/helpers/test_dispatcher.py
@@ -5,6 +5,7 @@ import pytest
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import (
+    SignalType,
     async_dispatcher_connect,
     async_dispatcher_send,
 )
@@ -28,6 +29,26 @@ async def test_simple_function(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert calls == [3, "bla"]
+
+
+async def test_signal_type(hass: HomeAssistant) -> None:
+    """Test dispatcher with SignalType."""
+    signal: SignalType[str, int] = SignalType("test")
+    calls: list[tuple[str, int]] = []
+
+    def test_funct(data1: str, data2: int) -> None:
+        calls.append((data1, data2))
+
+    async_dispatcher_connect(hass, signal, test_funct)
+    async_dispatcher_send(hass, signal, "Hello", 2)
+    await hass.async_block_till_done()
+
+    assert calls == [("Hello", 2)]
+
+    async_dispatcher_send(hass, signal, "World", 3)
+    await hass.async_block_till_done()
+
+    assert calls == [("Hello", 2), ("World", 3)]
 
 
 async def test_simple_function_unsub(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change
An idea to improve the dispatcher typing, in particular `async_dispatcher_connect` and `async_dispatcher_send`.

```py
def funct(data1: str, data2: int) -> None:
    ...

def other_funct(data1: str, data2: int, x: int) -> None:
    ...

async_dispatcher_connect(hass, "signal", funct)
async_dispatcher_connect(hass, "signal", other_funct)  # one more required argument
async_dispatcher_send(hass, "signal", "Hello")  # missing 'data2' arg
```

At the moment there is no automated check to see if either a compatible callable is passed to `async_dispatcher_connect` or `async_dispatcher_send` is called with the right arguments.

This PR adds a new generic type `SignalType` to enable mypy to find these issues and Pylance to provide better intellisense support.

```py
SIGNAL: SignalType[str, int] = SignalType("signal")

async_dispatcher_connect(hass, SIGNAL, funct)
async_dispatcher_send(hass, SIGNAL, "Hello", 2)

async_dispatcher_connect(hass, SIGNAL, other_funct)  # mypy error
async_dispatcher_send(hass, SIGNAL, "Hello", 2, 2)  # type error; mypy can't detect that yet
```

With the updated typing the last two calls will result in type errors.
_Pylance can already detect both whereas mypy seems have a bug with the second one, unfortunately._

--
My first idea was to make `SignalType` inherit from `str` to be able to use them interchangeably. Unfortunately, that meant the type checkers would revert back to the `str` overload if the arguments didn't match defeating the whole purpose of this change. I've added custom `__hash__` and `__eq__` methods for `SignalType` to be compatible with string dict keys.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
