### PR TITLE
Add test coverage for ESPHome service calls

### DIFF
--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -203,14 +203,19 @@ class ESPHomeManager:
                     template.render_complex(data_template, service.variables)
                 )
             except TemplateError as ex:
-                _LOGGER.error("Error rendering data template for %s: %s", self.host, ex)
+                _LOGGER.error(
+                    "Error rendering data template %s for %s: %s",
+                    service.data_template,
+                    self.host,
+                    ex,
+                )
                 return
 
         if service.is_event:
             device_id = self.device_id
             # ESPHome uses service call packet for both events and service calls
             # Ensure the user can only send events of form 'esphome.xyz'
-            if domain != "esphome":
+            if domain != DOMAIN:
                 _LOGGER.error(
                     "Can only generate events under esphome domain! (%s)", self.host
                 )

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -7,6 +7,7 @@ from aioesphomeapi import (
     DeviceInfo,
     EntityInfo,
     EntityState,
+    HomeassistantServiceCall,
     UserService,
     UserServiceArg,
     UserServiceArgType,
@@ -16,19 +17,203 @@ import pytest
 from homeassistant import config_entries
 from homeassistant.components import dhcp
 from homeassistant.components.esphome.const import (
+    CONF_ALLOW_SERVICE_CALLS,
     CONF_DEVICE_NAME,
     DOMAIN,
     STABLE_BLE_VERSION_STR,
 )
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
 
 from .conftest import MockESPHomeDevice
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_capture_events, async_mock_service
+
+
+async def test_esphome_device_service_calls_not_allowed(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: Callable[
+        [APIClient, list[EntityInfo], list[UserService], list[EntityState]],
+        Awaitable[MockESPHomeDevice],
+    ],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a device with service calls not allowed."""
+    entity_info = []
+    states = []
+    user_service = []
+    device: MockESPHomeDevice = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+        device_info={"esphome_version": "2023.3.0"},
+    )
+    await hass.async_block_till_done()
+    mock_esphome_test = async_mock_service(hass, "esphome", "test")
+    device.mock_service_call(
+        HomeassistantServiceCall(
+            service="esphome.test",
+            data={},
+        )
+    )
+    await hass.async_block_till_done()
+    assert len(mock_esphome_test) == 0
+    issue_registry = ir.async_get(hass)
+    issue = issue_registry.async_get_issue(
+        "esphome", "service_calls_not_enabled-11:22:33:44:55:aa"
+    )
+    assert issue is not None
+    assert (
+        "If you trust this device and want to allow access "
+        "for it to make Home Assistant service calls, you can "
+        "enable this functionality in the options flow"
+    ) in caplog.text
+
+
+async def test_esphome_device_service_calls_allowed(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: APIClient,
+    mock_esphome_device: Callable[
+        [APIClient, list[EntityInfo], list[UserService], list[EntityState]],
+        Awaitable[MockESPHomeDevice],
+    ],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a device with service calls are allowed."""
+    entity_info = []
+    states = []
+    user_service = []
+    mock_config_entry.options = {CONF_ALLOW_SERVICE_CALLS: True}
+    device: MockESPHomeDevice = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+        device_info={"esphome_version": "2023.3.0"},
+        entry=mock_config_entry,
+    )
+    await hass.async_block_till_done()
+    mock_calls: list[ServiceCall] = []
+
+    async def _mock_service(call: ServiceCall) -> None:
+        mock_calls.append(call)
+
+    hass.services.async_register(DOMAIN, "test", _mock_service)
+    device.mock_service_call(
+        HomeassistantServiceCall(
+            service="esphome.test",
+            data={"raw": "data"},
+        )
+    )
+    await hass.async_block_till_done()
+    issue_registry = ir.async_get(hass)
+    issue = issue_registry.async_get_issue(
+        "esphome", "service_calls_not_enabled-11:22:33:44:55:aa"
+    )
+    assert issue is None
+    assert len(mock_calls) == 1
+    service_call = mock_calls[0]
+    assert service_call.domain == DOMAIN
+    assert service_call.service == "test"
+    assert service_call.data == {"raw": "data"}
+    mock_calls.clear()
+    device.mock_service_call(
+        HomeassistantServiceCall(
+            service="esphome.test",
+            data_template={"raw": "{{invalid}}"},
+        )
+    )
+    await hass.async_block_till_done()
+    assert (
+        "Template variable warning: 'invalid' is undefined when rendering '{{invalid}}'"
+        in caplog.text
+    )
+    assert len(mock_calls) == 1
+    service_call = mock_calls[0]
+    assert service_call.domain == DOMAIN
+    assert service_call.service == "test"
+    assert service_call.data == {"raw": ""}
+    mock_calls.clear()
+    caplog.clear()
+
+    device.mock_service_call(
+        HomeassistantServiceCall(
+            service="esphome.test",
+            data_template={"raw": "{{-- invalid --}}"},
+        )
+    )
+    await hass.async_block_till_done()
+    assert "TemplateSyntaxError" in caplog.text
+    assert "{{-- invalid --}}" in caplog.text
+    assert len(mock_calls) == 0
+    mock_calls.clear()
+    caplog.clear()
+
+    device.mock_service_call(
+        HomeassistantServiceCall(
+            service="esphome.test",
+            data_template={"raw": "{{var}}"},
+            variables={"var": "value"},
+        )
+    )
+    await hass.async_block_till_done()
+    assert len(mock_calls) == 1
+    service_call = mock_calls[0]
+    assert service_call.domain == DOMAIN
+    assert service_call.service == "test"
+    assert service_call.data == {"raw": "value"}
+    mock_calls.clear()
+
+    device.mock_service_call(
+        HomeassistantServiceCall(
+            service="esphome.test",
+            data_template={"raw": "valid"},
+        )
+    )
+    await hass.async_block_till_done()
+    assert len(mock_calls) == 1
+    service_call = mock_calls[0]
+    assert service_call.domain == DOMAIN
+    assert service_call.service == "test"
+    assert service_call.data == {"raw": "valid"}
+    mock_calls.clear()
+
+    # Try firing events
+    events = async_capture_events(hass, "esphome.test")
+    device.mock_service_call(
+        HomeassistantServiceCall(
+            service="esphome.test",
+            is_event=True,
+            data={"raw": "event"},
+        )
+    )
+    await hass.async_block_till_done()
+    assert len(events) == 1
+    event = events[0]
+    assert event.data["raw"] == "event"
+    assert event.event_type == "esphome.test"
+    events.clear()
+    caplog.clear()
+
+    # Try firing events for disallowed domain
+    events = async_capture_events(hass, "wrong.test")
+    device.mock_service_call(
+        HomeassistantServiceCall(
+            service="wrong.test",
+            is_event=True,
+            data={"raw": "event"},
+        )
+    )
+    await hass.async_block_till_done()
+    assert len(events) == 0
+    assert "Can only generate events under esphome domain" in caplog.text
+    events.clear()
 
 
 async def test_esphome_device_with_old_bluetooth(


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add test coverage for ESPHome service calls

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
