### PR TITLE
Add default parameter to as_datetime template function/filter

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1836,7 +1836,7 @@ def as_datetime(value: Any, default: Any = _SENTINEL) -> Any:
             return dt_util.parse_datetime(value, raise_on_error=True)
         except (ValueError, TypeError):
             if default is _SENTINEL:
-                # Return None on string input
+                # Return None on string input to ensure backwards compatibality with HA Core 2024.1 and before
                 if isinstance(value, str):
                     return None
                 raise_no_default("as_datetime", value)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1836,7 +1836,8 @@ def as_datetime(value: Any, default: Any = _SENTINEL) -> Any:
             return dt_util.parse_datetime(value, raise_on_error=True)
         except (ValueError, TypeError):
             if default is _SENTINEL:
-                # Return None on string input to ensure backwards compatibality with HA Core 2024.1 and before
+                # Return None on string input
+                # to ensure backwards compatibility with HA Core 2024.1 and before.
                 if isinstance(value, str):
                     return None
                 raise_no_default("as_datetime", value)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1825,12 +1825,18 @@ def forgiving_as_timestamp(value, default=_SENTINEL):
 
 
 def as_datetime(value: Any, default: Any = _SENTINEL) -> Any:
-    """Filter and to convert a time string or UNIX timestamp to datetime object."""
+    """Filter and to convert a time string or UNIX timestamp to datetime object.
+    
+    Input values wil be parsed to string to before parsing them to datetime to allow 
+    datetime.datetime and datetime.date to be used as input as well, and avoid errors
+    on other input like lists or mappings
+    """
     try:
         # Check for a valid UNIX timestamp string, int or float
         timestamp = float(value)
         return dt_util.utc_from_timestamp(timestamp)
     except (ValueError, TypeError):
+        # convert value parsed to string to datetime
         if (
             parsed := dt_util.parse_datetime(str(value))
         ) is not None or default is _SENTINEL:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1825,18 +1825,13 @@ def forgiving_as_timestamp(value, default=_SENTINEL):
 
 
 def as_datetime(value: Any, default: Any = _SENTINEL) -> Any:
-    """Filter and to convert a time string or UNIX timestamp to datetime object.
-
-    Input values will be parsed to string to before parsing them to datetime to allow
-    datetime.datetime and datetime.date to be used as input as well, and avoid errors
-    on other input like lists or mappings
-    """
+    """Filter and to convert a time string or UNIX timestamp to datetime object."""
     try:
         # Check for a valid UNIX timestamp string, int or float
         timestamp = float(value)
         return dt_util.utc_from_timestamp(timestamp)
     except (ValueError, TypeError):
-        # convert value parsed to string to datetime
+        # Try to parse datetime string to datetime object
         try:
             return dt_util.parse_datetime(value, raise_on_error=True)
         except (ValueError, TypeError):

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1824,14 +1824,18 @@ def forgiving_as_timestamp(value, default=_SENTINEL):
         return default
 
 
-def as_datetime(value):
+def as_datetime(value: Any, default: Any = _SENTINEL) -> Any:
     """Filter and to convert a time string or UNIX timestamp to datetime object."""
     try:
         # Check for a valid UNIX timestamp string, int or float
         timestamp = float(value)
         return dt_util.utc_from_timestamp(timestamp)
-    except ValueError:
-        return dt_util.parse_datetime(value)
+    except (ValueError, TypeError):
+        if (
+            parsed := dt_util.parse_datetime(str(value))
+        ) is not None or default is _SENTINEL:
+            return parsed
+        return default
 
 
 def as_timedelta(value: str) -> timedelta | None:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1837,11 +1837,15 @@ def as_datetime(value: Any, default: Any = _SENTINEL) -> Any:
         return dt_util.utc_from_timestamp(timestamp)
     except (ValueError, TypeError):
         # convert value parsed to string to datetime
