### PR TITLE
Add ZHA metering summation received sensor

### DIFF
--- a/homeassistant/components/zha/core/cluster_handlers/smartenergy.py
+++ b/homeassistant/components/zha/core/cluster_handlers/smartenergy.py
@@ -92,6 +92,9 @@ class Metering(ClusterHandler):
         AttrReportConfig(
             attr="current_tier6_summ_delivered", config=REPORT_CONFIG_DEFAULT
         ),
+        AttrReportConfig(
+            attr="current_summ_received", config=REPORT_CONFIG_DEFAULT
+        ),
         AttrReportConfig(attr="status", config=REPORT_CONFIG_ASAP),
     )
     ZCL_INIT_ATTRS = {

--- a/homeassistant/components/zha/core/cluster_handlers/smartenergy.py
+++ b/homeassistant/components/zha/core/cluster_handlers/smartenergy.py
@@ -92,9 +92,7 @@ class Metering(ClusterHandler):
         AttrReportConfig(
             attr="current_tier6_summ_delivered", config=REPORT_CONFIG_DEFAULT
         ),
-        AttrReportConfig(
-            attr="current_summ_received", config=REPORT_CONFIG_DEFAULT
-        ),
+        AttrReportConfig(attr="current_summ_received", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="status", config=REPORT_CONFIG_ASAP),
     )
     ZCL_INIT_ATTRS = {

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -802,6 +802,19 @@ class Tier6SmartEnergySummation(PolledSmartEnergySummation):
     _attr_translation_key: str = "tier6_summation_delivered"
 
 
+@MULTI_MATCH(
+    cluster_handler_names=CLUSTER_HANDLER_SMARTENERGY_METERING,
+)
+# pylint: disable-next=hass-invalid-inheritance # needs fixing
+class SmartEnergySummationReceived(PolledSmartEnergySummation):
+    """Smart Energy Metering summation received sensor."""
+
+    _use_custom_polling = False  # Poll indirectly by PolledSmartEnergySummation
+    _attribute_name = "current_summ_received"
+    _unique_id_suffix = "summation_received"
+    _attr_translation_key: str = "summation_received"
+
+
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_PRESSURE)
 # pylint: disable-next=hass-invalid-inheritance # needs fixing
 class Pressure(Sensor):

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -831,6 +831,9 @@
       "tier6_summation_delivered": {
         "name": "Tier 6 summation delivered"
       },
+      "summation_received": {
+        "name": "Summation received"
+      },
       "device_temperature": {
         "name": "Device temperature"
       },

--- a/tests/components/zha/test_cluster_handlers.py
+++ b/tests/components/zha/test_cluster_handlers.py
@@ -235,6 +235,7 @@ async def poll_control_device(zha_device_restored, zigpy_device_mock):
                 "current_tier4_summ_delivered",
                 "current_tier5_summ_delivered",
                 "current_tier6_summ_delivered",
+                "current_summ_received",
                 "status",
             },
         ),

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -5,10 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import zigpy.profiles.zha
-import zigpy.zcl.clusters.general as general
-import zigpy.zcl.clusters.homeautomation as homeautomation
-import zigpy.zcl.clusters.measurement as measurement
-import zigpy.zcl.clusters.smartenergy as smartenergy
+from zigpy.zcl.clusters import general, homeautomation, measurement, smartenergy
 
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.zha.core.const import ZHA_CLUSTER_HANDLER_READS_PER_REQ
@@ -70,7 +67,7 @@ def sensor_platform_only():
 
 
 @pytest.fixture
