### PR TITLE
Revert "Bump aiohttp-zlib-ng to 0.2.0 (#106691)"

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -106,7 +106,7 @@ jobs:
           arch: ${{ matrix.arch }}
           wheels-key: ${{ secrets.WHEELS_KEY }}
           env-file: true
-          apk: "libffi-dev;openssl-dev;yaml-dev;nasm"
+          apk: "libffi-dev;openssl-dev;yaml-dev"
           skip-binary: aiohttp
           constraints: "homeassistant/package_constraints.txt"
           requirements-diff: "requirements_diff.txt"
@@ -214,7 +214,7 @@ jobs:
           arch: ${{ matrix.arch }}
           wheels-key: ${{ secrets.WHEELS_KEY }}
           env-file: true
-          apk: "bluez-dev;libffi-dev;openssl-dev;glib-dev;eudev-dev;libxml2-dev;libxslt-dev;libpng-dev;libjpeg-turbo-dev;tiff-dev;cups-dev;gmp-dev;mpfr-dev;mpc1-dev;ffmpeg-dev;gammu-dev;yaml-dev;openblas-dev;fftw-dev;lapack-dev;gfortran;blas-dev;eigen-dev;freetype-dev;glew-dev;harfbuzz-dev;hdf5-dev;libdc1394-dev;libtbb-dev;mesa-dev;openexr-dev;openjpeg-dev;uchardet-dev;nasm"
+          apk: "bluez-dev;libffi-dev;openssl-dev;glib-dev;eudev-dev;libxml2-dev;libxslt-dev;libpng-dev;libjpeg-turbo-dev;tiff-dev;cups-dev;gmp-dev;mpfr-dev;mpc1-dev;ffmpeg-dev;gammu-dev;yaml-dev;openblas-dev;fftw-dev;lapack-dev;gfortran;blas-dev;eigen-dev;freetype-dev;glew-dev;harfbuzz-dev;hdf5-dev;libdc1394-dev;libtbb-dev;mesa-dev;openexr-dev;openjpeg-dev;uchardet-dev"
           skip-binary: aiohttp;charset-normalizer;grpcio;SQLAlchemy;protobuf
           constraints: "homeassistant/package_constraints.txt"
           requirements-diff: "requirements_diff.txt"
@@ -228,7 +228,7 @@ jobs:
           arch: ${{ matrix.arch }}
           wheels-key: ${{ secrets.WHEELS_KEY }}
           env-file: true
-          apk: "bluez-dev;libffi-dev;openssl-dev;glib-dev;eudev-dev;libxml2-dev;libxslt-dev;libpng-dev;libjpeg-turbo-dev;tiff-dev;cups-dev;gmp-dev;mpfr-dev;mpc1-dev;ffmpeg-dev;gammu-dev;yaml-dev;openblas-dev;fftw-dev;lapack-dev;gfortran;blas-dev;eigen-dev;freetype-dev;glew-dev;harfbuzz-dev;hdf5-dev;libdc1394-dev;libtbb-dev;mesa-dev;openexr-dev;openjpeg-dev;uchardet-dev;nasm"
+          apk: "bluez-dev;libffi-dev;openssl-dev;glib-dev;eudev-dev;libxml2-dev;libxslt-dev;libpng-dev;libjpeg-turbo-dev;tiff-dev;cups-dev;gmp-dev;mpfr-dev;mpc1-dev;ffmpeg-dev;gammu-dev;yaml-dev;openblas-dev;fftw-dev;lapack-dev;gfortran;blas-dev;eigen-dev;freetype-dev;glew-dev;harfbuzz-dev;hdf5-dev;libdc1394-dev;libtbb-dev;mesa-dev;openexr-dev;openjpeg-dev;uchardet-dev"
           skip-binary: aiohttp;charset-normalizer;grpcio;SQLAlchemy;protobuf
           constraints: "homeassistant/package_constraints.txt"
           requirements-diff: "requirements_diff.txt"
@@ -242,7 +242,7 @@ jobs:
           arch: ${{ matrix.arch }}
           wheels-key: ${{ secrets.WHEELS_KEY }}
           env-file: true
