### PR TITLE
Add support for the Spotify DJ

### DIFF
--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -62,7 +62,7 @@ REPEAT_MODE_MAPPING_TO_SPOTIFY = {
 }
 
 # This is a minimal representation of the DJ playlist that Spotify now offers
-# The DJ is not fully integrated with the platlist API, so needs to have the playlist response mocked in order to maintain functionality
+# The DJ is not fully integrated with the playlist API, so needs to have the playlist response mocked in order to maintain functionality
 SPOTIFY_DJ_PLAYLIST = {"uri": "spotify:playlist:37i9dQZF1EYkqdzj48dyYq", "name": "DJ"}
 
 

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -61,6 +61,13 @@ REPEAT_MODE_MAPPING_TO_SPOTIFY = {
     value: key for key, value in REPEAT_MODE_MAPPING_TO_HA.items()
 }
 
+# This is a minimal representation of the DJ playlist that Spotify now offers
+# The DJ is not fully integrated with the platlist API, so needs to have the playlist response mocked in order to maintain functionality
+SPOTIFY_DJ_PLAYLIST = {
+    "uri": "spotify:playlist:37i9dQZF1EYkqdzj48dyYq",
+    "name": "DJ"
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -423,7 +430,16 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
         if context and (self._playlist is None or self._playlist["uri"] != uri):
             self._playlist = None
             if context["type"] == MediaType.PLAYLIST:
-                self._playlist = self.data.client.playlist(uri)
+                # The Spotify API does not currently support doing a lookup for the DJ playlist, so just use the minimal mock playlist object
+                if uri == SPOTIFY_DJ_PLAYLIST["uri"]:
+                    self._playlist = SPOTIFY_DJ_PLAYLIST
+                else:
+                    # Make sure any playlist lookups don't break the current playback state update
+                    try:
+                        self._playlist = self.data.client.playlist(uri)
+                    except:
+                        _LOGGER.debug(f"Unable to load spotify playlist '{uri}'. Continuing without playlist data.")
+                        self._playlist = None
 
         device = self._currently_playing.get("device")
         if device is not None:

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -63,10 +63,7 @@ REPEAT_MODE_MAPPING_TO_SPOTIFY = {
 
 # This is a minimal representation of the DJ playlist that Spotify now offers
 # The DJ is not fully integrated with the platlist API, so needs to have the playlist response mocked in order to maintain functionality
-SPOTIFY_DJ_PLAYLIST = {
-    "uri": "spotify:playlist:37i9dQZF1EYkqdzj48dyYq",
-    "name": "DJ"
-}
+SPOTIFY_DJ_PLAYLIST = {"uri": "spotify:playlist:37i9dQZF1EYkqdzj48dyYq", "name": "DJ"}
 
 
 async def async_setup_entry(
@@ -437,8 +434,11 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
                     # Make sure any playlist lookups don't break the current playback state update
                     try:
                         self._playlist = self.data.client.playlist(uri)
-                    except:
-                        _LOGGER.debug(f"Unable to load spotify playlist '{uri}'. Continuing without playlist data.")
+                    except SpotifyException:
+                        _LOGGER.debug(
+                            "Unable to load spotify playlist '%s'. Continuing without playlist data",
+                            uri,
+                        )
                         self._playlist = None
 
         device = self._currently_playing.get("device")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for the new Spotify DJ feature by mocking the playlist response. The Spotify Web API currently doesn't support the DJ feature and returns a 404 error when trying to lookup the playlist details. If the context contains the URI for the DJ playlist, instead of performing a playlist lookup, a mock playlist object will be used to provide the minimal set of required playlist data. 

I've also added some extra error handling around the playlist lookup to prevent a failing playlist request breaking the current playback state update. This error handling by itself could fix the issue, but I wanted to also have the `media_playlist` property be populated if the DJ URI is detected.

I've used this URI as the DJ playlist URI as it seems to be the same in my testing and from other users requesting support on the Spotify Community website:

```
spotify:playlist:37i9dQZF1EYkqdzj48dyYq
```

Spotify Community support requests:
- https://community.spotify.com/t5/Spotify-for-Developers/What-Spotify-Web-API-does-the-DJ-button-use/td-p/5660189
- https://community.spotify.com/t5/Spotify-for-Developers/Spotify-DJ-playlist-info-images/m-p/5587781

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #94670
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
