### PR TITLE
Make exceptions in rest_command services translatable

### DIFF
--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -169,28 +169,35 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                         else:
                             _content = await response.text()
                     except (JSONDecodeError, AttributeError) as err:
-                        _LOGGER.error("Response of `%s` has invalid JSON", request_url)
-                        raise HomeAssistantError from err
+                        raise HomeAssistantError(
+                            f"Response of '{request_url}' could not be decoded as JSON",
+                            translation_domain=DOMAIN,
+                            translation_key="decoding_error",
+                            translation_placeholders={"decoding_type": "json"},
+                        ) from err
 
                     except UnicodeDecodeError as err:
-                        _LOGGER.error(
-                            "Response of `%s` could not be interpreted as text",
-                            request_url,
-                        )
-                        raise HomeAssistantError from err
+                        raise HomeAssistantError(
+                            f"Response of '{request_url}' could not be decoded as text",
+                            translation_domain=DOMAIN,
+                            translation_key="decoding_error",
+                            translation_placeholders={"decoding_type": "text"},
+                        ) from err
                     return {"content": _content, "status": response.status}
 
             except asyncio.TimeoutError as err:
-                _LOGGER.warning("Timeout call %s", request_url)
-                raise HomeAssistantError from err
+                raise HomeAssistantError(
+                    f"Timeout when calling resource '{request_url}'",
+                    translation_domain=DOMAIN,
+                    translation_key="timeout",
+                ) from err
 
             except aiohttp.ClientError as err:
-                _LOGGER.error(
-                    "Client error. Url: %s. Error: %s",
-                    request_url,
-                    err,
-                )
-                raise HomeAssistantError from err
+                raise HomeAssistantError(
+                    f"Client error occurred when calling resource '{request_url}'",
+                    translation_domain=DOMAIN,
+                    translation_key="client_error",
+                ) from err
 
         # register services
         hass.services.async_register(

--- a/homeassistant/components/rest_command/strings.json
+++ b/homeassistant/components/rest_command/strings.json
@@ -4,5 +4,16 @@
       "name": "[%key:common::action::reload%]",
       "description": "Reloads RESTful commands from the YAML-configuration."
     }
+  },
+  "exceptions": {
+    "timeout": {
+      "message": "Timeout while waiting for response from the server"
+    },
+    "client_error": {
+      "message": "An error occurred while requesting the resource"
+    },
+    "decoding_error": {
+      "message": "The response from the server could not be decoded as {decoding_type}"
+    }
   }
 }

--- a/tests/components/rest_command/test_init.py
+++ b/tests/components/rest_command/test_init.py
@@ -115,8 +115,11 @@ class TestRestCommandComponent:
 
         aioclient_mock.get(self.url, exc=asyncio.TimeoutError())
 
-        self.hass.services.call(rc.DOMAIN, "get_test", {})
-        self.hass.block_till_done()
+        with pytest.raises(
+            HomeAssistantError,
+            match=r"^Timeout when calling resource 'https://example.com/'$",
+        ):
+            self.hass.services.call(rc.DOMAIN, "get_test", {}, blocking=True)
 
         assert len(aioclient_mock.mock_calls) == 1
 
@@ -127,8 +130,11 @@ class TestRestCommandComponent:
 
         aioclient_mock.get(self.url, exc=aiohttp.ClientError())
 
-        self.hass.services.call(rc.DOMAIN, "get_test", {})
-        self.hass.block_till_done()
+        with pytest.raises(
+            HomeAssistantError,
+            match=r"^Client error occurred when calling resource 'https://example.com/'$",
+        ):
+            self.hass.services.call(rc.DOMAIN, "get_test", {}, blocking=True)
 
         assert len(aioclient_mock.mock_calls) == 1
 
@@ -412,7 +418,10 @@ class TestRestCommandComponent:
         assert not response
 
         # Throws error when requesting response
-        with pytest.raises(HomeAssistantError):
+        with pytest.raises(
+            HomeAssistantError,
+            match=r"^Response of 'https://example.com/' could not be decoded as JSON$",
+        ):
             response = self.hass.services.call(
                 rc.DOMAIN, "get_test", {}, blocking=True, return_response=True
             )
@@ -439,7 +448,10 @@ class TestRestCommandComponent:
         assert not response
 
         # Throws Decode error when requesting response
-        with pytest.raises(HomeAssistantError):
+        with pytest.raises(
+            HomeAssistantError,
+            match=r"^Response of 'https://example.com/' could not be decoded as text$",
+        ):
             response = self.hass.services.call(
                 rc.DOMAIN, "get_test", {}, blocking=True, return_response=True
             )


### PR DESCRIPTION
## Proposed change
Make the existing exceptions in the `rest_command` services translatable. Removed the logging of the errors as well, as the trace of the exception is already logged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