-        if (
-            parsed := dt_util.parse_datetime(str(value))
-        ) is not None or default is _SENTINEL:
-            return parsed
-        return default
+        try:
+            return dt_util.parse_datetime(value, raise_on_error=True)
+        except (ValueError, TypeError):
+            if default is _SENTINEL:
+                # Return None on string input
+                if isinstance(value, str):
+                    return None
+                raise_no_default("as_datetime", value)
+            return default
 
 
 def as_timedelta(value: str) -> timedelta | None:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1826,8 +1826,8 @@ def forgiving_as_timestamp(value, default=_SENTINEL):
 
 def as_datetime(value: Any, default: Any = _SENTINEL) -> Any:
     """Filter and to convert a time string or UNIX timestamp to datetime object.
-    
-    Input values wil be parsed to string to before parsing them to datetime to allow 
+
+    Input values will be parsed to string to before parsing them to datetime to allow
     datetime.datetime and datetime.date to be used as input as well, and avoid errors
     on other input like lists or mappings
     """

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1169,11 +1169,12 @@ def test_as_datetime(hass: HomeAssistant, input) -> None:
         (-1, "1969-12-31 23:59:59+00:00"),
     ),
 )
-def test_as_datetime_from_timestamp(hass: HomeAssistant, input, output) -> None:
+def test_as_datetime_from_timestamp(
+    hass: HomeAssistant,
+    input: int | float,
+    output: str,
+) -> None:
     """Test converting a UNIX timestamp to a date object."""
