### PR TITLE
Specific Assist errors for domain/device class

### DIFF
--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -885,7 +885,18 @@ def _get_no_states_matched_response(
     error_response_args: dict[str, Any] = {}
 
     if no_states_error.area:
-        if no_states_error.domains:
+        # Check device classes first, since it's more specific than domain
+        if no_states_error.device_classes:
+            # No exposed entities of a particular class in an area.
+            # Example: "close the bedroom windows"
+            error_response_type = ResponseType.NO_DEVICE_CLASS
+            error_response_args["area"] = no_states_error.area
+
+            # Only use the first device class for the error message
+            error_response_args["device_class"] = next(
+                iter(no_states_error.device_classes)
+            )
+        elif no_states_error.domains:
             # No exposed entities of a domain in an area.
             # Example: "turn on lights in kitchen"
             error_response_type = ResponseType.NO_DOMAIN
@@ -893,16 +904,6 @@ def _get_no_states_matched_response(
 
             # Only use the first domain for the error message
             error_response_args["domain"] = next(iter(no_states_error.domains))
-        elif no_states_error.device_classes:
-            # No exposed entities of a particular class in an area.
-            # Example: "close the bedroom windows"
-            error_response_type = ResponseType.NO_DEVICE_CLASS
-            error_response_args["area"] = no_states_error.area
-
-            # Only use the first device class for the error message
-            error_response_args["device_classes"] = next(
-                iter(no_states_error.device_classes)
-            )
 
     return error_response_type, error_response_args
 

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -271,7 +271,6 @@ class DefaultAgent(AbstractConversationAgent):
             )
         except intent.NoStatesMatchedError as no_states_error:
             # Intent was valid, but no entities matched the constraints.
-            _LOGGER.exception("No states matched intent constraints")
             error_response_type, error_response_args = _get_no_states_matched_response(
                 no_states_error
             )

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -109,8 +109,8 @@ async def async_handle(
     except vol.Invalid as err:
         _LOGGER.warning("Received invalid slot info for %s: %s", intent_type, err)
         raise InvalidSlotInfo(f"Received invalid slot info for {intent_type}") from err
-    except IntentHandleError:
-        raise
+    except IntentError:
+        raise  # bubble up intent related errors
     except Exception as err:
         raise IntentUnexpectedError(f"Error handling {intent_type}") from err
 
@@ -133,6 +133,25 @@ class IntentHandleError(IntentError):
 
 class IntentUnexpectedError(IntentError):
     """Unexpected error while handling intent."""
+
+
+class NoStatesMatchedError(IntentError):
+    """Error when no states match the intent's constraints."""
+
+    def __init__(
+        self,
+        name: str | None,
+        area: str | None,
+        domains: set[str] | None,
+        device_classes: set[str] | None,
+    ) -> None:
+        """Initialize error."""
+        super().__init__()
+
+        self.name = name
+        self.area = area
+        self.domains = domains
+        self.device_classes = device_classes
 
 
 def _is_device_class(
@@ -421,8 +440,12 @@ class ServiceIntentHandler(IntentHandler):
         )
 
         if not states:
-            raise IntentHandleError(
-                f"No entities matched for: name={name}, area={area}, domains={domains}, device_classes={device_classes}",
+            # No states matched constraints
+            raise NoStatesMatchedError(
+                name=name,
+                area=area_name,
+                domains=domains,
+                device_classes=device_classes,
             )
 
         response = await self.async_handle_states(intent_obj, states, area)

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -129,7 +129,7 @@ async def test_exposed_areas(
 
     # This should be an error because the lights in that area are not exposed
     assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
+    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
 
     # But we can still ask questions about the bedroom, even with no exposed entities
     result = await conversation.async_converse(
@@ -453,6 +453,38 @@ async def test_error_missing_area(hass: HomeAssistant, init_components) -> None:
     assert result.response.response_type == intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert result.response.speech["plain"]["speech"] == "No area named missing area"
+
+
+async def test_error_no_exposed_for_domain(
+    hass: HomeAssistant, init_components, area_registry: ar.AreaRegistry
+) -> None:
+    """Test error message when no entities for a domain are exposed in an area."""
+    area_registry.async_get_or_create("kitchen")
+    result = await conversation.async_converse(
+        hass, "turn on the lights in the kitchen", None, Context(), None
+    )
+
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert (
+        result.response.speech["plain"]["speech"] == "kitchen does not contain a light"
+    )
+
+
+async def test_error_no_exposed_for_device_class(
+    hass: HomeAssistant, init_components, area_registry: ar.AreaRegistry
+) -> None:
+    """Test error message when no entities of a device class are exposed in an area."""
+    area_registry.async_get_or_create("bedroom")
+    result = await conversation.async_converse(
+        hass, "open bedroom windows", None, Context(), None
+    )
+
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert (
+        result.response.speech["plain"]["speech"] == "bedroom does not contain a cover"
+    )
 
 
 async def test_error_match_failure(hass: HomeAssistant, init_components) -> None:

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -483,7 +483,7 @@ async def test_error_no_exposed_for_device_class(
     assert result.response.response_type == intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
-        result.response.speech["plain"]["speech"] == "bedroom does not contain a cover"
+        result.response.speech["plain"]["speech"] == "bedroom does not contain a window"
     )
 
 

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -503,6 +503,31 @@ async def test_error_match_failure(hass: HomeAssistant, init_components) -> None
         )
 
 
+async def test_no_states_matched_default_error(
+    hass: HomeAssistant, init_components, area_registry: ar.AreaRegistry
+) -> None:
+    """Test default response when no states match and slots are missing."""
+    area_registry.async_get_or_create("kitchen")
+
+    with patch(
+        "homeassistant.components.conversation.default_agent.intent.async_handle",
+        side_effect=intent.NoStatesMatchedError(None, None, None, None),
+    ):
+        result = await conversation.async_converse(
+            hass, "turn on lights in the kitchen", None, Context(), None
+        )
+
+        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert (
+            result.response.error_code
+            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+        )
+        assert (
+            result.response.speech["plain"]["speech"]
+            == "Sorry, I couldn't understand that"
+        )
+
+
 async def test_empty_aliases(
     hass: HomeAssistant,
     init_components,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use specific Assist errors for domain/device class. For example, "turn on kitchen lights" will now respond with "kitchen does not contain a light" instead of "Sorry, I couldn't understand that". Likewise, "close bedroom windows" will respond "bedroom does not contain a window".

To make this work, the `ServiceIntentHandler` was modified to raise a new `NoStatesMatchedError`, which is bubbled up by `intent.async_handle` to the default agent. This error must be raised *inside* the intent handler because it is only after filtering entities based on the constraints that we know nothing matches [1]. The error must be bubbled up because only the default agent knows how to produce the correct translated responses.

[1] Additionally, other intent handlers may not care if nothing matches. `GetStateIntentHandler` is one of these, which would just respond "0" to "how many lights are in the kitchen" if there are no lights instead of raising an error.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