-async def elec_measurement_zigpy_dev(hass, zigpy_device_mock):
+async def elec_measurement_zigpy_dev(hass: HomeAssistant, zigpy_device_mock):
     """Electric Measurement zigpy device."""
 
     zigpy_device = zigpy_device_mock(
@@ -110,19 +107,19 @@ async def elec_measurement_zha_dev(elec_measurement_zigpy_dev, zha_device_joined
     return zha_dev
 
 
-async def async_test_humidity(hass, cluster, entity_id):
+async def async_test_humidity(hass: HomeAssistant, cluster, entity_id):
     """Test humidity sensor."""
     await send_attributes_report(hass, cluster, {1: 1, 0: 1000, 2: 100})
     assert_state(hass, entity_id, "10.0", PERCENTAGE)
 
 
-async def async_test_temperature(hass, cluster, entity_id):
+async def async_test_temperature(hass: HomeAssistant, cluster, entity_id):
     """Test temperature sensor."""
     await send_attributes_report(hass, cluster, {1: 1, 0: 2900, 2: 100})
     assert_state(hass, entity_id, "29.0", UnitOfTemperature.CELSIUS)
 
 
-async def async_test_pressure(hass, cluster, entity_id):
+async def async_test_pressure(hass: HomeAssistant, cluster, entity_id):
     """Test pressure sensor."""
     await send_attributes_report(hass, cluster, {1: 1, 0: 1000, 2: 10000})
     assert_state(hass, entity_id, "1000", UnitOfPressure.HPA)
@@ -131,7 +128,7 @@ async def async_test_pressure(hass, cluster, entity_id):
     assert_state(hass, entity_id, "1000", UnitOfPressure.HPA)
 
 
-async def async_test_illuminance(hass, cluster, entity_id):
+async def async_test_illuminance(hass: HomeAssistant, cluster, entity_id):
     """Test illuminance sensor."""
     await send_attributes_report(hass, cluster, {1: 1, 0: 10, 2: 20})
     assert_state(hass, entity_id, "1", LIGHT_LUX)
@@ -143,7 +140,7 @@ async def async_test_illuminance(hass, cluster, entity_id):
     assert_state(hass, entity_id, "unknown", LIGHT_LUX)
 
 
-async def async_test_metering(hass, cluster, entity_id):
+async def async_test_metering(hass: HomeAssistant, cluster, entity_id):
     """Test Smart Energy metering sensor."""
     await send_attributes_report(hass, cluster, {1025: 1, 1024: 12345, 1026: 100})
     assert_state(hass, entity_id, "12345.0", None)
@@ -164,7 +161,9 @@ async def async_test_metering(hass, cluster, entity_id):
     assert hass.states.get(entity_id).attributes["status"] in ("<bitmap8.32: 32>", "32")
 
 
-async def async_test_smart_energy_summation_delivered(hass, cluster, entity_id):
+async def async_test_smart_energy_summation_delivered(
+    hass: HomeAssistant, cluster, entity_id
+):
     """Test SmartEnergy Summation delivered sensor."""
 
     await send_attributes_report(
@@ -179,7 +178,9 @@ async def async_test_smart_energy_summation_delivered(hass, cluster, entity_id):
     )
 
 
-async def async_test_smart_energy_summation_received(hass, cluster, entity_id):
+async def async_test_smart_energy_summation_received(
+    hass: HomeAssistant, cluster, entity_id
+):
     """Test SmartEnergy Summation received sensor."""
 
     await send_attributes_report(
@@ -194,7 +195,7 @@ async def async_test_smart_energy_summation_received(hass, cluster, entity_id):
     )
 
 
-async def async_test_electrical_measurement(hass, cluster, entity_id):
+async def async_test_electrical_measurement(hass: HomeAssistant, cluster, entity_id):
     """Test electrical measurement sensor."""
     # update divisor cached value
     await send_attributes_report(hass, cluster, {"ac_power_divisor": 1})
@@ -216,7 +217,7 @@ async def async_test_electrical_measurement(hass, cluster, entity_id):
     assert hass.states.get(entity_id).attributes["active_power_max"] == "8.8"
 
 
-async def async_test_em_apparent_power(hass, cluster, entity_id):
+async def async_test_em_apparent_power(hass: HomeAssistant, cluster, entity_id):
     """Test electrical measurement Apparent Power sensor."""
     # update divisor cached value
     await send_attributes_report(hass, cluster, {"ac_power_divisor": 1})
@@ -234,7 +235,7 @@ async def async_test_em_apparent_power(hass, cluster, entity_id):
     assert_state(hass, entity_id, "9.9", UnitOfApparentPower.VOLT_AMPERE)
 
 
-async def async_test_em_rms_current(hass, cluster, entity_id):
+async def async_test_em_rms_current(hass: HomeAssistant, cluster, entity_id):
     """Test electrical measurement RMS Current sensor."""
 
     await send_attributes_report(hass, cluster, {0: 1, 0x0508: 1234, 10: 1000})
@@ -252,7 +253,7 @@ async def async_test_em_rms_current(hass, cluster, entity_id):
     assert hass.states.get(entity_id).attributes["rms_current_max"] == "8.8"
 
 
-async def async_test_em_rms_voltage(hass, cluster, entity_id):
+async def async_test_em_rms_voltage(hass: HomeAssistant, cluster, entity_id):
     """Test electrical measurement RMS Voltage sensor."""
 
     await send_attributes_report(hass, cluster, {0: 1, 0x0505: 1234, 10: 1000})
@@ -270,7 +271,7 @@ async def async_test_em_rms_voltage(hass, cluster, entity_id):
     assert hass.states.get(entity_id).attributes["rms_voltage_max"] == "8.9"
 
 
-async def async_test_powerconfiguration(hass, cluster, entity_id):
+async def async_test_powerconfiguration(hass: HomeAssistant, cluster, entity_id):
     """Test powerconfiguration/battery sensor."""
     await send_attributes_report(hass, cluster, {33: 98})
     assert_state(hass, entity_id, "49", "%")
@@ -281,7 +282,7 @@ async def async_test_powerconfiguration(hass, cluster, entity_id):
     assert hass.states.get(entity_id).attributes["battery_voltage"] == 2.0
 
 
-async def async_test_powerconfiguration2(hass, cluster, entity_id):
+async def async_test_powerconfiguration2(hass: HomeAssistant, cluster, entity_id):
     """Test powerconfiguration/battery sensor."""
     await send_attributes_report(hass, cluster, {33: -1})
     assert_state(hass, entity_id, STATE_UNKNOWN, "%")
@@ -293,7 +294,7 @@ async def async_test_powerconfiguration2(hass, cluster, entity_id):
     assert_state(hass, entity_id, "49", "%")
 
 
-async def async_test_device_temperature(hass, cluster, entity_id):
+async def async_test_device_temperature(hass: HomeAssistant, cluster, entity_id):
     """Test temperature sensor."""
     await send_attributes_report(hass, cluster, {0: 2900})
     assert_state(hass, entity_id, "29.0", UnitOfTemperature.CELSIUS)
@@ -345,7 +346,7 @@ async def async_test_device_temperature(hass, cluster, entity_id):
             smartenergy.Metering.cluster_id,
             "instantaneous_demand",
             async_test_metering,
-            9,
+            10,
             {
                 "demand_formatting": 0xF9,
                 "divisor": 1,
@@ -359,7 +360,7 @@ async def async_test_device_temperature(hass, cluster, entity_id):
             smartenergy.Metering.cluster_id,
             "summation_delivered",
             async_test_smart_energy_summation_delivered,
-            9,
+            10,
             {
                 "demand_formatting": 0xF9,
                 "divisor": 1000,
@@ -375,7 +376,7 @@ async def async_test_device_temperature(hass, cluster, entity_id):
             smartenergy.Metering.cluster_id,
             "summation_received",
             async_test_smart_energy_summation_received,
-            9,
+            10,
             {
                 "demand_formatting": 0xF9,
                 "divisor": 1000,
@@ -507,7 +508,7 @@ async def test_sensor(
     await async_test_rejoin(hass, zigpy_device, [cluster], (report_count,))
 
 
-def assert_state(hass, entity_id, state, unit_of_measurement):
+def assert_state(hass: HomeAssistant, entity_id, state, unit_of_measurement):
     """Check that the state is what is expected.
 
     This is used to ensure that the logic in each sensor class handled the
@@ -519,7 +520,7 @@ def assert_state(hass, entity_id, state, unit_of_measurement):
 
 
 @pytest.fixture
-def hass_ms(hass):
+def hass_ms(hass: HomeAssistant):
     """Hass instance with measurement system."""
 
     async def _hass_ms(meas_sys):

--- a/tests/components/zha/zha_devices_list.py
+++ b/tests/components/zha/zha_devices_list.py
@@ -233,6 +233,11 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.centralite_3210_l_summation_delivered",
             },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_received"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
+                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
+                DEV_SIG_ENT_MAP_ID: "sensor.centralite_3210_l_summation_received",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-0-rssi"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["basic"],
                 DEV_SIG_ENT_MAP_CLASS: "RSSISensor",
@@ -569,6 +574,13 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: (
                     "sensor.climaxtechnology_psmp5_00_00_02_02tc_summation_delivered"
+                ),
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_received"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
+                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
+                DEV_SIG_ENT_MAP_ID: (
+                    "sensor.climaxtechnology_psmp5_00_00_02_02tc_summation_received"
                 ),
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-0-rssi"): {
@@ -1510,6 +1522,11 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.jasco_products_45852_summation_delivered",
             },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_received"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
+                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
+                DEV_SIG_ENT_MAP_ID: "sensor.jasco_products_45852_summation_received",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-0-rssi"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["basic"],
                 DEV_SIG_ENT_MAP_CLASS: "RSSISensor",
@@ -1565,6 +1582,11 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.jasco_products_45856_summation_delivered",
             },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_received"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
+                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
+                DEV_SIG_ENT_MAP_ID: "sensor.jasco_products_45856_summation_received",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-0-rssi"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["basic"],
                 DEV_SIG_ENT_MAP_CLASS: "RSSISensor",
@@ -1619,6 +1641,11 @@ DEVICES = [
                 DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.jasco_products_45857_summation_delivered",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_received"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
+                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
+                DEV_SIG_ENT_MAP_ID: "sensor.jasco_products_45857_summation_received",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-0-rssi"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["basic"],
@@ -2182,6 +2209,11 @@ DEVICES = [
                 DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_relay_c2acn01_summation_delivered",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_received"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
+                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
+                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_relay_c2acn01_summation_received",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-1794"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
@@ -4199,6 +4231,11 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.sercomm_corp_sz_esw01_summation_delivered",
             },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_received"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
+                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
+                DEV_SIG_ENT_MAP_ID: "sensor.sercomm_corp_sz_esw01_summation_received",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-0-rssi"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["basic"],
                 DEV_SIG_ENT_MAP_CLASS: "RSSISensor",
@@ -4955,6 +4992,11 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.sengled_e11_g13_summation_delivered",
             },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_received"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
+                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
+                DEV_SIG_ENT_MAP_ID: "sensor.sengled_e11_g13_summation_received",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-0-rssi"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["basic"],
                 DEV_SIG_ENT_MAP_CLASS: "RSSISensor",
@@ -5003,6 +5045,11 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.sengled_e12_n14_summation_delivered",
             },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_received"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
+                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
+                DEV_SIG_ENT_MAP_ID: "sensor.sengled_e12_n14_summation_received",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-0-rssi"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["basic"],
                 DEV_SIG_ENT_MAP_CLASS: "RSSISensor",
@@ -5050,6 +5097,11 @@ DEVICES = [
                 DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.sengled_z01_a19nae26_summation_delivered",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_received"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
+                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
+                DEV_SIG_ENT_MAP_ID: "sensor.sengled_z01_a19nae26_summation_received",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-0-rssi"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["basic"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Introduce a sensor for exposing the 'current_summ_received' attribute from Zigbee's Metering cluster.
This is similar in function to summation delivered, however shows energy received into the meter (i.e. exported back to the grid).

<img width="252" alt="image" src="https://github.com/home-assistant/core/assets/46714706/11f87ccf-9c62-4a18-ab02-7a9feef95b32">

This is particularly useful with the Energy dashboard for configuring a 'Return to grid' sensor:

<img width="309" alt="image" src="https://github.com/home-assistant/core/assets/46714706/a3d408d7-6843-42d2-ac39-b1a76eadae84">

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
