### PR TITLE
2024.1.2

### DIFF
--- a/homeassistant/components/enigma2/media_player.py
+++ b/homeassistant/components/enigma2/media_player.py
@@ -1,6 +1,7 @@
 """Support for Enigma2 media players."""
 from __future__ import annotations
 
+from aiohttp.client_exceptions import ClientConnectorError
 from openwebif.api import OpenWebIfDevice
 from openwebif.enums import RemoteControlCodes
 import voluptuous as vol
@@ -20,6 +21,7 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -96,9 +98,13 @@ async def async_setup_platform(
         source_bouquet=config.get(CONF_SOURCE_BOUQUET),
     )
 
-    async_add_entities(
-        [Enigma2Device(config[CONF_NAME], device, await device.get_about())]
-    )
+    try:
+        about = await device.get_about()
+    except ClientConnectorError as err:
+        await device.close()
+        raise PlatformNotReady from err
+
+    async_add_entities([Enigma2Device(config[CONF_NAME], device, about)])
 
 
 class Enigma2Device(MediaPlayerEntity):
@@ -169,8 +175,8 @@ class Enigma2Device(MediaPlayerEntity):
         await self._device.send_remote_control_action(RemoteControlCodes.CHANNEL_UP)
 
     async def async_media_previous_track(self) -> None:
