### PR TITLE
Update Hydrawise from the legacy API to the new GraphQL API

### DIFF
--- a/homeassistant/components/hydrawise/__init__.py
+++ b/homeassistant/components/hydrawise/__init__.py
@@ -1,10 +1,11 @@
 """Support for Hydrawise cloud."""
 
-from pydrawise import legacy
+from pydrawise import auth, client
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_API_KEY, Platform
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 
 from .const import DOMAIN, SCAN_INTERVAL
 from .coordinator import HydrawiseDataUpdateCoordinator
@@ -14,8 +15,15 @@ PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.S
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Set up Hydrawise from a config entry."""
-    access_token = config_entry.data[CONF_API_KEY]
-    hydrawise = legacy.LegacyHydrawiseAsync(access_token)
+    if CONF_USERNAME not in config_entry.data or CONF_PASSWORD not in config_entry.data:
+        # The GraphQL API requires username and password to authenticate. If either is
+        # missing, reauth is required.
+        raise ConfigEntryAuthFailed
+
+    hydrawise = client.Hydrawise(
+        auth.Auth(config_entry.data[CONF_USERNAME], config_entry.data[CONF_PASSWORD])
+    )
+
     coordinator = HydrawiseDataUpdateCoordinator(hass, hydrawise, SCAN_INTERVAL)
     await coordinator.async_config_entry_first_refresh()
     hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = coordinator

--- a/homeassistant/components/hydrawise/config_flow.py
+++ b/homeassistant/components/hydrawise/config_flow.py
@@ -27,8 +27,8 @@ class HydrawiseConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def _create_or_update_entry(
         self,
-        username: str | None = None,
-        password: str | None = None,
+        username: str,
+        password: str,
         *,
         on_failure: Callable[[str], ConfigFlowResult],
     ) -> ConfigFlowResult:

--- a/homeassistant/components/hydrawise/config_flow.py
+++ b/homeassistant/components/hydrawise/config_flow.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Any
 
 from aiohttp import ClientError
-from pydrawise import legacy
+from pydrawise import auth, client
+from pydrawise.exceptions import NotAuthorizedError
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_API_KEY
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
 from .const import DOMAIN, LOGGER
 
@@ -20,14 +21,26 @@ class HydrawiseConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def _create_entry(
-        self, api_key: str, *, on_failure: Callable[[str], ConfigFlowResult]
+    def __init__(self) -> None:
+        """Construct a ConfigFlow."""
+        self.reauth_entry: ConfigEntry | None = None
+
+    async def _create_or_update_entry(
+        self,
+        username: str | None = None,
+        password: str | None = None,
+        *,
+        on_failure: Callable[[str], ConfigFlowResult],
     ) -> ConfigFlowResult:
         """Create the config entry."""
-        api = legacy.LegacyHydrawiseAsync(api_key)
+
+        # Verify that the provided credentials work."""
+        api = client.Hydrawise(auth.Auth(username, password))
         try:
             # Skip fetching zones to save on metered API calls.
-            user = await api.get_user(fetch_zones=False)
+            user = await api.get_user()
+        except NotAuthorizedError:
+            return on_failure("invalid_auth")
         except TimeoutError:
             return on_failure("timeout_connect")
         except ClientError as ex:
@@ -35,17 +48,33 @@ class HydrawiseConfigFlow(ConfigFlow, domain=DOMAIN):
             return on_failure("cannot_connect")
 
         await self.async_set_unique_id(f"hydrawise-{user.customer_id}")
-        self._abort_if_unique_id_configured()
 
