### PR TITLE
Add config flow to Mold Indicator

### DIFF
--- a/homeassistant/components/mold_indicator/__init__.py
+++ b/homeassistant/components/mold_indicator/__init__.py
@@ -1,1 +1,20 @@
 """Calculates mold growth indication from temperature and humidity."""
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Mold Indicator from a config entry."""
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/mold_indicator/config_flow.py
+++ b/homeassistant/components/mold_indicator/config_flow.py
@@ -1,0 +1,115 @@
+"""Config flow for Mold Indicator integration."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN, SensorDeviceClass
+from homeassistant.config_entries import ConfigFlow
+from homeassistant.const import CONF_NAME
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import selector
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
+
+from .const import (
+    CONF_CALIBRATION_FACTOR,
+    CONF_INDOOR_HUMIDITY,
+    CONF_INDOOR_TEMP,
+    CONF_OUTDOOR_TEMP,
+    DEFAULT_NAME,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+ISSUE_PLACEHOLDER = {"url": "/config/integrations/dashboard/add?domain=mold_indicator"}
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_INDOOR_TEMP): selector.EntitySelector(
+            selector.EntitySelectorConfig(
+                domain=SENSOR_DOMAIN,
+                filter=selector.EntityFilterSelectorConfig(
+                    device_class=SensorDeviceClass.TEMPERATURE
+                ),
+            ),
+        ),
+        vol.Required(CONF_OUTDOOR_TEMP): selector.EntitySelector(
+            selector.EntitySelectorConfig(
+                domain=SENSOR_DOMAIN,
+                filter=selector.EntityFilterSelectorConfig(
+                    device_class=SensorDeviceClass.TEMPERATURE
+                ),
+            ),
+        ),
+        vol.Required(CONF_INDOOR_HUMIDITY): selector.EntitySelector(
+            selector.EntitySelectorConfig(
+                domain=SENSOR_DOMAIN,
+                filter=selector.EntityFilterSelectorConfig(
+                    device_class=SensorDeviceClass.HUMIDITY
+                ),
+            ),
+        ),
+        vol.Optional(CONF_CALIBRATION_FACTOR): vol.Coerce(float),
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    }
+)
+
+
+class MoldIndicatorConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Mold Indicator."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            self._async_abort_entries_match(
+                {
+                    CONF_INDOOR_HUMIDITY: user_input[CONF_INDOOR_HUMIDITY],
+                    CONF_INDOOR_TEMP: user_input[CONF_INDOOR_TEMP],
+                    CONF_OUTDOOR_TEMP: user_input[CONF_OUTDOOR_TEMP],
+                }
+            )
+
+            await self.async_set_unique_id(user_input[CONF_NAME])
+            self._abort_if_unique_id_configured()
+
+            return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)
+
+        return self.async_show_form(
+            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_import(self, user_input: dict[str, Any]) -> FlowResult:
+        """Import the YAML config."""
+        self._async_abort_entries_match(
+            {
+                CONF_INDOOR_HUMIDITY: user_input[CONF_INDOOR_HUMIDITY],
+                CONF_INDOOR_TEMP: user_input[CONF_INDOOR_TEMP],
+                CONF_OUTDOOR_TEMP: user_input[CONF_OUTDOOR_TEMP],
+            }
+        )
+
+        async_create_issue(
+            self.hass,
+            HOMEASSISTANT_DOMAIN,
+            f"deprecated_yaml_{DOMAIN}",
+            breaks_in_ha_version="2024.7.0",
+            is_fixable=False,
+            issue_domain=DOMAIN,
+            severity=IssueSeverity.WARNING,
+            translation_key="deprecated_yaml",
+            translation_placeholders={
+                "domain": DOMAIN,
+                "integration_title": "Mold Indicator",
+            },
+        )
+
+        return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)

--- a/homeassistant/components/mold_indicator/const.py
+++ b/homeassistant/components/mold_indicator/const.py
@@ -1,0 +1,17 @@
+"""Constants for the Mold Indicator integration."""
+from typing import Final
+
+DOMAIN: Final = "mold_indicator"
+
+ATTR_CRITICAL_TEMP = "estimated_critical_temp"
+ATTR_DEWPOINT = "dewpoint"
+
+CONF_CALIBRATION_FACTOR = "calibration_factor"
+CONF_INDOOR_HUMIDITY = "indoor_humidity_sensor"
+CONF_INDOOR_TEMP = "indoor_temp_sensor"
+CONF_OUTDOOR_TEMP = "outdoor_temp_sensor"
+
+DEFAULT_NAME = "Mold Indicator"
+
+MAGNUS_K2 = 17.62
+MAGNUS_K3 = 243.12

--- a/homeassistant/components/mold_indicator/manifest.json
+++ b/homeassistant/components/mold_indicator/manifest.json
@@ -2,6 +2,7 @@
   "domain": "mold_indicator",
   "name": "Mold Indicator",
   "codeowners": [],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/mold_indicator",
   "iot_class": "local_polling",
   "quality_scale": "internal"

