### PR TITLE
Add state_class - measurement to device_class - monetary

### DIFF
--- a/homeassistant/components/sensor/const.py
+++ b/homeassistant/components/sensor/const.py
@@ -595,7 +595,7 @@ DEVICE_CLASS_STATE_CLASSES: dict[SensorDeviceClass, set[SensorStateClass]] = {
     SensorDeviceClass.ILLUMINANCE: {SensorStateClass.MEASUREMENT},
     SensorDeviceClass.IRRADIANCE: {SensorStateClass.MEASUREMENT},
     SensorDeviceClass.MOISTURE: {SensorStateClass.MEASUREMENT},
-    SensorDeviceClass.MONETARY: {SensorStateClass.TOTAL},
+    SensorDeviceClass.MONETARY: {SensorStateClass.MEASUREMENT, SensorStateClass.TOTAL},
     SensorDeviceClass.NITROGEN_DIOXIDE: {SensorStateClass.MEASUREMENT},
     SensorDeviceClass.NITROGEN_MONOXIDE: {SensorStateClass.MEASUREMENT},
     SensorDeviceClass.NITROUS_OXIDE: {SensorStateClass.MEASUREMENT},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add `state_class` - `measurement` to `device_class` - `monetary`, this will remove the warning in sensors:
```
[homeassistant.components.sensor] Entity sensor.... (<class 'homeassistant.components....'>) is using state class 'measurement' which is impossible considering device class ('monetary') it is using; expected None or one of 'total';
```
That use `device_class` - `monetary`, like:
```
sensor:
  - name: ...
    unit_of_measurement: UAH
    state_class: measurement
    device_class: monetary
```
In order to monitor changes in monetary values, with their placement in Long term statistics. To track both current changes and long-term analysis, according to the documentation https://data.home-assistant.io/docs/statistics/

Sensor entities with a `measurement` (the sensor's state_class is `measurement`):
`mean` - hourly time-weighted average
`min` - hourly minimum
`max` - hourly maximum

For example, tracking fluctuations in exchange rates, stocks, prices for gasoline, diesel, etc.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
