### PR TITLE
Fastdotcom service optimization

### DIFF
--- a/homeassistant/components/fastdotcom/__init__.py
+++ b/homeassistant/components/fastdotcom/__init__.py
@@ -60,6 +60,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             PLATFORMS,
         )
 
+    # Don't start a speedtest during startup, this will slow down the overall startup dramatically
     async_at_started(hass, _async_finish_startup)
     return True
 

--- a/homeassistant/components/fastdotcom/__init__.py
+++ b/homeassistant/components/fastdotcom/__init__.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import CONF_MANUAL, DEFAULT_INTERVAL, DOMAIN, PLATFORMS
 from .coordinator import FastdotcomDataUpdateCoordindator
+from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,7 +35,7 @@ CONFIG_SCHEMA = vol.Schema(
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the Fast.com component. (deprecated)."""
+    """Set up the Fastdotcom component."""
     if DOMAIN in config:
         hass.async_create_task(
             hass.config_entries.flow.async_init(
@@ -43,6 +44,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 data=config[DOMAIN],
             )
         )
+    async_setup_services(hass)
     return True
 
 

--- a/homeassistant/components/fastdotcom/__init__.py
+++ b/homeassistant/components/fastdotcom/__init__.py
@@ -50,6 +50,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Fast.com from a config entry."""
     coordinator = FastdotcomDataUpdateCoordindator(hass)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
     async def _async_finish_startup(hass: HomeAssistant) -> None:
         """Run this only when HA has finished its startup."""
@@ -59,10 +60,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             PLATFORMS,
         )
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
-
     async_at_started(hass, _async_finish_startup)
-
     return True
 
 

--- a/homeassistant/components/fastdotcom/__init__.py
+++ b/homeassistant/components/fastdotcom/__init__.py
@@ -52,13 +52,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = FastdotcomDataUpdateCoordindator(hass)
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
+    await hass.config_entries.async_forward_entry_setups(
+        entry,
+        PLATFORMS,
+    )
+
     async def _async_finish_startup(hass: HomeAssistant) -> None:
         """Run this only when HA has finished its startup."""
         await coordinator.async_config_entry_first_refresh()
-        await hass.config_entries.async_forward_entry_setups(
-            entry,
-            PLATFORMS,
-        )
 
     # Don't start a speedtest during startup, this will slow down the overall startup dramatically
     async_at_started(hass, _async_finish_startup)

--- a/homeassistant/components/fastdotcom/__init__.py
+++ b/homeassistant/components/fastdotcom/__init__.py
@@ -7,8 +7,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_SCAN_INTERVAL
-from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.helpers import issue_registry as ir
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.start import async_at_started
 from homeassistant.helpers.typing import ConfigType
@@ -60,22 +59,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             PLATFORMS,
         )
 
-    async def _request_refresh_service(call: ServiceCall) -> None:
-        """Request a refresh via the service."""
-        ir.async_create_issue(
-            hass,
-            DOMAIN,
-            "service_deprecation",
-            breaks_in_ha_version="2024.7.0",
-            is_fixable=True,
-            is_persistent=False,
-            severity=ir.IssueSeverity.WARNING,
-            translation_key="service_deprecation",
-        )
-        await coordinator.async_request_refresh()
-
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
-    hass.services.async_register(DOMAIN, "speedtest", _request_refresh_service)
 
     async_at_started(hass, _async_finish_startup)
 
