### PR TITLE
Fix switch states in AVM FRITZ!Box Tools

### DIFF
--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -1063,6 +1063,7 @@ class SwitchInfo(TypedDict):
     type: str
     callback_update: Callable
     callback_switch: Callable
+    init_state: bool
 
 
 class FritzBoxBaseEntity:

--- a/homeassistant/components/fritz/switch.py
+++ b/homeassistant/components/fritz/switch.py
@@ -166,9 +166,7 @@ async def _async_wifi_entities_list(
 
     _LOGGER.debug("WiFi networks list: %s", networks)
     return [
-        FritzBoxWifiSwitch(
-            avm_wrapper, device_friendly_name, index, data["switch_name"]
-        )
+        FritzBoxWifiSwitch(avm_wrapper, device_friendly_name, index, data)
         for index, data in networks.items()
     ]
 
@@ -313,7 +311,7 @@ class FritzBoxBaseCoordinatorSwitch(CoordinatorEntity[AvmWrapper], SwitchEntity)
 class FritzBoxBaseSwitch(FritzBoxBaseEntity):
     """Fritz switch base class."""
 
-    _attr_is_on: bool | None = False
+    _attr_is_on: bool | None
 
     def __init__(
         self,
@@ -321,7 +319,7 @@ class FritzBoxBaseSwitch(FritzBoxBaseEntity):
         device_friendly_name: str,
         switch_info: SwitchInfo,
     ) -> None:
-        """Init Fritzbox port switch."""
+        """Init Fritzbox base switch."""
         super().__init__(avm_wrapper, device_friendly_name)
 
         self._description = switch_info["description"]
@@ -330,6 +328,7 @@ class FritzBoxBaseSwitch(FritzBoxBaseEntity):
         self._type = switch_info["type"]
         self._update = switch_info["callback_update"]
         self._switch = switch_info["callback_switch"]
+        self._attr_is_on = switch_info["init_state"]
 
         self._name = f"{self._friendly_name} {self._description}"
         self._unique_id = f"{self._avm_wrapper.unique_id}-{slugify(self._description)}"
@@ -412,6 +411,7 @@ class FritzBoxPortSwitch(FritzBoxBaseSwitch, SwitchEntity):
             type=SWITCH_TYPE_PORTFORWARD,
             callback_update=self._async_fetch_update,
             callback_switch=self._async_switch_on_off_executor,
+            init_state=port_mapping["NewEnabled"],
         )
         super().__init__(avm_wrapper, device_friendly_name, switch_info)
 
@@ -561,7 +561,7 @@ class FritzBoxWifiSwitch(FritzBoxBaseSwitch, SwitchEntity):
         avm_wrapper: AvmWrapper,
         device_friendly_name: str,
         network_num: int,
-        network_name: str,
+        network_data: dict,
     ) -> None:
         """Init Fritz Wifi switch."""
         self._avm_wrapper = avm_wrapper
@@ -571,12 +571,13 @@ class FritzBoxWifiSwitch(FritzBoxBaseSwitch, SwitchEntity):
         self._network_num = network_num
 
         switch_info = SwitchInfo(
-            description=f"Wi-Fi {network_name}",
+            description=f"Wi-Fi {network_data['switch_name']}",
             friendly_name=device_friendly_name,
             icon="mdi:wifi",
             type=SWITCH_TYPE_WIFINETWORK,
             callback_update=self._async_fetch_update,
             callback_switch=self._async_switch_on_off_executor,
+            init_state=network_data["enabled"],
         )
         super().__init__(self._avm_wrapper, device_friendly_name, switch_info)
 

--- a/homeassistant/components/fritz/switch.py
+++ b/homeassistant/components/fritz/switch.py
@@ -308,10 +308,8 @@ class FritzBoxBaseCoordinatorSwitch(CoordinatorEntity[AvmWrapper], SwitchEntity)
         await self._async_handle_turn_on_off(turn_on=False)
 
 
-class FritzBoxBaseSwitch(FritzBoxBaseEntity):
+class FritzBoxBaseSwitch(FritzBoxBaseEntity, SwitchEntity):
     """Fritz switch base class."""
-
-    _attr_is_on: bool | None
 
     def __init__(
         self,
@@ -380,7 +378,7 @@ class FritzBoxBaseSwitch(FritzBoxBaseEntity):
         self._attr_is_on = turn_on
 
 
-class FritzBoxPortSwitch(FritzBoxBaseSwitch, SwitchEntity):
+class FritzBoxPortSwitch(FritzBoxBaseSwitch):
     """Defines a FRITZ!Box Tools PortForward switch."""
 
     def __init__(
@@ -553,7 +551,7 @@ class FritzBoxProfileSwitch(FritzDeviceBase, SwitchEntity):
         return True
 
 
-class FritzBoxWifiSwitch(FritzBoxBaseSwitch, SwitchEntity):
+class FritzBoxWifiSwitch(FritzBoxBaseSwitch):
     """Defines a FRITZ!Box Tools Wifi switch."""
 
     def __init__(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since property caching has been introduced, when setting a value to a class variable, it seems to be assumed unchangeable and those never read/considered again. btw this also fixes an issue were the initial value was always `False` and corrected after first data fetch.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #107106
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
