### PR TITLE
Improve To-do service error handling

### DIFF
--- a/homeassistant/components/todo/__init__.py
+++ b/homeassistant/components/todo/__init__.py
@@ -107,7 +107,10 @@ def _validate_supported_features(
             continue
         if not supported_features or not supported_features & desc.required_feature:
             raise ServiceValidationError(
-                f"Entity does not support setting field '{desc.service_field}'"
+                f"Entity does not support setting field '{desc.service_field}'",
+                translation_domain=DOMAIN,
+                translation_key="update_field_not_supported",
+                translation_placeholders={"service_field": desc.service_field},
             )
 
 

--- a/homeassistant/components/todo/__init__.py
+++ b/homeassistant/components/todo/__init__.py
@@ -484,7 +484,12 @@ async def _async_update_todo_item(entity: TodoListEntity, call: ServiceCall) -> 
     item = call.data["item"]
     found = _find_by_uid_or_summary(item, entity.todo_items)
     if not found:
-        raise HomeAssistantError(f"Unable to find To-do item '{item}'")
+        raise ServiceValidationError(
+            f"Unable to find To-do item '{item}'",
+            translation_domain=DOMAIN,
+            translation_key="item_not_found",
+            translation_placeholders={"item": item},
+        )
 
     _validate_supported_features(entity.supported_features, call.data)
 
@@ -512,7 +517,12 @@ async def _async_remove_todo_items(entity: TodoListEntity, call: ServiceCall) ->
     for item in call.data.get("item", []):
         found = _find_by_uid_or_summary(item, entity.todo_items)
         if not found or not found.uid:
-            raise HomeAssistantError(f"Unable to find To-do item '{item}")
+            raise ServiceValidationError(
+                f"Unable to find To-do item '{item}'",
+                translation_domain=DOMAIN,
+                translation_key="item_not_found",
+                translation_placeholders={"item": item},
+            )
         uids.append(found.uid)
     await entity.async_delete_todo_items(uids=uids)
 

--- a/homeassistant/components/todo/__init__.py
+++ b/homeassistant/components/todo/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.core import (
     SupportsResponse,
     callback,
 )
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
@@ -106,7 +106,7 @@ def _validate_supported_features(
         if desc.service_field not in call_data:
             continue
         if not supported_features or not supported_features & desc.required_feature:
-            raise ValueError(
+            raise ServiceValidationError(
                 f"Entity does not support setting field '{desc.service_field}'"
             )
 
@@ -481,7 +481,7 @@ async def _async_update_todo_item(entity: TodoListEntity, call: ServiceCall) -> 
     item = call.data["item"]
     found = _find_by_uid_or_summary(item, entity.todo_items)
     if not found:
-        raise ValueError(f"Unable to find To-do item '{item}'")
+        raise HomeAssistantError(f"Unable to find To-do item '{item}'")
 
     _validate_supported_features(entity.supported_features, call.data)
 
@@ -509,7 +509,7 @@ async def _async_remove_todo_items(entity: TodoListEntity, call: ServiceCall) ->
     for item in call.data.get("item", []):
         found = _find_by_uid_or_summary(item, entity.todo_items)
         if not found or not found.uid:
-            raise ValueError(f"Unable to find To-do item '{item}")
+            raise HomeAssistantError(f"Unable to find To-do item '{item}")
         uids.append(found.uid)
     await entity.async_delete_todo_items(uids=uids)
 

--- a/homeassistant/components/todo/strings.json
+++ b/homeassistant/components/todo/strings.json
@@ -90,5 +90,10 @@
         "completed": "Completed"
       }
     }
+  },
+  "exceptions": {
+    "update_field_not_supported": {
+      "message": "Entity does not support setting field: {service_field}"
+    }
   }
 }