@@ -84,7 +68,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload Fast.com config entry."""
-    hass.services.async_remove(DOMAIN, "speedtest")
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok

--- a/homeassistant/components/fastdotcom/const.py
+++ b/homeassistant/components/fastdotcom/const.py
@@ -10,6 +10,8 @@ DATA_UPDATED = f"{DOMAIN}_data_updated"
 
 CONF_MANUAL = "manual"
 
+SERVICE_NAME = "speedtest"
+
 DEFAULT_NAME = "Fast.com"
 DEFAULT_INTERVAL = 1
 PLATFORMS: list[Platform] = [Platform.SENSOR]

--- a/homeassistant/components/fastdotcom/services.py
+++ b/homeassistant/components/fastdotcom/services.py
@@ -1,9 +1,10 @@
 """Services for the Fastdotcom integration."""
 from __future__ import annotations
 
-from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import issue_registry as ir
 
 from .const import DOMAIN, SERVICE_NAME
 from .coordinator import FastdotcomDataUpdateCoordindator
@@ -14,7 +15,8 @@ def async_setup_services(hass: HomeAssistant) -> None:
 
     @callback
     def collect_coordinator() -> FastdotcomDataUpdateCoordindator:
-        config_entries = list[ConfigEntry]()
+        """Collect the coordinator Fastdotcom."""
+        config_entries = hass.config_entries.async_entries(DOMAIN)
         for config_entry in config_entries:
             if config_entry.state != ConfigEntryState.LOADED:
                 raise HomeAssistantError(f"{config_entry.title} is not loaded")
@@ -25,9 +27,19 @@ def async_setup_services(hass: HomeAssistant) -> None:
         return coordinator
 
     async def async_perform_service(call: ServiceCall) -> None:
-        """Perform a service on the device."""
+        """Perform a service call to manually run Fastdotcom."""
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            "service_deprecation",
+            breaks_in_ha_version="2024.7.0",
+            is_fixable=True,
+            is_persistent=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="service_deprecation",
+        )
         coordinator = collect_coordinator()
-        await coordinator.async_refresh()
+        await coordinator.async_request_refresh()
 
     hass.services.async_register(
         DOMAIN,

--- a/homeassistant/components/fastdotcom/services.py
+++ b/homeassistant/components/fastdotcom/services.py
@@ -17,7 +17,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
     def collect_coordinator() -> FastdotcomDataUpdateCoordindator:
         """Collect the coordinator Fastdotcom."""
         config_entries = hass.config_entries.async_entries(DOMAIN)
-        if len(config_entries) == 0:
+        if not config_entries:
             raise HomeAssistantError("No Fast.com config entries found")
 
         for config_entry in config_entries:

--- a/homeassistant/components/fastdotcom/services.py
+++ b/homeassistant/components/fastdotcom/services.py
@@ -34,7 +34,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
             "service_deprecation",
             breaks_in_ha_version="2024.7.0",
             is_fixable=True,
-            is_persistent=False,
+            is_persistent=True,
             severity=ir.IssueSeverity.WARNING,
             translation_key="service_deprecation",
         )

--- a/homeassistant/components/fastdotcom/services.py
+++ b/homeassistant/components/fastdotcom/services.py
@@ -17,6 +17,9 @@ def async_setup_services(hass: HomeAssistant) -> None:
     def collect_coordinator() -> FastdotcomDataUpdateCoordindator:
         """Collect the coordinator Fastdotcom."""
         config_entries = hass.config_entries.async_entries(DOMAIN)
+        if len(config_entries) == 0:
+            raise HomeAssistantError("No Fastdotcom config entries found")
+
         for config_entry in config_entries:
             if config_entry.state != ConfigEntryState.LOADED:
                 raise HomeAssistantError(f"{config_entry.title} is not loaded")

--- a/homeassistant/components/fastdotcom/services.py
+++ b/homeassistant/components/fastdotcom/services.py
@@ -18,7 +18,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
         """Collect the coordinator Fastdotcom."""
         config_entries = hass.config_entries.async_entries(DOMAIN)
         if len(config_entries) == 0:
-            raise HomeAssistantError("No Fastdotcom config entries found")
+            raise HomeAssistantError("No Fast.com config entries found")
 
         for config_entry in config_entries:
             if config_entry.state != ConfigEntryState.LOADED:

--- a/homeassistant/components/fastdotcom/services.py
+++ b/homeassistant/components/fastdotcom/services.py
@@ -1,0 +1,36 @@
+"""Services for the Fastdotcom integration."""
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import HomeAssistantError
+
+from .const import DOMAIN, SERVICE_NAME
+from .coordinator import FastdotcomDataUpdateCoordindator
+
+
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Set up the service for the Fastdotcom integration."""
+
+    @callback
+    def collect_coordinator() -> FastdotcomDataUpdateCoordindator:
+        config_entries = list[ConfigEntry]()
+        for config_entry in config_entries:
+            if config_entry.state != ConfigEntryState.LOADED:
+                raise HomeAssistantError(f"{config_entry.title} is not loaded")
+            coordinator: FastdotcomDataUpdateCoordindator = hass.data[DOMAIN][
+                config_entry.entry_id
+            ]
+            break
+        return coordinator
+
+    async def async_perform_service(call: ServiceCall) -> None:
+        """Perform a service on the device."""
+        coordinator = collect_coordinator()
+        await coordinator.async_refresh()
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_NAME,
+        async_perform_service,
+    )