-        return self.async_create_entry(title="Hydrawise", data={CONF_API_KEY: api_key})
+        if not self.reauth_entry:
+            self._abort_if_unique_id_configured()
+            return self.async_create_entry(
+                title="Hydrawise",
+                data={CONF_USERNAME: username, CONF_PASSWORD: password},
+            )
+
+        self.hass.config_entries.async_update_entry(
+            self.reauth_entry,
+            data=self.reauth_entry.data
+            | {CONF_USERNAME: username, CONF_PASSWORD: password},
+        )
+        await self.hass.config_entries.async_reload(self.reauth_entry.entry_id)
+        return self.async_abort(reason="reauth_successful")
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial setup."""
         if user_input is not None:
-            api_key = user_input[CONF_API_KEY]
-            return await self._create_entry(api_key, on_failure=self._show_form)
+            username = user_input[CONF_USERNAME]
+            password = user_input[CONF_PASSWORD]
+
+            return await self._create_or_update_entry(
+                username=username, password=password, on_failure=self._show_form
+            )
         return self._show_form()
 
     def _show_form(self, error_type: str | None = None) -> ConfigFlowResult:
@@ -54,6 +83,17 @@ class HydrawiseConfigFlow(ConfigFlow, domain=DOMAIN):
             errors["base"] = error_type
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema({vol.Required(CONF_API_KEY): str}),
+            data_schema=vol.Schema(
+                {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
+            ),
             errors=errors,
         )
+
+    async def async_step_reauth(
+        self, user_input: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Perform reauth after updating config to username/password."""
+        self.reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        return await self.async_step_user()

--- a/homeassistant/components/hydrawise/strings.json
+++ b/homeassistant/components/hydrawise/strings.json
@@ -2,8 +2,11 @@
   "config": {
     "step": {
       "user": {
+        "title": "Hydrawise Login",
+        "description": "Please provide the username and password for your Hydrawise cloud account:",
         "data": {
-          "api_key": "[%key:common::config_flow::data::api_key%]"
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
         }
       }
     },
@@ -13,7 +16,8 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
   "entity": {

--- a/tests/components/hydrawise/test_config_flow.py
+++ b/tests/components/hydrawise/test_config_flow.py
@@ -3,13 +3,17 @@
 from unittest.mock import AsyncMock
 
 from aiohttp import ClientError
+from pydrawise.exceptions import NotAuthorizedError
 from pydrawise.schema import User
 import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.hydrawise.const import DOMAIN
+from homeassistant.const import CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
@@ -24,21 +28,25 @@ async def test_form(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] is FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
     result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"api_key": "abc123"}
+        result["flow_id"],
+        {CONF_USERNAME: "asdf@asdf.com", CONF_PASSWORD: "__password__"},
     )
     mock_pydrawise.get_user.return_value = user
     await hass.async_block_till_done()
 
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["title"] == "Hydrawise"
-    assert result2["data"] == {"api_key": "abc123"}
+    assert result2["data"] == {
+        CONF_USERNAME: "asdf@asdf.com",
+        CONF_PASSWORD: "__password__",
+    }
     assert len(mock_setup_entry.mock_calls) == 1