-          apk: "bluez-dev;libffi-dev;openssl-dev;glib-dev;eudev-dev;libxml2-dev;libxslt-dev;libpng-dev;libjpeg-turbo-dev;tiff-dev;cups-dev;gmp-dev;mpfr-dev;mpc1-dev;ffmpeg-dev;gammu-dev;yaml-dev;openblas-dev;fftw-dev;lapack-dev;gfortran;blas-dev;eigen-dev;freetype-dev;glew-dev;harfbuzz-dev;hdf5-dev;libdc1394-dev;libtbb-dev;mesa-dev;openexr-dev;openjpeg-dev;uchardet-dev;nasm"
+          apk: "bluez-dev;libffi-dev;openssl-dev;glib-dev;eudev-dev;libxml2-dev;libxslt-dev;libpng-dev;libjpeg-turbo-dev;tiff-dev;cups-dev;gmp-dev;mpfr-dev;mpc1-dev;ffmpeg-dev;gammu-dev;yaml-dev;openblas-dev;fftw-dev;lapack-dev;gfortran;blas-dev;eigen-dev;freetype-dev;glew-dev;harfbuzz-dev;hdf5-dev;libdc1394-dev;libtbb-dev;mesa-dev;openexr-dev;openjpeg-dev;uchardet-dev"
           skip-binary: aiohttp;charset-normalizer;grpcio;SQLAlchemy;protobuf
           constraints: "homeassistant/package_constraints.txt"
           requirements-diff: "requirements_diff.txt"

--- a/homeassistant/components/http/manifest.json
+++ b/homeassistant/components/http/manifest.json
@@ -9,6 +9,6 @@
   "requirements": [
     "aiohttp_cors==0.7.0",
     "aiohttp-fast-url-dispatcher==0.3.0",
-    "aiohttp-zlib-ng==0.2.0"
+    "aiohttp-zlib-ng==0.1.3"
   ]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -2,7 +2,7 @@
 
 aiodiscover==1.6.0
 aiohttp-fast-url-dispatcher==0.3.0
-aiohttp-zlib-ng==0.2.0
+aiohttp-zlib-ng==0.1.3
 aiohttp==3.9.1
 aiohttp_cors==0.7.0
 astral==2.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies    = [
     "aiohttp==3.9.1",
     "aiohttp_cors==0.7.0",
     "aiohttp-fast-url-dispatcher==0.3.0",
-    "aiohttp-zlib-ng==0.2.0",
+    "aiohttp-zlib-ng==0.1.3",
     "astral==2.2",
     "attrs==23.1.0",
     "atomicwrites-homeassistant==1.4.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 aiohttp==3.9.1
 aiohttp_cors==0.7.0
 aiohttp-fast-url-dispatcher==0.3.0
-aiohttp-zlib-ng==0.2.0
+aiohttp-zlib-ng==0.1.3
 astral==2.2
 attrs==23.1.0
 atomicwrites-homeassistant==1.4.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -263,7 +263,7 @@ aiohomekit==3.1.1
 aiohttp-fast-url-dispatcher==0.3.0
 
 # homeassistant.components.http
-aiohttp-zlib-ng==0.2.0
+aiohttp-zlib-ng==0.1.3
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -239,7 +239,7 @@ aiohomekit==3.1.1
 aiohttp-fast-url-dispatcher==0.3.0
 
 # homeassistant.components.http
-aiohttp-zlib-ng==0.2.0
+aiohttp-zlib-ng==0.1.3
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http


### PR DESCRIPTION
This reverts commit e1f078b70aa9097436603ea7b250ac8c223feb53.

Our i386 builder runs on an x86_64 system and tries to match x86_64 packages. My attempt at fixing it in https://github.com/home-assistant/builder/pull/189 didn't solve the issue, and since this is blocking nightly from building, revert the change.

the intel `isal` lib only provides the acceleration on aarch64/x86_64 (which covers the majority of our install base) so there are markers to only install it on those <https://github.com/bdraco/aiohttp-zlib-ng/blob/a82a022e9270fa75c3ac2a08620365ff841f4e4e/pyproject.toml#L28>. It works fine on the wheel builder because it sees i386 as i386 because of linux32. For the image builds I think it trying to install the dep because sees the `platform_machine` as `x86_64` but pip knows it wants `i686` wheels so it tries to find the wheel for `i686` which isn't there.

* This probably also explains the problems with had with i686 and sqlalchemy in the past so it would be nice to come up with a solution. Their solution was to drop all the platform markers and move to extras if I recall correctly.