-        """Send next track command."""
-        self._device.send_remote_control_action(RemoteControlCodes.CHANNEL_DOWN)
+        """Send previous track command."""
+        await self._device.send_remote_control_action(RemoteControlCodes.CHANNEL_DOWN)
 
     async def async_mute_volume(self, mute: bool) -> None:
         """Mute or unmute."""

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -36,6 +36,7 @@ from .coordinator import async_reconnect_soon
 from .utils import (
     get_block_device_sleep_period,
     get_coap_context,
+    get_device_entry_gen,
     get_info_auth,
     get_info_gen,
     get_model_name,
@@ -322,7 +323,7 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
             except (DeviceConnectionError, InvalidAuthError, FirmwareUnsupported):
                 return self.async_abort(reason="reauth_unsuccessful")
 
-            if self.entry.data.get(CONF_GEN, 1) != 1:
+            if get_device_entry_gen(self.entry) != 1:
                 user_input[CONF_USERNAME] = "admin"
             try:
                 await validate_input(self.hass, host, info, user_input)
@@ -335,7 +336,7 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
             await self.hass.config_entries.async_reload(self.entry.entry_id)
             return self.async_abort(reason="reauth_successful")
 
-        if self.entry.data.get(CONF_GEN, 1) in BLOCK_GENERATIONS:
+        if get_device_entry_gen(self.entry) in BLOCK_GENERATIONS:
             schema = {
                 vol.Required(CONF_USERNAME): str,
                 vol.Required(CONF_PASSWORD): str,
@@ -364,7 +365,7 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
     def async_supports_options_flow(cls, config_entry: ConfigEntry) -> bool:
         """Return options flow support for this handler."""
         return (
-            config_entry.data.get(CONF_GEN) in RPC_GENERATIONS
+            get_device_entry_gen(config_entry) in RPC_GENERATIONS
             and not config_entry.data.get(CONF_SLEEP_PERIOD)
             and config_entry.data.get("model") != MODEL_WALL_DISPLAY
         )

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -33,7 +33,6 @@ from .const import (
     ATTR_GENERATION,
     BATTERY_DEVICES_WITH_PERMANENT_CONNECTION,
     CONF_BLE_SCANNER_MODE,
-    CONF_GEN,
     CONF_SLEEP_PERIOD,
     DATA_CONFIG_ENTRY,
     DOMAIN,
@@ -58,7 +57,11 @@ from .const import (
     UPDATE_PERIOD_MULTIPLIER,
     BLEScannerMode,
 )
-from .utils import get_rpc_device_wakeup_period, update_device_fw_info
+from .utils import (
+    get_device_entry_gen,
+    get_rpc_device_wakeup_period,
+    update_device_fw_info,
+)
 
 _DeviceT = TypeVar("_DeviceT", bound="BlockDevice|RpcDevice")
 
@@ -136,7 +139,7 @@ class ShellyCoordinatorBase(DataUpdateCoordinator[None], Generic[_DeviceT]):
             manufacturer="Shelly",
             model=aioshelly.const.MODEL_NAMES.get(self.model, self.model),
             sw_version=self.sw_version,
-            hw_version=f"gen{self.entry.data[CONF_GEN]} ({self.model})",
+            hw_version=f"gen{get_device_entry_gen(self.entry)} ({self.model})",
             configuration_url=f"http://{self.entry.data[CONF_HOST]}",
         )
         self.device_id = device_entry.id

--- a/homeassistant/components/streamlabswater/__init__.py
+++ b/homeassistant/components/streamlabswater/__init__.py
@@ -107,9 +107,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     def set_away_mode(service: ServiceCall) -> None:
         """Set the StreamLabsWater Away Mode."""
         away_mode = service.data.get(ATTR_AWAY_MODE)
-        location_id = (
-            service.data.get(CONF_LOCATION_ID) or list(coordinator.data.values())[0]
-        )
+        location_id = service.data.get(CONF_LOCATION_ID) or list(coordinator.data)[0]
         client.update_location(location_id, away_mode)
 
     hass.services.async_register(

--- a/homeassistant/components/system_bridge/media_player.py
+++ b/homeassistant/components/system_bridge/media_player.py
@@ -118,10 +118,8 @@ class SystemBridgeMediaPlayer(SystemBridgeEntity, MediaPlayerEntity):
             features |= MediaPlayerEntityFeature.PREVIOUS_TRACK
         if data.media.is_next_enabled:
             features |= MediaPlayerEntityFeature.NEXT_TRACK
-        if data.media.is_pause_enabled:
-            features |= MediaPlayerEntityFeature.PAUSE
-        if data.media.is_play_enabled:
-            features |= MediaPlayerEntityFeature.PLAY
+        if data.media.is_pause_enabled or data.media.is_play_enabled:
+            features |= MediaPlayerEntityFeature.PAUSE | MediaPlayerEntityFeature.PLAY
         if data.media.is_stop_enabled:
             features |= MediaPlayerEntityFeature.STOP
 

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -216,9 +216,9 @@ class PollableSensor(Sensor):
 
     async def async_will_remove_from_hass(self) -> None:
         """Disconnect entity object when removed."""
-        assert self._cancel_refresh_handle
-        self._cancel_refresh_handle()
-        self._cancel_refresh_handle = None
+        if self._cancel_refresh_handle is not None:
+            self._cancel_refresh_handle()
+            self._cancel_refresh_handle = None
         self.debug("stopped polling during device removal")
         await super().async_will_remove_from_hass()
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -16,7 +16,7 @@ from .helpers.deprecation import (
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2024
 MINOR_VERSION: Final = 1
-PATCH_VERSION: Final = "1"
+PATCH_VERSION: Final = "2"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 11, 0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2024.1.1"
+version     = "2024.1.2"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/tests/components/shelly/__init__.py
+++ b/tests/components/shelly/__init__.py
@@ -12,6 +12,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.shelly.const import (
+    CONF_GEN,
     CONF_SLEEP_PERIOD,
     DOMAIN,
     REST_SENSORS_UPDATE_INTERVAL,
@@ -30,7 +31,7 @@ MOCK_MAC = "123456789ABC"
 
 async def init_integration(
     hass: HomeAssistant,
-    gen: int,
+    gen: int | None,
     model=MODEL_25,
     sleep_period=0,
     options: dict[str, Any] | None = None,
@@ -41,8 +42,9 @@ async def init_integration(
         CONF_HOST: "192.168.1.37",
         CONF_SLEEP_PERIOD: sleep_period,
         "model": model,
-        "gen": gen,
     }
+    if gen is not None:
+        data[CONF_GEN] = gen
 
     entry = MockConfigEntry(
         domain=DOMAIN, data=data, unique_id=MOCK_MAC, options=options

--- a/tests/components/shelly/test_init.py
+++ b/tests/components/shelly/test_init.py
@@ -301,3 +301,11 @@ async def test_no_attempt_to_stop_scanner_with_sleepy_devices(
         mock_rpc_device.mock_update()
         await hass.async_block_till_done()
         assert not mock_stop_scanner.call_count
+
+
+async def test_entry_missing_gen(hass: HomeAssistant, mock_block_device) -> None:
+    """Test successful Gen1 device init when gen is missing in entry data."""
+    entry = await init_integration(hass, None)
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert hass.states.get("switch.test_name_channel_1").state is STATE_ON


### PR DESCRIPTION
- Fix support for play/pause functionality in System Bridge ([@timmo001] - [#103423]) ([system_bridge docs])
- Fix passing correct location id to streamlabs water ([@joostlek] - [#107291]) ([streamlabswater docs])
- Fix Shelly missing Gen value for older devices ([@thecode] - [#107294]) ([shelly docs])
- enigma2: fix exception when device in deep sleep, fix previous track ([@autinerd] - [#107296]) ([enigma2 docs])
- Fix assertion error when unloading ZHA with pollable entities ([@dmulcahey] - [#107311]) ([zha docs])

[#103423]: https://github.com/home-assistant/core/pull/103423
[#106970]: https://github.com/home-assistant/core/pull/106970
[#107239]: https://github.com/home-assistant/core/pull/107239
[#107291]: https://github.com/home-assistant/core/pull/107291
[#107294]: https://github.com/home-assistant/core/pull/107294
[#107296]: https://github.com/home-assistant/core/pull/107296
[#107311]: https://github.com/home-assistant/core/pull/107311
[@autinerd]: https://github.com/autinerd
[@dmulcahey]: https://github.com/dmulcahey
[@frenck]: https://github.com/frenck
[@joostlek]: https://github.com/joostlek
[@thecode]: https://github.com/thecode
[@timmo001]: https://github.com/timmo001
[enigma2 docs]: https://www.home-assistant.io/integrations/enigma2/
[shelly docs]: https://www.home-assistant.io/integrations/shelly/
[streamlabswater docs]: https://www.home-assistant.io/integrations/streamlabswater/
[system_bridge docs]: https://www.home-assistant.io/integrations/system_bridge/
[zha docs]: https://www.home-assistant.io/integrations/zha/

Docs PR: <https://github.com/home-assistant/home-assistant.io/pull/30678>