### PR TITLE
Enable strict typing for duotecno

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -143,6 +143,7 @@ homeassistant.components.doorbird.*
 homeassistant.components.dormakaba_dkey.*
 homeassistant.components.dsmr.*
 homeassistant.components.dunehd.*
+homeassistant.components.duotecno.*
 homeassistant.components.efergy.*
 homeassistant.components.electrasmart.*
 homeassistant.components.electric_kiwi.*

--- a/homeassistant/components/duotecno/binary_sensor.py
+++ b/homeassistant/components/duotecno/binary_sensor.py
@@ -1,5 +1,7 @@
 """Support for Duotecno binary sensors."""
+from __future__ import annotations
 
+from duotecno.controller import PyDuotecno
 from duotecno.unit import ControlUnit, VirtualUnit
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
@@ -17,7 +19,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Duotecno binary sensor on config_entry."""
-    cntrl = hass.data[DOMAIN][entry.entry_id]
+    cntrl: PyDuotecno = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
         DuotecnoBinarySensor(channel)
         for channel in cntrl.get_units(["ControlUnit", "VirtualUnit"])

--- a/homeassistant/components/duotecno/climate.py
+++ b/homeassistant/components/duotecno/climate.py
@@ -1,6 +1,9 @@
 """Support for Duotecno climate devices."""
+from __future__ import annotations
+
 from typing import Any, Final
 
+from duotecno.controller import PyDuotecno
 from duotecno.unit import SensUnit
 
 from homeassistant.components.climate import (
@@ -33,7 +36,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Duotecno climate based on config_entry."""
-    cntrl = hass.data[DOMAIN][entry.entry_id]
+    cntrl: PyDuotecno = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
         DuotecnoClimate(channel) for channel in cntrl.get_units(["SensUnit"])
     )

--- a/homeassistant/components/duotecno/cover.py
+++ b/homeassistant/components/duotecno/cover.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from duotecno.controller import PyDuotecno
 from duotecno.unit import DuoswitchUnit
 
 from homeassistant.components.cover import CoverEntity, CoverEntityFeature
@@ -20,7 +21,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the duoswitch endities."""
-    cntrl = hass.data[DOMAIN][entry.entry_id]
+    cntrl: PyDuotecno = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
         DuotecnoCover(channel) for channel in cntrl.get_units("DuoswitchUnit")
     )
@@ -30,13 +31,9 @@ class DuotecnoCover(DuotecnoEntity, CoverEntity):
     """Representation a Velbus cover."""
 
     _unit: DuoswitchUnit
-
-    def __init__(self, unit: DuoswitchUnit) -> None:
-        """Initialize the cover."""
-        super().__init__(unit)
-        self._attr_supported_features = (
-            CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE | CoverEntityFeature.STOP
-        )
+    _attr_supported_features = (
+        CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE | CoverEntityFeature.STOP
+    )
 
     @property
     def is_closed(self) -> bool | None:

--- a/homeassistant/components/duotecno/entity.py
+++ b/homeassistant/components/duotecno/entity.py
@@ -17,10 +17,9 @@ from .const import DOMAIN
 class DuotecnoEntity(Entity):
     """Representation of a Duotecno entity."""
 
-    _attr_should_poll: bool = False
-    _unit: BaseUnit
+    _attr_should_poll = False
 
-    def __init__(self, unit) -> None:
+    def __init__(self, unit: BaseUnit) -> None:
         """Initialize a Duotecno entity."""
         self._unit = unit
         self._attr_name = unit.get_name()

--- a/homeassistant/components/duotecno/light.py
+++ b/homeassistant/components/duotecno/light.py
@@ -1,6 +1,7 @@
 """Support for Duotecno lights."""
 from typing import Any
 
+from duotecno.controller import PyDuotecno
 from duotecno.unit import DimUnit
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
@@ -18,7 +19,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Duotecno light based on config_entry."""
-    cntrl = hass.data[DOMAIN][entry.entry_id]
+    cntrl: PyDuotecno = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(DuotecnoLight(channel) for channel in cntrl.get_units("DimUnit"))
 
 

--- a/homeassistant/components/duotecno/switch.py
+++ b/homeassistant/components/duotecno/switch.py
@@ -1,6 +1,7 @@
 """Support for Duotecno switches."""
 from typing import Any
 
+from duotecno.controller import PyDuotecno
 from duotecno.unit import SwitchUnit
 
 from homeassistant.components.switch import SwitchEntity
@@ -18,7 +19,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Velbus switch based on config_entry."""
-    cntrl = hass.data[DOMAIN][entry.entry_id]
+    cntrl: PyDuotecno = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
         DuotecnoSwitch(channel) for channel in cntrl.get_units("SwitchUnit")
     )

--- a/mypy.ini
+++ b/mypy.ini
@@ -1191,6 +1191,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.duotecno.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.efergy.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true


### PR DESCRIPTION
## Proposed change
Improve annotations and enable strict typing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
