### PR TITLE
Fix mobile_app cloudhook creation

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -177,7 +177,6 @@ def async_active_subscription(hass: HomeAssistant) -> bool:
     return async_is_logged_in(hass) and not hass.data[DOMAIN].subscription_expired
 
 
-@bind_hass
 async def async_get_or_create_cloudhook(hass: HomeAssistant, webhook_id: str) -> str:
     """Get or create a cloudhook."""
     if not async_is_connected(hass):

--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -5,6 +5,7 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 from enum import Enum
+from typing import cast
 
 from hass_nabucasa import Cloud
 import voluptuous as vol
@@ -174,6 +175,23 @@ def async_listen_connection_change(
 def async_active_subscription(hass: HomeAssistant) -> bool:
     """Test if user has an active subscription."""
     return async_is_logged_in(hass) and not hass.data[DOMAIN].subscription_expired
+
+
+@bind_hass
+async def async_get_or_create_cloudhook(hass: HomeAssistant, webhook_id: str) -> str:
+    """Get or create a cloudhook."""
+    if not async_is_connected(hass):
+        raise CloudNotConnected
+
+    if not async_is_logged_in(hass):
+        raise CloudNotAvailable
+
+    cloud: Cloud[CloudClient] = hass.data[DOMAIN]
+    cloudhooks = cloud.client.cloudhooks
+    if hook := cloudhooks.get(webhook_id):
+        return cast(str, hook["cloudhook_url"])
+
+    return await async_create_cloudhook(hass, webhook_id)
 
 
 @bind_hass

--- a/homeassistant/components/mobile_app/__init__.py
+++ b/homeassistant/components/mobile_app/__init__.py
@@ -43,6 +43,21 @@ PLATFORMS = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.DEVICE_TRACKER]
 
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
+_CLOUD_HOOK_LOCK = asyncio.Lock()
+
+
+async def create_cloud_hook(
+    hass: HomeAssistant, webhook_id: str, entry: ConfigEntry | None
+) -> str:
+    """Create a cloud hook."""
+    async with _CLOUD_HOOK_LOCK:
+        hook = await cloud.async_get_or_create_cloudhook(hass, webhook_id)
+        if entry:
+            hass.config_entries.async_update_entry(
+                entry, data={**entry.data, CONF_CLOUDHOOK_URL: hook}
+            )
+        return hook
+
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the mobile app component."""
@@ -104,29 +119,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     registration_name = f"Mobile App: {registration[ATTR_DEVICE_NAME]}"
     webhook_register(hass, DOMAIN, registration_name, webhook_id, handle_webhook)
 
-    cloud_hook_lock = asyncio.Lock()
-
-    async def create_cloud_hook() -> None:
-        """Create a cloud hook."""
-        async with cloud_hook_lock:
-            hook = await cloud.async_get_or_create_cloudhook(hass, webhook_id)
-            hass.config_entries.async_update_entry(
-                entry, data={**entry.data, CONF_CLOUDHOOK_URL: hook}
-            )
-
     async def manage_cloudhook(state: cloud.CloudConnectionState) -> None:
         if (
             state is cloud.CloudConnectionState.CLOUD_CONNECTED
             and CONF_CLOUDHOOK_URL not in entry.data
         ):
-            await create_cloud_hook()
+            await create_cloud_hook(hass, webhook_id, entry)
 
     if (
         CONF_CLOUDHOOK_URL not in entry.data
         and cloud.async_active_subscription(hass)
         and cloud.async_is_connected(hass)
     ):
-        await create_cloud_hook()
+        await create_cloud_hook(hass, webhook_id, entry)
 
     entry.async_on_unload(cloud.async_listen_connection_change(hass, manage_cloudhook))
 

--- a/homeassistant/components/mobile_app/__init__.py
+++ b/homeassistant/components/mobile_app/__init__.py
@@ -1,5 +1,4 @@
 """Integrates Native Apps to Home Assistant."""
-import asyncio
 from contextlib import suppress
 from typing import Any
 
@@ -37,26 +36,12 @@ from .const import (
 )
 from .helpers import savable_state
 from .http_api import RegistrationsView
+from .util import create_cloud_hook
 from .webhook import handle_webhook
 
 PLATFORMS = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.DEVICE_TRACKER]
 
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
-
-_CLOUD_HOOK_LOCK = asyncio.Lock()
-
-
-async def create_cloud_hook(
-    hass: HomeAssistant, webhook_id: str, entry: ConfigEntry | None
-) -> str:
-    """Create a cloud hook."""
-    async with _CLOUD_HOOK_LOCK:
-        hook = await cloud.async_get_or_create_cloudhook(hass, webhook_id)
-        if entry:
-            hass.config_entries.async_update_entry(
-                entry, data={**entry.data, CONF_CLOUDHOOK_URL: hook}
-            )
-        return hook
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/mobile_app/__init__.py
+++ b/homeassistant/components/mobile_app/__init__.py
@@ -36,7 +36,7 @@ from .const import (
 )
 from .helpers import savable_state
 from .http_api import RegistrationsView
-from .util import create_cloud_hook
+from .util import async_create_cloud_hook
 from .webhook import handle_webhook
 
 PLATFORMS = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.DEVICE_TRACKER]
@@ -109,14 +109,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             state is cloud.CloudConnectionState.CLOUD_CONNECTED
             and CONF_CLOUDHOOK_URL not in entry.data
         ):
-            await create_cloud_hook(hass, webhook_id, entry)
+            await async_create_cloud_hook(hass, webhook_id, entry)
 
     if (
         CONF_CLOUDHOOK_URL not in entry.data
         and cloud.async_active_subscription(hass)
         and cloud.async_is_connected(hass)
     ):
-        await create_cloud_hook(hass, webhook_id, entry)
+        await async_create_cloud_hook(hass, webhook_id, entry)
 
     entry.async_on_unload(cloud.async_listen_connection_change(hass, manage_cloudhook))
 

--- a/homeassistant/components/mobile_app/__init__.py
+++ b/homeassistant/components/mobile_app/__init__.py
@@ -109,9 +109,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def create_cloud_hook() -> None:
         """Create a cloud hook."""
         async with cloud_hook_lock:
-            if CONF_CLOUDHOOK_URL in entry.data:
-                return  # We already have a cloudhook
-            hook = await cloud.async_create_cloudhook(hass, webhook_id)
+            hook = await cloud.async_get_or_create_cloudhook(hass, webhook_id)
             hass.config_entries.async_update_entry(
                 entry, data={**entry.data, CONF_CLOUDHOOK_URL: hook}
             )

--- a/homeassistant/components/mobile_app/http_api.py
+++ b/homeassistant/components/mobile_app/http_api.py
@@ -35,7 +35,7 @@ from .const import (
     SCHEMA_APP_DATA,
 )
 from .helpers import supports_encryption
-from .util import create_cloud_hook
+from .util import async_create_cloud_hook
 
 
 class RegistrationsView(HomeAssistantView):
@@ -70,7 +70,9 @@ class RegistrationsView(HomeAssistantView):
         webhook_id = secrets.token_hex()
 
         if cloud.async_active_subscription(hass):
-            data[CONF_CLOUDHOOK_URL] = await create_cloud_hook(hass, webhook_id, None)
+            data[CONF_CLOUDHOOK_URL] = await async_create_cloud_hook(
+                hass, webhook_id, None
+            )
 
         data[CONF_WEBHOOK_ID] = webhook_id
 

--- a/homeassistant/components/mobile_app/http_api.py
+++ b/homeassistant/components/mobile_app/http_api.py
@@ -16,7 +16,6 @@ from homeassistant.const import ATTR_DEVICE_ID, CONF_WEBHOOK_ID
 from homeassistant.helpers import config_validation as cv
 from homeassistant.util import slugify
 
-from . import create_cloud_hook
 from .const import (
     ATTR_APP_DATA,
     ATTR_APP_ID,
@@ -36,6 +35,7 @@ from .const import (
     SCHEMA_APP_DATA,
 )
 from .helpers import supports_encryption
+from .util import create_cloud_hook
 
 
 class RegistrationsView(HomeAssistantView):

--- a/homeassistant/components/mobile_app/http_api.py
+++ b/homeassistant/components/mobile_app/http_api.py
@@ -16,6 +16,7 @@ from homeassistant.const import ATTR_DEVICE_ID, CONF_WEBHOOK_ID
 from homeassistant.helpers import config_validation as cv
 from homeassistant.util import slugify
 
+from . import create_cloud_hook
 from .const import (
     ATTR_APP_DATA,
     ATTR_APP_ID,
@@ -69,9 +70,7 @@ class RegistrationsView(HomeAssistantView):
         webhook_id = secrets.token_hex()
 
         if cloud.async_active_subscription(hass):
-            data[CONF_CLOUDHOOK_URL] = await cloud.async_create_cloudhook(
-                hass, webhook_id
-            )
+            data[CONF_CLOUDHOOK_URL] = await create_cloud_hook(hass, webhook_id, None)
 
         data[CONF_WEBHOOK_ID] = webhook_id
 

--- a/homeassistant/components/mobile_app/util.py
+++ b/homeassistant/components/mobile_app/util.py
@@ -62,8 +62,7 @@ def get_notify_service(hass: HomeAssistant, webhook_id: str) -> str | None:
 _CLOUD_HOOK_LOCK = asyncio.Lock()
 
 
-@callback
-async def create_cloud_hook(
+async def async_create_cloud_hook(
     hass: HomeAssistant, webhook_id: str, entry: ConfigEntry | None
 ) -> str:
     """Create a cloud hook."""

--- a/homeassistant/components/mobile_app/util.py
+++ b/homeassistant/components/mobile_app/util.py
@@ -1,8 +1,11 @@
 """Mobile app utility functions."""
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
+from homeassistant.components import cloud
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 
 from .const import (
@@ -10,6 +13,7 @@ from .const import (
     ATTR_PUSH_TOKEN,
     ATTR_PUSH_URL,
     ATTR_PUSH_WEBSOCKET_CHANNEL,
+    CONF_CLOUDHOOK_URL,
     DATA_CONFIG_ENTRIES,
     DATA_DEVICES,
     DATA_NOTIFY,
@@ -53,3 +57,20 @@ def get_notify_service(hass: HomeAssistant, webhook_id: str) -> str | None:
             return target_service
 
     return None
+
+
+_CLOUD_HOOK_LOCK = asyncio.Lock()
+
+
+@callback
+async def create_cloud_hook(
+    hass: HomeAssistant, webhook_id: str, entry: ConfigEntry | None
+) -> str:
+    """Create a cloud hook."""
+    async with _CLOUD_HOOK_LOCK:
+        hook = await cloud.async_get_or_create_cloudhook(hass, webhook_id)
+        if entry:
+            hass.config_entries.async_update_entry(
+                entry, data={**entry.data, CONF_CLOUDHOOK_URL: hook}
+            )
+        return hook

--- a/tests/components/cloud/conftest.py
+++ b/tests/components/cloud/conftest.py
@@ -109,6 +109,7 @@ async def cloud_fixture() -> AsyncGenerator[MagicMock, None]:
 
         is_connected = PropertyMock(side_effect=mock_is_connected)
         type(mock_cloud).is_connected = is_connected
+        type(mock_cloud.iot).connected = is_connected
 
         # Properties that we mock as attributes.
         mock_cloud.expiration_date = utcnow()

--- a/tests/components/cloud/test_init.py
+++ b/tests/components/cloud/test_init.py
@@ -1,14 +1,14 @@
 """Test the cloud component."""
+from collections.abc import Callable, Coroutine
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from hass_nabucasa import Cloud
 import pytest
 
 from homeassistant.components import cloud
-from homeassistant.components.cloud.client import CloudClient
 from homeassistant.components.cloud.const import DOMAIN
-from homeassistant.components.cloud.prefs import STORAGE_KEY, CloudPreferences
+from homeassistant.components.cloud.prefs import STORAGE_KEY
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.exceptions import Unauthorized
@@ -217,27 +217,25 @@ async def test_remote_ui_url(hass: HomeAssistant, mock_cloud_fixture) -> None:
         assert cloud.async_remote_ui_url(hass) == "https://example.com"
 
 
+@pytest.fixture
+def cloud_mock(cloud: MagicMock) -> MagicMock:
+    """Rename cloud mock."""
+    return cloud
+
+
 async def test_async_get_or_create_cloudhook(
-    hass: HomeAssistant, mock_cloud_fixture: CloudPreferences
+    hass: HomeAssistant,
+    cloud_mock: MagicMock,
+    set_cloud_prefs: Callable[[dict[str, Any]], Coroutine[Any, Any, None]],
 ) -> None:
     """Test async_get_or_create_cloudhook."""
-    cl: Cloud[CloudClient] = hass.data[DOMAIN]
+    assert await async_setup_component(hass, "cloud", {"cloud": {}})
+    await hass.async_block_till_done()
+
     webhook_id = "mock-webhook-id"
-
-    # Not connected
-    with pytest.raises(cloud.CloudNotConnected):
-        await cloud.async_get_or_create_cloudhook(hass, webhook_id)
-
-    # Simulate connected
-    cl.iot.state = "connected"
-
-    # Not logged in
-    with pytest.raises(cloud.CloudNotAvailable):
-        await cloud.async_get_or_create_cloudhook(hass, webhook_id)
-
     cloudhook_url = "https://cloudhook.nabu.casa/abcdefg"
 
-    with patch.object(cloud, "async_is_logged_in", return_value=True), patch.object(
+    with patch.object(
         cloud, "async_create_cloudhook", return_value=cloudhook_url
     ) as async_create_cloudhook_mock:
         # create cloudhook as it does not exist
@@ -246,14 +244,19 @@ async def test_async_get_or_create_cloudhook(
         ) == cloudhook_url
         async_create_cloudhook_mock.assert_called_once_with(hass, webhook_id)
 
-        mock_cloud_fixture._prefs[cloud.const.PREF_CLOUDHOOKS] = {
-            webhook_id: {
-                "webhook_id": webhook_id,
-                "cloudhook_id": "random-id",
-                "cloudhook_url": cloudhook_url,
-                "managed": True,
+        await set_cloud_prefs(
+            {
+                cloud.const.PREF_CLOUDHOOKS: {
+                    webhook_id: {
+                        "webhook_id": webhook_id,
+                        "cloudhook_id": "random-id",
+                        "cloudhook_url": cloudhook_url,
+                        "managed": True,
+                    }
+                }
             }
-        }
+        )
+
         async_create_cloudhook_mock.reset_mock()
 
         # get cloudhook as it exists
@@ -261,3 +264,17 @@ async def test_async_get_or_create_cloudhook(
             await cloud.async_get_or_create_cloudhook(hass, webhook_id) == cloudhook_url
         )
         async_create_cloudhook_mock.assert_not_called()
+
+    # Simulate logged out
+    cloud_mock.id_token = None
+
+    # Not logged in
+    with pytest.raises(cloud.CloudNotAvailable):
+        await cloud.async_get_or_create_cloudhook(hass, webhook_id)
+
+    # Simulate disconnected
+    cloud_mock.iot.state = "disconnected"
+
+    # Not connected
+    with pytest.raises(cloud.CloudNotConnected):
+        await cloud.async_get_or_create_cloudhook(hass, webhook_id)

--- a/tests/components/mobile_app/test_init.py
+++ b/tests/components/mobile_app/test_init.py
@@ -88,15 +88,17 @@ async def _test_create_cloud_hook(
     ), patch(
         "homeassistant.components.cloud.async_is_connected", return_value=True
     ), patch(
-        "homeassistant.components.cloud.async_create_cloudhook", autospec=True
-    ) as mock_create_cloudhook:
+        "homeassistant.components.cloud.async_get_or_create_cloudhook", autospec=True
+    ) as mock_async_get_or_create_cloudhook:
         cloud_hook = "https://hook-url"
-        mock_create_cloudhook.return_value = cloud_hook
+        mock_async_get_or_create_cloudhook.return_value = cloud_hook
 
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
         assert config_entry.state is ConfigEntryState.LOADED
-        await additional_steps(config_entry, mock_create_cloudhook, cloud_hook)
+        await additional_steps(
+            config_entry, mock_async_get_or_create_cloudhook, cloud_hook
+        )
 
 
 async def test_create_cloud_hook_on_setup(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
During a debug session with @ludeeus, we found that for some devices a cloudhook already exists but was not saved in the mobile_app config entry. We couldn't identify when they were created (at least on my instance) but they were created before HA 2024.1.
Other integrations like withings are always deleting the cloudhook before creating:
https://github.com/home-assistant/core/blob/896ca8ce83ff2c945b62e424028beb81e64b7c1d/homeassistant/components/withings/__init__.py#L334-L340

Deleting and then creating returns a different (new) cloudhook url. In the mobile app use case, we don't want to do that as maybe the cloud hook is used by the app even when it was not correctly stored in the config entry.

To reuse already created cloud hooks  `async_get_or_create_cloudhook` is added, which returns the cloudhook_url if a cloudhook for the passed webhook_id exists. Otherwise, a cloudhook is created.

We think that also other integrations like withings can benefit from the new function.


In addition we guard the cloudhook creation with a `asyncio.Lock` to prevent parallel execution.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #107021
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
