### PR TITLE
Fix Permobil eula error

### DIFF
--- a/homeassistant/components/permobil/config_flow.py
+++ b/homeassistant/components/permobil/config_flow.py
@@ -152,7 +152,10 @@ class PermobilConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if errors or not user_input:
             return self.async_show_form(
-                step_id="email_code", data_schema=GET_TOKEN_SCHEMA, errors=errors
+                step_id="email_code",
+                data_schema=GET_TOKEN_SCHEMA,
+                errors=errors,
+                description_placeholders={"app_name": "MyPermobil"},
             )
 
         return self.async_create_entry(title=self.data[CONF_EMAIL], data=self.data)

--- a/homeassistant/components/permobil/config_flow.py
+++ b/homeassistant/components/permobil/config_flow.py
@@ -5,7 +5,12 @@ from collections.abc import Mapping
 import logging
 from typing import Any
 
-from mypermobil import MyPermobil, MyPermobilAPIException, MyPermobilClientException
+from mypermobil import (
+    MyPermobil,
+    MyPermobilAPIException,
+    MyPermobilClientException,
+    MyPermobilEulaException,
+)
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -141,6 +146,10 @@ class PermobilConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 # or the backend returned an error when trying to validate the code
                 _LOGGER.exception("Error verifying code")
                 errors["base"] = "invalid_code"
+            except MyPermobilEulaException:
+                # The user has not accepted the EULA
+                _LOGGER.exception("Error EULA not signed")
+                errors["base"] = "unsigned_eula"
 
         if errors or not user_input:
             return self.async_show_form(

--- a/homeassistant/components/permobil/config_flow.py
+++ b/homeassistant/components/permobil/config_flow.py
@@ -148,7 +148,6 @@ class PermobilConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "invalid_code"
             except MyPermobilEulaException:
                 # The user has not accepted the EULA
-                _LOGGER.exception("Error EULA not signed")
                 errors["base"] = "unsigned_eula"
 
         if errors or not user_input:

--- a/homeassistant/components/permobil/manifest.json
+++ b/homeassistant/components/permobil/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/permobil",
   "iot_class": "cloud_polling",
-  "requirements": ["mypermobil==0.1.6"]
+  "requirements": ["mypermobil==0.1.8"]
 }

--- a/homeassistant/components/permobil/strings.json
+++ b/homeassistant/components/permobil/strings.json
@@ -28,7 +28,7 @@
       "code_request_error": "Error requesting application code",
       "invalid_email": "Invalid email",
       "invalid_code": "The code you gave is incorrect",
-      "unsigned_eula": "Please sign the EULA in the MyPermobil app"
+      "unsigned_eula": "Please sign the EULA in the {app_name} app"
     }
   },
   "entity": {

--- a/homeassistant/components/permobil/strings.json
+++ b/homeassistant/components/permobil/strings.json
@@ -28,7 +28,7 @@
       "code_request_error": "Error requesting application code",
       "invalid_email": "Invalid email",
       "invalid_code": "The code you gave is incorrect",
-      "unsigned_eula": "Please sign the EULA in the MyPermobil app and start over"
+      "unsigned_eula": "Please sign the EULA in the MyPermobil app"
     }
   },
   "entity": {

--- a/homeassistant/components/permobil/strings.json
+++ b/homeassistant/components/permobil/strings.json
@@ -27,7 +27,8 @@
       "region_fetch_error": "Error fetching regions",
       "code_request_error": "Error requesting application code",
       "invalid_email": "Invalid email",
-      "invalid_code": "The code you gave is incorrect"
+      "invalid_code": "The code you gave is incorrect",
+      "unsigned_eula": "Please sign the EULA in the MyPermobil app and start over"
     }
   },
   "entity": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1306,7 +1306,7 @@ mutagen==1.47.0
 mutesync==0.0.1
 
 # homeassistant.components.permobil
-mypermobil==0.1.6
+mypermobil==0.1.8
 
 # homeassistant.components.nad
 nad-receiver==0.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1036,7 +1036,7 @@ mutagen==1.47.0
 mutesync==0.0.1
 
 # homeassistant.components.permobil