-    mock_pydrawise.get_user.assert_called_once_with(fetch_zones=False)
+    mock_pydrawise.get_user.assert_called_once_with()
 
 
 async def test_form_api_error(
@@ -50,17 +58,17 @@ async def test_form_api_error(
     init_result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    data = {"api_key": "abc123"}
+    data = {CONF_USERNAME: "asdf@asdf.com", CONF_PASSWORD: "__password__"}
     result = await hass.config_entries.flow.async_configure(
         init_result["flow_id"], data
     )
-    assert result["type"] is FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}
 
     mock_pydrawise.get_user.reset_mock(side_effect=True)
     mock_pydrawise.get_user.return_value = user
     result2 = await hass.config_entries.flow.async_configure(result["flow_id"], data)
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
 
 
 async def test_form_connect_timeout(
@@ -71,15 +79,72 @@ async def test_form_connect_timeout(
     init_result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    data = {"api_key": "abc123"}
+    data = {CONF_USERNAME: "asdf@asdf.com", CONF_PASSWORD: "__password__"}
     result = await hass.config_entries.flow.async_configure(
         init_result["flow_id"], data
     )
 
-    assert result["type"] is FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["errors"] == {"base": "timeout_connect"}
 
     mock_pydrawise.get_user.reset_mock(side_effect=True)
     mock_pydrawise.get_user.return_value = user
     result2 = await hass.config_entries.flow.async_configure(result["flow_id"], data)
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+
+
+async def test_form_not_authorized_error(
+    hass: HomeAssistant, mock_pydrawise: AsyncMock, user: User
+) -> None:
+    """Test we handle API errors."""
+    mock_pydrawise.get_user.side_effect = NotAuthorizedError
+
+    init_result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    data = {CONF_USERNAME: "asdf@asdf.com", CONF_PASSWORD: "__password__"}
+    result = await hass.config_entries.flow.async_configure(
+        init_result["flow_id"], data
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+    mock_pydrawise.get_user.reset_mock(side_effect=True)
+    mock_pydrawise.get_user.return_value = user
+    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], data)
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+
+
+async def test_reauth(
+    hass: HomeAssistant,
+    user: User,
+    mock_pydrawise: AsyncMock,
+) -> None:
+    """Test that re-authorization works."""
+    mock_config_entry = MockConfigEntry(
+        title="Hydrawise",
+        domain=DOMAIN,
+        data={
+            CONF_API_KEY: "__api_key__",
+        },
+        unique_id="hydrawise-12345",
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    mock_config_entry.async_start_reauth(hass)
+    await hass.async_block_till_done()
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    [result] = flows
+    assert result["step_id"] == "user"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_USERNAME: "asdf@asdf.com", CONF_PASSWORD: "__password__"},
+    )
+    mock_pydrawise.get_user.return_value = user
+    await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "reauth_successful"

--- a/tests/components/hydrawise/test_config_flow.py
+++ b/tests/components/hydrawise/test_config_flow.py
@@ -28,7 +28,7 @@ async def test_form(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
@@ -39,7 +39,7 @@ async def test_form(
     mock_pydrawise.get_user.return_value = user
     await hass.async_block_till_done()
 
-    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["title"] == "Hydrawise"
     assert result2["data"] == {
         CONF_USERNAME: "asdf@asdf.com",
@@ -62,13 +62,13 @@ async def test_form_api_error(
     result = await hass.config_entries.flow.async_configure(
         init_result["flow_id"], data
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}
 
     mock_pydrawise.get_user.reset_mock(side_effect=True)
     mock_pydrawise.get_user.return_value = user
     result2 = await hass.config_entries.flow.async_configure(result["flow_id"], data)
-    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_form_connect_timeout(
@@ -84,13 +84,13 @@ async def test_form_connect_timeout(
         init_result["flow_id"], data
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "timeout_connect"}
 
     mock_pydrawise.get_user.reset_mock(side_effect=True)
     mock_pydrawise.get_user.return_value = user
     result2 = await hass.config_entries.flow.async_configure(result["flow_id"], data)
-    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_form_not_authorized_error(
@@ -106,13 +106,13 @@ async def test_form_not_authorized_error(
     result = await hass.config_entries.flow.async_configure(
         init_result["flow_id"], data
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_auth"}
 
     mock_pydrawise.get_user.reset_mock(side_effect=True)
     mock_pydrawise.get_user.return_value = user
     result2 = await hass.config_entries.flow.async_configure(result["flow_id"], data)
-    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_reauth(
@@ -146,5 +146,5 @@ async def test_reauth(
     mock_pydrawise.get_user.return_value = user
     await hass.async_block_till_done()
 
-    assert result2["type"] == FlowResultType.ABORT
+    assert result2["type"] is FlowResultType.ABORT
     assert result2["reason"] == "reauth_successful"

--- a/tests/components/hydrawise/test_init.py
+++ b/tests/components/hydrawise/test_init.py
@@ -19,3 +19,16 @@ async def test_connect_retry(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_update_version(
+    hass: HomeAssistant, mock_config_entry_legacy: MockConfigEntry
+) -> None:
+    """Test updating to the GaphQL API works."""
+    mock_config_entry_legacy.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry_legacy.entry_id)
+    await hass.async_block_till_done()
+    assert mock_config_entry_legacy.state is ConfigEntryState.SETUP_ERROR
+
+    # Make sure reauth flow has been initiated
+    assert any(mock_config_entry_legacy.async_get_active_flows(hass, {"reauth"}))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This change is fully backwards compatible in terms of functionality. However, 
users will have to reauthenticate.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move the Hydrawise integration from the old legacy Hydrawise API to the new
GraphQL API. This change is fully backwards compatible but will unlock new
functionality going forward.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30607

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
