### PR TITLE
Improve fitbit authentication error handling

### DIFF
--- a/homeassistant/components/fitbit/application_credentials.py
+++ b/homeassistant/components/fitbit/application_credentials.py
@@ -69,6 +69,8 @@ class FitbitOAuth2Implementation(AuthImplementation):
                 )
             if err.status == HTTPStatus.UNAUTHORIZED:
                 raise FitbitAuthException(f"Unauthorized error: {err}") from err
+            if err.status == HTTPStatus.BAD_REQUEST:
+                raise FitbitAuthException(f"Bad Request error: {err}") from err
             raise FitbitApiException(f"Server error response: {err}") from err
         except aiohttp.ClientError as err:
             raise FitbitApiException(f"Client connection error: {err}") from err

--- a/tests/components/fitbit/test_init.py
+++ b/tests/components/fitbit/test_init.py
@@ -106,7 +106,13 @@ async def test_token_refresh_success(
     )
 
 
-@pytest.mark.parametrize("token_expiration_time", [12345])
+@pytest.mark.parametrize(
+    ("token_expiration_time", "server_status"),
+    [
+        (12345, HTTPStatus.UNAUTHORIZED),
+        (12345, HTTPStatus.BAD_REQUEST),
+    ],
+)
 @pytest.mark.parametrize("closing", [True, False])
 async def test_token_requires_reauth(
     hass: HomeAssistant,
@@ -114,13 +120,14 @@ async def test_token_requires_reauth(
     config_entry: MockConfigEntry,
     aioclient_mock: AiohttpClientMocker,
     setup_credentials: None,
+    server_status: HTTPStatus,
     closing: bool,
 ) -> None:
     """Test where token is expired and the refresh attempt requires reauth."""
 
     aioclient_mock.post(
         OAUTH2_TOKEN,
-        status=HTTPStatus.UNAUTHORIZED,
+        status=server_status,
         closing=closing,
     )
 

--- a/tests/components/fitbit/test_sensor.py
+++ b/tests/components/fitbit/test_sensor.py
@@ -599,21 +599,25 @@ async def test_settings_scope_config_entry(
 
 
 @pytest.mark.parametrize(
-    ("scopes"),
-    [(["heartrate"])],
+    ("scopes", "server_status"),
+    [
+        (["heartrate"], HTTPStatus.INTERNAL_SERVER_ERROR),
+        (["heartrate"], HTTPStatus.BAD_REQUEST),
+    ],
 )
 async def test_sensor_update_failed(
     hass: HomeAssistant,
     setup_credentials: None,
     integration_setup: Callable[[], Awaitable[bool]],
     requests_mock: Mocker,
+    server_status: HTTPStatus,
 ) -> None:
     """Test a failed sensor update when talking to the API."""
 
     requests_mock.register_uri(
         "GET",
         TIMESERIES_API_URL_FORMAT.format(resource="activities/heart"),
-        status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+        status_code=server_status,
     )
 
     assert await integration_setup()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve fitbit authentication error code handling by treating a 400 Bad Request as needing reauth since this can happen with credentials get invalidated. Adds test coverage for (1) oauth endpoint token refresh on startup confirming that it it initiates reauth and (2) that normal sensor updates do *not* trigger this behavior and are still just treated like failures.

Note: This is not a new issue, but an existing issue. This is tagged for the next milestone, but can happen in any upcoming milestone, and is not a release blocker.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

Issue observed on my production instance:
<img width="944" alt="Screenshot 2024-01-02 at 8 31 21 AM" src="https://github.com/home-assistant/core/assets/6026418/a4ef692c-b55c-4627-b7af-aa94349a771d">

Debug log:
```
2023-12-31 20:01:35.661 DEBUG (MainThread) [homeassistant.components.fitbit.application_credentials] Client response error status=400, body=
```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
