### PR TITLE
Add option to choose a rounding mode for display values of temperatures

### DIFF
--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 from __future__ import annotations
 
-from enum import StrEnum
+from enum import Enum, StrEnum
 from functools import partial
 from typing import Final
 
@@ -1556,6 +1556,24 @@ WEEKDAYS: Final[list[str]] = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
 PRECISION_WHOLE: Final = 1
 PRECISION_HALVES: Final = 0.5
 PRECISION_TENTHS: Final = 0.1
+
+
+class Precision(Enum):
+    """Precision of a platform."""
+
+    WHOLE = PRECISION_WHOLE
+    HALVES = PRECISION_HALVES
+    TENTHS = PRECISION_TENTHS
+
+
+# The round mode when using precision for platforms
+class RoundMode(StrEnum):
+    """Rounding mode of a platform."""
+
+    NEAREST = "nearest"
+    DOWN = "down"
+    UP = "up"
+
 
 # Static list of entities that will never be exposed to
 # cloud, alexa, or google_home components

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1552,28 +1552,19 @@ ACCUMULATED_PRECIPITATION: Final = "accumulated_precipitation"
 
 WEEKDAYS: Final[list[str]] = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
 
+
 # The degree of precision for platforms
-PRECISION_WHOLE: Final = 1
-PRECISION_HALVES: Final = 0.5
-PRECISION_TENTHS: Final = 0.1
-
-
 class Precision(Enum):
     """Precision of a platform."""
 
-    WHOLE = PRECISION_WHOLE
-    HALVES = PRECISION_HALVES
-    TENTHS = PRECISION_TENTHS
+    WHOLE = 1
+    HALVES = 0.5
+    TENTHS = 0.1
 
 
-# The round mode when using precision for platforms
-class RoundMode(StrEnum):
-    """Rounding mode of a platform."""
-
-    NEAREST = "nearest"
-    DOWN = "down"
-    UP = "up"
-
+PRECISION_WHOLE: Final = DeprecatedConstantEnum(Precision.WHOLE, "2025.1")
+PRECISION_HALVES: Final = DeprecatedConstantEnum(Precision.HALVES, "2025.1")
+PRECISION_TENTHS: Final = DeprecatedConstantEnum(Precision.TENTHS, "2025.1")
 
 # Static list of entities that will never be exposed to
 # cloud, alexa, or google_home components

--- a/homeassistant/helpers/temperature.py
+++ b/homeassistant/helpers/temperature.py
@@ -1,15 +1,21 @@
 """Temperature helpers for Home Assistant."""
 from __future__ import annotations
 
+from collections.abc import Callable
+from math import ceil, floor
 from numbers import Number
 
-from homeassistant.const import PRECISION_HALVES, PRECISION_TENTHS
+from homeassistant.const import Precision, RoundMode
 from homeassistant.core import HomeAssistant
 from homeassistant.util.unit_conversion import TemperatureConverter
 
 
 def display_temp(
-    hass: HomeAssistant, temperature: float | None, unit: str, precision: float
+    hass: HomeAssistant,
+    temperature: float | None,
+    unit: str,
+    precision: Precision,
+    round_mode: RoundMode = RoundMode.NEAREST,
 ) -> float | None:
     """Convert temperature into preferred units/precision for display."""
     temperature_unit = unit
@@ -28,10 +34,38 @@ def display_temp(
             temperature
         )
 
-    # Round in the units appropriate
-    if precision == PRECISION_HALVES:
-        return round(temperature * 2) / 2.0
-    if precision == PRECISION_TENTHS:
-        return round(temperature, 1)
+    round_funcs: dict[RoundMode, Callable[[float], int]] = {
+        # "nearest" requires a lambda because function "round" has 2 arguments, so else types do not match.
+        # This is despite the fact that the second argument to "round" has a default value, and thus "round" can be called with just 1 argument.
+        RoundMode.NEAREST: lambda x: round(x, None),
+        RoundMode.DOWN: floor,
+        RoundMode.UP: ceil,
+    }
+
+    # Requiring the steps to be of type int means that any precision used must be of the form "1/n" for an integer "n". This dict maps the values "1/n" to "n".
+    steps: dict[Precision, int] = {
+        Precision.WHOLE: 1,
+        Precision.HALVES: 2,
+        Precision.TENTHS: 10,
+    }
+
     # Integer as a fall back (PRECISION_WHOLE)
