### PR TITLE
Separate ecobee start and end date/times for create_vacation service

### DIFF
--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -114,9 +114,12 @@ SERVICE_SET_DST_MODE = "set_dst_mode"
 SERVICE_SET_MIC_MODE = "set_mic_mode"
 SERVICE_SET_OCCUPANCY_MODES = "set_occupancy_modes"
 
-DTGROUP_INCLUSIVE_MSG = (
-    f"{ATTR_START_DATE}, {ATTR_START_TIME}, {ATTR_END_DATE}, "
-    f"and {ATTR_END_TIME} must be specified together"
+DTGROUP_START_INCLUSIVE_MSG = (
+    f"{ATTR_START_DATE} and {ATTR_START_TIME} must be specified together"
+)
+
+DTGROUP_END_INCLUSIVE_MSG = (
+    f"{ATTR_END_DATE} and {ATTR_END_TIME} must be specified together"
 )
 
 CREATE_VACATION_SCHEMA = vol.Schema(
@@ -126,13 +129,17 @@ CREATE_VACATION_SCHEMA = vol.Schema(
         vol.Required(ATTR_COOL_TEMP): vol.Coerce(float),
         vol.Required(ATTR_HEAT_TEMP): vol.Coerce(float),
         vol.Inclusive(
-            ATTR_START_DATE, "dtgroup", msg=DTGROUP_INCLUSIVE_MSG
+            ATTR_START_DATE, "dtgroup_start", msg=DTGROUP_START_INCLUSIVE_MSG
         ): ecobee_date,
         vol.Inclusive(
-            ATTR_START_TIME, "dtgroup", msg=DTGROUP_INCLUSIVE_MSG
+            ATTR_START_TIME, "dtgroup_start", msg=DTGROUP_START_INCLUSIVE_MSG
         ): ecobee_time,
-        vol.Inclusive(ATTR_END_DATE, "dtgroup", msg=DTGROUP_INCLUSIVE_MSG): ecobee_date,
-        vol.Inclusive(ATTR_END_TIME, "dtgroup", msg=DTGROUP_INCLUSIVE_MSG): ecobee_time,
+        vol.Inclusive(
+            ATTR_END_DATE, "dtgroup_end", msg=DTGROUP_END_INCLUSIVE_MSG
+        ): ecobee_date,
+        vol.Inclusive(
+            ATTR_END_TIME, "dtgroup_end", msg=DTGROUP_END_INCLUSIVE_MSG
+        ): ecobee_time,
         vol.Optional(ATTR_FAN_MODE, default="auto"): vol.Any("auto", "on"),
         vol.Optional(ATTR_FAN_MIN_ON_TIME, default=0): vol.All(
             int, vol.Range(min=0, max=60)

--- a/homeassistant/components/ecobee/strings.json
+++ b/homeassistant/components/ecobee/strings.json
@@ -52,7 +52,7 @@
         },
         "start_date": {
           "name": "Start date",
-          "description": "Date the vacation starts in the YYYY-MM-DD format (optional, immediately if not provided along with start_time, end_date, and end_time)."
+          "description": "Date the vacation starts in the YYYY-MM-DD format (optional, immediately if not provided along with start_time)."
         },
         "start_time": {
           "name": "Start time",
@@ -60,7 +60,7 @@
         },
         "end_date": {
           "name": "End date",
-          "description": "Date the vacation ends in the YYYY-MM-DD format (optional, 14 days from now if not provided along with start_date, start_time, and end_time)."
+          "description": "Date the vacation ends in the YYYY-MM-DD format (optional, 14 days from now if not provided along with end_time)."
         },
         "end_time": {
           "name": "End time",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently when setting a vacation with ecobee, if end_date and end_time contain data, then start_date and start_time must also contain data. This is not be necessary since if no start_date and start_time is provided, the vacation will start immediately and if no end_date and end_time is provided the vacation will last 14 days ([api docs](https://www.ecobee.com/home/developer/api/documentation/v1/functions/CreateVacation.shtml)).

This PR separates these two. Now only end_date and end_time OR start_date and start_time are required together.

Marking as bugfix, though not really sure the applicable category.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
