### PR TITLE
Expose goodwe grid_export switch

### DIFF
--- a/homeassistant/components/goodwe/const.py
+++ b/homeassistant/components/goodwe/const.py
@@ -5,7 +5,13 @@ from homeassistant.const import Platform
 
 DOMAIN = "goodwe"
 
-PLATFORMS = [Platform.BUTTON, Platform.NUMBER, Platform.SELECT, Platform.SENSOR]
+PLATFORMS = [
+    Platform.BUTTON,
+    Platform.NUMBER,
+    Platform.SELECT,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]
 
 DEFAULT_NAME = "GoodWe"
 SCAN_INTERVAL = timedelta(seconds=10)

--- a/homeassistant/components/goodwe/switch.py
+++ b/homeassistant/components/goodwe/switch.py
@@ -1,0 +1,131 @@
+"""GoodWe PV inverter switch settings entities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from goodwe import Inverter, InverterError
+
+from homeassistant.components.switch import (
+    SwitchDeviceClass,
+    SwitchEntity,
+    SwitchEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, KEY_DEVICE_INFO, KEY_INVERTER
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class GoodweSwitchEntityDescriptionBase:
+    """Required values when describing Goodwe switch settings."""
+
+    icon_on: str
+    icon_off: str
+
+
+@dataclass(frozen=True)
+class GoodweNumberEntityDescription(
+    SwitchEntityDescription, GoodweSwitchEntityDescriptionBase
+):
+    """Class describing Goodwe switch entities."""
+
+
+SWITCHES = (
+    # Export limit Enabled
+    GoodweNumberEntityDescription(
+        key="grid_export",
+        translation_key="grid_export",
+        icon_on="mdi:transmission-tower-off",
+        icon_off="mdi:transmission-tower-export",
+        entity_category=EntityCategory.CONFIG,
+        device_class=SwitchDeviceClass.SWITCH,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the inverter switch entities from a config entry."""
+    inverter = hass.data[DOMAIN][config_entry.entry_id][KEY_INVERTER]
+    device_info = hass.data[DOMAIN][config_entry.entry_id][KEY_DEVICE_INFO]
+
+    entities = []
+
+    for description in SWITCHES:
+        try:
+            current_value = await inverter.read_setting(description.key)
+        except (InverterError, ValueError):
+            # Inverter model does not support this setting
+            _LOGGER.debug("Could not read inverter setting %s", description.key)
+            continue
+
+        entities.append(
+            InverterSwitchEntity(device_info, description, inverter, current_value == 1)
+        )
+
+    async_add_entities(entities)
+
+
+class InverterSwitchEntity(SwitchEntity):
+    """Inverter switch setting entity."""
+
+    entity_description: GoodweNumberEntityDescription
+
+    _attr_should_poll = False
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        device_info: DeviceInfo,
+        description: GoodweNumberEntityDescription,
+        inverter: Inverter,
+        current_state: bool,
+    ) -> None:
+        """Initialize the inverter switch setting entity."""
+        self.entity_description = description
+        self._attr_unique_id = f"{DOMAIN}-{description.key}-{inverter.serial_number}"
+        self._attr_device_info = device_info
+        self._attr_is_on = current_state
+        self._inverter: Inverter = inverter
+
+    @property
+    def icon(self):
+        """Return the icon to be displayed for the switch."""
+        if self._attr_is_on:
+            return self.entity_description.icon_on
+
+        return self.entity_description.icon_off
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+        await self._write_setting(1)
+        self._attr_is_on = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off."""
+        await self._write_setting(0)
+        self._attr_is_on = False
+        self.async_write_ha_state()
+
+    async def _write_setting(self, value):
+        try:
+            await self._inverter.write_setting(self.entity_description.key, value)
+        except InverterError as e:
+            _LOGGER.error(
+                "Error writing setting: %s=%s: %s",
+                self.entity_description.key,
+                value,
+                e,
+            )

--- a/homeassistant/components/goodwe/switch.py
+++ b/homeassistant/components/goodwe/switch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import logging
 from typing import Any
+from datetime import timedelta
 
 from goodwe import Inverter, InverterError
 
@@ -22,6 +23,7 @@ from .const import DOMAIN, KEY_DEVICE_INFO, KEY_INVERTER
 
 _LOGGER = logging.getLogger(__name__)
 
+SCAN_INTERVAL = timedelta(minutes=2)
 
 @dataclass(frozen=True)
 class GoodweSwitchEntityDescriptionBase:

--- a/homeassistant/components/goodwe/switch.py
+++ b/homeassistant/components/goodwe/switch.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import timedelta
 import logging
 from typing import Any
-from datetime import timedelta
 
 from goodwe import Inverter, InverterError
 
@@ -25,7 +25,8 @@ _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(minutes=2)
 
-@dataclass(frozen=True)
+
+@dataclass(frozen=True, kw_only=True)
 class GoodweSwitchEntityDescriptionBase:
     """Required values when describing Goodwe switch settings."""
 
@@ -33,7 +34,7 @@ class GoodweSwitchEntityDescriptionBase:
     icon_off: str
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class GoodweNumberEntityDescription(
     SwitchEntityDescription, GoodweSwitchEntityDescriptionBase
 ):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change exposes `grid_export` setting in addition to `grid_export_limit`.
`grid_export` enables/disables the restriction of the export, whilst `grid_export_limit` defines how much can be exported.
When `grid_export` is enabled, the inverter is taking the electricity from the grid even if we have enough PV to cover the house consumption (even if the export limit is high). It is beneficial to have `grid_export` off, and turn it on only in two scenarios:
- PV power is getting close to the reserved output
- electricity price is below 0 and it would cost money to sell the electricity



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30698

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
