### PR TITLE
Add moon phases calendar

### DIFF
--- a/homeassistant/components/moon/__init__.py
+++ b/homeassistant/components/moon/__init__.py
@@ -70,14 +70,16 @@ def get_moon_phases(
         current_date: datetime.datetime, current_phase: str
     ) -> datetime.datetime | None:
         """Get end date moon phase."""
+        date_moon_phase: datetime.datetime | None = None
         for date_phase in generate_daterange(
             current_date, current_date + datetime.timedelta(days=28)
         ):
             if (
                 moon_phase := get_moon_phase(date_phase)
             ) is not None and moon_phase != current_phase:
-                return date_phase
-        return None
+                date_moon_phase = date_phase
+                break
+        return date_moon_phase
 
     moon_phases = []
     moon_phase_previous = None

--- a/homeassistant/components/moon/__init__.py
+++ b/homeassistant/components/moon/__init__.py
@@ -1,8 +1,25 @@
 """The Moon integration."""
+from collections.abc import Iterable
+import datetime
+from typing import Any
+
+from astral import moon
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import PLATFORMS
+from .const import (
+    _LOGGER,
+    PLATFORMS,
+    STATE_FIRST_QUARTER,
+    STATE_FULL_MOON,
+    STATE_LAST_QUARTER,
+    STATE_NEW_MOON,
+    STATE_WANING_CRESCENT,
+    STATE_WANING_GIBBOUS,
+    STATE_WAXING_CRESCENT,
+    STATE_WAXING_GIBBOUS,
+)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -14,3 +31,79 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+def get_moon_phase(date: datetime.date) -> str:
+    """Get moon phase."""
+    state = moon.phase(date)
+
+    if state < 0.5 or state > 27.5:
+        return STATE_NEW_MOON
+    if state < 6.5:
+        return STATE_WAXING_CRESCENT
+    if state < 7.5:
+        return STATE_FIRST_QUARTER
+    if state < 13.5:
+        return STATE_WAXING_GIBBOUS
+    if state < 14.5:
+        return STATE_FULL_MOON
+    if state < 20.5:
+        return STATE_WANING_GIBBOUS
+    if state < 21.5:
+        return STATE_LAST_QUARTER
+    return STATE_WANING_CRESCENT
+
+
+def get_moon_phases(
+    start_date: datetime.datetime, end_date: datetime.datetime
+) -> list[dict[str, Any]]:
+    """Get moon phases for a range of dates."""
+
+    def generate_daterange(
+        start_date: datetime.datetime, end_date: datetime.datetime
+    ) -> Iterable[datetime.datetime]:
+        """Generate a range of dates."""
+        for n in range(int((end_date - start_date).days)):
+            yield start_date + datetime.timedelta(n)
+
+    def end_date_moon_phase(
+        current_date: datetime.datetime, current_phase: str
+    ) -> datetime.datetime | None:
+        """Get end date moon phase."""
+        for date_phase in generate_daterange(
+            current_date, current_date + datetime.timedelta(days=28)
+        ):
+            if (
+                moon_phase := get_moon_phase(date_phase)
+            ) is not None and moon_phase != current_phase:
+                return date_phase
+        return None
+
+    moon_phases = []
+    moon_phase_previous = None
+    for date_phase in generate_daterange(
+        start_date,
+        end_date
+        if end_date > start_date
+        else (start_date + datetime.timedelta(days=1)),
+    ):
+        moon_phase = None
+        if (
+            moon_phase := get_moon_phase(date_phase)
+        ) is not None and moon_phase != moon_phase_previous:
+            end: datetime.datetime | None = end_date_moon_phase(date_phase, moon_phase)
+            moon_phases.append(
+                {
+                    "date": date_phase.date(),
+                    "phase": moon_phase,
+                    "end": end.date() if end is not None else date_phase.date(),
+                }
+            )
+            moon_phase_previous = moon_phase
+    _LOGGER.debug(
+        "Get moon phases: start=%s, end=%s, result=%s",
+        start_date,
+        end_date,
+        moon_phases,
+    )
+    return moon_phases

--- a/homeassistant/components/moon/calendar.py
+++ b/homeassistant/components/moon/calendar.py
@@ -12,7 +12,28 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
 
 from . import get_moon_phases
