### PR TITLE
Add strict typing to command_line

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -116,6 +116,7 @@ homeassistant.components.clickatell.*
 homeassistant.components.clicksend.*
 homeassistant.components.climate.*
 homeassistant.components.cloud.*
+homeassistant.components.command_line.*
 homeassistant.components.configurator.*
 homeassistant.components.cover.*
 homeassistant.components.cpuspeed.*

--- a/homeassistant/components/command_line/__init__.py
+++ b/homeassistant/components/command_line/__init__.py
@@ -200,7 +200,7 @@ async def async_load_platforms(
 
     load_coroutines: list[Coroutine[Any, Any, None]] = []
     platforms: list[Platform] = []
-    reload_configs: list[tuple] = []
+    reload_configs: list[tuple[Platform, dict[str, Any]]] = []
     for platform_config in command_line_config:
         for platform, _config in platform_config.items():
             if (mapped_platform := PLATFORM_MAPPING[platform]) not in platforms:

--- a/homeassistant/components/command_line/binary_sensor.py
+++ b/homeassistant/components/command_line/binary_sensor.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import timedelta
-from typing import Any, cast
+from datetime import datetime, timedelta
+from typing import cast
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -115,7 +115,7 @@ class CommandBinarySensor(ManualTriggerEntity, BinarySensorEntity):
     async def async_added_to_hass(self) -> None:
         """Call when entity about to be added to hass."""
         await super().async_added_to_hass()
-        await self._update_entity_state(None)
+        await self._update_entity_state()
         self.async_on_remove(
             async_track_time_interval(
                 self.hass,
@@ -126,7 +126,7 @@ class CommandBinarySensor(ManualTriggerEntity, BinarySensorEntity):
             ),
         )
 
-    async def _update_entity_state(self, now: Any) -> None:
+    async def _update_entity_state(self, now: datetime | None = None) -> None:
         """Update the state of the entity."""
         if self._process_updates is None:
             self._process_updates = asyncio.Lock()

--- a/homeassistant/components/command_line/binary_sensor.py
+++ b/homeassistant/components/command_line/binary_sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import timedelta
-from typing import cast
+from typing import Any, cast
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -126,7 +126,7 @@ class CommandBinarySensor(ManualTriggerEntity, BinarySensorEntity):
             ),
         )
 
-    async def _update_entity_state(self, now) -> None:
+    async def _update_entity_state(self, now: Any) -> None:
         """Update the state of the entity."""
         if self._process_updates is None:
             self._process_updates = asyncio.Lock()

--- a/homeassistant/components/command_line/cover.py
+++ b/homeassistant/components/command_line/cover.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, cast
 
 from homeassistant.components.cover import CoverEntity
@@ -147,7 +147,7 @@ class CommandCover(ManualTriggerEntity, CoverEntity):
         if TYPE_CHECKING:
             return None
 
-    async def _update_entity_state(self, now: Any) -> None:
+    async def _update_entity_state(self, now: datetime | None = None) -> None:
         """Update the state of the entity."""
         if self._process_updates is None:
             self._process_updates = asyncio.Lock()
@@ -186,14 +186,14 @@ class CommandCover(ManualTriggerEntity, CoverEntity):
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         await self.hass.async_add_executor_job(self._move_cover, self._command_open)
-        await self._update_entity_state(None)
+        await self._update_entity_state()
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         await self.hass.async_add_executor_job(self._move_cover, self._command_close)
-        await self._update_entity_state(None)
+        await self._update_entity_state()
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         await self.hass.async_add_executor_job(self._move_cover, self._command_stop)
-        await self._update_entity_state(None)
+        await self._update_entity_state()

--- a/homeassistant/components/command_line/cover.py
+++ b/homeassistant/components/command_line/cover.py
@@ -147,7 +147,7 @@ class CommandCover(ManualTriggerEntity, CoverEntity):
         if TYPE_CHECKING:
             return None
 
-    async def _update_entity_state(self, now) -> None:
+    async def _update_entity_state(self, now: Any) -> None:
         """Update the state of the entity."""
         if self._process_updates is None:
             self._process_updates = asyncio.Lock()

