### PR TITLE
Bump Orvibo to 1.1.2

### DIFF
--- a/homeassistant/components/orvibo/manifest.json
+++ b/homeassistant/components/orvibo/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/orvibo",
   "iot_class": "local_push",
   "loggers": ["orvibo"],
-  "requirements": ["orvibo==1.1.1"]
+  "requirements": ["orvibo==1.1.2"]
 }

--- a/homeassistant/components/orvibo/manifest.json
+++ b/homeassistant/components/orvibo/manifest.json
@@ -5,6 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/orvibo",
   "iot_class": "local_push",
   "loggers": ["orvibo"],
-  "requirements": ["orvibo==1.1.2"],
-  "version": "1.0.1"
+  "requirements": ["orvibo==1.1.2"]
 }

--- a/homeassistant/components/orvibo/manifest.json
+++ b/homeassistant/components/orvibo/manifest.json
@@ -5,5 +5,6 @@
   "documentation": "https://www.home-assistant.io/integrations/orvibo",
   "iot_class": "local_push",
   "loggers": ["orvibo"],
-  "requirements": ["orvibo==1.1.2"]
+  "requirements": ["orvibo==1.1.2"],
+  "version": "1.0.1"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1443,7 +1443,7 @@ oralb-ble==0.17.6
 oru==0.1.11
 
 # homeassistant.components.orvibo
-orvibo==1.1.1
+orvibo==1.1.2
 
 # homeassistant.components.ourgroceries
 ourgroceries==1.5.4


### PR DESCRIPTION
Fixes https://github.com/home-assistant/core/issues/106923

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
https://github.com/happyleavesaoc/python-orvibo/compare/1.1.1...master
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This fixes error `TypeError: string argument without an encoding` which was introduced with the recent changed to how MAC addresses are typed.
The issue has been fixed in pypi/orvibo in a recent update released as 1.1.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #106923
- This was fixed in https://github.com/happyleavesaoc/python-orvibo/pull/11
- Diff https://github.com/happyleavesaoc/python-orvibo/commit/ded1136e8d3ce74f42f8e8aca65e5d06174e6dc7
- Pushed to pypi here https://pypi.org/project/orvibo/1.1.2/

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
