### PR TITLE
Allow integrations to set has_entity_name to False

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -242,7 +242,7 @@ class EntityDescription(metaclass=FrozenOrThawed, frozen_or_thawed=True):
     entity_registry_visible_default: bool = True
     force_update: bool = False
     icon: str | None = None
-    has_entity_name: bool = False
+    has_entity_name: bool | None = None
     name: str | UndefinedType | None = UNDEFINED
     translation_key: str | None = None
     unit_of_measurement: str | None = None
@@ -579,20 +579,20 @@ class Entity(
         return not self.name
 
     @cached_property
-    def has_entity_name(self) -> bool:
+    def has_entity_name(self) -> bool | None:
         """Return if the name of the entity is describing only the entity itself."""
         if hasattr(self, "_attr_has_entity_name"):
             return self._attr_has_entity_name
         if hasattr(self, "entity_description"):
             return self.entity_description.has_entity_name
-        return False
+        return None
 
     def _device_class_name_helper(
         self,
         component_translations: dict[str, Any],
     ) -> str | None:
         """Return a translated name of the entity based on its device class."""
-        if not self.has_entity_name:
+        if self.has_entity_name is None:
             return None
         device_class_key = self.device_class or "_"
         platform = self.platform
@@ -636,10 +636,8 @@ class Entity(
         """Return the name of the entity."""
         if hasattr(self, "_attr_name"):
             return self._attr_name
-        if (
-            self.has_entity_name
-            and (name_translation_key := self._name_translation_key)
-            and (name := platform_translations.get(name_translation_key))
+        if (name_translation_key := self._name_translation_key) and (
+            name := platform_translations.get(name_translation_key)
         ):
             if TYPE_CHECKING:
                 assert isinstance(name, str)

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -172,7 +172,7 @@ class RegistryEntry:
         default=None,
         converter=attr.converters.default_if_none(factory=uuid_util.random_uuid_hex),  # type: ignore[misc]
     )
-    has_entity_name: bool = attr.ib(default=False)
+    has_entity_name: bool | None = attr.ib(default=None)
     name: str | None = attr.ib(default=None)
     options: ReadOnlyEntityOptionsType = attr.ib(
         default=None, converter=_protect_entity_options
@@ -398,7 +398,7 @@ class EntityRegistryStore(storage.Store[dict[str, list[dict[str, Any]]]]):
         if old_major_version == 1 and old_minor_version < 7:
             # Version 1.7 adds has_entity_name
             for entity in data["entities"]:
-                entity["has_entity_name"] = False
+                entity["has_entity_name"] = None
 
         if old_major_version == 1 and old_minor_version < 8:
             # Cleanup after frontend bug which incorrectly updated device_class
@@ -617,7 +617,7 @@ class EntityRegistry:
         config_entry: ConfigEntry | None | UndefinedType = UNDEFINED,
         device_id: str | None | UndefinedType = UNDEFINED,
         entity_category: EntityCategory | UndefinedType | None = UNDEFINED,
-        has_entity_name: bool | UndefinedType = UNDEFINED,
+        has_entity_name: bool | None | UndefinedType = UNDEFINED,
         original_device_class: str | None | UndefinedType = UNDEFINED,
         original_icon: str | None | UndefinedType = UNDEFINED,
         original_name: str | None | UndefinedType = UNDEFINED,
@@ -698,7 +698,7 @@ class EntityRegistry:
             entity_category=none_if_undefined(entity_category),
             entity_id=entity_id,
             hidden_by=hidden_by,
-            has_entity_name=none_if_undefined(has_entity_name) or False,
+            has_entity_name=none_if_undefined(has_entity_name),
             id=entity_registry_id,
             options=initial_options,
             original_device_class=none_if_undefined(original_device_class),
@@ -821,7 +821,7 @@ class EntityRegistry:
         entity_category: EntityCategory | None | UndefinedType = UNDEFINED,
         hidden_by: RegistryEntryHider | None | UndefinedType = UNDEFINED,
         icon: str | None | UndefinedType = UNDEFINED,
-        has_entity_name: bool | UndefinedType = UNDEFINED,
+        has_entity_name: bool | None | UndefinedType = UNDEFINED,
         name: str | None | UndefinedType = UNDEFINED,
         new_entity_id: str | UndefinedType = UNDEFINED,
         new_unique_id: str | UndefinedType = UNDEFINED,
@@ -948,7 +948,7 @@ class EntityRegistry:
         entity_category: EntityCategory | None | UndefinedType = UNDEFINED,
         hidden_by: RegistryEntryHider | None | UndefinedType = UNDEFINED,
         icon: str | None | UndefinedType = UNDEFINED,
-        has_entity_name: bool | UndefinedType = UNDEFINED,
+        has_entity_name: bool | None | UndefinedType = UNDEFINED,
         name: str | None | UndefinedType = UNDEFINED,
         new_entity_id: str | UndefinedType = UNDEFINED,
         new_unique_id: str | UndefinedType = UNDEFINED,

--- a/tests/helpers/snapshots/test_entity.ambr
+++ b/tests/helpers/snapshots/test_entity.ambr
@@ -6,7 +6,7 @@
     'entity_registry_enabled_default': True,
     'entity_registry_visible_default': True,
     'force_update': False,
-    'has_entity_name': False,
+    'has_entity_name': None,
     'icon': None,
     'key': 'blah',
     'name': <UndefinedType._singleton: 0>,
@@ -15,7 +15,7 @@
   })
 # ---
 # name: test_entity_description_as_dataclass.1
-  "EntityDescription(key='blah', device_class='test', entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name=<UndefinedType._singleton: 0>, translation_key=None, unit_of_measurement=None)"
+  "EntityDescription(key='blah', device_class='test', entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=None, name=<UndefinedType._singleton: 0>, translation_key=None, unit_of_measurement=None)"
 # ---
 # name: test_extending_entity_description
   dict({
@@ -25,7 +25,7 @@
     'entity_registry_visible_default': True,
     'extra': 'foo',
     'force_update': False,
-    'has_entity_name': False,
+    'has_entity_name': None,
     'icon': None,
     'key': 'blah',
     'name': 'name',
@@ -34,7 +34,7 @@
   })
 # ---
 # name: test_extending_entity_description.1
-  "test_extending_entity_description.<locals>.FrozenEntityDescription(key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.FrozenEntityDescription(key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=None, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.10
   dict({
@@ -44,7 +44,7 @@
     'entity_registry_visible_default': True,
     'extra': 'foo',
     'force_update': False,
-    'has_entity_name': False,
+    'has_entity_name': None,
     'icon': None,
     'key': 'blah',
     'mixin': 'mixin',
@@ -54,7 +54,7 @@
   })
 # ---
 # name: test_extending_entity_description.11
-  "test_extending_entity_description.<locals>.ComplexEntityDescription1C(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription1C(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=None, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.12
   dict({
@@ -64,7 +64,7 @@
     'entity_registry_visible_default': True,
     'extra': 'foo',
     'force_update': False,
-    'has_entity_name': False,
+    'has_entity_name': None,
     'icon': None,
     'key': 'blah',
     'mixin': 'mixin',
@@ -74,7 +74,7 @@
   })
 # ---
 # name: test_extending_entity_description.13
-  "test_extending_entity_description.<locals>.ComplexEntityDescription1D(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription1D(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=None, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.14
   dict({
@@ -84,7 +84,7 @@
     'entity_registry_visible_default': True,
     'extra': 'foo',
     'force_update': False,
-    'has_entity_name': False,
+    'has_entity_name': None,
     'icon': None,
     'key': 'blah',
     'mixin': 'mixin',
@@ -94,7 +94,7 @@
   })
 # ---
 # name: test_extending_entity_description.15
-  "test_extending_entity_description.<locals>.ComplexEntityDescription2A(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription2A(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=None, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.16
   dict({
@@ -104,7 +104,7 @@
     'entity_registry_visible_default': True,
     'extra': 'foo',
     'force_update': False,
-    'has_entity_name': False,
+    'has_entity_name': None,
     'icon': None,
     'key': 'blah',
     'mixin': 'mixin',
@@ -114,7 +114,7 @@
   })
 # ---
 # name: test_extending_entity_description.17
-  "test_extending_entity_description.<locals>.ComplexEntityDescription2B(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription2B(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=None, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.18
   dict({
@@ -124,7 +124,7 @@
     'entity_registry_visible_default': True,
     'extra': 'foo',
     'force_update': False,
-    'has_entity_name': False,
+    'has_entity_name': None,
     'icon': None,
     'key': 'blah',
     'mixin': 'mixin',
@@ -134,7 +134,7 @@
   })
 # ---
 # name: test_extending_entity_description.19
-  "test_extending_entity_description.<locals>.ComplexEntityDescription2C(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription2C(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=None, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.2
   dict({
@@ -144,7 +144,7 @@
     'entity_registry_visible_default': True,
     'extra': 'foo',
     'force_update': False,
-    'has_entity_name': False,
+    'has_entity_name': None,
     'icon': None,
     'key': 'blah',
     'name': 'name',
@@ -160,7 +160,7 @@
     'entity_registry_visible_default': True,
     'extra': 'foo',
     'force_update': False,
-    'has_entity_name': False,
+    'has_entity_name': None,
     'icon': None,
     'key': 'blah',
     'mixin': 'mixin',
@@ -170,7 +170,7 @@
   })
 # ---
 # name: test_extending_entity_description.21
-  "test_extending_entity_description.<locals>.ComplexEntityDescription2D(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription2D(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=None, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.22
   dict({
@@ -180,7 +180,7 @@
     'entity_registry_visible_default': True,
     'extra': 'foo',
     'force_update': False,
-    'has_entity_name': False,
+    'has_entity_name': None,
     'icon': None,
     'key': 'blah',
     'mixin': 'mixin',
@@ -190,7 +190,7 @@
   })
 # ---
 # name: test_extending_entity_description.23
-  "test_extending_entity_description.<locals>.ComplexEntityDescription3A(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription3A(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=None, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.24
   dict({
@@ -200,7 +200,7 @@
     'entity_registry_visible_default': True,
     'extra': 'foo',
     'force_update': False,
-    'has_entity_name': False,
+    'has_entity_name': None,
     'icon': None,
     'key': 'blah',
     'mixin': 'mixin',
@@ -210,7 +210,7 @@
   })
 # ---
 # name: test_extending_entity_description.25
-  "test_extending_entity_description.<locals>.ComplexEntityDescription3B(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription3B(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=None, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.26
   dict({
@@ -220,7 +220,7 @@
     'entity_registry_visible_default': True,
     'extra': 'foo',
     'force_update': False,
-    'has_entity_name': False,
+    'has_entity_name': None,
     'icon': None,
     'key': 'blah',
     'mixin': 'mixin',
@@ -230,7 +230,7 @@
   })
 # ---
 # name: test_extending_entity_description.27
-  "test_extending_entity_description.<locals>.ComplexEntityDescription4A(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription4A(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=None, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.28
   dict({
@@ -240,7 +240,7 @@
     'entity_registry_visible_default': True,
     'extra': 'foo',
     'force_update': False,
-    'has_entity_name': False,
+    'has_entity_name': None,
     'icon': None,
     'key': 'blah',
     'mixin': 'mixin',
@@ -250,10 +250,10 @@
   })
 # ---
 # name: test_extending_entity_description.29
-  "test_extending_entity_description.<locals>.ComplexEntityDescription4B(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription4B(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=None, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.3
-  "test_extending_entity_description.<locals>.ThawedEntityDescription(key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ThawedEntityDescription(key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=None, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.30
   dict({
@@ -262,7 +262,7 @@
     'entity_registry_enabled_default': True,
     'entity_registry_visible_default': True,
     'force_update': False,
-    'has_entity_name': False,
+    'has_entity_name': None,
     'icon': None,
     'key': 'blah',
     'name': 'name',
@@ -271,7 +271,7 @@
   })
 # ---
 # name: test_extending_entity_description.31
-  "test_extending_entity_description.<locals>.CustomInitEntityDescription(key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None)"
+  "test_extending_entity_description.<locals>.CustomInitEntityDescription(key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=None, name='name', translation_key=None, unit_of_measurement=None)"
 # ---
 # name: test_extending_entity_description.4
   dict({
@@ -282,7 +282,7 @@
     'extension': 'ext',
     'extra': 'foo',
     'force_update': False,
-    'has_entity_name': False,
+    'has_entity_name': None,
     'icon': None,
     'key': 'blah',
     'name': 'name',
@@ -291,7 +291,7 @@
   })
 # ---
 # name: test_extending_entity_description.5
-  "test_extending_entity_description.<locals>.MyExtendedEntityDescription(key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extension='ext', extra='foo')"
+  "test_extending_entity_description.<locals>.MyExtendedEntityDescription(key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=None, name='name', translation_key=None, unit_of_measurement=None, extension='ext', extra='foo')"
 # ---
 # name: test_extending_entity_description.6
   dict({
@@ -301,7 +301,7 @@
     'entity_registry_visible_default': True,
     'extra': 'foo',
     'force_update': False,
-    'has_entity_name': False,
+    'has_entity_name': None,
     'icon': None,
     'key': 'blah',
     'mixin': 'mixin',
@@ -311,7 +311,7 @@
   })
 # ---
 # name: test_extending_entity_description.7
-  "test_extending_entity_description.<locals>.ComplexEntityDescription1A(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription1A(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=None, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
 # ---
 # name: test_extending_entity_description.8
   dict({
@@ -321,7 +321,7 @@
     'entity_registry_visible_default': True,
     'extra': 'foo',
     'force_update': False,
-    'has_entity_name': False,
+    'has_entity_name': None,
     'icon': None,
     'key': 'blah',
     'mixin': 'mixin',
@@ -331,5 +331,5 @@
   })
 # ---
 # name: test_extending_entity_description.9
-  "test_extending_entity_description.<locals>.ComplexEntityDescription1B(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=False, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
+  "test_extending_entity_description.<locals>.ComplexEntityDescription1B(mixin='mixin', key='blah', device_class=None, entity_category=None, entity_registry_enabled_default=True, entity_registry_visible_default=True, force_update=False, icon=None, has_entity_name=None, name='name', translation_key=None, unit_of_measurement=None, extra='foo')"
 # ---

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1003,6 +1003,8 @@ async def _test_friendly_name(
         "expected_friendly_name",
     ),
     (
+        (None, "Entity Blu", "Device Bla", "Entity Blu"),
+        (None, None, "Device Bla", None),
         (False, "Entity Blu", "Device Bla", "Entity Blu"),
         (False, None, "Device Bla", None),
         (True, "Entity Blu", "Device Bla", "Device Bla Entity Blu"),
@@ -1040,6 +1042,9 @@ async def test_friendly_name_attr(
 @pytest.mark.parametrize(
     ("has_entity_name", "entity_name", "expected_friendly_name"),
     (
+        (None, "Entity Blu", "Entity Blu"),
+        (None, None, None),
+        (None, UNDEFINED, None),
         (False, "Entity Blu", "Entity Blu"),
         (False, None, None),
         (False, UNDEFINED, None),
@@ -1077,9 +1082,12 @@ async def test_friendly_name_description(
 @pytest.mark.parametrize(
     ("has_entity_name", "entity_name", "expected_friendly_name"),
     (
+        (None, "Entity Blu", "Entity Blu"),
+        (None, None, None),
+        (None, UNDEFINED, None),
         (False, "Entity Blu", "Entity Blu"),
         (False, None, None),
-        (False, UNDEFINED, None),
+        (False, UNDEFINED, "English cls"),
         (True, "Entity Blu", "Device Bla Entity Blu"),
         (True, None, "Device Bla"),
         (True, UNDEFINED, "Device Bla English cls"),
@@ -1140,6 +1148,9 @@ async def test_friendly_name_description_device_class_name(
 @pytest.mark.parametrize(
     ("has_entity_name", "entity_name", "expected_friendly_name"),
     (
+        (None, "Entity Blu", "Entity Blu"),
+        (None, None, None),
+        (None, UNDEFINED, None),
         (False, "Entity Blu", "Entity Blu"),
         (False, None, None),
         (False, UNDEFINED, None),
@@ -1176,6 +1187,9 @@ async def test_friendly_name_property(
 @pytest.mark.parametrize(
     ("has_entity_name", "entity_name", "expected_friendly_name"),
     (
+        (None, "Entity Blu", "Entity Blu"),
+        (None, None, None),
+        (None, UNDEFINED, None),
         (False, "Entity Blu", "Entity Blu"),
         (False, None, None),
         (False, UNDEFINED, None),
@@ -1237,7 +1251,8 @@ async def test_friendly_name_property_device_class_name(
 @pytest.mark.parametrize(
     ("has_entity_name", "expected_friendly_name"),
     (
-        (False, None),
+        (None, None),
+        (False, "English cls"),
         (True, "Device Bla English cls"),
     ),
 )
@@ -2126,19 +2141,19 @@ async def test_cached_entity_property_delete_attr(hass: HomeAssistant) -> None:
     assert not hasattr(ent, f"_attr_{property}")
     with pytest.raises(AttributeError):
         delattr(ent, f"_attr_{property}")
-    assert getattr(ent, property) is False
+    assert getattr(ent, property) is None
 
     with pytest.raises(AttributeError):
         delattr(ent, f"_attr_{property}")
     assert not hasattr(ent, f"_attr_{property}")
-    assert getattr(ent, property) is False
+    assert getattr(ent, property) is None
 
     setattr(ent, f"_attr_{property}", True)
     assert getattr(ent, property) is True
 
     delattr(ent, f"_attr_{property}")
     assert not hasattr(ent, f"_attr_{property}")
-    assert getattr(ent, property) is False
+    assert getattr(ent, property) is None
 
 
 async def test_cached_entity_property_class_attribute(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow integrations to set `has_entity_name` to False

This implements the proposal in https://github.com/home-assistant/architecture/discussions/1023

Set to draft since the architecture discussion is still open

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
