### PR TITLE
Convert cert_expiry to use asyncio

### DIFF
--- a/homeassistant/components/cert_expiry/helper.py
+++ b/homeassistant/components/cert_expiry/helper.py
@@ -29,12 +29,11 @@ async def async_get_cert(
     port: int,
 ) -> dict[str, Any]:
     """Get the certificate for the host and port combination."""
-    ctx = _get_default_ssl_context()
     transport, _ = await hass.loop.create_connection(
         asyncio.Protocol,
         host,
         port,
-        ssl=ctx,
+        ssl=_get_default_ssl_context(),
         happy_eyeballs_delay=1,
         server_hostname=host,
     )

--- a/homeassistant/components/cert_expiry/helper.py
+++ b/homeassistant/components/cert_expiry/helper.py
@@ -34,7 +34,7 @@ async def async_get_cert(
         host,
         port,
         ssl=_get_default_ssl_context(),
-        happy_eyeballs_delay=1,
+        happy_eyeballs_delay=0.25,
         server_hostname=host,
     )
     try:

--- a/homeassistant/components/cert_expiry/helper.py
+++ b/homeassistant/components/cert_expiry/helper.py
@@ -4,6 +4,7 @@ import datetime
 from functools import cache
 import socket
 import ssl
+from typing import Any
 
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
@@ -26,7 +27,7 @@ async def async_get_cert(
     hass: HomeAssistant,
     host: str,
     port: int,
-):
+) -> dict[str, Any]:
     """Get the certificate for the host and port combination."""
     ctx = _get_default_ssl_context()
     transport, _ = await hass.loop.create_connection(

--- a/tests/components/cert_expiry/test_config_flow.py
+++ b/tests/components/cert_expiry/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the Cert Expiry config flow."""
+import asyncio
 import socket
 import ssl
 from unittest.mock import patch
@@ -209,7 +210,7 @@ async def test_abort_on_socket_failed(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.cert_expiry.helper.async_get_cert",
-        side_effect=socket.timeout(),
+        side_effect=asyncio.TimeoutError,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_HOST: HOST}

--- a/tests/components/cert_expiry/test_config_flow.py
+++ b/tests/components/cert_expiry/test_config_flow.py
@@ -153,7 +153,7 @@ async def test_import_with_name(hass: HomeAssistant) -> None:
 async def test_bad_import(hass: HomeAssistant) -> None:
     """Test import step."""
     with patch(
-        "homeassistant.components.cert_expiry.helper.get_cert",
+        "homeassistant.components.cert_expiry.helper.async_get_cert",
         side_effect=ConnectionRefusedError(),
     ):
         result = await hass.config_entries.flow.async_init(
@@ -198,7 +198,7 @@ async def test_abort_on_socket_failed(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "homeassistant.components.cert_expiry.helper.get_cert",
+        "homeassistant.components.cert_expiry.helper.async_get_cert",
         side_effect=socket.gaierror(),
     ):
         result = await hass.config_entries.flow.async_configure(
@@ -208,7 +208,7 @@ async def test_abort_on_socket_failed(hass: HomeAssistant) -> None:
     assert result["errors"] == {CONF_HOST: "resolve_failed"}
 
     with patch(
-        "homeassistant.components.cert_expiry.helper.get_cert",
+        "homeassistant.components.cert_expiry.helper.async_get_cert",
         side_effect=socket.timeout(),
     ):
         result = await hass.config_entries.flow.async_configure(
@@ -218,7 +218,7 @@ async def test_abort_on_socket_failed(hass: HomeAssistant) -> None:
     assert result["errors"] == {CONF_HOST: "connection_timeout"}
 
     with patch(
-        "homeassistant.components.cert_expiry.helper.get_cert",
+        "homeassistant.components.cert_expiry.helper.async_get_cert",
         side_effect=ConnectionRefusedError,
     ):
         result = await hass.config_entries.flow.async_configure(

--- a/tests/components/cert_expiry/test_config_flow.py
+++ b/tests/components/cert_expiry/test_config_flow.py
@@ -48,7 +48,7 @@ async def test_user_with_bad_cert(hass: HomeAssistant) -> None:
     assert result["step_id"] == "user"
 
     with patch(
-        "homeassistant.components.cert_expiry.helper.get_cert",
+        "homeassistant.components.cert_expiry.helper.async_get_cert",
         side_effect=ssl.SSLError("some error"),
     ):
         result = await hass.config_entries.flow.async_configure(

--- a/tests/components/cert_expiry/test_sensors.py
+++ b/tests/components/cert_expiry/test_sensors.py
@@ -57,7 +57,7 @@ async def test_async_setup_entry_bad_cert(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "homeassistant.components.cert_expiry.helper.get_cert",
+        "homeassistant.components.cert_expiry.helper.async_get_cert",
         side_effect=ssl.SSLError("some error"),
     ):
         entry.add_to_hass(hass)
@@ -146,7 +146,7 @@ async def test_update_sensor_network_errors(hass: HomeAssistant) -> None:
     next_update = starting_time + timedelta(hours=24)
 
     with freeze_time(next_update), patch(
-        "homeassistant.components.cert_expiry.helper.get_cert",
+        "homeassistant.components.cert_expiry.helper.async_get_cert",
         side_effect=socket.gaierror,
     ):
         async_fire_time_changed(hass, utcnow() + timedelta(hours=24))
@@ -174,7 +174,7 @@ async def test_update_sensor_network_errors(hass: HomeAssistant) -> None:
     next_update = starting_time + timedelta(hours=72)
 
     with freeze_time(next_update), patch(
-        "homeassistant.components.cert_expiry.helper.get_cert",
+        "homeassistant.components.cert_expiry.helper.async_get_cert",
         side_effect=ssl.SSLError("something bad"),
     ):
         async_fire_time_changed(hass, utcnow() + timedelta(hours=72))
@@ -189,7 +189,8 @@ async def test_update_sensor_network_errors(hass: HomeAssistant) -> None:
     next_update = starting_time + timedelta(hours=96)
 
     with freeze_time(next_update), patch(
-        "homeassistant.components.cert_expiry.helper.get_cert", side_effect=Exception()
+        "homeassistant.components.cert_expiry.helper.async_get_cert",
+        side_effect=Exception(),
     ):
         async_fire_time_changed(hass, utcnow() + timedelta(hours=96))
         await hass.async_block_till_done()


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Convert cert_expiry to use asyncio

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
