### PR TITLE
Fix missing unique_id for spt integration

### DIFF
--- a/homeassistant/components/swiss_public_transport/__init__.py
+++ b/homeassistant/components/swiss_public_transport/__init__.py
@@ -99,7 +99,7 @@ async def async_migrate_entry(
                 entity_id=entity_id,
                 new_unique_id=f"{new_unique_id}_departure",
             )
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Faulty entity with unique_id 'None_departure' migrated to new unique_id '%s'",
                 f"{new_unique_id}_departure",
             )

--- a/homeassistant/components/swiss_public_transport/__init__.py
+++ b/homeassistant/components/swiss_public_transport/__init__.py
@@ -10,7 +10,7 @@ from opendata_transport.exceptions import (
 from homeassistant import config_entries, core
 from homeassistant.const import Platform
 from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import CONF_DESTINATION, CONF_START, DOMAIN
@@ -79,9 +79,11 @@ async def async_migrate_entry(
         return False
 
     if config_entry.version == 1:
-        new = {**config_entry.data}
-
-        # Remove wrongly registered devices
+        # Remove wrongly registered devices and entries
+        new_unique_id = (
+            f"{config_entry.data[CONF_START]} {config_entry.data[CONF_DESTINATION]}"
+        )
+        entity_registry = er.async_get(hass)
         device_registry = dr.async_get(hass)
         device_entries = dr.async_entries_for_config_entry(
             device_registry, config_entry_id=config_entry.entry_id
@@ -89,13 +91,23 @@ async def async_migrate_entry(
         for dev in device_entries:
             device_registry.async_remove_device(dev.id)
 
-        # Set a valid unique id for config entries
-        config_entry.unique_id = (
-            f"{config_entry.data[CONF_START]} {config_entry.data[CONF_DESTINATION]}"
+        entity_id = entity_registry.async_get_entity_id(
+            Platform.SENSOR, DOMAIN, "None_departure"
         )
+        if entity_id:
+            entity_registry.async_update_entity(
+                entity_id=entity_id,
+                new_unique_id=f"{new_unique_id}_departure",
+            )
+            _LOGGER.info(
+                "Faulty entity with unique_id 'None_departure' migrated to new unique_id '%s'",
+                f"{new_unique_id}_departure",
+            )
 
+        # Set a valid unique id for config entries
+        config_entry.unique_id = new_unique_id
         config_entry.version = 2
-        hass.config_entries.async_update_entry(config_entry, data=new)
+        hass.config_entries.async_update_entry(config_entry)
 
     _LOGGER.debug("Migration to version %s successful", config_entry.version)
 

--- a/homeassistant/components/swiss_public_transport/__init__.py
+++ b/homeassistant/components/swiss_public_transport/__init__.py
@@ -109,6 +109,8 @@ async def async_migrate_entry(
         config_entry.minor_version = 2
         hass.config_entries.async_update_entry(config_entry)
 
-    _LOGGER.debug("Migration to minor version %s successful", config_entry.minor_version)
+    _LOGGER.debug(
+        "Migration to minor version %s successful", config_entry.minor_version
+    )
 
     return True

--- a/homeassistant/components/swiss_public_transport/__init__.py
+++ b/homeassistant/components/swiss_public_transport/__init__.py
@@ -74,11 +74,11 @@ async def async_migrate_entry(
     """Migrate config entry."""
     _LOGGER.debug("Migrating from version %s", config_entry.version)
 
-    if config_entry.version > 3:
+    if config_entry.minor_version > 3:
         # This means the user has downgraded from a future version
         return False
 
-    if config_entry.version == 1:
+    if config_entry.minor_version == 1:
         # Remove wrongly registered devices and entries
         new_unique_id = (
             f"{config_entry.data[CONF_START]} {config_entry.data[CONF_DESTINATION]}"
@@ -106,9 +106,9 @@ async def async_migrate_entry(
 
         # Set a valid unique id for config entries
         config_entry.unique_id = new_unique_id
-        config_entry.version = 2
+        config_entry.minor_version = 2
         hass.config_entries.async_update_entry(config_entry)
 
-    _LOGGER.debug("Migration to version %s successful", config_entry.version)
+    _LOGGER.debug("Migration to minor version %s successful", config_entry.minor_version)
 
     return True

--- a/homeassistant/components/swiss_public_transport/config_flow.py
+++ b/homeassistant/components/swiss_public_transport/config_flow.py
@@ -30,7 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 class SwissPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Swiss public transport config flow."""
 
-    VERSION = 2
+    MINOR_VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/swiss_public_transport/config_flow.py
+++ b/homeassistant/components/swiss_public_transport/config_flow.py
@@ -30,7 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 class SwissPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Swiss public transport config flow."""
 
-    VERSION = 1
+    VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -59,6 +59,9 @@ class SwissPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unknown error")
                 errors["base"] = "unknown"
             else:
+                await self.async_set_unique_id(
+                    f"{user_input[CONF_START]} {user_input[CONF_DESTINATION]}"
+                )
                 return self.async_create_entry(
                     title=f"{user_input[CONF_START]} {user_input[CONF_DESTINATION]}",
                     data=user_input,
@@ -98,6 +101,9 @@ class SwissPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             return self.async_abort(reason="unknown")
 
+        await self.async_set_unique_id(
+            f"{import_input[CONF_START]} {import_input[CONF_DESTINATION]}"
+        )
         return self.async_create_entry(
             title=import_input[CONF_NAME],
             data=import_input,

--- a/homeassistant/components/swiss_public_transport/config_flow.py
+++ b/homeassistant/components/swiss_public_transport/config_flow.py
@@ -30,6 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 class SwissPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Swiss public transport config flow."""
 
+    VERSION = 1
     MINOR_VERSION = 2
 
     async def async_step_user(

--- a/tests/components/swiss_public_transport/test_init.py
+++ b/tests/components/swiss_public_transport/test_init.py
@@ -1,0 +1,89 @@
+"""Test the swiss_public_transport config flow."""
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.components.swiss_public_transport.const import (
+    CONF_DESTINATION,
+    CONF_START,
+    DOMAIN,
+)
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry
+
+MOCK_DATA_STEP = {
+    CONF_START: "test_start",
+    CONF_DESTINATION: "test_destination",
+}
+
+CONNECTIONS = [
+    {
+        "departure": "2024-01-06T18:03:00+0100",
+        "number": 0,
+        "platform": 0,
+        "transfers": 0,
+        "duration": "10",
+        "delay": 0,
+    },
+    {
+        "departure": "2024-01-06T18:04:00+0100",
+        "number": 1,
+        "platform": 1,
+        "transfers": 0,
+        "duration": "10",
+        "delay": 0,
+    },
+    {
+        "departure": "2024-01-06T18:05:00+0100",
+        "number": 2,
+        "platform": 2,
+        "transfers": 0,
+        "duration": "10",
+        "delay": 0,
+    },
+]
+
+
+def side_effect_async_get_data(x):
+    """Side effect on calling async get data which fills the connections attribute."""
+    x.connections = CONNECTIONS
+
+
+async def test_migration_1_to_2(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test successful setup."""
+
+    with patch(
+        "homeassistant.components.swiss_public_transport.OpendataTransport",
+        return_value=AsyncMock(),
+    ) as mock:
+        mock().connections = CONNECTIONS
+
+        config_entry_faulty = MockConfigEntry(
+            domain=DOMAIN,
+            data=MOCK_DATA_STEP,
+            title="MIGRATION_TEST",
+        )
+        config_entry_faulty.add_to_hass(hass)
+
+        # Setup the config entry
+        await hass.config_entries.async_setup(config_entry_faulty.entry_id)
+        await hass.async_block_till_done()
+        assert entity_registry.async_is_registered(
+            entity_registry.entities.get_entity_id(
+                (Platform.SENSOR, DOMAIN, "test_start test_destination_departure")
+            )
+        )
+
+        # Check change in config entry
+        assert config_entry_faulty.version == 2
+        assert config_entry_faulty.unique_id == "test_start test_destination"
+
+        # Check "None" is gone
+        assert not entity_registry.async_is_registered(
+            entity_registry.entities.get_entity_id(
+                (Platform.SENSOR, DOMAIN, "None_departure")
+            )
+        )

--- a/tests/components/swiss_public_transport/test_init.py
+++ b/tests/components/swiss_public_transport/test_init.py
@@ -45,11 +45,6 @@ CONNECTIONS = [
 ]
 
 
-def side_effect_async_get_data(x):
-    """Side effect on calling async get data which fills the connections attribute."""
-    x.connections = CONNECTIONS
-
-
 async def test_migration_1_to_2(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
@@ -65,6 +60,7 @@ async def test_migration_1_to_2(
             domain=DOMAIN,
             data=MOCK_DATA_STEP,
             title="MIGRATION_TEST",
+            minor_version=1,
         )
         config_entry_faulty.add_to_hass(hass)
 
@@ -78,7 +74,7 @@ async def test_migration_1_to_2(
         )
 
         # Check change in config entry
-        assert config_entry_faulty.version == 2
+        assert config_entry_faulty.minor_version == 2
         assert config_entry_faulty.unique_id == "test_start test_destination"
 
         # Check "None" is gone


### PR DESCRIPTION
## Proposed change
Define unique id based on unique config, which is required for the entity registry. Currently the integration is broken and unusable for most of the users.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #107073
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
