### PR TITLE
Add support for bluetooth local name matchers shorter than 3 chars

### DIFF
--- a/homeassistant/components/bluetooth/match.py
+++ b/homeassistant/components/bluetooth/match.py
@@ -239,7 +239,7 @@ class BluetoothMatcherIndexBase(Generic[_T]):
         matches = []
         if (name := service_info.name) and (
             local_name_matchers := self.local_name.get(
-                name[:LOCAL_NAME_MIN_MATCH_LENGTH:]
+                name[:LOCAL_NAME_MIN_MATCH_LENGTH]
             )
         ):
             for matcher in local_name_matchers:
@@ -353,7 +353,7 @@ def _local_name_to_index_key(local_name: str) -> str:
     if they try to setup a matcher that will is overly broad
     as would match too many devices and cause a performance hit.
     """
-    match_part = local_name[:LOCAL_NAME_MIN_MATCH_LENGTH:]
+    match_part = local_name[:LOCAL_NAME_MIN_MATCH_LENGTH]
     if "*" in match_part or "[" in match_part:
         raise ValueError(
             "Local name matchers may not have patterns in the first "

--- a/homeassistant/components/bluetooth/match.py
+++ b/homeassistant/components/bluetooth/match.py
@@ -237,10 +237,12 @@ class BluetoothMatcherIndexBase(Generic[_T]):
     def match(self, service_info: BluetoothServiceInfoBleak) -> list[_T]:
         """Check for a match."""
         matches = []
-        if service_info.name and len(service_info.name) >= LOCAL_NAME_MIN_MATCH_LENGTH:
-            for matcher in self.local_name.get(
-                service_info.name[:LOCAL_NAME_MIN_MATCH_LENGTH], []
-            ):
+        if (name := service_info.name) and (
+            local_name_matchers := self.local_name.get(
+                name[:LOCAL_NAME_MIN_MATCH_LENGTH:]
+            )
+        ):
+            for matcher in local_name_matchers:
                 if ble_device_matches(matcher, service_info):
                     matches.append(matcher)
 
@@ -351,12 +353,7 @@ def _local_name_to_index_key(local_name: str) -> str:
     if they try to setup a matcher that will is overly broad
     as would match too many devices and cause a performance hit.
     """
-    if len(local_name) < LOCAL_NAME_MIN_MATCH_LENGTH:
-        raise ValueError(
-            "Local name matchers must be at least "
-            f"{LOCAL_NAME_MIN_MATCH_LENGTH} characters long ({local_name})"
-        )
-    match_part = local_name[:LOCAL_NAME_MIN_MATCH_LENGTH]
+    match_part = local_name[:LOCAL_NAME_MIN_MATCH_LENGTH:]
     if "*" in match_part or "[" in match_part:
         raise ValueError(
             "Local name matchers may not have patterns in the first "
@@ -377,35 +374,29 @@ def ble_device_matches(
     if matcher.get(CONNECTABLE, True) and not service_info.connectable:
         return False
 
-    advertisement_data = service_info.advertisement
     if (
         service_uuid := matcher.get(SERVICE_UUID)
-    ) and service_uuid not in advertisement_data.service_uuids:
+    ) and service_uuid not in service_info.service_uuids:
         return False
 
     if (
         service_data_uuid := matcher.get(SERVICE_DATA_UUID)
-    ) and service_data_uuid not in advertisement_data.service_data:
+    ) and service_data_uuid not in service_info.service_data:
         return False
 
-    if manfacturer_id := matcher.get(MANUFACTURER_ID):
-        if manfacturer_id not in advertisement_data.manufacturer_data:
+    if manufacturer_id := matcher.get(MANUFACTURER_ID):
+        if manufacturer_id not in service_info.manufacturer_data:
             return False
+
         if manufacturer_data_start := matcher.get(MANUFACTURER_DATA_START):
-            manufacturer_data_start_bytes = bytearray(manufacturer_data_start)
-            if not any(
-                manufacturer_data.startswith(manufacturer_data_start_bytes)
-                for manufacturer_data in advertisement_data.manufacturer_data.values()
+            if not service_info.manufacturer_data[manufacturer_id].startswith(
+                bytes(manufacturer_data_start)
             ):
                 return False
 
-    if (local_name := matcher.get(LOCAL_NAME)) and (
-        (device_name := advertisement_data.local_name or service_info.device.name)
-        is None
-        or not _memorized_fnmatch(
-            device_name,
-            local_name,
-        )
+    if (local_name := matcher.get(LOCAL_NAME)) and not _memorized_fnmatch(
+        service_info.name,
+        local_name,
     ):
         return False
 

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -2070,14 +2070,6 @@ async def test_register_callback_by_local_name_overly_broad(
         bluetooth.async_register_callback(
             hass,
             _fake_subscriber,
-            {LOCAL_NAME: "a"},
-            BluetoothScanningMode.ACTIVE,
-        )
-
-    with pytest.raises(ValueError):
-        bluetooth.async_register_callback(
-            hass,
-            _fake_subscriber,
             {LOCAL_NAME: "ab*"},
             BluetoothScanningMode.ACTIVE,
         )

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -2,7 +2,7 @@
 import asyncio
 from datetime import timedelta
 import time
-from unittest.mock import ANY, MagicMock, Mock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 
 from bleak import BleakError
 from bleak.backends.scanner import AdvertisementData, BLEDevice
@@ -374,6 +374,56 @@ async def test_discovery_match_by_service_uuid(
 
         assert len(mock_config_flow.mock_calls) == 1
         assert mock_config_flow.mock_calls[0][1][0] == "switchbot"
+
+
+@patch.object(
+    bluetooth,
+    "async_get_bluetooth",
+    return_value=[
+        {
+            "domain": "sensorpush",
+            "local_name": "s",
+            "service_uuid": "ef090000-11d6-42ba-93b8-9dd7ec090aa9",
+        }
+    ],
+)
+async def test_discovery_match_by_service_uuid_and_short_local_name(
+    mock_async_get_bluetooth: AsyncMock,
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
+    """Test bluetooth discovery match by service_uuid and short local name."""
+    entry = MockConfigEntry(domain="bluetooth", unique_id="00:00:00:00:00:01")
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    with patch.object(hass.config_entries.flow, "async_init") as mock_config_flow:
+        await async_setup_with_default_adapter(hass)
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+        assert len(mock_bleak_scanner_start.mock_calls) == 1
+
+        wrong_device = generate_ble_device("44:44:33:11:23:45", "wrong_name")
+        wrong_adv = generate_advertisement_data(local_name="s", service_uuids=[])
+
+        inject_advertisement(hass, wrong_device, wrong_adv)
+        await hass.async_block_till_done()
+
+        assert len(mock_config_flow.mock_calls) == 0
+
+        ht1_device = generate_ble_device("44:44:33:11:23:45", "s")
+        ht1_adv = generate_advertisement_data(
+            local_name="s", service_uuids=["ef090000-11d6-42ba-93b8-9dd7ec090aa9"]
+        )
+
+        inject_advertisement(hass, ht1_device, ht1_adv)
+        await hass.async_block_till_done()
+
+        assert len(mock_config_flow.mock_calls) == 1
+        assert mock_config_flow.mock_calls[0][1][0] == "sensorpush"
 
 
 def _domains_from_mock_config_flow(mock_config_flow: Mock) -> list[str]:


### PR DESCRIPTION
unblocks https://github.com/home-assistant/core/pull/107410

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for bluetooth local name matchers shorter than 3 chars

We still have the restriction on now wildcards in the first 3 chars, but exact matches work now without making the matcher slower

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2031

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
