### PR TITLE
Remove assert for unique_id

### DIFF
--- a/homeassistant/components/axis/device.py
+++ b/homeassistant/components/axis/device.py
@@ -3,7 +3,7 @@
 import asyncio
 from asyncio import timeout
 from types import MappingProxyType
-from typing import Any
+from typing import Any, cast
 
 import axis
 from axis.configuration import Configuration
@@ -103,8 +103,7 @@ class AxisNetworkDevice:
     @property
     def unique_id(self) -> str:
         """Return the unique ID (serial number) of this device."""
-        assert (unique_id := self.config_entry.unique_id)
-        return unique_id
+        return cast(str, self.config_entry.unique_id)
 
     # Options
 

--- a/homeassistant/components/axis/device.py
+++ b/homeassistant/components/axis/device.py
@@ -3,7 +3,7 @@
 import asyncio
 from asyncio import timeout
 from types import MappingProxyType
-from typing import Any, cast
+from typing import Any
 
 import axis
 from axis.configuration import Configuration
@@ -101,9 +101,9 @@ class AxisNetworkDevice:
         return name
 
     @property
-    def unique_id(self) -> str:
+    def unique_id(self) -> str | None:
         """Return the unique ID (serial number) of this device."""
-        return cast(str, self.config_entry.unique_id)
+        return self.config_entry.unique_id
 
     # Options
 
@@ -175,8 +175,8 @@ class AxisNetworkDevice:
         device_registry.async_get_or_create(
             config_entry_id=self.config_entry.entry_id,
             configuration_url=self.api.config.url,
-            connections={(CONNECTION_NETWORK_MAC, self.unique_id)},
-            identifiers={(AXIS_DOMAIN, self.unique_id)},
+            connections={(CONNECTION_NETWORK_MAC, self.unique_id)},  # type: ignore[arg-type]
+            identifiers={(AXIS_DOMAIN, self.unique_id)},  # type: ignore[arg-type]
             manufacturer=ATTR_MANUFACTURER,
             model=f"{self.model} {self.product_type}",
             name=self.name,

--- a/homeassistant/components/axis/entity.py
+++ b/homeassistant/components/axis/entity.py
@@ -42,7 +42,7 @@ class AxisEntity(Entity):
         self.device = device
 
         self._attr_device_info = DeviceInfo(
-            identifiers={(AXIS_DOMAIN, device.unique_id)},
+            identifiers={(AXIS_DOMAIN, device.unique_id)},  # type: ignore[arg-type]
             serial_number=device.unique_id,
         )
 


### PR DESCRIPTION
## Proposed change
Followup to https://github.com/home-assistant/core/pull/106844#discussion_r1439773088

/CC: @frenck

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