--- a/homeassistant/components/todo/strings.json
+++ b/homeassistant/components/todo/strings.json
@@ -92,6 +92,9 @@
     }
   },
   "exceptions": {
+    "item_not_found": {
+      "message": "Unable to find To-do item: {item}"
+    },
     "update_field_not_supported": {
       "message": "Entity does not support setting field: {service_field}"
     }

--- a/tests/components/shopping_list/test_todo.py
+++ b/tests/components/shopping_list/test_todo.py
@@ -7,6 +7,7 @@ import pytest
 
 from homeassistant.components.todo import DOMAIN as TODO_DOMAIN
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 from tests.typing import WebSocketGenerator
 
@@ -338,7 +339,7 @@ async def test_update_invalid_item(
 ) -> None:
     """Test updating a todo item that does not exist."""
 
-    with pytest.raises(ValueError, match="Unable to find"):
+    with pytest.raises(HomeAssistantError, match="Unable to find"):
         await hass.services.async_call(
             TODO_DOMAIN,
             "update_item",

--- a/tests/components/shopping_list/test_todo.py
+++ b/tests/components/shopping_list/test_todo.py
@@ -7,7 +7,7 @@ import pytest
 
 from homeassistant.components.todo import DOMAIN as TODO_DOMAIN
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import ServiceValidationError
 
 from tests.typing import WebSocketGenerator
 
@@ -339,7 +339,7 @@ async def test_update_invalid_item(
 ) -> None:
     """Test updating a todo item that does not exist."""
 
-    with pytest.raises(HomeAssistantError, match="Unable to find"):
+    with pytest.raises(ServiceValidationError, match="Unable to find"):
         await hass.services.async_call(
             TODO_DOMAIN,
             "update_item",

--- a/tests/components/todo/test_init.py
+++ b/tests/components/todo/test_init.py
@@ -622,7 +622,7 @@ async def test_update_todo_item_service_by_summary_not_found(
 
     await create_mock_platform(hass, [test_entity])
 
-    with pytest.raises(HomeAssistantError, match="Unable to find"):
+    with pytest.raises(ServiceValidationError, match="Unable to find"):
         await hass.services.async_call(
             DOMAIN,
             "update_item",
@@ -931,7 +931,7 @@ async def test_remove_todo_item_service_by_summary_not_found(
 
     await create_mock_platform(hass, [test_entity])
 
-    with pytest.raises(HomeAssistantError, match="Unable to find"):
+    with pytest.raises(ServiceValidationError, match="Unable to find"):
         await hass.services.async_call(
             DOMAIN,
             "remove_item",

--- a/tests/components/todo/test_init.py
+++ b/tests/components/todo/test_init.py
@@ -20,7 +20,7 @@ from homeassistant.components.todo import (
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState, ConfigFlow
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import intent
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -347,12 +347,12 @@ async def test_add_item_service_raises(
         ({"item": ""}, vol.Invalid, "length of value must be at least 1"),
         (
             {"item": "Submit forms", "description": "Submit tax forms"},
-            ValueError,
+            ServiceValidationError,
             "does not support setting field 'description'",
         ),
         (
             {"item": "Submit forms", "due_date": "2023-11-17"},
-            ValueError,
+            ServiceValidationError,
             "does not support setting field 'due_date'",
         ),
         (
@@ -360,7 +360,7 @@ async def test_add_item_service_raises(
                 "item": "Submit forms",
                 "due_datetime": f"2023-11-17T17:00:00{TEST_OFFSET}",
             },
-            ValueError,
+            ServiceValidationError,
             "does not support setting field 'due_datetime'",
         ),
     ],
@@ -622,7 +622,7 @@ async def test_update_todo_item_service_by_summary_not_found(
 
     await create_mock_platform(hass, [test_entity])
 
-    with pytest.raises(ValueError, match="Unable to find"):
+    with pytest.raises(HomeAssistantError, match="Unable to find"):
         await hass.services.async_call(
             DOMAIN,
             "update_item",
@@ -681,7 +681,7 @@ async def test_update_todo_item_field_unsupported(
 
     await create_mock_platform(hass, [test_entity])
 
-    with pytest.raises(ValueError, match="does not support"):
+    with pytest.raises(ServiceValidationError, match="does not support"):
         await hass.services.async_call(
             DOMAIN,
             "update_item",
@@ -931,7 +931,7 @@ async def test_remove_todo_item_service_by_summary_not_found(
 
     await create_mock_platform(hass, [test_entity])
 
-    with pytest.raises(ValueError, match="Unable to find"):
+    with pytest.raises(HomeAssistantError, match="Unable to find"):
         await hass.services.async_call(
             DOMAIN,
             "remove_item",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update To-do service error handling to use ServiceValidationError and translations. These are now `HomeAssistantError` which allows `continue_on_error` to work.

Note: This is not a "new" problem that is a release blocker, so it can go with any upcoming patch milestone


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #105402
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
