### PR TITLE
Remove calls to distribution and legacy zip support from package util

### DIFF
--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 
 import asyncio
 from functools import cache
-from importlib.metadata import PackageNotFoundError, distribution, version
+from importlib.metadata import PackageNotFoundError, version
 import logging
 import os
 from pathlib import Path
 from subprocess import PIPE, Popen
 import sys
-from urllib.parse import urlparse
 
 from packaging.requirements import InvalidRequirement, Requirement
 
@@ -30,29 +29,26 @@ def is_docker_env() -> bool:
     return Path("/.dockerenv").exists()
 
 
-def is_installed(package: str) -> bool:
+def is_installed(requirement_str: str) -> bool:
     """Check if a package is installed and will be loaded when we import it.
+
+    expected input is a pip compatible package specifier (requirement string)
+    e.g. "package==1.0.0" or "package>=1.0.0,<2.0.0"
 
     Returns True when the requirement is met.
     Returns False when the package is not installed or doesn't meet req.
     """
     try:
-        distribution(package)
-        return True
-    except (IndexError, PackageNotFoundError):
-        try:
-            req = Requirement(package)
-        except InvalidRequirement:
-            # This is a zip file. We no longer use this in Home Assistant,
-            # leaving it in for custom components.
-            req = Requirement(urlparse(package).fragment)
+        req = Requirement(requirement_str)
+    except InvalidRequirement:
+        _LOGGER.error("Invalid requirement '%s'", requirement_str)
+        return False
 
     try:
-        installed_version = version(req.name)
-        # This will happen when an install failed or
-        # was aborted while in progress see
-        # https://github.com/home-assistant/core/issues/47699
-        if installed_version is None:
+        if (installed_version := version(req.name)) is None:
+            # This can happen when an install failed or
+            # was aborted while in progress see
+            # https://github.com/home-assistant/core/issues/47699
             _LOGGER.error(  # type: ignore[unreachable]
                 "Installed version for %s resolved to None", req.name
             )

--- a/tests/util/test_package.py
+++ b/tests/util/test_package.py
@@ -1,6 +1,6 @@
 """Test Home Assistant package util methods."""
 import asyncio
-from importlib.metadata import PackageNotFoundError, metadata
+from importlib.metadata import metadata
 import logging
 import os
 from subprocess import PIPE
@@ -235,21 +235,17 @@ def test_check_package_zip() -> None:
     assert not package.is_installed(TEST_ZIP_REQ)
 
 
-def test_get_distribution_falls_back_to_version() -> None:
-    """Test for get_distribution failing and fallback to version."""
+def test_get_is_installed() -> None:
+    """Test is_installed can parse complex requirements."""
     pkg = metadata("homeassistant")
     installed_package = pkg["name"]
     installed_version = pkg["version"]
 
-    with patch(
-        "homeassistant.util.package.distribution",
-        side_effect=PackageNotFoundError,
-    ):
-        assert package.is_installed(installed_package)
-        assert package.is_installed(f"{installed_package}=={installed_version}")
-        assert package.is_installed(f"{installed_package}>={installed_version}")
-        assert package.is_installed(f"{installed_package}<={installed_version}")
-        assert not package.is_installed(f"{installed_package}<{installed_version}")
+    assert package.is_installed(installed_package)
+    assert package.is_installed(f"{installed_package}=={installed_version}")
+    assert package.is_installed(f"{installed_package}>={installed_version}")
+    assert package.is_installed(f"{installed_package}<={installed_version}")
+    assert not package.is_installed(f"{installed_package}<{installed_version}")
 
 
 def test_check_package_previous_failed_install() -> None:
@@ -258,9 +254,6 @@ def test_check_package_previous_failed_install() -> None:
     installed_package = pkg["name"]
     installed_version = pkg["version"]
 
-    with patch(
-        "homeassistant.util.package.distribution",
-        side_effect=PackageNotFoundError,
-    ), patch("homeassistant.util.package.version", return_value=None):
+    with patch("homeassistant.util.package.version", return_value=None):
         assert not package.is_installed(installed_package)
         assert not package.is_installed(f"{installed_package}=={installed_version}")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In #97628 `pkg_resources` was replaced with `importlib.metadata` and everything was tried with `importlib.metadata.distribution` first, but since `is_installed actually` gets requirements specifiers, it would always exception with `PackageNotFoundError` and fall through to be parsed with `Requirement`. 

Remove the code that always exceptions.

This also removes the old zip file support as it likely has not been used for years


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