--- a/tests/components/fastdotcom/test_init.py
+++ b/tests/components/fastdotcom/test_init.py
@@ -7,7 +7,7 @@ from freezegun.api import FrozenDateTimeFactory
 
 from homeassistant import config_entries
 from homeassistant.components.fastdotcom.const import DEFAULT_NAME, DOMAIN
-from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, STATE_UNKNOWN
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
@@ -72,8 +72,8 @@ async def test_delayed_speedtest_during_startup(
 
     assert config_entry.state == config_entries.ConfigEntryState.LOADED
     state = hass.states.get("sensor.fast_com_download")
-    # Assert state is None as fast.com isn't starting until HA has started
-    assert state is None
+    # Assert state is Unknown as fast.com isn't starting until HA has started
+    assert state.state is STATE_UNKNOWN
 
     with patch(
         "homeassistant.components.fastdotcom.coordinator.fast_com", return_value=5.0

--- a/tests/components/fastdotcom/test_init.py
+++ b/tests/components/fastdotcom/test_init.py
@@ -7,7 +7,7 @@ from freezegun.api import FrozenDateTimeFactory
 
 from homeassistant import config_entries
 from homeassistant.components.fastdotcom.const import DEFAULT_NAME, DOMAIN
-from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, STATE_UNKNOWN
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
@@ -65,23 +65,25 @@ async def test_delayed_speedtest_during_startup(
     config_entry.add_to_hass(hass)
 
     with patch(
-        "homeassistant.components.fastdotcom.coordinator.fast_com", return_value=5.0
+        "homeassistant.components.fastdotcom.coordinator.fast_com"
     ), patch.object(hass, "state", CoreState.starting):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
     assert config_entry.state == config_entries.ConfigEntryState.LOADED
     state = hass.states.get("sensor.fast_com_download")
-    assert state is not None
-    # Assert state is unknown as coordinator is not allowed to start and fetch data yet
-    assert state.state == STATE_UNKNOWN
+    # Assert state is None as fast.com isn't starting until HA has started
+    assert state is None
 
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
-    await hass.async_block_till_done()
+    with patch(
+        "homeassistant.components.fastdotcom.coordinator.fast_com", return_value=5.0
+    ):
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
 
     state = hass.states.get("sensor.fast_com_download")
     assert state is not None
-    assert state.state == "0"
+    assert state.state == "5.0"
 
     assert config_entry.state == config_entries.ConfigEntryState.LOADED
 

--- a/tests/components/fastdotcom/test_service.py
+++ b/tests/components/fastdotcom/test_service.py
@@ -84,4 +84,4 @@ async def test_service_removed_entry(hass: HomeAssistant) -> None:
     with pytest.raises(HomeAssistantError) as exc:
         await hass.services.async_call(DOMAIN, SERVICE_NAME, blocking=True)
 
-    assert "No Fastdotcom config entries found" in str(exc)
+    assert "No Fast.com config entries found" in str(exc)

--- a/tests/components/fastdotcom/test_service.py
+++ b/tests/components/fastdotcom/test_service.py
@@ -1,0 +1,63 @@
+"""Test Fastdotcom service."""
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.fastdotcom.const import DEFAULT_NAME, DOMAIN, SERVICE_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from tests.common import MockConfigEntry
+
+
+async def test_service(hass: HomeAssistant) -> None:
+    """Test the Fastdotcom service."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="UNIQUE_TEST_ID",
+        title=DEFAULT_NAME,
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.fastdotcom.coordinator.fast_com", return_value=0
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.fast_com_download")
+    assert state is not None
+    assert state.state == "0"
+
+    with patch(
+        "homeassistant.components.fastdotcom.coordinator.fast_com", return_value=5.0
+    ):
+        await hass.services.async_call(DOMAIN, SERVICE_NAME, blocking=True)
+
+    state = hass.states.get("sensor.fast_com_download")
+    assert state is not None
+    assert state.state == "5.0"
+
+
+async def test_service_unloaded_entry(hass: HomeAssistant) -> None:
+    """Test service called when config entry unloaded."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="UNIQUE_TEST_ID",
+        title=DEFAULT_NAME,
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.fastdotcom.coordinator.fast_com", return_value=0
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry
+    await config_entry.async_unload(hass)
+
+    with pytest.raises(HomeAssistantError) as exc:
+        await hass.services.async_call(DOMAIN, SERVICE_NAME, blocking=True)
+
+    assert "Fast.com is not loaded" in str(exc)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Continuation of #105929. As [hinted out](https://github.com/home-assistant/core/pull/104839#discussion_r1429279398) by @MartinHjelmare to optimize the service for Fast.com.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr