### PR TITLE
Refactor translations to reduce dict lookups

### DIFF
--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -197,23 +197,25 @@ class _TranslationCache:
         """Initialize the cache."""
         self.hass = hass
         self.loaded: dict[str, set[str]] = {}
-        self.cache: dict[str, dict[str, dict[str, Any]]] = {}
+        self.cache: dict[str, dict[str, dict[str, dict[str, str]]]] = {}
 
     async def async_fetch(
         self,
         language: str,
         category: str,
         components: set[str],
-    ) -> list[dict[str, dict[str, Any]]]:
+    ) -> dict[str, str]:
         """Load resources into the cache."""
         components_to_load = components - self.loaded.setdefault(language, set())
 
         if components_to_load:
             await self._async_load(language, components_to_load)
 
-        cached = self.cache.get(language, {})
-
-        return [cached.get(component, {}).get(category, {}) for component in components]
+        result: dict[str, str] = {}
+        category_cache = self.cache.get(language, {}).get(category, {})
+        for component in components.intersection(category_cache):
+            result.update(category_cache[component])
+        return result
 
     async def _async_load(self, language: str, components: set[str]) -> None:
         """Populate the cache for a given set of components."""
@@ -289,6 +291,7 @@ class _TranslationCache:
         """Extract resources into the cache."""
         resource: dict[str, Any] | str
         cached = self.cache.setdefault(language, {})
+
         categories: set[str] = set()
         for resource in translation_strings.values():
             categories.update(resource)
@@ -305,10 +308,10 @@ class _TranslationCache:
                     translation_strings, components, category
                 )
 
+            category_cache = cached.setdefault(category, {})
+
             for component, resource in new_resources.items():
-                category_cache: dict[str, Any] = cached.setdefault(
-                    component, {}
-                ).setdefault(category, {})
+                component_cache = category_cache.setdefault(component, {})
 
                 if isinstance(resource, dict):
                     resources_flatten = recursive_flatten(
@@ -316,11 +319,11 @@ class _TranslationCache:
                         resource,
                     )
                     resources_flatten = self._validate_placeholders(
-                        language, resources_flatten, category_cache
+                        language, resources_flatten, component_cache
                     )
-                    category_cache.update(resources_flatten)
+                    component_cache.update(resources_flatten)
                 else:
-                    category_cache[f"component.{component}.{category}"] = resource
+                    component_cache[f"component.{component}.{category}"] = resource
 
 
 @bind_hass
@@ -330,7 +333,7 @@ async def async_get_translations(
     category: str,
     integrations: Iterable[str] | None = None,
     config_flow: bool | None = None,
-) -> dict[str, Any]:
+) -> dict[str, str]:
     """Return all backend translations.
 
     If integration specified, load it for that one.
@@ -353,12 +356,8 @@ async def async_get_translations(
 
     async with lock:
         if TRANSLATION_FLATTEN_CACHE in hass.data:
-            cache = hass.data[TRANSLATION_FLATTEN_CACHE]
+            cache: _TranslationCache = hass.data[TRANSLATION_FLATTEN_CACHE]
         else:
             cache = hass.data[TRANSLATION_FLATTEN_CACHE] = _TranslationCache(hass)
-        cached = await cache.async_fetch(language, category, components)
 
-    result = {}
-    for entry in cached:
-        result.update(entry)
-    return result
+        return await cache.async_fetch(language, category, components)

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -347,7 +347,7 @@ async def async_get_translations(
     elif config_flow:
         components = (await async_get_config_flows(hass)) - hass.config.components
     elif category in ("state", "entity_component", "services"):
-        components = set(hass.config.components)
+        components = hass.config.components
     else:
         # Only 'state' supports merging, so remove platforms from selection
         components = {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

TLDR: the O(n) lookup (set of components) is now at the tail of the cache instead of having to transverse it in the middle of the cache. This allows the cache fetch to avoid looking up the `category` each loop.

This started to matter a bit more now that we translate a lot more things.

All of our cache lookups used:

`cache[language][O(component)][category]`

The cache was designed as

`cache[language][component][category][flatted_key]`

The lookups are now

`cache[language][category][O(component)]`

The cache is now stored as

`cache[language][category][component][flatted_key]`

This provides better alignment with how the fetch function asks for the data
```
        language: str,
        category: str,
        components: set[str],
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
