### PR TITLE
Migrate kmtronic to has entity name

### DIFF
--- a/homeassistant/components/kmtronic/strings.json
+++ b/homeassistant/components/kmtronic/strings.json
@@ -29,5 +29,12 @@
         }
       }
     }
+  },
+  "entity": {
+    "switch": {
+      "relay": {
+        "name": "Relay {relay_id}"
+      }
+    }
   }
 }

--- a/homeassistant/components/kmtronic/switch.py
+++ b/homeassistant/components/kmtronic/switch.py
@@ -32,6 +32,9 @@ async def async_setup_entry(
 class KMtronicSwitch(CoordinatorEntity, SwitchEntity):
     """KMtronic Switch Entity."""
 
+    _attr_translation_key = "relay"
+    _attr_has_entity_name = True
+
     def __init__(self, hub, coordinator, relay, reverse, config_entry_id):
         """Pass coordinator to CoordinatorEntity."""
         super().__init__(coordinator)
@@ -46,7 +49,7 @@ class KMtronicSwitch(CoordinatorEntity, SwitchEntity):
             configuration_url=hub.host,
         )
 
-        self._attr_name = f"Relay{relay.id}"
+        self._attr_translation_placeholders = {"relay_id": relay.id}
         self._attr_unique_id = f"{config_entry_id}_relay{relay.id}"
 
     @property

--- a/tests/components/kmtronic/test_switch.py
+++ b/tests/components/kmtronic/test_switch.py
@@ -39,15 +39,18 @@ async def test_relay_on_off(
         text="",
     )
 
-    state = hass.states.get("switch.relay1")
+    state = hass.states.get("switch.controller_1_1_1_1_relay_1")
     assert state.state == "off"
 
     await hass.services.async_call(
-        "switch", "turn_on", {"entity_id": "switch.relay1"}, blocking=True
+        "switch",
+        "turn_on",
+        {"entity_id": "switch.controller_1_1_1_1_relay_1"},
+        blocking=True,
     )
 
     await hass.async_block_till_done()
-    state = hass.states.get("switch.relay1")
+    state = hass.states.get("switch.controller_1_1_1_1_relay_1")
     assert state.state == "on"
 
     # Mocks the response for turning a relay1 off
@@ -57,11 +60,14 @@ async def test_relay_on_off(
     )
 
     await hass.services.async_call(
-        "switch", "turn_off", {"entity_id": "switch.relay1"}, blocking=True
+        "switch",
+        "turn_off",
+        {"entity_id": "switch.controller_1_1_1_1_relay_1"},
+        blocking=True,
     )
 
     await hass.async_block_till_done()
-    state = hass.states.get("switch.relay1")
+    state = hass.states.get("switch.controller_1_1_1_1_relay_1")
     assert state.state == "off"
 
     # Mocks the response for turning a relay1 on
@@ -71,11 +77,14 @@ async def test_relay_on_off(
     )
 
     await hass.services.async_call(
-        "switch", "toggle", {"entity_id": "switch.relay1"}, blocking=True
+        "switch",
+        "toggle",
+        {"entity_id": "switch.controller_1_1_1_1_relay_1"},
+        blocking=True,
     )
 
     await hass.async_block_till_done()
-    state = hass.states.get("switch.relay1")
+    state = hass.states.get("switch.controller_1_1_1_1_relay_1")
     assert state.state == "on"
 
 
@@ -95,7 +104,7 @@ async def test_update(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) 
     assert await async_setup_component(hass, DOMAIN, {})
 
     await hass.async_block_till_done()
-    state = hass.states.get("switch.relay1")
+    state = hass.states.get("switch.controller_1_1_1_1_relay_1")
     assert state.state == "off"
 
     aioclient_mock.clear_requests()
@@ -106,7 +115,7 @@ async def test_update(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) 
     async_fire_time_changed(hass, future)
 
     await hass.async_block_till_done()
-    state = hass.states.get("switch.relay1")
+    state = hass.states.get("switch.controller_1_1_1_1_relay_1")
     assert state.state == "on"
 
 
@@ -128,7 +137,7 @@ async def test_failed_update(
     assert await async_setup_component(hass, DOMAIN, {})
 
     await hass.async_block_till_done()
-    state = hass.states.get("switch.relay1")
+    state = hass.states.get("switch.controller_1_1_1_1_relay_1")
     assert state.state == "off"
 
     aioclient_mock.clear_requests()
@@ -140,7 +149,7 @@ async def test_failed_update(
     async_fire_time_changed(hass, future)
 
     await hass.async_block_till_done()
-    state = hass.states.get("switch.relay1")
+    state = hass.states.get("switch.controller_1_1_1_1_relay_1")
     assert state.state == STATE_UNAVAILABLE
 
     future += timedelta(minutes=10)
@@ -152,7 +161,7 @@ async def test_failed_update(
     async_fire_time_changed(hass, future)
 
     await hass.async_block_till_done()
-    state = hass.states.get("switch.relay1")
+    state = hass.states.get("switch.controller_1_1_1_1_relay_1")
     assert state.state == STATE_UNAVAILABLE
 
 
@@ -180,15 +189,18 @@ async def test_relay_on_off_reversed(
         text="",
     )
 
-    state = hass.states.get("switch.relay1")
+    state = hass.states.get("switch.controller_1_1_1_1_relay_1")
     assert state.state == "on"
 
     await hass.services.async_call(
-        "switch", "turn_off", {"entity_id": "switch.relay1"}, blocking=True
+        "switch",
+        "turn_off",
+        {"entity_id": "switch.controller_1_1_1_1_relay_1"},
+        blocking=True,
     )
 
     await hass.async_block_till_done()
-    state = hass.states.get("switch.relay1")
+    state = hass.states.get("switch.controller_1_1_1_1_relay_1")
     assert state.state == "off"
 
     # Mocks the response for turning a relay1 off
@@ -198,9 +210,12 @@ async def test_relay_on_off_reversed(
     )
 
     await hass.services.async_call(
-        "switch", "turn_on", {"entity_id": "switch.relay1"}, blocking=True
+        "switch",
+        "turn_on",
+        {"entity_id": "switch.controller_1_1_1_1_relay_1"},
+        blocking=True,
     )
 
     await hass.async_block_till_done()
-    state = hass.states.get("switch.relay1")
+    state = hass.states.get("switch.controller_1_1_1_1_relay_1")
     assert state.state == "on"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate kmtronic to has entity name

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr