### PR TITLE
Add invert option to switch_as_x

### DIFF
--- a/homeassistant/components/switch_as_x/__init__.py
+++ b/homeassistant/components/switch_as_x/__init__.py
@@ -114,7 +114,6 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         options = {**config_entry.options}
         if config_entry.minor_version < 2:
             options.setdefault(CONF_INVERT, False)
-        config_entry.version = 1
         config_entry.minor_version = 2
         hass.config_entries.async_update_entry(config_entry, options=options)
 

--- a/homeassistant/components/switch_as_x/__init__.py
+++ b/homeassistant/components/switch_as_x/__init__.py
@@ -91,6 +91,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass, entity_id, async_registry_updated
         )
     )
+    entry.async_on_unload(entry.add_update_listener(config_entry_update_listener))
 
     device_id = async_add_to_device(hass, entry, entity_id)
 
@@ -124,6 +125,11 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     )
 
     return True
+
+
+async def config_entry_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Update listener, called when the config entry options are changed."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/switch_as_x/__init__.py
+++ b/homeassistant/components/switch_as_x/__init__.py
@@ -113,7 +113,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     if config_entry.version == 1:
         options = {**config_entry.options}
         if config_entry.minor_version < 2:
-            options[CONF_INVERT] = False
+            options.setdefault(CONF_INVERT, False)
         config_entry.version = 1
         config_entry.minor_version = 2
         hass.config_entries.async_update_entry(config_entry, options=options)

--- a/homeassistant/components/switch_as_x/config_flow.py
+++ b/homeassistant/components/switch_as_x/config_flow.py
@@ -32,7 +32,7 @@ CONFIG_FLOW = {
                 vol.Required(CONF_ENTITY_ID): selector.EntitySelector(
                     selector.EntitySelectorConfig(domain=Platform.SWITCH),
                 ),
-                vol.Required(CONF_INVERT): selector.BooleanSelector(),
+                vol.Optional(CONF_INVERT, default=False): selector.BooleanSelector(),
                 vol.Required(CONF_TARGET_DOMAIN): selector.SelectSelector(
                     selector.SelectSelectorConfig(options=TARGET_DOMAIN_OPTIONS),
                 ),

--- a/homeassistant/components/switch_as_x/config_flow.py
+++ b/homeassistant/components/switch_as_x/config_flow.py
@@ -41,11 +41,18 @@ CONFIG_FLOW = {
     )
 }
 
+OPTIONS_FLOW = {
+    "init": SchemaFlowFormStep(
+        vol.Schema({vol.Required(CONF_INVERT): selector.BooleanSelector()})
+    ),
+}
+
 
 class SwitchAsXConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
     """Handle a config flow for Switch as X."""
 
     config_flow = CONFIG_FLOW
+    options_flow = OPTIONS_FLOW
 
     VERSION = 1
     MINOR_VERSION = 2

--- a/homeassistant/components/switch_as_x/config_flow.py
+++ b/homeassistant/components/switch_as_x/config_flow.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.schema_config_entry_flow import (
     wrapped_entity_config_entry_title,
 )
 
-from .const import CONF_TARGET_DOMAIN, DOMAIN
+from .const import CONF_INVERT, CONF_TARGET_DOMAIN, DOMAIN
 
 TARGET_DOMAIN_OPTIONS = [
     selector.SelectOptionDict(value=Platform.COVER, label="Cover"),
@@ -32,6 +32,7 @@ CONFIG_FLOW = {
                 vol.Required(CONF_ENTITY_ID): selector.EntitySelector(
                     selector.EntitySelectorConfig(domain=Platform.SWITCH),
                 ),
+                vol.Required(CONF_INVERT): selector.BooleanSelector(),
                 vol.Required(CONF_TARGET_DOMAIN): selector.SelectSelector(
                     selector.SelectSelectorConfig(options=TARGET_DOMAIN_OPTIONS),
                 ),
@@ -45,6 +46,9 @@ class SwitchAsXConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
     """Handle a config flow for Switch as X."""
 
     config_flow = CONFIG_FLOW
+
+    VERSION = 1
+    MINOR_VERSION = 2
 
     def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
         """Return config entry title and hide the wrapped entity if registered."""

--- a/homeassistant/components/switch_as_x/const.py
+++ b/homeassistant/components/switch_as_x/const.py
@@ -4,4 +4,5 @@ from typing import Final
 
 DOMAIN: Final = "switch_as_x"
 
+CONF_INVERT: Final = "invert"
 CONF_TARGET_DOMAIN: Final = "target_domain"

--- a/homeassistant/components/switch_as_x/cover.py
+++ b/homeassistant/components/switch_as_x/cover.py
@@ -61,7 +61,7 @@ class CoverSwitch(BaseInvertableEntity, CoverEntity):
         """Open the cover."""
         await self.hass.services.async_call(
             SWITCH_DOMAIN,
-            SERVICE_TURN_ON if not self._invert_state else SERVICE_TURN_OFF,
+            SERVICE_TURN_OFF if self._invert_state else SERVICE_TURN_ON,
             {ATTR_ENTITY_ID: self._switch_entity_id},
             blocking=True,
             context=self._context,
@@ -71,7 +71,7 @@ class CoverSwitch(BaseInvertableEntity, CoverEntity):
         """Close cover."""
         await self.hass.services.async_call(
             SWITCH_DOMAIN,
-            SERVICE_TURN_OFF if not self._invert_state else SERVICE_TURN_ON,
+            SERVICE_TURN_ON if self._invert_state else SERVICE_TURN_OFF,
             {ATTR_ENTITY_ID: self._switch_entity_id},
             blocking=True,
             context=self._context,

--- a/homeassistant/components/switch_as_x/cover.py
+++ b/homeassistant/components/switch_as_x/cover.py
@@ -89,7 +89,7 @@ class CoverSwitch(BaseInvertableEntity, CoverEntity):
         ):
             return
 
-        if not self._invert_state:
-            self._attr_is_closed = state.state != STATE_ON
-        else:
+        if self._invert_state:
             self._attr_is_closed = state.state == STATE_ON
+        else:
+            self._attr_is_closed = state.state != STATE_ON

--- a/homeassistant/components/switch_as_x/cover.py
+++ b/homeassistant/components/switch_as_x/cover.py
@@ -23,7 +23,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import EventStateChangedData
 from homeassistant.helpers.typing import EventType
 
-from .entity import BaseEntity
+from .const import CONF_INVERT
+from .entity import BaseInvertableEntity
 
 
 async def async_setup_entry(
@@ -43,6 +44,7 @@ async def async_setup_entry(
                 hass,
                 config_entry.title,
                 COVER_DOMAIN,
+                config_entry.options[CONF_INVERT],
                 entity_id,
                 config_entry.entry_id,
             )
@@ -50,7 +52,7 @@ async def async_setup_entry(
     )
 
 
-class CoverSwitch(BaseEntity, CoverEntity):
+class CoverSwitch(BaseInvertableEntity, CoverEntity):
     """Represents a Switch as a Cover."""
 
     _attr_supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
@@ -59,7 +61,7 @@ class CoverSwitch(BaseEntity, CoverEntity):
         """Open the cover."""
         await self.hass.services.async_call(
             SWITCH_DOMAIN,
-            SERVICE_TURN_ON,
+            SERVICE_TURN_ON if not self._invert_state else SERVICE_TURN_OFF,
             {ATTR_ENTITY_ID: self._switch_entity_id},
             blocking=True,
             context=self._context,
@@ -69,7 +71,7 @@ class CoverSwitch(BaseEntity, CoverEntity):
         """Close cover."""
         await self.hass.services.async_call(
             SWITCH_DOMAIN,
-            SERVICE_TURN_OFF,
+            SERVICE_TURN_OFF if not self._invert_state else SERVICE_TURN_ON,
             {ATTR_ENTITY_ID: self._switch_entity_id},
             blocking=True,
             context=self._context,
@@ -87,4 +89,7 @@ class CoverSwitch(BaseEntity, CoverEntity):
         ):
             return
 
-        self._attr_is_closed = state.state != STATE_ON
+        if not self._invert_state:
+            self._attr_is_closed = state.state != STATE_ON
+        else:
+            self._attr_is_closed = state.state == STATE_ON

--- a/homeassistant/components/switch_as_x/entity.py
+++ b/homeassistant/components/switch_as_x/entity.py
@@ -178,3 +178,20 @@ class BaseToggleEntity(BaseEntity, ToggleEntity):
             return
 
         self._attr_is_on = state.state == STATE_ON
+
+
+class BaseInvertableEntity(BaseEntity):
+    """Represents a Switch as an X."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry_title: str,
+        domain: str,
+        invert: bool,
+        switch_entity_id: str,
+        unique_id: str,
+    ) -> None:
+        """Initialize Switch as an X."""
+        super().__init__(hass, config_entry_title, domain, switch_entity_id, unique_id)
+        self._invert_state = invert

--- a/homeassistant/components/switch_as_x/entity.py
+++ b/homeassistant/components/switch_as_x/entity.py
@@ -106,7 +106,7 @@ class BaseEntity(Entity):
             registry.async_update_entity_options(
                 self.entity_id,
                 SWITCH_AS_X_DOMAIN,
-                {"entity_id": self._switch_entity_id},
+                self.async_generate_entity_options(),
             )
 
         if not self._is_new_entity or not (
@@ -140,6 +140,11 @@ class BaseEntity(Entity):
 
         copy_custom_name(wrapped_switch)
         copy_expose_settings()
+
+    @callback
+    def async_generate_entity_options(self) -> dict[str, Any]:
+        """Generate entity options."""
+        return {"entity_id": self._switch_entity_id, "invert": False}
 
 
 class BaseToggleEntity(BaseEntity, ToggleEntity):
@@ -195,3 +200,8 @@ class BaseInvertableEntity(BaseEntity):
         """Initialize Switch as an X."""
         super().__init__(hass, config_entry_title, domain, switch_entity_id, unique_id)
         self._invert_state = invert
+
+    @callback
+    def async_generate_entity_options(self) -> dict[str, Any]:
+        """Generate entity options."""
+        return super().async_generate_entity_options() | {"invert": self._invert_state}

--- a/homeassistant/components/switch_as_x/lock.py
+++ b/homeassistant/components/switch_as_x/lock.py
@@ -55,7 +55,7 @@ class LockSwitch(BaseInvertableEntity, LockEntity):
         """Lock the lock."""
         await self.hass.services.async_call(
             SWITCH_DOMAIN,
-            SERVICE_TURN_OFF if not self._invert_state else SERVICE_TURN_ON,
+            SERVICE_TURN_ON if self._invert_state else SERVICE_TURN_OFF,
             {ATTR_ENTITY_ID: self._switch_entity_id},
             blocking=True,
             context=self._context,
@@ -65,7 +65,7 @@ class LockSwitch(BaseInvertableEntity, LockEntity):
         """Unlock the lock."""
         await self.hass.services.async_call(
             SWITCH_DOMAIN,
-            SERVICE_TURN_ON if not self._invert_state else SERVICE_TURN_OFF,
+            SERVICE_TURN_OFF if self._invert_state else SERVICE_TURN_ON,
             {ATTR_ENTITY_ID: self._switch_entity_id},
             blocking=True,
             context=self._context,

--- a/homeassistant/components/switch_as_x/lock.py
+++ b/homeassistant/components/switch_as_x/lock.py
@@ -85,7 +85,7 @@ class LockSwitch(BaseInvertableEntity, LockEntity):
 
         # Logic is the same as the lock device class for binary sensors
         # on means open (unlocked), off means closed (locked)
-        if not self._invert_state:
-            self._attr_is_locked = state.state != STATE_ON
-        else:
+        if self._invert_state:
             self._attr_is_locked = state.state == STATE_ON
+        else:
+            self._attr_is_locked = state.state != STATE_ON

--- a/homeassistant/components/switch_as_x/lock.py
+++ b/homeassistant/components/switch_as_x/lock.py
@@ -19,7 +19,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import EventStateChangedData
 from homeassistant.helpers.typing import EventType
 
-from .entity import BaseEntity
+from .const import CONF_INVERT
+from .entity import BaseInvertableEntity
 
 
 async def async_setup_entry(
@@ -39,6 +40,7 @@ async def async_setup_entry(
                 hass,
                 config_entry.title,
                 LOCK_DOMAIN,
+                config_entry.options[CONF_INVERT],
                 entity_id,
                 config_entry.entry_id,
             )
@@ -46,14 +48,14 @@ async def async_setup_entry(
     )
 
 
-class LockSwitch(BaseEntity, LockEntity):
+class LockSwitch(BaseInvertableEntity, LockEntity):
     """Represents a Switch as a Lock."""
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the lock."""
         await self.hass.services.async_call(
             SWITCH_DOMAIN,
-            SERVICE_TURN_OFF,
+            SERVICE_TURN_OFF if not self._invert_state else SERVICE_TURN_ON,
             {ATTR_ENTITY_ID: self._switch_entity_id},
             blocking=True,
             context=self._context,
@@ -63,7 +65,7 @@ class LockSwitch(BaseEntity, LockEntity):
         """Unlock the lock."""
         await self.hass.services.async_call(
             SWITCH_DOMAIN,
-            SERVICE_TURN_ON,
+            SERVICE_TURN_ON if not self._invert_state else SERVICE_TURN_OFF,
             {ATTR_ENTITY_ID: self._switch_entity_id},
             blocking=True,
             context=self._context,
@@ -83,4 +85,7 @@ class LockSwitch(BaseEntity, LockEntity):
 
         # Logic is the same as the lock device class for binary sensors
         # on means open (unlocked), off means closed (locked)
-        self._attr_is_locked = state.state != STATE_ON
+        if not self._invert_state:
+            self._attr_is_locked = state.state != STATE_ON
+        else:
+            self._attr_is_locked = state.state == STATE_ON

--- a/homeassistant/components/switch_as_x/strings.json
+++ b/homeassistant/components/switch_as_x/strings.json
@@ -19,10 +19,10 @@
     "step": {
       "init": {
         "data": {
-          "forecast": "[%key:component::switch_as_x::config::step::user::data::invert%]"
+          "invert": "[%key:component::switch_as_x::config::step::user::data::invert%]"
         },
         "data_description": {
-          "forecast": "[%key:component::switch_as_x::config::step::user::data_description::invert%]"
+          "invert": "[%key:component::switch_as_x::config::step::user::data_description::invert%]"
         }
       }
     }

--- a/homeassistant/components/switch_as_x/strings.json
+++ b/homeassistant/components/switch_as_x/strings.json
@@ -8,6 +8,21 @@
           "entity_id": "Switch",
           "invert": "Invert state",
           "target_domain": "New Type"
+        },
+        "data_description": {
+          "invert": "Invert state, only supported for cover, lock and valve."
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "forecast": "[%key:component::switch_as_x::config::step::user::data::invert%]"
+        },
+        "data_description": {
+          "forecast": "[%key:component::switch_as_x::config::step::user::data_description::invert%]"
         }
       }
     }

--- a/homeassistant/components/switch_as_x/strings.json
+++ b/homeassistant/components/switch_as_x/strings.json
@@ -6,6 +6,7 @@
         "description": "Pick a switch that you want to show up in Home Assistant as a light, cover or anything else. The original switch will be hidden.",
         "data": {
           "entity_id": "Switch",
+          "invert": "Invert state",
           "target_domain": "New Type"
         }
       }

--- a/homeassistant/components/switch_as_x/valve.py
+++ b/homeassistant/components/switch_as_x/valve.py
@@ -90,7 +90,7 @@ class ValveSwitch(BaseInvertableEntity, ValveEntity):
         ):
             return
 
-        if not self._invert_state:
-            self._attr_is_closed = state.state != STATE_ON
-        else:
+        if self._invert_state:
             self._attr_is_closed = state.state == STATE_ON
+        else:
+            self._attr_is_closed = state.state != STATE_ON

--- a/homeassistant/components/switch_as_x/valve.py
+++ b/homeassistant/components/switch_as_x/valve.py
@@ -62,7 +62,7 @@ class ValveSwitch(BaseInvertableEntity, ValveEntity):
         """Open the valve."""
         await self.hass.services.async_call(
             SWITCH_DOMAIN,
-            SERVICE_TURN_ON if not self._invert_state else SERVICE_TURN_OFF,
+            SERVICE_TURN_OFF if self._invert_state else SERVICE_TURN_ON,
             {ATTR_ENTITY_ID: self._switch_entity_id},
             blocking=True,
             context=self._context,
@@ -72,7 +72,7 @@ class ValveSwitch(BaseInvertableEntity, ValveEntity):
         """Close valve."""
         await self.hass.services.async_call(
             SWITCH_DOMAIN,
-            SERVICE_TURN_OFF if not self._invert_state else SERVICE_TURN_ON,
+            SERVICE_TURN_ON if self._invert_state else SERVICE_TURN_OFF,
             {ATTR_ENTITY_ID: self._switch_entity_id},
             blocking=True,
             context=self._context,

--- a/homeassistant/components/switch_as_x/valve.py
+++ b/homeassistant/components/switch_as_x/valve.py
@@ -23,7 +23,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import EventStateChangedData
 from homeassistant.helpers.typing import EventType
 
-from .entity import BaseEntity
+from .const import CONF_INVERT
+from .entity import BaseInvertableEntity
 
 
 async def async_setup_entry(
@@ -43,6 +44,7 @@ async def async_setup_entry(
                 hass,
                 config_entry.title,
                 VALVE_DOMAIN,
+                config_entry.options[CONF_INVERT],
                 entity_id,
                 config_entry.entry_id,
             )
@@ -50,7 +52,7 @@ async def async_setup_entry(
     )
 
 
-class ValveSwitch(BaseEntity, ValveEntity):
+class ValveSwitch(BaseInvertableEntity, ValveEntity):
     """Represents a Switch as a Valve."""
 
     _attr_supported_features = ValveEntityFeature.OPEN | ValveEntityFeature.CLOSE
@@ -60,7 +62,7 @@ class ValveSwitch(BaseEntity, ValveEntity):
         """Open the valve."""
         await self.hass.services.async_call(
             SWITCH_DOMAIN,
-            SERVICE_TURN_ON,
+            SERVICE_TURN_ON if not self._invert_state else SERVICE_TURN_OFF,
             {ATTR_ENTITY_ID: self._switch_entity_id},
             blocking=True,
             context=self._context,
@@ -70,7 +72,7 @@ class ValveSwitch(BaseEntity, ValveEntity):
         """Close valve."""
         await self.hass.services.async_call(
             SWITCH_DOMAIN,
-            SERVICE_TURN_OFF,
+            SERVICE_TURN_OFF if not self._invert_state else SERVICE_TURN_ON,
             {ATTR_ENTITY_ID: self._switch_entity_id},
             blocking=True,
             context=self._context,
@@ -88,4 +90,7 @@ class ValveSwitch(BaseEntity, ValveEntity):
         ):
             return
 
-        self._attr_is_closed = state.state != STATE_ON
+        if not self._invert_state:
+            self._attr_is_closed = state.state != STATE_ON
+        else:
+            self._attr_is_closed = state.state == STATE_ON

--- a/tests/components/switch_as_x/__init__.py
+++ b/tests/components/switch_as_x/__init__.py
@@ -1,1 +1,39 @@
 """The tests for Switch as X platforms."""
+
+from homeassistant.const import (
+    STATE_CLOSED,
+    STATE_LOCKED,
+    STATE_OFF,
+    STATE_ON,
+    STATE_OPEN,
+    STATE_UNLOCKED,
+    Platform,
+)
+
+PLATFORMS_TO_TEST = (
+    Platform.COVER,
+    Platform.FAN,
+    Platform.LIGHT,
+    Platform.LOCK,
+    Platform.SIREN,
+    Platform.VALVE,
+)
+
+STATE_MAP = {
+    False: {
+        Platform.COVER: {STATE_ON: STATE_OPEN, STATE_OFF: STATE_CLOSED},
+        Platform.FAN: {STATE_ON: STATE_ON, STATE_OFF: STATE_OFF},
+        Platform.LIGHT: {STATE_ON: STATE_ON, STATE_OFF: STATE_OFF},
+        Platform.LOCK: {STATE_ON: STATE_UNLOCKED, STATE_OFF: STATE_LOCKED},
+        Platform.SIREN: {STATE_ON: STATE_ON, STATE_OFF: STATE_OFF},
+        Platform.VALVE: {STATE_ON: STATE_OPEN, STATE_OFF: STATE_CLOSED},
+    },
+    True: {
+        Platform.COVER: {STATE_ON: STATE_CLOSED, STATE_OFF: STATE_OPEN},
+        Platform.FAN: {STATE_ON: STATE_ON, STATE_OFF: STATE_OFF},
+        Platform.LIGHT: {STATE_ON: STATE_ON, STATE_OFF: STATE_OFF},
+        Platform.LOCK: {STATE_ON: STATE_LOCKED, STATE_OFF: STATE_UNLOCKED},
+        Platform.SIREN: {STATE_ON: STATE_ON, STATE_OFF: STATE_OFF},
+        Platform.VALVE: {STATE_ON: STATE_CLOSED, STATE_OFF: STATE_OPEN},
+    },
+}

--- a/tests/components/switch_as_x/test_config_flow.py
+++ b/tests/components/switch_as_x/test_config_flow.py
@@ -125,17 +125,6 @@ async def test_config_flow_registered_entity(
     assert switch_entity_entry.hidden_by == hidden_by_after
 
 
-def get_suggested(schema, key):
-    """Get suggested value for key in voluptuous schema."""
-    for k in schema:
-        if k == key:
-            if k.description is None or "suggested_value" not in k.description:
-                return None
-            return k.description["suggested_value"]
-    # Wanted key absent from schema
-    raise Exception
-
-
 @pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
 async def test_options(
     hass: HomeAssistant,
@@ -171,7 +160,8 @@ async def test_options(
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "init"
     schema = result["data_schema"].schema
-    assert get_suggested(schema, CONF_INVERT) is True
+    schema_key = next(k for k in schema if k == CONF_INVERT)
+    assert schema_key.description["suggested_value"] is True
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],

--- a/tests/components/switch_as_x/test_config_flow.py
+++ b/tests/components/switch_as_x/test_config_flow.py
@@ -6,7 +6,11 @@ from unittest.mock import AsyncMock
 import pytest
 
 from homeassistant import config_entries, data_entry_flow
-from homeassistant.components.switch_as_x.const import CONF_TARGET_DOMAIN, DOMAIN
+from homeassistant.components.switch_as_x.const import (
+    CONF_INVERT,
+    CONF_TARGET_DOMAIN,
+    DOMAIN,
+)
 from homeassistant.const import CONF_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -41,6 +45,7 @@ async def test_config_flow(
         result["flow_id"],
         {
             CONF_ENTITY_ID: "switch.ceiling",
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
     )
@@ -51,6 +56,7 @@ async def test_config_flow(
     assert result["data"] == {}
     assert result["options"] == {
         CONF_ENTITY_ID: "switch.ceiling",
+        CONF_INVERT: False,
         CONF_TARGET_DOMAIN: target_domain,
     }
     assert len(mock_setup_entry.mock_calls) == 1
@@ -59,6 +65,7 @@ async def test_config_flow(
     assert config_entry.data == {}
     assert config_entry.options == {
         CONF_ENTITY_ID: "switch.ceiling",
+        CONF_INVERT: False,
         CONF_TARGET_DOMAIN: target_domain,
     }
 
@@ -96,6 +103,7 @@ async def test_config_flow_registered_entity(
         result["flow_id"],
         {
             CONF_ENTITY_ID: "switch.ceiling",
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
     )
@@ -106,6 +114,7 @@ async def test_config_flow_registered_entity(
     assert result["data"] == {}
     assert result["options"] == {
         CONF_ENTITY_ID: "switch.ceiling",
+        CONF_INVERT: False,
         CONF_TARGET_DOMAIN: target_domain,
     }
     assert len(mock_setup_entry.mock_calls) == 1
@@ -114,6 +123,7 @@ async def test_config_flow_registered_entity(
     assert config_entry.data == {}
     assert config_entry.options == {
         CONF_ENTITY_ID: "switch.ceiling",
+        CONF_INVERT: False,
         CONF_TARGET_DOMAIN: target_domain,
     }
 

--- a/tests/components/switch_as_x/test_cover.py
+++ b/tests/components/switch_as_x/test_cover.py
@@ -1,7 +1,13 @@
 """Tests for the Switch as X Cover platform."""
+
 from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.components.switch_as_x.const import CONF_TARGET_DOMAIN, DOMAIN
+from homeassistant.components.switch_as_x.config_flow import SwitchAsXConfigFlowHandler
+from homeassistant.components.switch_as_x.const import (
+    CONF_INVERT,
+    CONF_TARGET_DOMAIN,
+    DOMAIN,
+)
 from homeassistant.const import (
     CONF_ENTITY_ID,
     SERVICE_CLOSE_COVER,
@@ -28,9 +34,12 @@ async def test_default_state(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: "switch.test",
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: Platform.COVER,
         },
         title="Garage Door",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -51,9 +60,12 @@ async def test_service_calls(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: "switch.decorative_lights",
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: Platform.COVER,
         },
         title="Title is ignored",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -120,3 +132,86 @@ async def test_service_calls(hass: HomeAssistant) -> None:
 
     assert hass.states.get("switch.decorative_lights").state == STATE_ON
     assert hass.states.get("cover.decorative_lights").state == STATE_OPEN
+
+
+async def test_service_calls_inverted(hass: HomeAssistant) -> None:
+    """Test service calls to cover."""
+    await async_setup_component(hass, "switch", {"switch": [{"platform": "demo"}]})
+    await hass.async_block_till_done()
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: "switch.decorative_lights",
+            CONF_INVERT: True,
+            CONF_TARGET_DOMAIN: Platform.COVER,
+        },
+        title="Title is ignored",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("cover.decorative_lights").state == STATE_CLOSED
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_TOGGLE,
+        {CONF_ENTITY_ID: "cover.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("cover.decorative_lights").state == STATE_OPEN
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {CONF_ENTITY_ID: "cover.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("cover.decorative_lights").state == STATE_OPEN
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_CLOSE_COVER,
+        {CONF_ENTITY_ID: "cover.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_ON
+    assert hass.states.get("cover.decorative_lights").state == STATE_CLOSED
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_ON
+    assert hass.states.get("cover.decorative_lights").state == STATE_CLOSED
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("cover.decorative_lights").state == STATE_OPEN
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TOGGLE,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_ON
+    assert hass.states.get("cover.decorative_lights").state == STATE_CLOSED

--- a/tests/components/switch_as_x/test_fan.py
+++ b/tests/components/switch_as_x/test_fan.py
@@ -1,7 +1,12 @@
 """Tests for the Switch as X Fan platform."""
 from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.components.switch_as_x.const import CONF_TARGET_DOMAIN, DOMAIN
+from homeassistant.components.switch_as_x.config_flow import SwitchAsXConfigFlowHandler
+from homeassistant.components.switch_as_x.const import (
+    CONF_INVERT,
+    CONF_TARGET_DOMAIN,
+    DOMAIN,
+)
 from homeassistant.const import (
     CONF_ENTITY_ID,
     SERVICE_TOGGLE,
@@ -24,9 +29,12 @@ async def test_default_state(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: "switch.test",
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: Platform.FAN,
         },
         title="Wind Machine",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -47,9 +55,95 @@ async def test_service_calls(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: "switch.decorative_lights",
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: Platform.FAN,
         },
         title="Title is ignored",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("fan.decorative_lights").state == STATE_ON
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_TOGGLE,
+        {CONF_ENTITY_ID: "fan.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("fan.decorative_lights").state == STATE_OFF
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_TURN_ON,
+        {CONF_ENTITY_ID: "fan.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_ON
+    assert hass.states.get("fan.decorative_lights").state == STATE_ON
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_TURN_OFF,
+        {CONF_ENTITY_ID: "fan.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("fan.decorative_lights").state == STATE_OFF
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_ON
+    assert hass.states.get("fan.decorative_lights").state == STATE_ON
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("fan.decorative_lights").state == STATE_OFF
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TOGGLE,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_ON
+    assert hass.states.get("fan.decorative_lights").state == STATE_ON
+
+
+async def test_service_calls_inverted(hass: HomeAssistant) -> None:
+    """Test service calls affecting the switch as fan entity."""
+    await async_setup_component(hass, "switch", {"switch": [{"platform": "demo"}]})
+    await hass.async_block_till_done()
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: "switch.decorative_lights",
+            CONF_INVERT: True,
+            CONF_TARGET_DOMAIN: Platform.FAN,
+        },
+        title="Title is ignored",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/switch_as_x/test_init.py
+++ b/tests/components/switch_as_x/test_init.py
@@ -6,7 +6,13 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components.homeassistant import exposed_entities
-from homeassistant.components.switch_as_x.const import CONF_TARGET_DOMAIN, DOMAIN
+from homeassistant.components.switch_as_x.config_flow import SwitchAsXConfigFlowHandler
+from homeassistant.components.switch_as_x.const import (
+    CONF_INVERT,
+    CONF_TARGET_DOMAIN,
+    DOMAIN,
+)
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     CONF_ENTITY_ID,
     STATE_CLOSED,
@@ -22,6 +28,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
+from . import PLATFORMS_TO_TEST
+
 from tests.common import MockConfigEntry
 
 EXPOSE_SETTINGS = {
@@ -29,15 +37,6 @@ EXPOSE_SETTINGS = {
     "cloud.google_assistant": False,
     "conversation": True,
 }
-
-PLATFORMS_TO_TEST = (
-    Platform.COVER,
-    Platform.FAN,
-    Platform.LIGHT,
-    Platform.LOCK,
-    Platform.SIREN,
-    Platform.VALVE,
-)
 
 
 @pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
@@ -52,9 +51,12 @@ async def test_config_entry_unregistered_uuid(
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: fake_uuid,
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
         title="ABC",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
 
     config_entry.add_to_hass(hass)
@@ -92,9 +94,12 @@ async def test_entity_registry_events(
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: registry_entry.id,
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
         title="ABC",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
 
     config_entry.add_to_hass(hass)
@@ -169,9 +174,12 @@ async def test_device_registry_config_entry_1(
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
         title="ABC",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     switch_as_x_config_entry.add_to_hass(hass)
 
@@ -224,9 +232,12 @@ async def test_device_registry_config_entry_2(
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
         title="ABC",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
 
     switch_as_x_config_entry.add_to_hass(hass)
@@ -258,9 +269,12 @@ async def test_config_entry_entity_id(
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: "switch.abc",
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
         title="ABC",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
 
     config_entry.add_to_hass(hass)
@@ -296,9 +310,12 @@ async def test_config_entry_uuid(hass: HomeAssistant, target_domain: Platform) -
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: registry_entry.id,
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
         title="ABC",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
 
     config_entry.add_to_hass(hass)
@@ -331,9 +348,12 @@ async def test_device(hass: HomeAssistant, target_domain: Platform) -> None:
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
         title="ABC",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
 
     switch_as_x_config_entry.add_to_hass(hass)
@@ -360,9 +380,12 @@ async def test_setup_and_remove_config_entry(
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: "switch.test",
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
         title="ABC",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     switch_as_x_config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(switch_as_x_config_entry.entry_id)
@@ -409,9 +432,12 @@ async def test_reset_hidden_by(
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
         title="ABC",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     switch_as_x_config_entry.add_to_hass(hass)
 
@@ -445,9 +471,12 @@ async def test_entity_category_inheritance(
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
         title="ABC",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     switch_as_x_config_entry.add_to_hass(hass)
 
@@ -481,9 +510,12 @@ async def test_entity_options(
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
         title="ABC",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     switch_as_x_config_entry.add_to_hass(hass)
 
@@ -534,9 +566,12 @@ async def test_entity_name(
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
         title="ABC",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     switch_as_x_config_entry.add_to_hass(hass)
 
@@ -592,9 +627,12 @@ async def test_custom_name_1(
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
         title="ABC",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     switch_as_x_config_entry.add_to_hass(hass)
 
@@ -656,9 +694,12 @@ async def test_custom_name_2(
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
         title="ABC",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     switch_as_x_config_entry.add_to_hass(hass)
 
@@ -719,9 +760,12 @@ async def test_import_expose_settings_1(
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
         title="ABC",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     switch_as_x_config_entry.add_to_hass(hass)
 
@@ -777,9 +821,12 @@ async def test_import_expose_settings_2(
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
         title="ABC",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     switch_as_x_config_entry.add_to_hass(hass)
 
@@ -842,9 +889,12 @@ async def test_restore_expose_settings(
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
         title="ABC",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     switch_as_x_config_entry.add_to_hass(hass)
 
@@ -871,3 +921,80 @@ async def test_restore_expose_settings(
     )
     for assistant in EXPOSE_SETTINGS:
         assert expose_settings[assistant]["should_expose"] == EXPOSE_SETTINGS[assistant]
+
+
+@pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
+async def test_migrate(
+    hass: HomeAssistant,
+    target_domain: Platform,
+) -> None:
+    """Test migration."""
+    registry = er.async_get(hass)
+
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: "switch.test",
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+        version=1,
+        minor_version=1,
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Check migration was successful and added invert option
+    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.options == {
+        CONF_ENTITY_ID: "switch.test",
+        CONF_INVERT: False,
+        CONF_TARGET_DOMAIN: target_domain,
+    }
+    assert config_entry.version == SwitchAsXConfigFlowHandler.VERSION
+    assert config_entry.minor_version == SwitchAsXConfigFlowHandler.MINOR_VERSION
+
+    # Check the state and entity registry entry are present
+    assert hass.states.get(f"{target_domain}.abc") is not None
+    assert registry.async_get(f"{target_domain}.abc") is not None
+
+
+@pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
+async def test_migrate_from_future(
+    hass: HomeAssistant,
+    target_domain: Platform,
+) -> None:
+    """Test migration."""
+    registry = er.async_get(hass)
+
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: "switch.test",
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+        version=2,
+        minor_version=1,
+    )
+    config_entry.add_to_hass(hass)
+    assert not await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Check migration was not successful and did not add invert option
+    assert config_entry.state == ConfigEntryState.MIGRATION_ERROR
+    assert config_entry.options == {
+        CONF_ENTITY_ID: "switch.test",
+        CONF_TARGET_DOMAIN: target_domain,
+    }
+    assert config_entry.version == 2
+    assert config_entry.minor_version == 1
+
+    # Check the state and entity registry entry are not present
+    assert hass.states.get(f"{target_domain}.abc") is None
+    assert registry.async_get(f"{target_domain}.abc") is None

--- a/tests/components/switch_as_x/test_init.py
+++ b/tests/components/switch_as_x/test_init.py
@@ -494,7 +494,7 @@ async def test_entity_options(
     assert entity_entry
     assert entity_entry.device_id == switch_entity_entry.device_id
     assert entity_entry.options == {
-        DOMAIN: {"entity_id": switch_entity_entry.entity_id}
+        DOMAIN: {"entity_id": switch_entity_entry.entity_id, "invert": False},
     }
 
 
@@ -550,7 +550,7 @@ async def test_entity_name(
     assert entity_entry.name is None
     assert entity_entry.original_name is None
     assert entity_entry.options == {
-        DOMAIN: {"entity_id": switch_entity_entry.entity_id}
+        DOMAIN: {"entity_id": switch_entity_entry.entity_id, "invert": False}
     }
 
 
@@ -610,7 +610,7 @@ async def test_custom_name_1(
     assert entity_entry.name == "Custom entity name"
     assert entity_entry.original_name == "Original entity name"
     assert entity_entry.options == {
-        DOMAIN: {"entity_id": switch_entity_entry.entity_id}
+        DOMAIN: {"entity_id": switch_entity_entry.entity_id, "invert": False}
     }
 
 
@@ -689,7 +689,7 @@ async def test_custom_name_2(
     assert entity_entry.name == "Old custom entity name"
     assert entity_entry.original_name == "Original entity name"
     assert entity_entry.options == {
-        DOMAIN: {"entity_id": switch_entity_entry.entity_id}
+        DOMAIN: {"entity_id": switch_entity_entry.entity_id, "invert": False}
     }
 
 

--- a/tests/components/switch_as_x/test_light.py
+++ b/tests/components/switch_as_x/test_light.py
@@ -11,7 +11,12 @@ from homeassistant.components.light import (
     ColorMode,
 )
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.components.switch_as_x.const import CONF_TARGET_DOMAIN, DOMAIN
+from homeassistant.components.switch_as_x.config_flow import SwitchAsXConfigFlowHandler
+from homeassistant.components.switch_as_x.const import (
+    CONF_INVERT,
+    CONF_TARGET_DOMAIN,
+    DOMAIN,
+)
 from homeassistant.const import (
     CONF_ENTITY_ID,
     SERVICE_TOGGLE,
@@ -34,9 +39,12 @@ async def test_default_state(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: "switch.test",
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: Platform.LIGHT,
         },
         title="Christmas Tree Lights",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -64,9 +72,12 @@ async def test_light_service_calls(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: "switch.decorative_lights",
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: Platform.LIGHT,
         },
         title="decorative_lights",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -118,9 +129,112 @@ async def test_switch_service_calls(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: "switch.decorative_lights",
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: Platform.LIGHT,
         },
         title="Title is ignored",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("light.decorative_lights").state == STATE_ON
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("light.decorative_lights").state == STATE_OFF
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_ON
+    assert hass.states.get("light.decorative_lights").state == STATE_ON
+
+
+async def test_light_service_calls_inverted(hass: HomeAssistant) -> None:
+    """Test service calls to light."""
+    await async_setup_component(hass, "switch", {"switch": [{"platform": "demo"}]})
+    await hass.async_block_till_done()
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: "switch.decorative_lights",
+            CONF_INVERT: True,
+            CONF_TARGET_DOMAIN: Platform.LIGHT,
+        },
+        title="decorative_lights",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("light.decorative_lights").state == STATE_ON
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TOGGLE,
+        {CONF_ENTITY_ID: "light.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("light.decorative_lights").state == STATE_OFF
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {CONF_ENTITY_ID: "light.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_ON
+    assert hass.states.get("light.decorative_lights").state == STATE_ON
+    assert (
+        hass.states.get("light.decorative_lights").attributes.get(ATTR_COLOR_MODE)
+        == ColorMode.ONOFF
+    )
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {CONF_ENTITY_ID: "light.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("light.decorative_lights").state == STATE_OFF
+
+
+async def test_switch_service_calls_inverted(hass: HomeAssistant) -> None:
+    """Test service calls to switch."""
+    await async_setup_component(hass, "switch", {"switch": [{"platform": "demo"}]})
+    await hass.async_block_till_done()
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: "switch.decorative_lights",
+            CONF_INVERT: True,
+            CONF_TARGET_DOMAIN: Platform.LIGHT,
+        },
+        title="Title is ignored",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/switch_as_x/test_lock.py
+++ b/tests/components/switch_as_x/test_lock.py
@@ -1,7 +1,12 @@
 """Tests for the Switch as X Lock platform."""
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.components.switch_as_x.const import CONF_TARGET_DOMAIN, DOMAIN
+from homeassistant.components.switch_as_x.config_flow import SwitchAsXConfigFlowHandler
+from homeassistant.components.switch_as_x.const import (
+    CONF_INVERT,
+    CONF_TARGET_DOMAIN,
+    DOMAIN,
+)
 from homeassistant.const import (
     CONF_ENTITY_ID,
     SERVICE_LOCK,
@@ -28,9 +33,12 @@ async def test_default_state(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: "switch.test",
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: Platform.LOCK,
         },
         title="candy_jar",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -50,9 +58,12 @@ async def test_service_calls(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: "switch.decorative_lights",
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: Platform.LOCK,
         },
         title="Title is ignored",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -109,3 +120,76 @@ async def test_service_calls(hass: HomeAssistant) -> None:
 
     assert hass.states.get("switch.decorative_lights").state == STATE_OFF
     assert hass.states.get("lock.decorative_lights").state == STATE_LOCKED
+
+
+async def test_service_calls_inverted(hass: HomeAssistant) -> None:
+    """Test service calls affecting the switch as lock entity."""
+    await async_setup_component(hass, "switch", {"switch": [{"platform": "demo"}]})
+    await hass.async_block_till_done()
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: "switch.decorative_lights",
+            CONF_INVERT: True,
+            CONF_TARGET_DOMAIN: Platform.LOCK,
+        },
+        title="Title is ignored",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("lock.decorative_lights").state == STATE_LOCKED
+
+    await hass.services.async_call(
+        LOCK_DOMAIN,
+        SERVICE_LOCK,
+        {CONF_ENTITY_ID: "lock.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_ON
+    assert hass.states.get("lock.decorative_lights").state == STATE_LOCKED
+
+    await hass.services.async_call(
+        LOCK_DOMAIN,
+        SERVICE_UNLOCK,
+        {CONF_ENTITY_ID: "lock.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("lock.decorative_lights").state == STATE_UNLOCKED
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("lock.decorative_lights").state == STATE_UNLOCKED
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_ON
+    assert hass.states.get("lock.decorative_lights").state == STATE_LOCKED
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TOGGLE,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("lock.decorative_lights").state == STATE_UNLOCKED

--- a/tests/components/switch_as_x/test_siren.py
+++ b/tests/components/switch_as_x/test_siren.py
@@ -1,7 +1,12 @@
 """Tests for the Switch as X Siren platform."""
 from homeassistant.components.siren import DOMAIN as SIREN_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.components.switch_as_x.const import CONF_TARGET_DOMAIN, DOMAIN
+from homeassistant.components.switch_as_x.config_flow import SwitchAsXConfigFlowHandler
+from homeassistant.components.switch_as_x.const import (
+    CONF_INVERT,
+    CONF_TARGET_DOMAIN,
+    DOMAIN,
+)
 from homeassistant.const import (
     CONF_ENTITY_ID,
     SERVICE_TOGGLE,
@@ -24,9 +29,12 @@ async def test_default_state(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: "switch.test",
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: Platform.SIREN,
         },
         title="Noise Maker",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -47,9 +55,95 @@ async def test_service_calls(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: "switch.decorative_lights",
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: Platform.SIREN,
         },
         title="Title is ignored",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("siren.decorative_lights").state == STATE_ON
+
+    await hass.services.async_call(
+        SIREN_DOMAIN,
+        SERVICE_TOGGLE,
+        {CONF_ENTITY_ID: "siren.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("siren.decorative_lights").state == STATE_OFF
+
+    await hass.services.async_call(
+        SIREN_DOMAIN,
+        SERVICE_TURN_ON,
+        {CONF_ENTITY_ID: "siren.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_ON
+    assert hass.states.get("siren.decorative_lights").state == STATE_ON
+
+    await hass.services.async_call(
+        SIREN_DOMAIN,
+        SERVICE_TURN_OFF,
+        {CONF_ENTITY_ID: "siren.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("siren.decorative_lights").state == STATE_OFF
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_ON
+    assert hass.states.get("siren.decorative_lights").state == STATE_ON
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("siren.decorative_lights").state == STATE_OFF
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TOGGLE,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_ON
+    assert hass.states.get("siren.decorative_lights").state == STATE_ON
+
+
+async def test_service_calls_inverted(hass: HomeAssistant) -> None:
+    """Test service calls affecting the switch as siren entity."""
+    await async_setup_component(hass, "switch", {"switch": [{"platform": "demo"}]})
+    await hass.async_block_till_done()
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: "switch.decorative_lights",
+            CONF_INVERT: True,
+            CONF_TARGET_DOMAIN: Platform.SIREN,
+        },
+        title="Title is ignored",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/switch_as_x/test_valve.py
+++ b/tests/components/switch_as_x/test_valve.py
@@ -1,6 +1,11 @@
 """Tests for the Switch as X Valve platform."""
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.components.switch_as_x.const import CONF_TARGET_DOMAIN, DOMAIN
+from homeassistant.components.switch_as_x.config_flow import SwitchAsXConfigFlowHandler
+from homeassistant.components.switch_as_x.const import (
+    CONF_INVERT,
+    CONF_TARGET_DOMAIN,
+    DOMAIN,
+)
 from homeassistant.components.valve import DOMAIN as VALVE_DOMAIN
 from homeassistant.const import (
     CONF_ENTITY_ID,
@@ -28,9 +33,12 @@ async def test_default_state(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: "switch.test",
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: Platform.VALVE,
         },
         title="Garage Door",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -51,9 +59,12 @@ async def test_service_calls(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         options={
             CONF_ENTITY_ID: "switch.decorative_lights",
+            CONF_INVERT: False,
             CONF_TARGET_DOMAIN: Platform.VALVE,
         },
         title="Title is ignored",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -120,3 +131,86 @@ async def test_service_calls(hass: HomeAssistant) -> None:
 
     assert hass.states.get("switch.decorative_lights").state == STATE_ON
     assert hass.states.get("valve.decorative_lights").state == STATE_OPEN
+
+
+async def test_service_calls_inverted(hass: HomeAssistant) -> None:
+    """Test service calls to valve."""
+    await async_setup_component(hass, "switch", {"switch": [{"platform": "demo"}]})
+    await hass.async_block_till_done()
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: "switch.decorative_lights",
+            CONF_INVERT: True,
+            CONF_TARGET_DOMAIN: Platform.VALVE,
+        },
+        title="Title is ignored",
+        version=SwitchAsXConfigFlowHandler.VERSION,
+        minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("valve.decorative_lights").state == STATE_CLOSED
+
+    await hass.services.async_call(
+        VALVE_DOMAIN,
+        SERVICE_TOGGLE,
+        {CONF_ENTITY_ID: "valve.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("valve.decorative_lights").state == STATE_OPEN
+
+    await hass.services.async_call(
+        VALVE_DOMAIN,
+        SERVICE_OPEN_VALVE,
+        {CONF_ENTITY_ID: "valve.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("valve.decorative_lights").state == STATE_OPEN
+
+    await hass.services.async_call(
+        VALVE_DOMAIN,
+        SERVICE_CLOSE_VALVE,
+        {CONF_ENTITY_ID: "valve.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_ON
+    assert hass.states.get("valve.decorative_lights").state == STATE_CLOSED
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_ON
+    assert hass.states.get("valve.decorative_lights").state == STATE_CLOSED
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("valve.decorative_lights").state == STATE_OPEN
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TOGGLE,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_ON
+    assert hass.states.get("valve.decorative_lights").state == STATE_CLOSED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add invert option to switch_as_x cover, lock and valve entities.
When the invert option is enabled, the state of the entity is reversed, as an example an inverted switch_as_x valve will be open when the switch is turned off.

Needs frontend change

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/107011
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to frontend PR: https://github.com/home-assistant/frontend/pull/19324

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