--- a/homeassistant/components/command_line/sensor.py
+++ b/homeassistant/components/command_line/sensor.py
@@ -108,7 +108,7 @@ class CommandSensor(ManualTriggerSensorEntity):
         """Initialize the sensor."""
         super().__init__(self.hass, config)
         self.data = data
-        self._attr_extra_state_attributes = {}
+        self._attr_extra_state_attributes: dict[str, Any] = {}
         self._json_attributes = json_attributes
         self._attr_native_value = None
         self._value_template = value_template
@@ -118,7 +118,7 @@ class CommandSensor(ManualTriggerSensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra state attributes."""
-        return cast(dict, self._attr_extra_state_attributes)
+        return self._attr_extra_state_attributes
 
     async def async_added_to_hass(self) -> None:
         """Call when entity about to be added to hass."""
@@ -134,7 +134,7 @@ class CommandSensor(ManualTriggerSensorEntity):
             ),
         )
 
-    async def _update_entity_state(self, now) -> None:
+    async def _update_entity_state(self, now: Any) -> None:
         """Update the state of the entity."""
         if self._process_updates is None:
             self._process_updates = asyncio.Lock()

--- a/homeassistant/components/command_line/sensor.py
+++ b/homeassistant/components/command_line/sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping
-from datetime import timedelta
+from datetime import datetime, timedelta
 import json
 from typing import Any, cast
 
@@ -123,7 +123,7 @@ class CommandSensor(ManualTriggerSensorEntity):
     async def async_added_to_hass(self) -> None:
         """Call when entity about to be added to hass."""
         await super().async_added_to_hass()
-        await self._update_entity_state(None)
+        await self._update_entity_state()
         self.async_on_remove(
             async_track_time_interval(
                 self.hass,
@@ -134,7 +134,7 @@ class CommandSensor(ManualTriggerSensorEntity):
             ),
         )
 
-    async def _update_entity_state(self, now: Any) -> None:
+    async def _update_entity_state(self, now: datetime | None = None) -> None:
         """Update the state of the entity."""
         if self._process_updates is None:
             self._process_updates = asyncio.Lock()

--- a/homeassistant/components/command_line/switch.py
+++ b/homeassistant/components/command_line/switch.py
@@ -155,7 +155,7 @@ class CommandSwitch(ManualTriggerEntity, SwitchEntity):
         if TYPE_CHECKING:
             return None
 
-    async def _update_entity_state(self, now) -> None:
+    async def _update_entity_state(self, now: Any) -> None:
         """Update the state of the entity."""
         if self._process_updates is None:
             self._process_updates = asyncio.Lock()

--- a/homeassistant/components/command_line/switch.py
+++ b/homeassistant/components/command_line/switch.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, cast
 
 from homeassistant.components.switch import ENTITY_ID_FORMAT, SwitchEntity
@@ -155,7 +155,7 @@ class CommandSwitch(ManualTriggerEntity, SwitchEntity):
         if TYPE_CHECKING:
             return None
 
-    async def _update_entity_state(self, now: Any) -> None:
+    async def _update_entity_state(self, now: datetime | None = None) -> None:
         """Update the state of the entity."""
         if self._process_updates is None:
             self._process_updates = asyncio.Lock()
@@ -197,11 +197,11 @@ class CommandSwitch(ManualTriggerEntity, SwitchEntity):
         if await self._switch(self._command_on) and not self._command_state:
             self._attr_is_on = True
             self.async_schedule_update_ha_state()
-        await self._update_entity_state(None)
+        await self._update_entity_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         if await self._switch(self._command_off) and not self._command_state:
             self._attr_is_on = False
             self.async_schedule_update_ha_state()
-        await self._update_entity_state(None)
+        await self._update_entity_state()

--- a/mypy.ini
+++ b/mypy.ini
@@ -920,6 +920,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.command_line.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.configurator.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true


### PR DESCRIPTION
## Proposed change
Improve annotations and enable strict typing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
