### PR TITLE
Enable strict typing for system_health

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -367,6 +367,7 @@ homeassistant.components.switchbee.*
 homeassistant.components.switchbot_cloud.*
 homeassistant.components.switcher_kis.*
 homeassistant.components.synology_dsm.*
+homeassistant.components.system_health.*
 homeassistant.components.systemmonitor.*
 homeassistant.components.tag.*
 homeassistant.components.tailscale.*

--- a/homeassistant/components/system_health/__init__.py
+++ b/homeassistant/components/system_health/__init__.py
@@ -6,7 +6,7 @@ from collections.abc import Awaitable, Callable
 import dataclasses
 from datetime import datetime
 import logging
-from typing import Any
+from typing import Any, Protocol
 
 import aiohttp
 import voluptuous as vol
@@ -30,13 +30,22 @@ INFO_CALLBACK_TIMEOUT = 5
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 
+class SystemHealthProtocol(Protocol):
+    """Define the format of system_health platforms."""
+
+    def async_register(
+        self, hass: HomeAssistant, register: SystemHealthRegistration
+    ) -> None:
+        """Register system health callbacks."""
+
+
 @bind_hass
 @callback
 def async_register_info(
     hass: HomeAssistant,
     domain: str,
     info_callback: Callable[[HomeAssistant], Awaitable[dict]],
-):
+) -> None:
     """Register an info callback.
 
     Deprecated.
@@ -61,7 +70,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def _register_system_health_platform(hass, integration_domain, platform):
+async def _register_system_health_platform(
+    hass: HomeAssistant, integration_domain: str, platform: SystemHealthProtocol
+) -> None:
     """Register a system health platform."""
     platform.async_register(hass, SystemHealthRegistration(hass, integration_domain))
 
@@ -89,7 +100,7 @@ async def get_integration_info(
 
 
 @callback
-def _format_value(val):
+def _format_value(val: Any) -> Any:
     """Format a system health value."""
     if isinstance(val, datetime):
         return {"value": val.isoformat(), "type": "date"}
@@ -207,7 +218,7 @@ class SystemHealthRegistration:
         self,
         info_callback: Callable[[HomeAssistant], Awaitable[dict]],
         manage_url: str | None = None,
-    ):
+    ) -> None:
         """Register an info callback."""
         self.info_callback = info_callback
         self.manage_url = manage_url

--- a/mypy.ini
+++ b/mypy.ini
@@ -3432,6 +3432,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.system_health.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.systemmonitor.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true


### PR DESCRIPTION
## Proposed change
Improve annotations and enable strict typing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
