### PR TITLE
Add test for avoid triggering ping device tracker `home` after reload

### DIFF
--- a/tests/components/ping/test_device_tracker.py
+++ b/tests/components/ping/test_device_tracker.py
@@ -1,4 +1,5 @@
 """Test the binary sensor platform of ping."""
+from collections.abc import Generator
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -15,6 +16,16 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util.yaml import dump
 
 from tests.common import MockConfigEntry, async_fire_time_changed, patch_yaml_files
+
+
+@pytest.fixture
+def entity_registry_enabled_by_default() -> Generator[None, None, None]:
+    """Test fixture that ensures ping device_tracker entities are enabled in the registry."""
+    with patch(
+        "homeassistant.components.ping.device_tracker.PingDeviceTracker.entity_registry_enabled_default",
+        return_value=True,
+    ):
+        yield
 
 
 @pytest.mark.usefixtures("setup_integration")
@@ -125,3 +136,38 @@ async def test_import_delete_known_devices(
         await hass.async_block_till_done()
 
         assert len(remove_device_from_config.mock_calls) == 1
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "setup_integration")
+async def test_reload_not_triggering_home(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    config_entry: MockConfigEntry,
+):
+    """Test if reload/restart does not trigger home when device is unavailable."""
+    assert hass.states.get("device_tracker.10_10_10_10").state == "home"
+
+    with patch(
+        "homeassistant.components.ping.helpers.async_ping",
+        return_value=Host("10.10.10.10", 5, []),
+    ):
+        # device should be "not_home" after consider_home interval
+        freezer.tick(timedelta(minutes=5, seconds=10))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+        assert hass.states.get("device_tracker.10_10_10_10").state == "not_home"
+
+        # reload config entry
+        await hass.config_entries.async_reload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # device should still be "not_home" after a reload
+    assert hass.states.get("device_tracker.10_10_10_10").state == "not_home"
+
+    # device should be "home" after the next refresh
+    freezer.tick(timedelta(seconds=30))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("device_tracker.10_10_10_10").state == "home"


### PR DESCRIPTION
## Proposed change
This PR adds a test for the fix introduced with https://github.com/home-assistant/core/pull/106913

Needed to create a own `entity_registry_enabled_by_default` fixture as the existing fixture does not worked here.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
