### PR TITLE
Fix first ESPHome device update entity not offering install feature

### DIFF
--- a/homeassistant/components/esphome/update.py
+++ b/homeassistant/components/esphome/update.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, cast
+from typing import Any
 
 from aioesphomeapi import DeviceInfo as ESPHomeDeviceInfo, EntityInfo
 
@@ -27,6 +27,7 @@ from .entry_data import RuntimeEntryData
 
 KEY_UPDATE_LOCK = "esphome_update_lock"
 
+NO_FEATURES = UpdateEntityFeature(0)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -76,6 +77,7 @@ class ESPHomeUpdateEntity(CoordinatorEntity[ESPHomeDashboard], UpdateEntity):
     _attr_device_class = UpdateDeviceClass.FIRMWARE
     _attr_title = "ESPHome"
     _attr_name = "Firmware"
+    _attr_release_url = "https://esphome.io/changelog/"
 
     def __init__(
         self, entry_data: RuntimeEntryData, coordinator: ESPHomeDashboard
@@ -90,15 +92,36 @@ class ESPHomeUpdateEntity(CoordinatorEntity[ESPHomeDashboard], UpdateEntity):
                 (dr.CONNECTION_NETWORK_MAC, entry_data.device_info.mac_address)
             }
         )
+        self._update_attrs()
 
+    @callback
+    def _update_attrs(self) -> None:
+        """Update the supported features."""
         # If the device has deep sleep, we can't assume we can install updates
         # as the ESP will not be connectable (by design).
+        coordinator = self.coordinator
+        device_info = self._device_info
+        # Install support can change at run time
         if (
             coordinator.last_update_success
             and coordinator.supports_update
-            and not self._device_info.has_deep_sleep
+            and not device_info.has_deep_sleep
         ):
             self._attr_supported_features = UpdateEntityFeature.INSTALL
+        else:
+            self._attr_supported_features = NO_FEATURES
+        self._attr_installed_version = device_info.esphome_version
+        device = coordinator.data.get(device_info.name)
+        if device is None:
+            self._attr_latest_version = None
+        else:
+            self._attr_latest_version = device["current_version"]
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._update_attrs()
+        super()._handle_coordinator_update()
 
     @property
     def _device_info(self) -> ESPHomeDeviceInfo:
@@ -119,44 +142,29 @@ class ESPHomeUpdateEntity(CoordinatorEntity[ESPHomeDashboard], UpdateEntity):
             or self._device_info.has_deep_sleep
         )
 
-    @property
-    def installed_version(self) -> str | None:
-        """Version currently installed and in use."""
-        return self._device_info.esphome_version
-
-    @property
-    def latest_version(self) -> str | None:
-        """Latest version available for install."""
-        device = self.coordinator.data.get(self._device_info.name)
-        if device is None:
-            return None
-        return cast(str, device["current_version"])
-
-    @property
-    def release_url(self) -> str | None:
-        """URL to the full release notes of the latest version available."""
-        return "https://esphome.io/changelog/"
-
     @callback
-    def _async_static_info_updated(self, _: list[EntityInfo]) -> None:
-        """Handle static info update."""
+    def _handle_device_update(self, static_info: EntityInfo | None = None) -> None:
+        """Handle updated data from the device."""
+        self._update_attrs()
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:
         """Handle entity added to Home Assistant."""
         await super().async_added_to_hass()
+        hass = self.hass
+        entry_data = self._entry_data
         self.async_on_remove(
             async_dispatcher_connect(
-                self.hass,
-                self._entry_data.signal_static_info_updated,
-                self._async_static_info_updated,
+                hass,
+                entry_data.signal_static_info_updated,
+                self._handle_device_update,
             )
         )
         self.async_on_remove(
             async_dispatcher_connect(
-                self.hass,
-                self._entry_data.signal_device_updated,
-                self.async_write_ha_state,
+                hass,
+                entry_data.signal_device_updated,
+                self._handle_device_update,
             )
         )
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In the case where the user gets their first ESPHome device such as a RATGDO, they will usually add the device first in HA, and than find the dashboard.

The install function will be missing because we do not know if the dashboard supports updating devices until the first device is added. We now set the supported features when we learn the version when the first device is added

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
