### PR TITLE
Enable strict typing for blueprint

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -101,6 +101,7 @@ homeassistant.components.binary_sensor.*
 homeassistant.components.bitcoin.*
 homeassistant.components.blockchain.*
 homeassistant.components.blue_current.*
+homeassistant.components.blueprint.*
 homeassistant.components.bluetooth.*
 homeassistant.components.bluetooth_tracker.*
 homeassistant.components.bmw_connected_drive.*

--- a/homeassistant/components/blueprint/models.py
+++ b/homeassistant/components/blueprint/models.py
@@ -90,17 +90,17 @@ class Blueprint:
     @property
     def name(self) -> str:
         """Return blueprint name."""
-        return self.data[CONF_BLUEPRINT][CONF_NAME]
+        return self.data[CONF_BLUEPRINT][CONF_NAME]  # type: ignore[no-any-return]
 
     @property
-    def inputs(self) -> dict:
+    def inputs(self) -> dict[str, Any]:
         """Return blueprint inputs."""
-        return self.data[CONF_BLUEPRINT][CONF_INPUT]
+        return self.data[CONF_BLUEPRINT][CONF_INPUT]  # type: ignore[no-any-return]
 
     @property
-    def metadata(self) -> dict:
+    def metadata(self) -> dict[str, Any]:
         """Return blueprint metadata."""
-        return self.data[CONF_BLUEPRINT]
+        return self.data[CONF_BLUEPRINT]  # type: ignore[no-any-return]
 
     def update_metadata(self, *, source_url: str | None = None) -> None:
         """Update metadata."""
@@ -140,12 +140,12 @@ class BlueprintInputs:
         self.config_with_inputs = config_with_inputs
 
     @property
-    def inputs(self):
+    def inputs(self) -> dict[str, Any]:
         """Return the inputs."""
-        return self.config_with_inputs[CONF_USE_BLUEPRINT][CONF_INPUT]
+        return self.config_with_inputs[CONF_USE_BLUEPRINT][CONF_INPUT]  # type: ignore[no-any-return]
 
     @property
-    def inputs_with_default(self):
+    def inputs_with_default(self) -> dict[str, Any]:
         """Return the inputs and fallback to defaults."""
         no_input = set(self.blueprint.inputs) - set(self.inputs)
 
@@ -212,7 +212,7 @@ class DomainBlueprints:
         async with self._load_lock:
             self._blueprints = {}
 
-    def _load_blueprint(self, blueprint_path) -> Blueprint:
+    def _load_blueprint(self, blueprint_path: str) -> Blueprint:
         """Load a blueprint."""
         try:
             blueprint_data = yaml.load_yaml_dict(self.blueprint_folder / blueprint_path)
@@ -262,7 +262,7 @@ class DomainBlueprints:
     async def async_get_blueprint(self, blueprint_path: str) -> Blueprint:
         """Get a blueprint."""
 
-        def load_from_cache():
+        def load_from_cache() -> Blueprint:
             """Load blueprint from cache."""
             if (blueprint := self._blueprints[blueprint_path]) is None:
                 raise FailedToLoad(
@@ -337,7 +337,7 @@ class DomainBlueprints:
         return exists
 
     async def async_add_blueprint(
-        self, blueprint: Blueprint, blueprint_path: str, allow_override=False
+        self, blueprint: Blueprint, blueprint_path: str, allow_override: bool = False
     ) -> bool:
         """Add a blueprint."""
         overrides_existing = await self.hass.async_add_executor_job(
@@ -359,7 +359,7 @@ class DomainBlueprints:
 
         integration = await loader.async_get_integration(self.hass, self.domain)
 
-        def populate():
+        def populate() -> None:
             if self.blueprint_folder.exists():
                 return
 

--- a/homeassistant/components/blueprint/schemas.py
+++ b/homeassistant/components/blueprint/schemas.py
@@ -25,7 +25,7 @@ from .const import (
 )
 
 
-def version_validator(value):
+def version_validator(value: Any) -> str:
     """Validate a Home Assistant version."""
     if not isinstance(value, str):
         raise vol.Invalid("Version needs to be a string")
@@ -36,7 +36,7 @@ def version_validator(value):
         raise vol.Invalid("Version needs to be formatted as {major}.{minor}.{patch}")
 
     try:
-        parts = [int(p) for p in parts]
+        [int(p) for p in parts]
     except ValueError:
         raise vol.Invalid(
             "Major, minor and patch version needs to be an integer"

--- a/homeassistant/components/blueprint/websocket_api.py
+++ b/homeassistant/components/blueprint/websocket_api.py
@@ -18,7 +18,7 @@ from .errors import FailedToLoad, FileAlreadyExists
 
 
 @callback
-def async_setup(hass: HomeAssistant):
+def async_setup(hass: HomeAssistant) -> None:
     """Set up the websocket API."""
     websocket_api.async_register_command(hass, ws_list_blueprints)
     websocket_api.async_register_command(hass, ws_import_blueprint)
@@ -76,7 +76,7 @@ async def ws_import_blueprint(
         imported_blueprint = await importer.fetch_blueprint_from_url(hass, msg["url"])
 
     if imported_blueprint is None:
-        connection.send_error(
+        connection.send_error(  # type: ignore[unreachable]
             msg["id"], websocket_api.ERR_NOT_SUPPORTED, "This url is not supported"
         )
         return

--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -81,7 +81,7 @@ class Secrets:
 
         _LOGGER.debug("Loading %s", secret_path)
         try:
-            secrets = load_yaml(str(secret_path))
+            secrets = load_yaml(secret_path)
 
             if not isinstance(secrets, dict):
                 raise HomeAssistantError("Secrets is not a dictionary")
@@ -215,7 +215,9 @@ class SafeLineLoader(PythonSafeLoader):
 LoaderType = FastSafeLoader | PythonSafeLoader
 
 
-def load_yaml(fname: str, secrets: Secrets | None = None) -> JSON_TYPE | None:
+def load_yaml(
+    fname: str | os.PathLike[str], secrets: Secrets | None = None
+) -> JSON_TYPE | None:
     """Load a YAML file."""
     try:
         with open(fname, encoding="utf-8") as conf_file:
@@ -225,7 +227,9 @@ def load_yaml(fname: str, secrets: Secrets | None = None) -> JSON_TYPE | None:
         raise HomeAssistantError(exc) from exc
 
 
-def load_yaml_dict(fname: str, secrets: Secrets | None = None) -> dict:
+def load_yaml_dict(
+    fname: str | os.PathLike[str], secrets: Secrets | None = None
+) -> dict:
     """Load a YAML file and ensure the top level is a dict.
 
     Raise if the top level is not a dict.

--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -81,7 +81,7 @@ class Secrets:
 
         _LOGGER.debug("Loading %s", secret_path)
         try:
-            secrets = load_yaml(secret_path)
+            secrets = load_yaml(str(secret_path))
 
             if not isinstance(secrets, dict):
                 raise HomeAssistantError("Secrets is not a dictionary")

--- a/mypy.ini
+++ b/mypy.ini
@@ -770,6 +770,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.blueprint.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.bluetooth.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true


### PR DESCRIPTION
## Proposed change
Improve annotations and enable strict typing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
