### PR TITLE
Show default profiles in homematic cloud climate entity

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -599,6 +599,8 @@ build.json @home-assistant/supervisor
 /tests/components/homekit_controller/ @Jc2k @bdraco
 /homeassistant/components/homematic/ @pvizeli
 /tests/components/homematic/ @pvizeli
+/homeassistant/components/homematicip_cloud/ @hahn-th
+/tests/components/homematicip_cloud/ @hahn-th
 /homeassistant/components/homewizard/ @DCSBL
 /tests/components/homewizard/ @DCSBL
 /homeassistant/components/honeywell/ @rdfurman @mkmer

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -13,6 +13,7 @@ from homematicip.aio.group import AsyncHeatingGroup
 from homematicip.base.enums import AbsenceType
 from homematicip.device import Switch
 from homematicip.functionalHomes import IndoorClimateHome
+from homematicip.group import HeatingCoolingProfile
 
 from homeassistant.components.climate import (
     PRESET_AWAY,
@@ -262,7 +263,7 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
         return self._home.get_functionalHome(IndoorClimateHome)
 
     @property
-    def _device_profiles(self) -> list[Any]:
+    def _device_profiles(self) -> list[HeatingCoolingProfile]:
         """Return the relevant profiles."""
         return [
             profile
@@ -278,7 +279,8 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
             for profile in self._device_profiles
         ]
 
-    def _get_qualified_profile_name(self, profile) -> str:
+    def _get_qualified_profile_name(self, profile: HeatingCoolingProfile) -> str:
+        """Get a name for the given profile. If exists, this is the name of the profile."""
         if profile.name != "":
             return profile.name
         if profile.index in NICE_PROFILE_NAMES:

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -35,6 +35,14 @@ from .hap import HomematicipHAP
 
 HEATING_PROFILES = {"PROFILE_1": 0, "PROFILE_2": 1, "PROFILE_3": 2}
 COOLING_PROFILES = {"PROFILE_4": 3, "PROFILE_5": 4, "PROFILE_6": 5}
+NICE_PROFILE_NAMES = {
+    "PROFILE_1": "Default",
+    "PROFILE_2": "Alternative 1",
+    "PROFILE_3": "Alternative 2",
+    "PROFILE_4": "Cooling 1",
+    "PROFILE_5": "Cooling 2",
+    "PROFILE_6": "Cooling 3",
+}
 
 ATTR_PRESET_END_TIME = "preset_end_time"
 PERMANENT_END_TIME = "permanent"
@@ -164,8 +172,9 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
                 return PRESET_ECO
 
         return (
-            self._device.activeProfile.name
-            if self._device.activeProfile.name in self._device_profile_names
+            self._get_qualified_profile_name(self._device.activeProfile)
+            if self._get_qualified_profile_name(self._device.activeProfile)
+            in self._device_profile_names
             else None
         )
 
@@ -209,7 +218,7 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         if hvac_mode not in self.hvac_modes:
-            return
+            raise ValueError(f"Unsupported hvac mode: {hvac_mode}")
 
         if hvac_mode == HVACMode.AUTO:
             await self._device.set_control_mode(HMIP_AUTOMATIC_CM)
@@ -219,7 +228,7 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         if preset_mode not in self.preset_modes:
-            return
+            raise ValueError(f"Unsupported preset mode: {preset_mode}")
 
         if self._device.boostMode and preset_mode != PRESET_BOOST:
             await self._device.set_boost(False)
@@ -261,15 +270,24 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
         return [
             profile
             for profile in self._device.profiles
-            if profile.visible
-            and profile.name != ""
-            and profile.index in self._relevant_profile_group
+            if profile.visible and profile.index in self._relevant_profile_group
         ]
 
     @property
     def _device_profile_names(self) -> list[str]:
         """Return a collection of profile names."""
-        return [profile.name for profile in self._device_profiles]
+        return [
+            self._get_qualified_profile_name(profile)
+            for profile in self._device_profiles
+        ]
+
+    def _get_qualified_profile_name(self, profile) -> str:
+        if profile.name != "":
+            return profile.name
+        if profile.index in NICE_PROFILE_NAMES:
+            return NICE_PROFILE_NAMES[profile.index]
+
+        return profile.index
 
     def _get_profile_idx_by_name(self, profile_name: str) -> int:
         """Return a profile index by name."""
@@ -277,7 +295,7 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
         index_name = [
             profile.index
             for profile in self._device_profiles
-            if profile.name == profile_name
+            if self._get_qualified_profile_name(profile) == profile_name
         ]
 
         return relevant_index[index_name[0]]

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -227,9 +227,6 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
-        if preset_mode not in self.preset_modes:
-            raise ValueError(f"Unsupported preset mode: {preset_mode}")
-
         if self._device.boostMode and preset_mode != PRESET_BOOST:
             await self._device.set_boost(False)
         if preset_mode == PRESET_BOOST:

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -219,7 +219,7 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         if hvac_mode not in self.hvac_modes:
-            raise ValueError(f"Unsupported hvac mode: {hvac_mode}")
+            return
 
         if hvac_mode == HVACMode.AUTO:
             await self._device.set_control_mode(HMIP_AUTOMATIC_CM)

--- a/homeassistant/components/homematicip_cloud/manifest.json
+++ b/homeassistant/components/homematicip_cloud/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "homematicip_cloud",
   "name": "HomematicIP Cloud",
-  "codeowners": [],
+  "codeowners": ["@hahn-th"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homematicip_cloud",
   "iot_class": "cloud_push",

--- a/tests/components/homematicip_cloud/fixtures/homematicip_cloud.json
+++ b/tests/components/homematicip_cloud/fixtures/homematicip_cloud.json
@@ -8535,6 +8535,200 @@
       "windowOpenTemperature": 5.0,
       "windowState": null
     },
+    "00000000-0000-0000-0001-000000000019": {
+      "activeProfile": "PROFILE_1",
+      "actualTemperature": null,
+      "boostDuration": 15,
+      "boostMode": false,
+      "channels": [
+        {
+          "channelIndex": 1,
+          "deviceId": "3014F7110000000000000013"
+        }
+      ],
+      "controlMode": "AUTOMATIC",
+      "controllable": true,
+      "cooling": null,
+      "coolingAllowed": false,
+      "coolingIgnored": false,
+      "dutyCycle": false,
+      "ecoAllowed": true,
+      "ecoIgnored": false,
+      "externalClockCoolingTemperature": 23.0,
+      "externalClockEnabled": false,
+      "externalClockHeatingTemperature": 19.0,
+      "floorHeatingMode": "FLOOR_HEATING_STANDARD",
+      "homeId": "00000000-0000-0000-0000-000000000001",
+      "humidity": null,
+      "humidityLimitEnabled": true,
+      "humidityLimitValue": 60,
+      "id": "00000000-0000-0000-0001-000000000019",
+      "label": "Vorzimmer",
+      "lastSetPointReachedTimestamp": 1557767559939,
+      "lastSetPointUpdatedTimestamp": 1557767559939,
+      "lastStatusUpdate": 1524514007132,
+      "lowBat": false,
+      "maxTemperature": 30.0,
+      "metaGroupId": "00000000-0000-0000-0000-000000000014",
+      "minTemperature": 5.0,
+      "partyMode": false,
+      "profiles": {
+        "PROFILE_1": {
+          "enabled": true,
+          "groupId": "00000000-0000-0000-0001-000000000019",
+          "index": "PROFILE_1",
+          "name": "",
+          "profileId": "00000000-0000-0000-0000-000000000058",
+          "visible": true
+        },
+        "PROFILE_2": {
+          "enabled": true,
+          "groupId": "00000000-0000-0000-0001-000000000019",
+          "index": "PROFILE_2",
+          "name": "",
+          "profileId": "00000000-0000-0000-0000-000000000059",
+          "visible": false
+        },
+        "PROFILE_3": {
+          "enabled": true,
+          "groupId": "00000000-0000-0000-0001-000000000019",
+          "index": "PROFILE_3",
+          "name": "",
+          "profileId": "00000000-0000-0000-0000-000000000060",
+          "visible": false
+        },
+        "PROFILE_4": {
+          "enabled": false,
+          "groupId": "00000000-0000-0000-0001-000000000019",
+          "index": "PROFILE_4",
+          "name": "",
+          "profileId": "00000000-0000-0000-0000-000000000061",
+          "visible": true
+        },
+        "PROFILE_5": {
+          "enabled": false,
+          "groupId": "00000000-0000-0000-0001-000000000019",
+          "index": "PROFILE_5",
+          "name": "",
+          "profileId": "00000000-0000-0000-0000-000000000062",
+          "visible": false
+        },
+        "PROFILE_6": {
+          "enabled": false,
+          "groupId": "00000000-0000-0000-0001-000000000019",
+          "index": "PROFILE_6",
+          "name": "",
+          "profileId": "00000000-0000-0000-0000-000000000063",
+          "visible": false
+        }
+      },
+      "setPointTemperature": 5.0,
+      "type": "HEATING",
+      "unreach": false,
+      "valvePosition": 0.0,
+      "valveSilentModeEnabled": false,
+      "valveSilentModeSupported": false,
+      "heatingFailureSupported": true,
+      "windowOpenTemperature": 5.0,
+      "windowState": null
+    },
+    "00000000-0000-0001-0001-000000000019": {
+      "activeProfile": "PROFILE_1",
+      "actualTemperature": null,
+      "boostDuration": 15,
+      "boostMode": false,
+      "channels": [
+        {
+          "channelIndex": 1,
+          "deviceId": "3014F7110000000000000013"
+        }
+      ],
+      "controlMode": "AUTOMATIC",
+      "controllable": true,
+      "cooling": null,
+      "coolingAllowed": false,
+      "coolingIgnored": false,
+      "dutyCycle": false,
+      "ecoAllowed": true,
+      "ecoIgnored": false,
+      "externalClockCoolingTemperature": 23.0,
+      "externalClockEnabled": false,
+      "externalClockHeatingTemperature": 19.0,
+      "floorHeatingMode": "FLOOR_HEATING_STANDARD",
+      "homeId": "00000000-0000-0000-0000-000000000001",
+      "humidity": null,
+      "humidityLimitEnabled": true,
+      "humidityLimitValue": 60,
+      "id": "00000000-0000-0001-0001-000000000019",
+      "label": "Vorzimmer2",
+      "lastSetPointReachedTimestamp": 1557767559939,
+      "lastSetPointUpdatedTimestamp": 1557767559939,
+      "lastStatusUpdate": 1524514007132,
+      "lowBat": false,
+      "maxTemperature": 30.0,
+      "metaGroupId": "00000000-0000-0000-0000-000000000014",
+      "minTemperature": 5.0,
+      "partyMode": false,
+      "profiles": {
+        "PROFILE_1": {
+          "enabled": true,
+          "groupId": "00000000-0000-0001-0001-000000000019",
+          "index": "PROFILE_1",
+          "name": "Testprofile",
+          "profileId": "00000000-0000-0000-0001-000000000058",
+          "visible": true
+        },
+        "PROFILE_2": {
+          "enabled": true,
+          "groupId": "00000000-0000-0001-0001-000000000019",
+          "index": "PROFILE_2",
+          "name": "",
+          "profileId": "00000000-0000-0000-0001-000000000059",
+          "visible": true
+        },
+        "PROFILE_3": {
+          "enabled": true,
+          "groupId": "00000000-0000-0001-0001-000000000019",
+          "index": "PROFILE_3",
+          "name": "",
+          "profileId": "00000000-0000-0000-0001-000000000060",
+          "visible": false
+        },
+        "PROFILE_4": {
+          "enabled": false,
+          "groupId": "00000000-0000-0001-0001-000000000019",
+          "index": "PROFILE_4",
+          "name": "",
+          "profileId": "00000000-0000-0000-0001-000000000061",
+          "visible": true
+        },
+        "PROFILE_5": {
+          "enabled": false,
+          "groupId": "00000000-0000-0001-0001-000000000019",
+          "index": "PROFILE_5",
+          "name": "",
+          "profileId": "00000000-0000-0000-0001-000000000062",
+          "visible": false
+        },
+        "PROFILE_6": {
+          "enabled": false,
+          "groupId": "00000000-0000-0001-0001-000000000019",
+          "index": "PROFILE_6",
+          "name": "",
+          "profileId": "00000000-0000-0000-0001-000000000063",
+          "visible": false
+        }
+      },
+      "setPointTemperature": 5.0,
+      "type": "HEATING",
+      "unreach": false,
+      "valvePosition": 0.0,
+      "valveSilentModeEnabled": false,
+      "valveSilentModeSupported": false,
+      "heatingFailureSupported": true,
+      "windowOpenTemperature": 5.0,
+      "windowState": null
+    },
     "00000000-AAAA-0000-0000-000000000001": {
       "actualTemperature": 15.4,
       "channels": [

--- a/tests/components/homematicip_cloud/fixtures/homematicip_cloud.json
+++ b/tests/components/homematicip_cloud/fixtures/homematicip_cloud.json
@@ -4791,6 +4791,59 @@
       "type": "HEATING_THERMOSTAT",
       "updateState": "UP_TO_DATE"
     },
+    "3014F71100000000ETRV0013": {
+      "automaticValveAdaptionNeeded": false,
+      "availableFirmwareVersion": "2.0.2",
+      "connectionType": "HMIP_RF",
+      "firmwareVersion": "2.0.2",
+      "firmwareVersionInteger": 131074,
+      "functionalChannels": {
+        "0": {
+          "configPending": false,
+          "deviceId": "3014F71100000000ETRV0013",
+          "dutyCycle": false,
+          "functionalChannelType": "DEVICE_OPERATIONLOCK",
+          "groupIndex": 0,
+          "groups": ["00000000-0000-0000-0000-000000000014"],
+          "index": 0,
+          "label": "",
+          "lowBat": false,
+          "operationLockActive": false,
+          "routerModuleEnabled": false,
+          "routerModuleSupported": false,
+          "rssiDeviceValue": -58,
+          "rssiPeerValue": -58,
+          "unreach": false,
+          "supportedOptionalFeatures": {}
+        },
+        "1": {
+          "deviceId": "3014F71100000000ETRV0013",
+          "functionalChannelType": "HEATING_THERMOSTAT_CHANNEL",
+          "groupIndex": 1,
+          "groups": ["00000000-0000-0000-0005-000000000019"],
+          "index": 1,
+          "label": "",
+          "valveActualTemperature": 20.0,
+          "setPointTemperature": 5.0,
+          "temperatureOffset": 0.0,
+          "valvePosition": 0.0,
+          "valveState": "ADAPTION_DONE"
+        }
+      },
+      "homeId": "00000000-0000-0000-0000-000000000001",
+      "id": "3014F71100000000ETRV0013",
+      "label": "Heizkörperthermostat4",
+      "lastStatusUpdate": 1524514007132,
+      "liveUpdateState": "LIVE_UPDATE_NOT_SUPPORTED",
+      "manufacturerCode": 1,
+      "modelId": 269,
+      "modelType": "HMIP-eTRV",
+      "oem": "eQ-3",
+      "permanentlyReachable": true,
+      "serializedGlobalTradeItemNumber": "3014F71100000000ETRV0013",
+      "type": "HEATING_THERMOSTAT",
+      "updateState": "UP_TO_DATE"
+    },
     "3014F7110000000000000014": {
       "automaticValveAdaptionNeeded": false,
       "availableFirmwareVersion": "2.0.2",
@@ -8519,6 +8572,103 @@
         "PROFILE_6": {
           "enabled": false,
           "groupId": "00000000-0000-0000-0000-000000000019",
+          "index": "PROFILE_6",
+          "name": "",
+          "profileId": "00000000-0000-0000-0000-000000000063",
+          "visible": false
+        }
+      },
+      "setPointTemperature": 5.0,
+      "type": "HEATING",
+      "unreach": false,
+      "valvePosition": 0.0,
+      "valveSilentModeEnabled": false,
+      "valveSilentModeSupported": false,
+      "heatingFailureSupported": true,
+      "windowOpenTemperature": 5.0,
+      "windowState": null
+    },
+    "00000000-0000-0000-0005-000000000019": {
+      "activeProfile": "PROFILE_1",
+      "actualTemperature": null,
+      "boostDuration": 15,
+      "boostMode": false,
+      "channels": [
+        {
+          "channelIndex": 1,
+          "deviceId": "3014F71100000000ETRV0013"
+        }
+      ],
+      "controlMode": "AUTOMATIC",
+      "controllable": true,
+      "cooling": null,
+      "coolingAllowed": false,
+      "coolingIgnored": false,
+      "dutyCycle": false,
+      "ecoAllowed": true,
+      "ecoIgnored": false,
+      "externalClockCoolingTemperature": 23.0,
+      "externalClockEnabled": false,
+      "externalClockHeatingTemperature": 19.0,
+      "floorHeatingMode": "FLOOR_HEATING_STANDARD",
+      "homeId": "00000000-0000-0000-0000-000000000001",
+      "humidity": null,
+      "humidityLimitEnabled": true,
+      "humidityLimitValue": 60,
+      "id": "00000000-0000-0000-0005-000000000019",
+      "label": "Vorzimmer3",
+      "lastSetPointReachedTimestamp": 1557767559939,
+      "lastSetPointUpdatedTimestamp": 1557767559939,
+      "lastStatusUpdate": 1524514007132,
+      "lowBat": false,
+      "maxTemperature": 30.0,
+      "metaGroupId": "00000000-0000-0000-0000-000000000014",
+      "minTemperature": 5.0,
+      "partyMode": false,
+      "profiles": {
+        "PROFILE_1": {
+          "enabled": true,
+          "groupId": "00000000-0000-0000-0005-000000000019",
+          "index": "PROFILE_1",
+          "name": "",
+          "profileId": "00000000-0000-0000-0000-000000000058",
+          "visible": true
+        },
+        "PROFILE_2": {
+          "enabled": true,
+          "groupId": "00000000-0000-0000-0005-000000000019",
+          "index": "PROFILE_2",
+          "name": "",
+          "profileId": "00000000-0000-0000-0000-000000000059",
+          "visible": true
+        },
+        "PROFILE_3": {
+          "enabled": true,
+          "groupId": "00000000-0000-0000-0005-000000000019",
+          "index": "PROFILE_3",
+          "name": "",
+          "profileId": "00000000-0000-0000-0000-000000000060",
+          "visible": false
+        },
+        "PROFILE_4": {
+          "enabled": false,
+          "groupId": "00000000-0000-0000-0005-000000000019",
+          "index": "PROFILE_4",
+          "name": "",
+          "profileId": "00000000-0000-0000-0000-000000000061",
+          "visible": true
+        },
+        "PROFILE_5": {
+          "enabled": false,
+          "groupId": "00000000-0000-0000-0005-000000000019",
+          "index": "PROFILE_5",
+          "name": "",
+          "profileId": "00000000-0000-0000-0000-000000000062",
+          "visible": false
+        },
+        "PROFILE_6": {
+          "enabled": false,
+          "groupId": "00000000-0000-0000-0005-000000000019",
           "index": "PROFILE_6",
           "name": "",
           "profileId": "00000000-0000-0000-0000-000000000063",

--- a/tests/components/homematicip_cloud/test_climate.py
+++ b/tests/components/homematicip_cloud/test_climate.py
@@ -218,13 +218,12 @@ async def test_hmip_heating_group_heat(
     assert ha_state.state == HVACMode.AUTO
 
     # hvac mode "dry" is not available. expect a valueerror.
-    with pytest.raises(ValueError):
-        await hass.services.async_call(
-            "climate",
-            "set_hvac_mode",
-            {"entity_id": entity_id, "hvac_mode": "dry"},
-            blocking=True,
-        )
+    await hass.services.async_call(
+        "climate",
+        "set_hvac_mode",
+        {"entity_id": entity_id, "hvac_mode": "dry"},
+        blocking=True,
+    )
 
     assert len(hmip_device.mock_calls) == service_call_counter + 24
     # Only fire event from last async_manipulate_test_data available.

--- a/tests/components/homematicip_cloud/test_device.py
+++ b/tests/components/homematicip_cloud/test_device.py
@@ -26,7 +26,7 @@ async def test_hmip_load_all_supported_devices(
         test_devices=None, test_groups=None
     )
 
-    assert len(mock_hap.hmip_device_by_entity_id) == 272
+    assert len(mock_hap.hmip_device_by_entity_id) == 274
 
 
 async def test_hmip_remove_device(

--- a/tests/components/homematicip_cloud/test_device.py
+++ b/tests/components/homematicip_cloud/test_device.py
@@ -26,7 +26,7 @@ async def test_hmip_load_all_supported_devices(
         test_devices=None, test_groups=None
     )
 
-    assert len(mock_hap.hmip_device_by_entity_id) == 274
+    assert len(mock_hap.hmip_device_by_entity_id) == 278
 
 
 async def test_hmip_remove_device(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Showing heating profiles in climate entity, if they have no custom name in the Homematicip App. If they have a custom name, they are already displayed.
Profiles are shown with following names:
PROFILE_1 = Default
PROFILE_2 = Alternative 1
PROFILE_3 = Alternative 2

This fixes issue https://github.com/home-assistant/core/issues/101455

After i made some mistakes with rebasing in PR #101985 i decided to start from scratch and open a new pull request.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #101455 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
