### PR TITLE
Bump rachiopy to 1.1.0

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1034,8 +1034,8 @@ build.json @home-assistant/supervisor
 /homeassistant/components/qvr_pro/ @oblogic7
 /homeassistant/components/qwikswitch/ @kellerza
 /tests/components/qwikswitch/ @kellerza
-/homeassistant/components/rachio/ @bdraco
-/tests/components/rachio/ @bdraco
+/homeassistant/components/rachio/ @bdraco @rfverbruggen
+/tests/components/rachio/ @bdraco @rfverbruggen
 /homeassistant/components/radarr/ @tkdrob
 /tests/components/radarr/ @tkdrob
 /homeassistant/components/radio_browser/ @frenck

--- a/homeassistant/components/rachio/manifest.json
+++ b/homeassistant/components/rachio/manifest.json
@@ -25,7 +25,7 @@
   },
   "iot_class": "cloud_push",
   "loggers": ["rachiopy"],
-  "requirements": ["RachioPy==1.0.3"],
+  "requirements": ["RachioPy==1.1.0"],
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/homeassistant/components/rachio/manifest.json
+++ b/homeassistant/components/rachio/manifest.json
@@ -2,7 +2,7 @@
   "domain": "rachio",
   "name": "Rachio",
   "after_dependencies": ["cloud"],
-  "codeowners": ["@bdraco"],
+  "codeowners": ["@bdraco","@rfverbruggen"],
   "config_flow": true,
   "dependencies": ["http"],
   "dhcp": [

--- a/homeassistant/components/rachio/manifest.json
+++ b/homeassistant/components/rachio/manifest.json
@@ -2,7 +2,7 @@
   "domain": "rachio",
   "name": "Rachio",
   "after_dependencies": ["cloud"],
-  "codeowners": ["@bdraco","@rfverbruggen"],
+  "codeowners": ["@bdraco", "@rfverbruggen"],
   "config_flow": true,
   "dependencies": ["http"],
   "dhcp": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -118,7 +118,7 @@ PyViCare==2.32.0
 PyXiaomiGateway==0.14.3
 
 # homeassistant.components.rachio
-RachioPy==1.0.3
+RachioPy==1.1.0
 
 # homeassistant.components.python_script
 RestrictedPython==7.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -103,7 +103,7 @@ PyViCare==2.32.0
 PyXiaomiGateway==0.14.3
 
 # homeassistant.components.rachio
-RachioPy==1.0.3
+RachioPy==1.1.0
 
 # homeassistant.components.python_script
 RestrictedPython==7.0


### PR DESCRIPTION
## Proposed change

Update the rachiopy library to the latest version.

This version enables integrating the Smart Hose Timer into Home Assistant.

Release notes of the library [https://github.com/rfverbruggen/rachiopy/releases](https://github.com/rfverbruggen/rachiopy/releases)

Diff of previous (1.0.3) vs this release (1.1.0) [Compare 1.0.3 ... 1.1.0](https://github.com/rfverbruggen/rachiopy/compare/1.0.3...1.1.0)


## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
None.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