-    return round(temperature)
+    precision = precision if precision else Precision.WHOLE
+
+    try:
+        round_func = round_funcs[round_mode]
+    except KeyError as e:
+        raise ValueError(
+            f"RoundMode not in [{', '.join(map(str, RoundMode))}]: {round_mode}"
+        ) from e
+
+    try:
+        step = steps[precision]
+    except KeyError as e:
+        raise ValueError(
+            f"Precision not in [{', '.join(map(str, Precision))}]: {precision}"
+        ) from e
+
+    temperature = round_func(temperature * step) / step
+
+    return temperature

--- a/homeassistant/helpers/temperature.py
+++ b/homeassistant/helpers/temperature.py
@@ -1,21 +1,15 @@
 """Temperature helpers for Home Assistant."""
 from __future__ import annotations
 
-from collections.abc import Callable
-from math import ceil, floor
 from numbers import Number
 
-from homeassistant.const import Precision, RoundMode
+from homeassistant.const import Precision
 from homeassistant.core import HomeAssistant
 from homeassistant.util.unit_conversion import TemperatureConverter
 
 
 def display_temp(
-    hass: HomeAssistant,
-    temperature: float | None,
-    unit: str,
-    precision: Precision,
-    round_mode: RoundMode = RoundMode.NEAREST,
+    hass: HomeAssistant, temperature: float | None, unit: str, precision: Precision
 ) -> float | None:
     """Convert temperature into preferred units/precision for display."""
     temperature_unit = unit
@@ -34,14 +28,6 @@ def display_temp(
             temperature
         )
 