-    if output is not None:
-        output = str(output)
-
     assert (
         template.Template(f"{{{{ as_datetime({input}) }}}}", hass).async_render()
         == output
@@ -1218,37 +1219,27 @@ def test_as_datetime_from_datetime(hass: HomeAssistant, input) -> None:
 
 
 @pytest.mark.parametrize(
-    "input",
-    (
-        '"invalid"',
-        ["a", "list"],
-        {"a": "dict"},
-    ),
+    ("input", "output")[
+        ('"invalid"', "default output"),
+        (["a", "list"], "default output"),
+        ({"a": "dict"}, "default output"),
+    ],
 )
-def test_as_datetime_default(hass: HomeAssistant, input) -> None:
+def test_as_datetime_default(hass: HomeAssistant, input, output) -> None:
     """Test converting a timestamp string to a date object."""
     default = "default output"
-    try:
-        timestamp = float(input)
-        expected = dt_util.utc_from_timestamp(timestamp)
-    except (ValueError, TypeError):
-        expected = dt_util.parse_datetime(str(input))
-        if expected is not None:
-            expected = str(expected)
-        else:
-            expected = default
 
     assert (
         template.Template(
             f"{{{{ as_datetime({input}, default='{default}') }}}}", hass
         ).async_render()
-        == expected
+        == output
     )
     assert (
         template.Template(
             f"{{{{ {input} | as_datetime('{default}') }}}}", hass
         ).async_render()
-        == expected
+        == output
     )
 
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1194,54 +1194,28 @@ def test_as_datetime_from_timestamp(
 
 
 @pytest.mark.parametrize(
-    ("input", "output"),
+    ("input", "default", "output"),
     [
-        (
-            "{% set dt = as_datetime('2024-01-01 16:00:00-08:00') %}",
-            "2024-01-01 16:00:00-08:00",
-        ),
-        (
-            "{% set dt = as_datetime('2024-01-01').date() %}",
-            "2024-01-01 00:00:00",
-        ),
+        (1469119144, 123, "2016-07-21 16:39:04+00:00"),
+        ('"invalid"', ["default output"], ["default output"]),
+        (["a", "list"], 0, 0),
+        ({"a": "dict"}, None, None),
     ],
 )
-def test_as_datetime_from_datetime(
-    hass: HomeAssistant, input: str, output: str
+def test_as_datetime_default(
+    hass: HomeAssistant, input: Any, default: Any, output: str
 ) -> None:
-    """Test converting a datetime.datetime or datetime.date to a date object."""
-
-    assert (
-        template.Template(f"{input}{{{{ dt | as_datetime }}}}", hass).async_render()
-        == output
-    )
-
-    assert (
-        template.Template(f"{input}{{{{ as_datetime(dt) }}}}", hass).async_render()
-        == output
-    )
-
-
-@pytest.mark.parametrize(
-    ("input", "output"),
-    [
-        ('"invalid"', ["default output"]),
-        (["a", "list"], 0),
-        ({"a": "dict"}, None),
-    ],
-)
-def test_as_datetime_default(hass: HomeAssistant, input: Any, output: str) -> None:
     """Test invalid input and return default value."""
 
     assert (
         template.Template(
-            f"{{{{ as_datetime({input}, default={output}) }}}}", hass
+            f"{{{{ as_datetime({input}, default={default}) }}}}", hass
         ).async_render()
         == output
     )
     assert (
         template.Template(
-            f"{{{{ {input} | as_datetime({output}) }}}}", hass
+            f"{{{{ {input} | as_datetime({default}) }}}}", hass
         ).async_render()
         == output
     )

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1209,7 +1209,7 @@ def test_as_datetime_from_timestamp(
 def test_as_datetime_from_datetime(
     hass: HomeAssistant, input: str, output: str
 ) -> None:
-    """Test converting a timestamp string to a date object."""
+    """Test converting a datetime.datetime or datetime.date to a date object."""
 
     assert (
         template.Template(f"{input}{{{{ dt | as_datetime }}}}", hass).async_render()
@@ -1231,7 +1231,7 @@ def test_as_datetime_from_datetime(
     ],
 )
 def test_as_datetime_default(hass: HomeAssistant, input: Any, output: str) -> None:
-    """Test converting a timestamp string to a date object."""
+    """Test invalid input and return default value."""
 
     assert (
         template.Template(

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1197,11 +1197,11 @@ def test_as_datetime_from_timestamp(
     ("input", "output"),
     [
         (
-            "today_at('16:00').replace(year=2024, month=1, day=1)",
+            "{% set dt = as_datetime('2024-01-01 16:00:00-08:00') %}",
             "2024-01-01 16:00:00-08:00",
         ),
         (
-            "today_at('16:00').replace(year=2024, month=1, day=1).date()",
+            "{% set dt = as_datetime('2024-01-01').date() %}",
             "2024-01-01 00:00:00",
         ),
     ],
@@ -1212,11 +1212,12 @@ def test_as_datetime_from_datetime(
     """Test converting a timestamp string to a date object."""
 
     assert (
-        template.Template(f"{{{{ as_datetime({input}) }}}}", hass).async_render()
+        template.Template(f"{input}{{{{ dt | as_datetime }}}}", hass).async_render()
         == output
     )
+
     assert (
-        template.Template(f"{{{{ {input} | as_datetime }}}}", hass).async_render()
+        template.Template(f"{input}{{{{ as_datetime(dt) }}}}", hass).async_render()
         == output
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds support for the `default` parameter to the `as_datetime` filter/function.

To avoid breaking changes, a string input which can't be parsed to a datetime object returns `None` if no default is provided. In case a default is provided it will use that for strings which can't be parsed to datetime.

_Scope of PR changed, previous description below_
~~The main reason for this proposed change to the `as_datetime` is to allow datetime objects to be used as input for the filter/function. In devtools > states it is not clear if an attribute is a datetime object, or a string. For example, the `last_triggered` attribute of an automation is shown as `last_triggered: "2023-12-29T08:24:05.196004+00:00"` which looks like a string, but is a full datetime object. With this proposed change `as_datetime` can not only be used to convert a timestamp or datetime string to a datetime object, but also be used to _ensure_  the input is a datetime object.~~

~~I first created #107127 in which I also added a `local` parameter, which would convert the output to the local timezone, however I decided to start over, as this can also be done by `as_local` and without it I could solve the issue described above very simple by parsing the input to a string before it is used in `dt_util.parese_datetime`. 
This will have 2 effects:~~
* ~~it will allow using datetime.datetime and datedatime.date objects to be used as input, as they will be parsed to a string, and then back to a datetime object (adding midnight for a datetime.date object).~~
* ~~it will return `None` for all input which can not be converted to a datetime object, as is will convert types like list or mapping to a string as well, and as [parse_datetime](<https://github.com/home-assistant/core/blob/dev/homeassistant/util/dt.py#L197C1-L233C30>) is used without setting `raise_on_error=True` it will not raise a ValueError.~~

~~With that change, it also makes it very easy to add a `default` parameter, as the output is now really predictable. It will be either a datetime object or  `None`. So only a check if the output is `None` and a value for `default` is provided is needed.~~

_Old proposed change_
~~Add additional functionality to the `as_datetime` function/filter~~
* ~~add option to provide a `default` value where it otherwise would return `None`~~
* ~~datetime.date and datetime.datetime objects are parsed to a string, so it will not error on it~~
* ~~It will no longer error on unexpected types like a list or dictionary, but will return `None` like it already did for a non convertible string.~~


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/31048

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
