### PR TITLE
Add value templates for sensor group

### DIFF
--- a/homeassistant/components/group/sensor.py
+++ b/homeassistant/components/group/sensor.py
@@ -38,11 +38,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant, State, callback
-<<<<<<< HEAD
-from homeassistant.exceptions import HomeAssistantError
-=======
-from homeassistant.exceptions import TemplateError
->>>>>>> a123fe0006 (Add value templates for sensor group)
+from homeassistant.exceptions import HomeAssistantError, TemplateError
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.entity import (
     get_capability,
@@ -50,15 +46,12 @@ from homeassistant.helpers.entity import (
     get_unit_of_measurement,
 )
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-<<<<<<< HEAD
 from homeassistant.helpers.issue_registry import (
     IssueSeverity,
     async_create_issue,
     async_delete_issue,
 )
-=======
 from homeassistant.helpers.template import Template
->>>>>>> a123fe0006 (Add value templates for sensor group)
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
 
 from .const import CONF_IGNORE_NON_NUMERIC, DOMAIN as GROUP_DOMAIN
@@ -369,13 +362,9 @@ class SensorGroup(GroupEntity, SensorEntity):
             self._attr_name = f"{DEFAULT_NAME} {sensor_type}".capitalize()
         self._attr_extra_state_attributes = {ATTR_ENTITY_ID: entity_ids}
         self._attr_unique_id = unique_id
-<<<<<<< HEAD
         self._ignore_non_numeric = ignore_non_numeric
         self.mode = all if ignore_non_numeric is False else any
-=======
-        self.mode = all if mode is False else any
         self.value_template = value_template
->>>>>>> a123fe0006 (Add value templates for sensor group)
         self._state_calc: Callable[
             [SensorGroup, list[tuple[str, float, State]]],
             tuple[dict[str, str | None], float | None],

--- a/homeassistant/components/group/strings.json
+++ b/homeassistant/components/group/strings.json
@@ -86,7 +86,8 @@
           "round_digits": "Round value to number of decimals",
           "device_class": "Device class",
           "state_class": "State class",
-          "unit_of_measurement": "Unit of Measurement"
+          "unit_of_measurement": "Unit of Measurement",
+          "value_template": "Value template"
         }
       },
       "switch": {
@@ -97,6 +98,9 @@
           "name": "[%key:common::config_flow::data::name%]"
         }
       }
+    },
+    "error": {
+      "missing_value_template": "Value template is missing"
     }
   },
   "options": {
@@ -196,6 +200,7 @@
         "last": "Most recently updated",
         "range": "Statistical range",
         "sum": "Sum",
+        "template": "Value template",
         "product": "Product"
       }
     }

--- a/tests/components/group/test_config_flow.py
+++ b/tests/components/group/test_config_flow.py
@@ -138,24 +138,19 @@ async def test_config_flow(
 
 
 @pytest.mark.parametrize(
-<<<<<<< HEAD
-    ("hide_members", "hidden_by"), [(False, None), (True, "integration")]
-=======
-    ("group_type", "member_state", "member_attributes", "extra_input", "error"),
-    (("sensor", "20.0", {}, {"type": "template"}, "missing_value_template"),),
+    ("group_type", "member_state", "error"),
+    [("sensor", "20.0", "missing_value_template")],
 )
-async def test_config_flow_errors(
+async def test_missing_value_template(
     hass: HomeAssistant,
     group_type,
     member_state,
-    member_attributes,
-    extra_input,
     error,
 ) -> None:
     """Test errors in the config flow."""
     members = [f"{group_type}.one", f"{group_type}.two"]
     for member in members:
-        hass.states.async_set(member, member_state, member_attributes)
+        hass.states.async_set(member, member_state, {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -178,7 +173,7 @@ async def test_config_flow_errors(
             {
                 "name": "Living Room",
                 "entities": members,
-                **extra_input,
+                "type": "template",
             },
         )
         await hass.async_block_till_done()
@@ -188,8 +183,7 @@ async def test_config_flow_errors(
 
 
 @pytest.mark.parametrize(
-    ("hide_members", "hidden_by"), ((False, None), (True, "integration"))
->>>>>>> a123fe0006 (Add value templates for sensor group)
+    ("hide_members", "hidden_by"), [(False, None), (True, "integration")]
 )
 @pytest.mark.parametrize(
     ("group_type", "extra_input"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
N/A

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add the ability to use a custom value template to calculate the value of a sensor group. While the current sensor group provides some standard aggregation functions, it is quite likely that users may want to aggregate data using different functions. 

For example, I want to aggregate weather data from multiple weather stations around me but I want to drop stations that report outlier data first. Weather stations can be notoriously inaccurate depending on the exact placement of a station. For example, depending on wind direction, the reported precipitation may be more or less inaccurate.

Using this functionality, my group sensor setup would look like this:

![group_sensor](https://github.com/home-assistant/core/assets/542423/785f6054-d7e3-4a31-8318-98206fddf951)

and the corresponding jinja2 file would contain this:

```
{#- Removing outliers using a median absolute deviation algorithm -#}
{%- macro remove_outliers(values) -%}
{%-   set vars = namespace(result=[], abs_deviations=[]) -%}
{#-   Return original data points if we have fewer than 4 data points -#}
{%-   if values | length < 3 -%}
{{-     values -}}
{%-   else -%}
{%-     set med = median(values) -%}
{%-     for value in values -%}
{%-       set vars.abs_deviations = vars.abs_deviations + [value - med | abs | float] -%}
{%-     endfor -%}
{%-     set median_abs_deviation = median(vars.abs_deviations) -%}
{%-     set upper_bound = med + 2.5 * median_abs_deviation -%}
{%-     set lower_bound = med - 2.5 * median_abs_deviation -%}
{%-     for value in values -%}
{%-       if lower_bound <= value <= upper_bound -%}
{%-         set vars.result = vars.result + [value] -%}
{%-       endif -%}
{%-     endfor -%}
{#-     Return original data points if we eliminated all data points -#}
{%-     if vars.result | length == 0 -%}
{{-       values -}}
{%-     else -%}
{{-       vars.result -}}
{%-     endif -%}
{%-   endif -%}
{%- endmacro -%}
```

Why not use the standard template helper? Because groups have a lot of built in functionality such as:

- The group state is `unavailable` if all group members are `unavailable`.
- The group state can be made `unavailable` if one members is `unavailable` or does not have a numeric state.
- Unavailable members are automatically filtered out.
- The icon and unit is automatically derived from the individual members.
- There is really no need to replicate this functionality all over the place in each template.

In addition to that, it is much easier to change the group members through the UI instead of having to go to the editor and modify the yaml file in multiple places.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
