### PR TITLE
Expose slot value ID to intents

### DIFF
--- a/homeassistant/components/intent/__init__.py
+++ b/homeassistant/components/intent/__init__.py
@@ -276,7 +276,8 @@ class IntentHandleView(http.HomeAssistantView):
         try:
             intent_name = data["name"]
             slots = {
-                key: {"value": value} for key, value in data.get("data", {}).items()
+                key: {"id": value, "value": value}
+                for key, value in data.get("data", {}).items()
             }
             intent_result = await intent.async_handle(
                 hass, DOMAIN, intent_name, slots, "", self.context(request)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
For users of `intent_script` and the default conversation agent: `area` now contains the name of the area instead of its ID. The ID of the area can be found under the new `slots.area.id` field.

For custom component developers using the default conversation agent: the `value` field in the `area` slot passed to intents now contains the name of the area instead of its ID. The area's ID can be found under the new `id` field in the area slot.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change allows intent writers to access the ID of a matched entity without having to look it up by name. This is especially useful for `intent_script`, as previously there was no way to get the entity ID of a referenced entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Hassil PR: https://github.com/home-assistant/hassil/pull/100

This is a draft as I'd like to get some feedback on the implementation before proceeding.

There's some additional work to do on passing ID from other conversation providers (e.g. Alexa) and some unit tests to be written, however I'd like to sort out the implementation first before going any further.

I'm not overly fond of this implementation, but it seemed like the simplest way to go about it (and to get the discussion rolling). We effectively thread "name" through in a new `metadata` field and use it where available, always putting IDs in the slot value.

Another way this could be implemented is to just use the uttered text (provided in `MatchEntity#value`) as the value for the slot. This would mean we don't need the `metadata` field, but it would result in the name not matching the entity's actual name, instead being the uttered text. I imagine the main difference would be capitalisation and special characters.

The main "feature" / goal of this PR is that you can now access the ID of a matched entity inside an intent script (example from https://www.home-assistant.io/voice_control/custom_sentences/#setting-up-sentences-in-the-config-directory):

```yaml
language: "en"
intents:
  SetVolume:
    data:
      - sentences:
          - "(set|change) <name> volume to {volume} [percent]"
          - "(set|change) [the] volume for <name> to {volume} [percent]"
        requires_context:
          domain: "media_player"
lists:
  volume:
    range:
      from: 0
      to: 100
```

```yaml
intent_script:
  SetVolume:
    action:
      service: "media_player.volume_set"
      data:
        entity_id: "{{ slots.name.id }}"
        volume_level: "{{ volume / 100.0 }}"
    speech:
      text: "Volume changed to {{ volume }}"
```

This avoids needing to hard-code a list of supported devices.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