-    round_funcs: dict[RoundMode, Callable[[float], int]] = {
-        # "nearest" requires a lambda because function "round" has 2 arguments, so else types do not match.
-        # This is despite the fact that the second argument to "round" has a default value, and thus "round" can be called with just 1 argument.
-        RoundMode.NEAREST: lambda x: round(x, None),
-        RoundMode.DOWN: floor,
-        RoundMode.UP: ceil,
-    }
-
     # Requiring the steps to be of type int means that any precision used must be of the form "1/n" for an integer "n". This dict maps the values "1/n" to "n".
     steps: dict[Precision, int] = {
         Precision.WHOLE: 1,
@@ -53,19 +39,12 @@ def display_temp(
     precision = precision if precision else Precision.WHOLE
 
     try:
-        round_func = round_funcs[round_mode]
-    except KeyError as e:
-        raise ValueError(
-            f"RoundMode not in [{', '.join(map(str, RoundMode))}]: {round_mode}"
-        ) from e
-
-    try:
         step = steps[precision]
     except KeyError as e:
         raise ValueError(
             f"Precision not in [{', '.join(map(str, Precision))}]: {precision}"
         ) from e
 
-    temperature = round_func(temperature * step) / step
+    temperature = round(temperature * step) / step
 
     return temperature

--- a/tests/helpers/test_temperature.py
+++ b/tests/helpers/test_temperature.py
@@ -1,37 +1,166 @@
 """Tests Home Assistant temperature helpers."""
 import pytest
 
-from homeassistant.const import (
-    PRECISION_HALVES,
-    PRECISION_TENTHS,
-    PRECISION_WHOLE,
-    UnitOfTemperature,
-)
+from homeassistant.const import Precision, RoundMode, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.temperature import display_temp
 
 TEMP = 24.636626
 
 
+def test_temperature_none(hass: HomeAssistant) -> None:
+    """Test that temperature None returns None."""
+
+    assert display_temp(hass, None, UnitOfTemperature.CELSIUS, Precision.WHOLE) is None
+
+
 def test_temperature_not_a_number(hass: HomeAssistant) -> None:
     """Test that temperature is a number."""
     temp = "Temperature"
     with pytest.raises(Exception) as exception:
-        display_temp(hass, temp, UnitOfTemperature.CELSIUS, PRECISION_HALVES)
+        display_temp(hass, temp, UnitOfTemperature.CELSIUS, Precision.HALVES)
 
     assert f"Temperature is not a number: {temp}" in str(exception.value)
 
 
-def test_celsius_halves(hass: HomeAssistant) -> None:
-    """Test temperature to celsius rounding to halves."""
-    assert display_temp(hass, TEMP, UnitOfTemperature.CELSIUS, PRECISION_HALVES) == 24.5
+def test_precision_invalid(hass: HomeAssistant) -> None:
+    """Test that invalid precision values result in an exception."""
+    for precision in [0.2, 0.12345, 0.011]:
+        with pytest.raises(Exception) as exception:
+            display_temp(hass, TEMP, UnitOfTemperature.CELSIUS, precision)
+
+        expected_message = (
+            f"Precision not in [{', '.join(map(str, Precision))}]: {precision}"
+        )
+        assert expected_message == str(exception.value)
 
 
-def test_celsius_tenths(hass: HomeAssistant) -> None:
-    """Test temperature to celsius rounding to tenths."""
-    assert display_temp(hass, TEMP, UnitOfTemperature.CELSIUS, PRECISION_TENTHS) == 24.6
+def test_round_mode_invalid(hass: HomeAssistant) -> None:
+    """Test that invalid round_mode values result in an exception."""
+    for round_mode in ["Nearest", "flooR", "Foo"]:
+        with pytest.raises(Exception) as exception:
+            display_temp(hass, TEMP, UnitOfTemperature.CELSIUS, 1, round_mode)
+
+        expected_message = (
+            f"RoundMode not in [{', '.join(map(str, RoundMode))}]: {round_mode}"
+        )
+        assert expected_message == str(exception.value)
 
 
-def test_fahrenheit_wholes(hass: HomeAssistant) -> None:
-    """Test temperature to fahrenheit rounding to wholes."""
-    assert display_temp(hass, TEMP, UnitOfTemperature.FAHRENHEIT, PRECISION_WHOLE) == -4
+def test_temperature_default_precision(hass: HomeAssistant) -> None:
+    """Test default precision when a false value is given."""
+
+    assert display_temp(hass, TEMP, UnitOfTemperature.CELSIUS, 0) == 25
+    assert display_temp(hass, TEMP, UnitOfTemperature.CELSIUS, None) == 25
+
+
+def test_temperature_celsius_celsius(hass: HomeAssistant) -> None:
+    """Test temperature celsius to celsius."""
+
+    cases: dict[(Precision, RoundMode), float] = {
+        (Precision.WHOLE, RoundMode.NEAREST): 25,
+        (Precision.WHOLE, RoundMode.DOWN): 24,
+        (Precision.WHOLE, RoundMode.UP): 25,
+        (Precision.HALVES, RoundMode.NEAREST): 24.5,
+        (Precision.HALVES, RoundMode.DOWN): 24.5,
+        (Precision.HALVES, RoundMode.UP): 25.0,
+        (Precision.TENTHS, RoundMode.NEAREST): 24.6,
+        (Precision.TENTHS, RoundMode.DOWN): 24.6,
+        (Precision.TENTHS, RoundMode.UP): 24.7,
+    }
+
+    for precision in Precision:
+        for round_mode in RoundMode:
+            temp = cases[(precision, round_mode)]
+            assert (
+                display_temp(
+                    hass, TEMP, UnitOfTemperature.CELSIUS, precision, round_mode
+                )
+                == temp
+            )
+
+
+def test_temperature_fahrenheit_fahrenheit(hass: HomeAssistant) -> None:
+    """Test temperature fahrenheit to fahrenheit."""
+
+    cases: dict[(Precision, RoundMode), float] = {
+        (Precision.WHOLE, RoundMode.NEAREST): 25,
+        (Precision.WHOLE, RoundMode.DOWN): 24,
+        (Precision.WHOLE, RoundMode.UP): 25,
+        (Precision.HALVES, RoundMode.NEAREST): 24.5,
+        (Precision.HALVES, RoundMode.DOWN): 24.5,
+        (Precision.HALVES, RoundMode.UP): 25.0,
+        (Precision.TENTHS, RoundMode.NEAREST): 24.6,
+        (Precision.TENTHS, RoundMode.DOWN): 24.6,
+        (Precision.TENTHS, RoundMode.UP): 24.7,
+    }
+
+    hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+
+    for precision in Precision:
+        for round_mode in RoundMode:
+            temp = cases[(precision, round_mode)]
+            assert (
+                display_temp(
+                    hass, TEMP, UnitOfTemperature.FAHRENHEIT, precision, round_mode
+                )
+                == temp
+            )
+
+    hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
+
+
+def test_temperature_fahrenheit_to_celsius(hass: HomeAssistant) -> None:
+    """Test temperature fahrenheit to celsius. 24.6366 fahrenheit ~ -4.0908 celsius."""
+
+    cases: dict[(Precision, RoundMode), float] = {
+        (Precision.WHOLE, RoundMode.NEAREST): -4,
+        (Precision.WHOLE, RoundMode.DOWN): -5,
+        (Precision.WHOLE, RoundMode.UP): -4,
+        (Precision.HALVES, RoundMode.NEAREST): -4,
+        (Precision.HALVES, RoundMode.DOWN): -4.5,
+        (Precision.HALVES, RoundMode.UP): -4,
+        (Precision.TENTHS, RoundMode.NEAREST): -4.1,
+        (Precision.TENTHS, RoundMode.DOWN): -4.1,
+        (Precision.TENTHS, RoundMode.UP): -4,
+    }
+
+    for precision in Precision:
+        for round_mode in RoundMode:
+            temp = cases[(precision, round_mode)]
+            assert (
+                display_temp(
+                    hass, TEMP, UnitOfTemperature.FAHRENHEIT, precision, round_mode
+                )
+                == temp
+            )
+
+
+def test_temperature_celsius_to_fahrenheit(hass: HomeAssistant) -> None:
+    """Test temperature celsius to fahrenheit: 24.6366 celsius ~ 76.34588 fahrenheit."""
+
+    cases: dict[(Precision, RoundMode), float] = {
+        (Precision.WHOLE, RoundMode.NEAREST): 76,
+        (Precision.WHOLE, RoundMode.DOWN): 76,
+        (Precision.WHOLE, RoundMode.UP): 77,
+        (Precision.HALVES, RoundMode.NEAREST): 76.5,
+        (Precision.HALVES, RoundMode.DOWN): 76,
+        (Precision.HALVES, RoundMode.UP): 76.5,
+        (Precision.TENTHS, RoundMode.NEAREST): 76.3,
+        (Precision.TENTHS, RoundMode.DOWN): 76.3,
+        (Precision.TENTHS, RoundMode.UP): 76.4,
+    }
+
+    hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+
+    for precision in Precision:
+        for round_mode in RoundMode:
+            temp = cases[(precision, round_mode)]
+            assert (
+                display_temp(
+                    hass, TEMP, UnitOfTemperature.CELSIUS, precision, round_mode
+                )
+                == temp
+            )
+
+    hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS

--- a/tests/helpers/test_temperature.py
+++ b/tests/helpers/test_temperature.py
@@ -1,7 +1,7 @@
 """Tests Home Assistant temperature helpers."""
 import pytest
 
-from homeassistant.const import Precision, RoundMode, UnitOfTemperature
+from homeassistant.const import Precision, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.temperature import display_temp
 
@@ -35,18 +35,6 @@ def test_precision_invalid(hass: HomeAssistant) -> None:
         assert expected_message == str(exception.value)
 
 
-def test_round_mode_invalid(hass: HomeAssistant) -> None:
-    """Test that invalid round_mode values result in an exception."""
-    for round_mode in ["Nearest", "flooR", "Foo"]:
-        with pytest.raises(Exception) as exception:
-            display_temp(hass, TEMP, UnitOfTemperature.CELSIUS, 1, round_mode)
-
-        expected_message = (
-            f"RoundMode not in [{', '.join(map(str, RoundMode))}]: {round_mode}"
-        )
-        assert expected_message == str(exception.value)
-
-
 def test_temperature_default_precision(hass: HomeAssistant) -> None:
     """Test default precision when a false value is given."""
 
@@ -57,55 +45,31 @@ def test_temperature_default_precision(hass: HomeAssistant) -> None:
 def test_temperature_celsius_celsius(hass: HomeAssistant) -> None:
     """Test temperature celsius to celsius."""
 
-    cases: dict[(Precision, RoundMode), float] = {
-        (Precision.WHOLE, RoundMode.NEAREST): 25,
-        (Precision.WHOLE, RoundMode.DOWN): 24,
-        (Precision.WHOLE, RoundMode.UP): 25,
-        (Precision.HALVES, RoundMode.NEAREST): 24.5,
-        (Precision.HALVES, RoundMode.DOWN): 24.5,
-        (Precision.HALVES, RoundMode.UP): 25.0,
-        (Precision.TENTHS, RoundMode.NEAREST): 24.6,
-        (Precision.TENTHS, RoundMode.DOWN): 24.6,
-        (Precision.TENTHS, RoundMode.UP): 24.7,
+    cases: dict[Precision, float] = {
+        Precision.WHOLE: 25,
+        Precision.HALVES: 24.5,
+        Precision.TENTHS: 24.6,
     }
 
     for precision in Precision:
-        for round_mode in RoundMode:
-            temp = cases[(precision, round_mode)]
-            assert (
-                display_temp(
-                    hass, TEMP, UnitOfTemperature.CELSIUS, precision, round_mode
-                )
-                == temp
-            )
+        temp = cases[precision]
+        assert display_temp(hass, TEMP, UnitOfTemperature.CELSIUS, precision) == temp
 
 
 def test_temperature_fahrenheit_fahrenheit(hass: HomeAssistant) -> None:
     """Test temperature fahrenheit to fahrenheit."""
 
-    cases: dict[(Precision, RoundMode), float] = {
-        (Precision.WHOLE, RoundMode.NEAREST): 25,
-        (Precision.WHOLE, RoundMode.DOWN): 24,
-        (Precision.WHOLE, RoundMode.UP): 25,
-        (Precision.HALVES, RoundMode.NEAREST): 24.5,
-        (Precision.HALVES, RoundMode.DOWN): 24.5,
-        (Precision.HALVES, RoundMode.UP): 25.0,
-        (Precision.TENTHS, RoundMode.NEAREST): 24.6,
-        (Precision.TENTHS, RoundMode.DOWN): 24.6,
-        (Precision.TENTHS, RoundMode.UP): 24.7,
+    cases: dict[Precision, float] = {
+        Precision.WHOLE: 25,
+        Precision.HALVES: 24.5,
+        Precision.TENTHS: 24.6,
     }
 
     hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
 
     for precision in Precision:
-        for round_mode in RoundMode:
-            temp = cases[(precision, round_mode)]
-            assert (
-                display_temp(
-                    hass, TEMP, UnitOfTemperature.FAHRENHEIT, precision, round_mode
-                )
-                == temp
-            )
+        temp = cases[precision]
+        assert display_temp(hass, TEMP, UnitOfTemperature.FAHRENHEIT, precision) == temp
 
     hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
 
@@ -113,54 +77,30 @@ def test_temperature_fahrenheit_fahrenheit(hass: HomeAssistant) -> None:
 def test_temperature_fahrenheit_to_celsius(hass: HomeAssistant) -> None:
     """Test temperature fahrenheit to celsius. 24.6366 fahrenheit ~ -4.0908 celsius."""
 
-    cases: dict[(Precision, RoundMode), float] = {
-        (Precision.WHOLE, RoundMode.NEAREST): -4,
-        (Precision.WHOLE, RoundMode.DOWN): -5,
-        (Precision.WHOLE, RoundMode.UP): -4,
-        (Precision.HALVES, RoundMode.NEAREST): -4,
-        (Precision.HALVES, RoundMode.DOWN): -4.5,
-        (Precision.HALVES, RoundMode.UP): -4,
-        (Precision.TENTHS, RoundMode.NEAREST): -4.1,
-        (Precision.TENTHS, RoundMode.DOWN): -4.1,
-        (Precision.TENTHS, RoundMode.UP): -4,
+    cases: dict[Precision, float] = {
+        Precision.WHOLE: -4,
+        Precision.HALVES: -4,
+        Precision.TENTHS: -4.1,
     }
 
     for precision in Precision:
-        for round_mode in RoundMode:
-            temp = cases[(precision, round_mode)]
-            assert (
-                display_temp(
-                    hass, TEMP, UnitOfTemperature.FAHRENHEIT, precision, round_mode
-                )
-                == temp
-            )
+        temp = cases[precision]
+        assert display_temp(hass, TEMP, UnitOfTemperature.FAHRENHEIT, precision) == temp
 
 
 def test_temperature_celsius_to_fahrenheit(hass: HomeAssistant) -> None:
     """Test temperature celsius to fahrenheit: 24.6366 celsius ~ 76.34588 fahrenheit."""
 
-    cases: dict[(Precision, RoundMode), float] = {
-        (Precision.WHOLE, RoundMode.NEAREST): 76,
-        (Precision.WHOLE, RoundMode.DOWN): 76,
-        (Precision.WHOLE, RoundMode.UP): 77,
-        (Precision.HALVES, RoundMode.NEAREST): 76.5,
-        (Precision.HALVES, RoundMode.DOWN): 76,
-        (Precision.HALVES, RoundMode.UP): 76.5,
-        (Precision.TENTHS, RoundMode.NEAREST): 76.3,
-        (Precision.TENTHS, RoundMode.DOWN): 76.3,
-        (Precision.TENTHS, RoundMode.UP): 76.4,
+    cases: dict[Precision, float] = {
+        Precision.WHOLE: 76,
+        Precision.HALVES: 76.5,
+        Precision.TENTHS: 76.3,
     }
 
     hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
 
     for precision in Precision:
-        for round_mode in RoundMode:
-            temp = cases[(precision, round_mode)]
-            assert (
-                display_temp(
-                    hass, TEMP, UnitOfTemperature.CELSIUS, precision, round_mode
-                )
-                == temp
-            )
+        temp = cases[precision]
+        assert display_temp(hass, TEMP, UnitOfTemperature.CELSIUS, precision) == temp
 
     hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This change allows to choose the rounding mode when converting a temperature using `display_temp`, and streamlines how the precision values are used.

### Background

- This PR is related to issue: 104676. It prepares so that adding a precision value is easy, and there does not need to be a duplication of code due to the "round climate temperature down instead of round to nearest" option.

This way, the PR for fixing this issue is simply:
- Add a new value to `Precision`
- U[date all required code (which includes the `display_temp` function because otherwise the tests will fail, as they loop over all values of `Precision`, and without the update of that function, the test will throw a `KeyError` and subsequent `ValueError`.)
- Update the `opentherm_gw` config_flow code to allow using the new `Precision` value.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

~~If user exposed functionality or configuration variables are added/changed:~~

~~- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]~~

~~If the code communicates with devices, web services, or third-party tools:~~

~~- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  ~~
~~      Updated and included derived files by running: `python3 -m script.hassfest`.~~
~~- [ ] New or updated dependencies have been added to `requirements_all.txt`.  ~~
~~      Updated by running `python3 -m script.gen_requirements_all`.~~
~~- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.~~
~~- [ ] Untested files have been added to `.coveragerc`.~~

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
Not yet, but will do!

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