-from .const import DOMAIN
+from .const import (
+    DOMAIN,
+    STATE_FIRST_QUARTER,
+    STATE_FULL_MOON,
+    STATE_LAST_QUARTER,
+    STATE_NEW_MOON,
+    STATE_WANING_CRESCENT,
+    STATE_WANING_GIBBOUS,
+    STATE_WAXING_CRESCENT,
+    STATE_WAXING_GIBBOUS,
+)
+
+MOON_SUMMARY = {
+    STATE_FIRST_QUARTER: "First quarter",
+    STATE_FULL_MOON: "Full moon",
+    STATE_LAST_QUARTER: "Last quarter",
+    STATE_NEW_MOON: "New moon",
+    STATE_WANING_CRESCENT: "Waning crescent",
+    STATE_WANING_GIBBOUS: "Waning gibbous",
+    STATE_WAXING_CRESCENT: "Waxing crescent",
+    STATE_WAXING_GIBBOUS: "Waxing gibbous",
+}
 
 
 async def async_setup_entry(
@@ -62,18 +83,16 @@ class MoonCalendarEntity(CalendarEntity):
     @property
     def event(self) -> CalendarEvent | None:
         """Return the next upcoming moon    phase."""
-        next_moon_phase = None
+        summary: str
         for moon_phase in self._obj_moon_phases:
             if moon_phase["date"] >= dt_util.now().date():
+                summary = MOON_SUMMARY.get(moon_phase["phase"], moon_phase["phase"])
                 next_moon_phase = (
                     moon_phase["date"],
-                    moon_phase["phase"],
+                    summary,
                     moon_phase["end"],
                 )
                 break
-
-        if next_moon_phase is None:
-            return None
 
         return CalendarEvent(
             summary=next_moon_phase[1],
@@ -94,8 +113,9 @@ class MoonCalendarEntity(CalendarEntity):
                 end_date is not None
                 and start_date.date() <= moon_phase["date"] <= end_date.date()
             ):
+                summary = MOON_SUMMARY.get(moon_phase["phase"], moon_phase["phase"])
                 event = CalendarEvent(
-                    summary=moon_phase["phase"],
+                    summary=summary,
                     start=moon_phase["date"],
                     end=moon_phase["end"],
                 )

--- a/homeassistant/components/moon/calendar.py
+++ b/homeassistant/components/moon/calendar.py
@@ -1,0 +1,104 @@
+"""Moon phase Calendar."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+
+from homeassistant.components.calendar import CalendarEntity, CalendarEvent
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import dt as dt_util
+
+from . import get_moon_phases
+from .const import DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Moon phase Calendar config entry."""
+
+    obj_moon_phases = get_moon_phases(
+        dt_util.now(), (dt_util.now() + timedelta(days=30))
+    )
+
+    async_add_entities(
+        [
+            MoonCalendarEntity(
+                config_entry.title,
+                obj_moon_phases,
+                config_entry.entry_id,
+            )
+        ],
+        True,
+    )
+
+
+class MoonCalendarEntity(CalendarEntity):
+    """Representation of a Moon Phase Calendar element."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "moon_phases"
+
+    def __init__(
+        self,
+        name: str,
+        obj_moon_phases: list[dict[str, Any]],
+        unique_id: str,
+    ) -> None:
+        """Initialize MoonCalendarEntity."""
+        self._attr_unique_id = unique_id
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, unique_id)},
+            entry_type=DeviceEntryType.SERVICE,
+            name=name,
+        )
+        self._obj_moon_phases = obj_moon_phases
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        """Return the next upcoming moon    phase."""
+        next_moon_phase = None
+        for moon_phase in self._obj_moon_phases:
+            if moon_phase["date"] >= dt_util.now().date():
+                next_moon_phase = (
+                    moon_phase["date"],
+                    moon_phase["phase"],
+                    moon_phase["end"],
+                )
+                break
+
+        if next_moon_phase is None:
+            return None
+
+        return CalendarEvent(
+            summary=next_moon_phase[1],
+            start=next_moon_phase[0],
+            end=next_moon_phase[2],
+        )
+
+    async def async_get_events(
+        self, hass: HomeAssistant, start_date: datetime, end_date: datetime
+    ) -> list[CalendarEvent]:
+        """Get all events in a specific time frame."""
+        obj_moon_phases = get_moon_phases(start_date, end_date)
+
+        event_list: list[CalendarEvent] = []
+
+        for moon_phase in obj_moon_phases:
+            if (
+                end_date is not None
+                and start_date.date() <= moon_phase["date"] <= end_date.date()
+            ):
+                event = CalendarEvent(
+                    summary=moon_phase["phase"],
+                    start=moon_phase["date"],
+                    end=moon_phase["end"],
+                )
+                event_list.append(event)
+
+        return event_list

--- a/homeassistant/components/moon/const.py
+++ b/homeassistant/components/moon/const.py
@@ -1,9 +1,21 @@
 """Constants for the Moon integration."""
+import logging
 from typing import Final
 
 from homeassistant.const import Platform
 
 DOMAIN: Final = "moon"
-PLATFORMS: Final = [Platform.SENSOR]
+PLATFORMS: Final = [Platform.SENSOR, Platform.CALENDAR]
 
 DEFAULT_NAME: Final = "Moon"
+
+_LOGGER = logging.getLogger(__name__)
+
+STATE_FIRST_QUARTER = "first_quarter"
+STATE_FULL_MOON = "full_moon"
+STATE_LAST_QUARTER = "last_quarter"
+STATE_NEW_MOON = "new_moon"
+STATE_WANING_CRESCENT = "waning_crescent"
+STATE_WANING_GIBBOUS = "waning_gibbous"
+STATE_WAXING_CRESCENT = "waxing_crescent"
+STATE_WAXING_GIBBOUS = "waxing_gibbous"

--- a/homeassistant/components/moon/sensor.py
+++ b/homeassistant/components/moon/sensor.py
@@ -1,8 +1,6 @@
 """Support for tracking the moon phases."""
 from __future__ import annotations
 
-from astral import moon
-
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -10,16 +8,18 @@ from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
 
-from .const import DOMAIN
-
-STATE_FIRST_QUARTER = "first_quarter"
-STATE_FULL_MOON = "full_moon"
-STATE_LAST_QUARTER = "last_quarter"
-STATE_NEW_MOON = "new_moon"
-STATE_WANING_CRESCENT = "waning_crescent"
-STATE_WANING_GIBBOUS = "waning_gibbous"
-STATE_WAXING_CRESCENT = "waxing_crescent"
-STATE_WAXING_GIBBOUS = "waxing_gibbous"
+from . import get_moon_phase
+from .const import (
+    DOMAIN,
+    STATE_FIRST_QUARTER,
+    STATE_FULL_MOON,
+    STATE_LAST_QUARTER,
+    STATE_NEW_MOON,
+    STATE_WANING_CRESCENT,
+    STATE_WANING_GIBBOUS,
+    STATE_WAXING_CRESCENT,
+    STATE_WAXING_GIBBOUS,
+)
 
 MOON_ICONS = {
     STATE_FIRST_QUARTER: "mdi:moon-first-quarter",
@@ -71,23 +71,6 @@ class MoonSensorEntity(SensorEntity):
     async def async_update(self) -> None:
         """Get the time and updates the states."""
         today = dt_util.now().date()
-        state = moon.phase(today)
-
-        if state < 0.5 or state > 27.5:
-            self._attr_native_value = STATE_NEW_MOON
-        elif state < 6.5:
-            self._attr_native_value = STATE_WAXING_CRESCENT
-        elif state < 7.5:
-            self._attr_native_value = STATE_FIRST_QUARTER
-        elif state < 13.5:
-            self._attr_native_value = STATE_WAXING_GIBBOUS
-        elif state < 14.5:
-            self._attr_native_value = STATE_FULL_MOON
-        elif state < 20.5:
-            self._attr_native_value = STATE_WANING_GIBBOUS
-        elif state < 21.5:
-            self._attr_native_value = STATE_LAST_QUARTER
-        else:
-            self._attr_native_value = STATE_WANING_CRESCENT
+        self._attr_native_value = get_moon_phase(today)
 
         self._attr_icon = MOON_ICONS.get(self._attr_native_value)

--- a/homeassistant/components/moon/strings.json
+++ b/homeassistant/components/moon/strings.json
@@ -11,6 +11,11 @@
     }
   },
   "entity": {
+    "calendar": {
+      "moon_phases": {
+        "name": "Phases"
+      }
+    },
     "sensor": {
       "phase": {
         "name": "Phase",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds calendar entity in Moon integration.

### To do:
- [ ] Add tests to the calendar platform
- [ ] Create PR for documentation
- [ ] Translation of calendar event descriptions: is this possible? Can anyone point me to an example?

![image](https://github.com/home-assistant/core/assets/31328123/725bcc5b-468f-4e1a-afcd-d744d473ef23)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