-mypermobil==0.1.6
+mypermobil==0.1.8
 
 # homeassistant.components.keenetic_ndms2
 ndms2-client==0.1.2

--- a/tests/components/permobil/test_config_flow.py
+++ b/tests/components/permobil/test_config_flow.py
@@ -71,7 +71,11 @@ async def test_sucessful_config_flow(hass: HomeAssistant, my_permobil: Mock) -> 
 async def test_config_flow_incorrect_code(
     hass: HomeAssistant, my_permobil: Mock
 ) -> None:
-    """Test the config flow from start to until email code verification and have the API return API error."""
+    """Test email code verification with API error.
+
+    Test the config flow from start to until email code verification
+    and have the API return API error.
+    """
     my_permobil.request_application_token.side_effect = MyPermobilAPIException
     # init flow
     with patch(
@@ -112,7 +116,11 @@ async def test_config_flow_incorrect_code(
 async def test_config_flow_unsigned_eula(
     hass: HomeAssistant, my_permobil: Mock
 ) -> None:
-    """Test the config flow from start to until email code verification and the user has not accepted the eula."""
+    """Test email code verification with unsigned eula error.
+
+    Test the config flow from start to until email code verification
+    and have the API return that the eula is unsigned.
+    """
     my_permobil.request_application_token.side_effect = MyPermobilEulaException
     # init flow
     with patch(
@@ -168,7 +176,12 @@ async def test_config_flow_unsigned_eula(
 async def test_config_flow_incorrect_region(
     hass: HomeAssistant, my_permobil: Mock
 ) -> None:
-    """Test the config flow from start to until the request for email code and have the API return error."""
+    """Test when the user does not exist in the selected region.
+
+    Test the config flow from start to until the request for email
+    code and have the API return error because there is not user for
+    that email.
+    """
     my_permobil.request_application_code.side_effect = MyPermobilAPIException
     # init flow
     with patch(
@@ -200,7 +213,11 @@ async def test_config_flow_incorrect_region(
 async def test_config_flow_region_request_error(
     hass: HomeAssistant, my_permobil: Mock
 ) -> None:
-    """Test the config flow from start to until the request for regions and have the API return error."""
+    """Test region request error.
+
+    Test the config flow from start to until the request for regions
+    and have the API return an error.
+    """
     my_permobil.request_region_names.side_effect = MyPermobilAPIException
     # init flow
     # here the request_region_names raises a MyPermobilAPIException
@@ -222,7 +239,13 @@ async def test_config_flow_region_request_error(
 async def test_config_flow_invalid_email(
     hass: HomeAssistant, my_permobil: Mock
 ) -> None:
-    """Test the config flow from start to until the request for regions and have the API return error."""
+    """Test an incorrectly formatted email.
+
+    Test that the email must be formatted correctly. The schema for the
+    input should already check for this, but since the API does a
+    separate check that might not overlap 100% with the schema,
+    this test is still needed.
+    """
     my_permobil.set_email.side_effect = MyPermobilClientException()
     # init flow
     # here the set_email raises a MyPermobilClientException

--- a/tests/components/permobil/test_config_flow.py
+++ b/tests/components/permobil/test_config_flow.py
@@ -149,6 +149,21 @@ async def test_config_flow_unsigned_eula(
     assert result["step_id"] == "email_code"
     assert result["errors"]["base"] == "unsigned_eula"
 
+    # Retry to submit the code again, but this time the user has signed the EULA
+    with patch.object(
+        my_permobil,
+        "request_application_token",
+        return_value=MOCK_TOKEN,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_CODE: MOCK_CODE},
+        )
+
+    # Now the method should not raise an exception, and you can proceed with your assertions
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"] == VALID_DATA
+
 
 async def test_config_flow_incorrect_region(
     hass: HomeAssistant, my_permobil: Mock


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This pr bumps mypermobil package to 0.1.8 [diff](https://github.com/Permobil-Software/mypermobil/compare/v0.1.6...v0.1.8)
It also includes a more user friendly message in the config flow for when the user has not signed the mypermobil EULA. 
Previously the error was just printed to the hass log, but now it shows in the config flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
