### PR TITLE
Remove naming warnings and work-a-rounds for incorrectly configured MQTT entities

### DIFF
--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -93,10 +93,6 @@ SUBSCRIBE_COOLDOWN = 0.1
 UNSUBSCRIBE_COOLDOWN = 0.1
 TIMEOUT_ACK = 10
 
-MQTT_ENTRIES_NAMING_BLOG_URL = (
-    "https://developers.home-assistant.io/blog/2023-057-21-change-naming-mqtt-entities/"
-)
-
 SubscribePayloadType = str | bytes  # Only bytes if encoding is None
 
 

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -35,7 +35,6 @@ from homeassistant.core import (
 )
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import dispatcher_send
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 from homeassistant.util import dt as dt_util
@@ -425,7 +424,6 @@ class MQTT:
 
             @callback
             def ha_started(_: Event) -> None:
-                self.register_naming_issues()
                 self._ha_started.set()
 
             self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, ha_started)
@@ -437,25 +435,6 @@ class MQTT:
         self._cleanup_on_unload.append(
             hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_stop_mqtt)
         )
-
-    def register_naming_issues(self) -> None:
-        """Register issues with MQTT entity naming."""
-        mqtt_data = get_mqtt_data(self.hass)
-        for issue_key, items in mqtt_data.issues.items():
-            config_list = "\n".join([f"- {item}" for item in items])
-            async_create_issue(
-                self.hass,
-                DOMAIN,
-                issue_key,
-                breaks_in_ha_version="2024.2.0",
-                is_fixable=False,
-                translation_key=issue_key,
-                translation_placeholders={
-                    "config": config_list,
-                },
-                learn_more_url=MQTT_ENTRIES_NAMING_BLOG_URL,
-                severity=IssueSeverity.WARNING,
-            )
 
     def start(
         self,

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -1215,7 +1215,6 @@ class MqttEntity(
     _attr_should_poll = False
     _default_name: str | None
     _entity_id_format: str
-    _issue_key: str | None
 
     def __init__(
         self,
@@ -1253,7 +1252,6 @@ class MqttEntity(
     @final
     async def async_added_to_hass(self) -> None:
         """Subscribe to MQTT events."""
-        self.collect_issues()
         await super().async_added_to_hass()
         self._prepare_subscribe_topics()
         await self._subscribe_topics()
@@ -1326,7 +1324,6 @@ class MqttEntity(
 
     def _set_entity_name(self, config: ConfigType) -> None:
         """Help setting the entity name if needed."""
-        self._issue_key = None
         entity_name: str | None | UndefinedType = config.get(CONF_NAME, UNDEFINED)
         # Only set _attr_name if it is needed
         if entity_name is not UNDEFINED:
@@ -1339,50 +1336,13 @@ class MqttEntity(
             # don't set the name attribute and derive
             # the name from the device_class
             delattr(self, "_attr_name")
-        if CONF_DEVICE in config:
-            device_name: str
-            if CONF_NAME not in config[CONF_DEVICE]:
-                _LOGGER.info(
-                    "MQTT device information always needs to include a name, got %s, "
-                    "if device information is shared between multiple entities, the device "
-                    "name must be included in each entity's device configuration",
-                    config,
-                )
-            elif (device_name := config[CONF_DEVICE][CONF_NAME]) == entity_name:
-                self._attr_name = None
-                if not self._discovery:
-                    self._issue_key = "entity_name_is_device_name_yaml"
-                _LOGGER.warning(
-                    "MQTT device name is equal to entity name in your config %s, "
-                    "this is not expected. Please correct your configuration. "
-                    "The entity name will be set to `null`",
-                    config,
-                )
-            elif isinstance(entity_name, str) and entity_name.startswith(device_name):
-                self._attr_name = (
-                    new_entity_name := entity_name[len(device_name) :].lstrip()
-                )
-                if device_name[:1].isupper():
-                    # Ensure a capital if the device name first char is a capital
-                    new_entity_name = new_entity_name[:1].upper() + new_entity_name[1:]
-                if not self._discovery:
-                    self._issue_key = "entity_name_startswith_device_name_yaml"
-                _LOGGER.warning(
-                    "MQTT entity name starts with the device name in your config %s, "
-                    "this is not expected. Please correct your configuration. "
-                    "The device name prefix will be stripped off the entity name "
-                    "and becomes '%s'",
-                    config,
-                    new_entity_name,
-                )
-
-    def collect_issues(self) -> None:
-        """Process issues for MQTT entities."""
-        if self._issue_key is None:
-            return
-        mqtt_data = get_mqtt_data(self.hass)
-        issues = mqtt_data.issues.setdefault(self._issue_key, set())
-        issues.add(self.entity_id)
+        if CONF_DEVICE in config and CONF_NAME not in config[CONF_DEVICE]:
+            _LOGGER.info(
+                "MQTT device information always needs to include a name, got %s, "
+                "if device information is shared between multiple entities, the device "
+                "name must be included in each entity's device configuration",
+                config,
+            )
 
     def _setup_common_attributes_from_config(self, config: ConfigType) -> None:
         """(Re)Setup the common attributes for the entity."""

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -339,7 +339,6 @@ class MqttData:
     )
     discovery_unsubscribe: list[CALLBACK_TYPE] = field(default_factory=list)
     integration_unsubscribe: dict[str, CALLBACK_TYPE] = field(default_factory=dict)
-    issues: dict[str, set[str]] = field(default_factory=dict)
     last_discovery: float = 0.0
     reload_dispatchers: list[CALLBACK_TYPE] = field(default_factory=list)
     reload_handlers: dict[str, CALLBACK_TYPE] = field(default_factory=dict)

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -8,14 +8,6 @@
       "title": "MQTT vacuum entities with legacy schema added through MQTT discovery",
       "description": "MQTT vacuum entities that use the legacy schema are deprecated, please adjust your devices to use the correct schema and restart Home Assistant to fix this issue."
     },
-    "entity_name_is_device_name_yaml": {
-      "title": "Manual configured MQTT entities with a name that is equal to the device name",
-      "description": "Some MQTT entities have an entity name equal to the device name. This is not expected. The entity name is set to `null` as a work-a-round to avoid a duplicate name. Please update your configuration and restart Home Assistant to fix this issue.\n\nList of affected entities:\n\n{config}"
-    },
-    "entity_name_startswith_device_name_yaml": {
-      "title": "Manual configured MQTT entities with a name that starts with the device name",
-      "description": "Some MQTT entities have an entity name that starts with the device name. This is not expected. To avoid a duplicate name the device name prefix is stripped off the entity name as a work-a-round. Please update your configuration and restart Home Assistant to fix this issue. \n\nList of affected entities:\n\n{config}"
-    },
     "deprecated_climate_aux_property": {
       "title": "MQTT entities with auxiliary heat support found",
       "description": "Entity `{entity_id}` has auxiliary heat support enabled, which has been deprecated for MQTT climate devices. Please adjust your configuration and remove deprecated config options from your configuration and restart Home Assistant to fix this issue."

--- a/tests/components/mqtt/test_mixins.py
+++ b/tests/components/mqtt/test_mixins.py
@@ -89,7 +89,6 @@ async def test_availability_with_shared_state_topic(
         "friendly_name",
         "device_name",
         "assert_log",
-        "issue_events",
     ),
     [
         (  # default_entity_name_without_device_name
@@ -106,7 +105,6 @@ async def test_availability_with_shared_state_topic(
             DEFAULT_SENSOR_NAME,
             None,
             True,
-            0,
         ),
         (  # default_entity_name_with_device_name
             {
@@ -122,7 +120,6 @@ async def test_availability_with_shared_state_topic(
             "Test MQTT Sensor",
             "Test",
             False,
-            0,
         ),
         (  # name_follows_device_class
             {
@@ -139,7 +136,6 @@ async def test_availability_with_shared_state_topic(
             "Test Humidity",
             "Test",
             False,
-            0,
         ),
         (  # name_follows_device_class_without_device_name
             {
@@ -156,7 +152,6 @@ async def test_availability_with_shared_state_topic(
             "Humidity",
             None,
             True,
-            0,
         ),
         (  # name_overrides_device_class
             {
@@ -174,7 +169,6 @@ async def test_availability_with_shared_state_topic(
             "Test MySensor",
             "Test",
             False,
-            0,
         ),
         (  # name_set_no_device_name_set
             {
@@ -192,7 +186,6 @@ async def test_availability_with_shared_state_topic(
             "MySensor",
             None,
             True,
-            0,
         ),
         (  # none_entity_name_with_device_name
             {
@@ -210,7 +203,6 @@ async def test_availability_with_shared_state_topic(
             "Test",
             "Test",
             False,
-            0,
         ),
         (  # none_entity_name_without_device_name
             {
@@ -228,7 +220,6 @@ async def test_availability_with_shared_state_topic(
             "mqtt veryunique",
             None,
             True,
-            0,
         ),
         (  # entity_name_and_device_name_the_same
             {
@@ -245,11 +236,10 @@ async def test_availability_with_shared_state_topic(
                     }
                 }
             },
-            "sensor.hello_world",
-            "Hello world",
+            "sensor.hello_world_hello_world",
+            "Hello world Hello world",
             "Hello world",
             False,
-            1,
         ),
         (  # entity_name_startswith_device_name1
             {
@@ -266,11 +256,10 @@ async def test_availability_with_shared_state_topic(
                     }
                 }
             },
-            "sensor.world_automation",
-            "World automation",
+            "sensor.world_world_automation",
+            "World World automation",
             "World",
             False,
-            1,
         ),
         (  # entity_name_startswith_device_name2
             {
@@ -287,11 +276,10 @@ async def test_availability_with_shared_state_topic(
                     }
                 }
             },
-            "sensor.world_automation",
-            "world automation",
+            "sensor.world_world_automation",
+            "world world automation",
             "world",
             False,
-            1,
         ),
     ],
     ids=[
@@ -320,7 +308,6 @@ async def test_default_entity_and_device_name(
     friendly_name: str,
     device_name: str | None,
     assert_log: bool,
-    issue_events: int,
 ) -> None:
     """Test device name setup with and without a device_class set.
 
@@ -349,8 +336,8 @@ async def test_default_entity_and_device_name(
         "MQTT device information always needs to include a name" in caplog.text
     ) is assert_log
 
-    # Assert that an issues ware registered
-    assert len(events) == issue_events
+    # Assert that no issues ware registered
+    assert len(events) == 0
 
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.BINARY_SENSOR])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
When an MQTT entity has a device name that is equal to the entity name, or starts with the device name, this will no longer be corrected. When entities like these are created they will have both device and entity name in the friendly name. If the device name is to be omitted because it is the same as the entity name, then the entity `name` attribute sould be set to `null` in the JSON payload or YAML config.

Related blogpost: https://developers.home-assistant.io/blog/2023/07/21/change-naming-mqtt-entities

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove work-arounds, warnings and issue registrations for temporary fixing naming issues with MQTT entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
