### PR TITLE
Add an index for devices and config entries to the entity registry

### DIFF
--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -475,13 +475,15 @@ class EntityRegistryItems(UserDict[str, RegistryEntry]):
         del self._entry_ids[entry.id]
         del self._index[(entry.domain, entry.platform, entry.unique_id)]
         if entry.config_entry_id is not None:
-            self._config_entry_id_index[entry.config_entry_id].remove(entry)
-            if not self._config_entry_id_index[entry.config_entry_id]:
+            entries = self._config_entry_id_index[entry.config_entry_id]
+            entries.remove(entry)
+            if not entries:
                 del self._config_entry_id_index[entry.config_entry_id]
-        if entry.device_id is not None:
-            self._device_id_index[entry.device_id].remove(entry)
-            if not self._device_id_index[entry.device_id]:
-                del self._device_id_index[entry.device_id]
+        if (device_id := entry.device_id) is not None:
+            entries = self._device_id_index[device_id]
+            entries.remove(entry)
+            if not entries:
+                del self._device_id_index[device_id]
 
     def __delitem__(self, key: str) -> None:
         """Remove an item."""

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -439,8 +439,8 @@ class EntityRegistryItems(UserDict[str, RegistryEntry]):
     Maintains four additional indexes:
     - id -> entry
     - (domain, platform, unique_id) -> entity_id
-    - config_entry_id -> set[key]
-    - device_id -> set[key]
+    - config_entry_id -> list[key]
+    - device_id -> list[key]
     """
 
     def __init__(self) -> None:
@@ -448,8 +448,8 @@ class EntityRegistryItems(UserDict[str, RegistryEntry]):
         super().__init__()
         self._entry_ids: dict[str, RegistryEntry] = {}
         self._index: dict[tuple[str, str, str], str] = {}
-        self._config_entry_id_index: dict[str, set[str]] = {}
-        self._device_id_index: dict[str, set[str]] = {}
+        self._config_entry_id_index: dict[str, list[str]] = {}
+        self._device_id_index: dict[str, list[str]] = {}
 
     def values(self) -> ValuesView[RegistryEntry]:
         """Return the underlying values to avoid __iter__ overhead."""
@@ -464,9 +464,9 @@ class EntityRegistryItems(UserDict[str, RegistryEntry]):
         self._entry_ids[entry.id] = entry
         self._index[(entry.domain, entry.platform, entry.unique_id)] = entry.entity_id
         if (config_entry_id := entry.config_entry_id) is not None:
-            self._config_entry_id_index.setdefault(config_entry_id, set()).add(key)
+            self._config_entry_id_index.setdefault(config_entry_id, []).append(key)
         if (device_id := entry.device_id) is not None:
-            self._device_id_index.setdefault(device_id, set()).add(key)
+            self._device_id_index.setdefault(device_id, []).append(key)
 
     def _unindex_entry(self, key: str) -> None:
         """Unindex an entry."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As more entities have been added, the run time cost of looking up entities by device and config entries has increased.  For reference, the entity registry storage is now 4-5MB on most of my production systems. The number of entities in the registry continues to grow as more integrations are updated so the problem will continue to get worse over time.

More integrations have migrations of unique ids which tend to stay in the code base for a very long time.  They are frequent callers of `er.async_entries_for_device` and `er.async_entries_for_config_entry`.  Both of these functions have to do a linear search over the entire registry to find matching entries since there is no index for `device_id` or `config_entry id`

Side node: Ideally we would change these functions to return a set in another set so removing the the index is cheap, but a lot of the tests are expecting explicit order because its been a list even though its not needed

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
