### PR TITLE
Add support for payload_template in rest component

### DIFF
--- a/homeassistant/components/rest/__init__.py
+++ b/homeassistant/components/rest/__init__.py
@@ -45,6 +45,7 @@ from homeassistant.util.async_ import create_eager_task
 
 from .const import (
     CONF_ENCODING,
+    CONF_PAYLOAD_TEMPLATE,
     CONF_SSL_CIPHER_LIST,
     COORDINATOR,
     DEFAULT_SSL_CIPHER_LIST,
@@ -108,8 +109,11 @@ async def _async_process_config(hass: HomeAssistant, config: ConfigType) -> bool
     for rest_idx, conf in enumerate(rest_config):
         scan_interval: timedelta = conf.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         resource_template: template.Template | None = conf.get(CONF_RESOURCE_TEMPLATE)
+        payload_template: template.Template | None = conf.get(CONF_PAYLOAD_TEMPLATE)
         rest = create_rest_data_from_config(hass, conf)
-        coordinator = _rest_coordinator(hass, rest, resource_template, scan_interval)
+        coordinator = _rest_coordinator(
+            hass, rest, resource_template, payload_template, scan_interval
+        )
         refresh_coroutines.append(coordinator.async_refresh())
         hass.data[DOMAIN][REST_DATA].append({REST: rest, COORDINATOR: coordinator})
 
@@ -156,16 +160,20 @@ def _rest_coordinator(
     hass: HomeAssistant,
     rest: RestData,
     resource_template: template.Template | None,
+    payload_template: template.Template | None,
     update_interval: timedelta,
 ) -> DataUpdateCoordinator[None]:
     """Wrap a DataUpdateCoordinator around the rest object."""
-    if resource_template:
+    if resource_template or payload_template:
 
-        async def _async_refresh_with_resource_template() -> None:
-            rest.set_url(resource_template.async_render(parse_result=False))
+        async def _async_refresh_with_templates() -> None:
+            if resource_template:
+                rest.set_url(resource_template.async_render(parse_result=False))
+            if payload_template:
+                rest.set_payload(payload_template.async_render(parse_result=False))
             await rest.async_update()
 
-        update_method = _async_refresh_with_resource_template
+        update_method = _async_refresh_with_templates
     else:
         update_method = rest.async_update
 
@@ -184,6 +192,7 @@ def create_rest_data_from_config(hass: HomeAssistant, config: ConfigType) -> Res
     resource_template: template.Template | None = config.get(CONF_RESOURCE_TEMPLATE)
     method: str = config[CONF_METHOD]
     payload: str | None = config.get(CONF_PAYLOAD)
+    payload_template: template.Template | None = config.get(CONF_PAYLOAD_TEMPLATE)
     verify_ssl: bool = config[CONF_VERIFY_SSL]
     ssl_cipher_list: str = config.get(CONF_SSL_CIPHER_LIST, DEFAULT_SSL_CIPHER_LIST)
     username: str | None = config.get(CONF_USERNAME)
@@ -195,6 +204,10 @@ def create_rest_data_from_config(hass: HomeAssistant, config: ConfigType) -> Res
     if resource_template is not None:
         resource_template.hass = hass
         resource = resource_template.async_render(parse_result=False)
+
+    if payload_template is not None:
+        payload_template.hass = hass
+        payload = payload_template.async_render(parse_result=False)
 
     if not resource:
         raise HomeAssistantError("Resource not set for RestData")

--- a/homeassistant/components/rest/const.py
+++ b/homeassistant/components/rest/const.py
@@ -33,3 +33,5 @@ XML_MIME_TYPES = (
     "application/xml",
     "text/xml",
 )
+
+CONF_PAYLOAD_TEMPLATE = "payload_template"

--- a/homeassistant/components/rest/data.py
+++ b/homeassistant/components/rest/data.py
@@ -56,11 +56,6 @@ class RestData:
         self.last_exception: Exception | None = None
         self.headers: httpx.Headers | None = None
 
-    @property
-    def payload(self) -> str | None:
-        """Get request data."""
-        return self._request_data
-
     def set_payload(self, payload: str) -> None:
         """Set request data."""
         self._request_data = payload

--- a/homeassistant/components/rest/data.py
+++ b/homeassistant/components/rest/data.py
@@ -57,6 +57,15 @@ class RestData:
         self.headers: httpx.Headers | None = None
 
     @property
+    def payload(self) -> str | None:
+        """Get request data."""
+        return self._request_data
+
+    def set_payload(self, payload: str) -> None:
+        """Set request data."""
+        self._request_data = payload
+
+    @property
     def url(self) -> str:
         """Get url."""
         return self._resource

--- a/homeassistant/components/rest/schema.py
+++ b/homeassistant/components/rest/schema.py
@@ -61,7 +61,7 @@ RESOURCE_SCHEMA = {
     vol.Optional(CONF_METHOD, default=DEFAULT_METHOD): vol.In(METHODS),
     vol.Optional(CONF_USERNAME): cv.string,
     vol.Optional(CONF_PASSWORD): cv.string,
-    vol.Optional(CONF_PAYLOAD): cv.string,
+    vol.Exclusive(CONF_PAYLOAD, CONF_PAYLOAD): cv.string,
     vol.Exclusive(CONF_PAYLOAD_TEMPLATE, CONF_PAYLOAD): cv.template,
     vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
     vol.Optional(

--- a/homeassistant/components/rest/schema.py
+++ b/homeassistant/components/rest/schema.py
@@ -38,6 +38,7 @@ from .const import (
     CONF_ENCODING,
     CONF_JSON_ATTRS,
     CONF_JSON_ATTRS_PATH,
+    CONF_PAYLOAD_TEMPLATE,
     CONF_SSL_CIPHER_LIST,
     DEFAULT_ENCODING,
     DEFAULT_FORCE_UPDATE,
@@ -61,6 +62,7 @@ RESOURCE_SCHEMA = {
     vol.Optional(CONF_USERNAME): cv.string,
     vol.Optional(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_PAYLOAD): cv.string,
+    vol.Exclusive(CONF_PAYLOAD_TEMPLATE, CONF_PAYLOAD): cv.template,
     vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
     vol.Optional(
         CONF_SSL_CIPHER_LIST,

--- a/tests/components/rest/test_init.py
+++ b/tests/components/rest/test_init.py
@@ -475,3 +475,62 @@ async def test_config_schema_via_packages(hass: HomeAssistant) -> None:
     assert len(config["rest"]) == 2
     assert config["rest"][0]["resource"] == "http://url1"
     assert config["rest"][1]["resource"] == "http://url2"
+
+
+@respx.mock
+async def test_setup_minimum_payload_template(hass: HomeAssistant) -> None:
+    """Test setup with minimum configuration (payload_template)."""
+
+    respx.post("http://localhost", json={"data": "value"}).respond(
+        status_code=HTTPStatus.OK,
+        json={
+            "sensor1": "1",
+            "sensor2": "2",
+            "binary_sensor1": "on",
+            "binary_sensor2": "off",
+        },
+    )
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: [
+                {
+                    "resource": "http://localhost",
+                    "payload_template": '{% set payload = {"data": "value"} %}{{ payload | to_json }}',
+                    "method": "POST",
+                    "verify_ssl": "false",
+                    "timeout": 30,
+                    "sensor": [
+                        {
+                            "unit_of_measurement": UnitOfInformation.MEGABYTES,
+                            "name": "sensor1",
+                            "value_template": "{{ value_json.sensor1 }}",
+                        },
+                        {
+                            "unit_of_measurement": UnitOfInformation.MEGABYTES,
+                            "name": "sensor2",
+                            "value_template": "{{ value_json.sensor2 }}",
+                        },
+                    ],
+                    "binary_sensor": [
+                        {
+                            "name": "binary_sensor1",
+                            "value_template": "{{ value_json.binary_sensor1 }}",
+                        },
+                        {
+                            "name": "binary_sensor2",
+                            "value_template": "{{ value_json.binary_sensor2 }}",
+                        },
+                    ],
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all()) == 4
+
+    assert hass.states.get("sensor.sensor1").state == "1"
+    assert hass.states.get("sensor.sensor2").state == "2"
+    assert hass.states.get("binary_sensor.binary_sensor1").state == "on"
+    assert hass.states.get("binary_sensor.binary_sensor2").state == "off"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR picks up where #73106 left off. This change adds the option to use templates in rest sensor payload option, allowing to send dynamically changed payloads to the remote endpoint. This is especially useful with APIs like GraphQL, as demonstrated in [my comment on the feature request thread](https://community.home-assistant.io/t/restful-sensor-please-allow-templates-for-the-post-payload/389843/13?u=ptashek) on the community forum.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30710

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