--- a/homeassistant/components/mold_indicator/strings.json
+++ b/homeassistant/components/mold_indicator/strings.json
@@ -1,0 +1,28 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "name": "[%key:common::config_flow::data::name%]",
+          "calibration_factor": "Calibration factor",
+          "indoor_humidity_sensor": "Indoor humidity sensor",
+          "indoor_temp_sensor": "Indoor temperature sensor",
+          "outdoor_temp_sensor": "Outdoor temperature sensor"
+        },
+        "title": "Mold Indicator"
+      }
+    },
+    "error": {
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  },
+  "issues": {
+    "deprecated_yaml_import_issue_unknown": {
+      "title": "The Mold indicator YAML configuration import failed",
+      "description": "Configuring Mold indicator using YAML is being removed but there was an unknown error when trying to import the YAML configuration.\n\nEnsure the imported configuration is correct and remove the Mold indicator YAML configuration from your configuration.yaml file and continue to [set up the integration]({url}) manually."
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -303,6 +303,7 @@ FLOWS = {
         "modem_callerid",
         "modern_forms",
         "moehlenhoff_alpha2",
+        "mold_indicator",
         "monoprice",
         "moon",
         "mopeka",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -3593,7 +3593,7 @@
     "mold_indicator": {
       "name": "Mold Indicator",
       "integration_type": "hub",
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "local_polling"
     },
     "monessen": {

--- a/tests/components/mold_indicator/conftest.py
+++ b/tests/components/mold_indicator/conftest.py
@@ -1,0 +1,15 @@
+"""Common fixtures for the mold_indicators tests."""
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.mold_indicator.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        yield mock_setup_entry

--- a/tests/components/mold_indicator/test_config_flow.py
+++ b/tests/components/mold_indicator/test_config_flow.py
@@ -1,0 +1,121 @@
+"""Test the mold_indicator config flow."""
+from unittest.mock import AsyncMock
+
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.mold_indicator import config_flow
+from homeassistant.components.mold_indicator.const import (
+    CONF_CALIBRATION_FACTOR,
+    CONF_INDOOR_HUMIDITY,
+    CONF_INDOOR_TEMP,
+    CONF_OUTDOOR_TEMP,
+    DEFAULT_NAME,
+)
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+pytestmark = pytest.mark.usefixtures("mock_setup_entry")
+
+MOCK_DATA_STEP = {
+    CONF_NAME: DEFAULT_NAME,
+    CONF_INDOOR_HUMIDITY: "sensor.test_indoor_humidity_entity_id",
+    CONF_INDOOR_TEMP: "sensor.test_indoor_temperature_entity_id",
+    CONF_OUTDOOR_TEMP: "sensor.test_outdoor_temperature_entity_id",
+    CONF_CALIBRATION_FACTOR: 1.0,
+}
+
+
+async def test_flow_user_init_data_success(hass: HomeAssistant) -> None:
+    """Test success response."""
+    result = await hass.config_entries.flow.async_init(
+        config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["handler"] == "mold_indicator"
+    assert result["data_schema"] == config_flow.DATA_SCHEMA
+
+    result = await hass.config_entries.flow.async_init(
+        config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input=MOCK_DATA_STEP,
+    )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["result"].title == "Mold Indicator"
+
+    assert result["data"] == MOCK_DATA_STEP
+
+
+async def test_flow_user_init_data_already_configured(hass: HomeAssistant) -> None:
+    """Test we abort user data set when entry is already configured."""
+
+    entry = MockConfigEntry(
+        domain=config_flow.DOMAIN,
+        data=MOCK_DATA_STEP,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input=MOCK_DATA_STEP,
+    )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+MOCK_DATA_IMPORT = {
+    CONF_NAME: DEFAULT_NAME,
+    CONF_INDOOR_HUMIDITY: "sensor.test_indoor_humidity_entity_id",
+    CONF_INDOOR_TEMP: "sensor.test_indoor_temperature_entity_id",
+    CONF_OUTDOOR_TEMP: "sensor.test_outdoor_temperature_entity_id",
+    CONF_CALIBRATION_FACTOR: 1.0,
+}
+
+
+async def test_import(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test import flow."""
+    result = await hass.config_entries.flow.async_init(
+        config_flow.DOMAIN,
+        context={"source": config_entries.SOURCE_IMPORT},
+        data=MOCK_DATA_IMPORT,
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"] == MOCK_DATA_IMPORT
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_import_already_configured(hass: HomeAssistant) -> None:
+    """Test we abort import when entry is already configured."""
+
+    entry = MockConfigEntry(
+        domain=config_flow.DOMAIN,
+        data=MOCK_DATA_IMPORT,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        config_flow.DOMAIN,
+        context={"source": config_entries.SOURCE_IMPORT},
+        data=MOCK_DATA_IMPORT,
+    )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The Mold Indicator YAML configuration is deprecated. Your old configuration will be imported.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add config flow to Mold Indicator.

This also adds a unique id for the mold indicator, which resolves [this feature request](https://community.home-assistant.io/t/add-unique-id-to-mold-indicator-sensor/650187). I'm not sure if this should be a separate PR though.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
