### PR TITLE
Remove deprecated YAML support from OpenSky

### DIFF
--- a/homeassistant/components/opensky/config_flow.py
+++ b/homeassistant/components/opensky/config_flow.py
@@ -25,10 +25,14 @@ from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_CONTRIBUTING_USER, DEFAULT_NAME, DOMAIN
-from .sensor import CONF_ALTITUDE, DEFAULT_ALTITUDE
+from .const import (
+    CONF_ALTITUDE,
+    CONF_CONTRIBUTING_USER,
+    DEFAULT_ALTITUDE,
+    DEFAULT_NAME,
+    DOMAIN,
+)
 
 
 class OpenSkyConfigFlowHandler(ConfigFlow, domain=DOMAIN):
@@ -75,24 +79,6 @@ class OpenSkyConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                     CONF_ALTITUDE: DEFAULT_ALTITUDE,
                 },
             ),
-        )
-
-    async def async_step_import(self, import_config: ConfigType) -> FlowResult:
-        """Import config from yaml."""
-        entry_data = {
-            CONF_LATITUDE: import_config.get(CONF_LATITUDE, self.hass.config.latitude),
-            CONF_LONGITUDE: import_config.get(
-                CONF_LONGITUDE, self.hass.config.longitude
-            ),
-        }
-        self._async_abort_entries_match(entry_data)
-        return self.async_create_entry(
-            title=import_config.get(CONF_NAME, DEFAULT_NAME),
-            data=entry_data,
-            options={
-                CONF_RADIUS: import_config[CONF_RADIUS] * 1000,
-                CONF_ALTITUDE: import_config.get(CONF_ALTITUDE, DEFAULT_ALTITUDE),
-            },
         )
 
 

--- a/homeassistant/components/opensky/sensor.py
+++ b/homeassistant/components/opensky/sensor.py
@@ -1,65 +1,15 @@
 """Sensor for the Open Sky Network."""
 from __future__ import annotations
 
-import voluptuous as vol
-
-from homeassistant.components.sensor import (
-    PLATFORM_SCHEMA,
-    SensorEntity,
-    SensorStateClass,
-)
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME, CONF_RADIUS
-from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
-import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CONF_ALTITUDE, DEFAULT_ALTITUDE, DOMAIN, MANUFACTURER
+from .const import DOMAIN, MANUFACTURER
 from .coordinator import OpenSkyDataUpdateCoordinator
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_RADIUS): vol.Coerce(float),
-        vol.Optional(CONF_NAME): cv.string,
-        vol.Inclusive(CONF_LATITUDE, "coordinates"): cv.latitude,
-        vol.Inclusive(CONF_LONGITUDE, "coordinates"): cv.longitude,
-        vol.Optional(CONF_ALTITUDE, default=DEFAULT_ALTITUDE): vol.Coerce(float),
-    }
-)
-
-
-async def async_setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the OpenSky sensor platform from yaml."""
-
-    async_create_issue(
-        hass,
-        HOMEASSISTANT_DOMAIN,
-        f"deprecated_yaml_{DOMAIN}",
-        breaks_in_ha_version="2024.1.0",
-        is_fixable=False,
-        issue_domain=DOMAIN,
-        severity=IssueSeverity.WARNING,
-        translation_key="deprecated_yaml",
-        translation_placeholders={
-            "domain": DOMAIN,
-            "integration_title": "OpenSky",
-        },
-    )
-
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
-        )
-    )
 
 
 async def async_setup_entry(

--- a/tests/components/opensky/test_config_flow.py
+++ b/tests/components/opensky/test_config_flow.py
@@ -9,14 +9,12 @@ from homeassistant import data_entry_flow
 from homeassistant.components.opensky.const import (
     CONF_ALTITUDE,
     CONF_CONTRIBUTING_USER,
-    DEFAULT_NAME,
     DOMAIN,
 )
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import (
     CONF_LATITUDE,
     CONF_LONGITUDE,
-    CONF_NAME,
     CONF_PASSWORD,
     CONF_RADIUS,
     CONF_USERNAME,
@@ -57,114 +55,6 @@ async def test_full_user_flow(hass: HomeAssistant) -> None:
             CONF_ALTITUDE: 0.0,
             CONF_RADIUS: 10.0,
         }
-
-
-@pytest.mark.parametrize(
-    ("config", "title", "data", "options"),
-    [
-        (
-            {CONF_RADIUS: 10.0},
-            DEFAULT_NAME,
-            {
-                CONF_LATITUDE: 32.87336,
-                CONF_LONGITUDE: -117.22743,
-            },
-            {
-                CONF_RADIUS: 10000.0,
-                CONF_ALTITUDE: 0,
-            },
-        ),
-        (
-            {
-                CONF_RADIUS: 10.0,
-                CONF_NAME: "My home",
-            },
-            "My home",
-            {
-                CONF_LATITUDE: 32.87336,
-                CONF_LONGITUDE: -117.22743,
-            },
-            {
-                CONF_RADIUS: 10000.0,
-                CONF_ALTITUDE: 0,
-            },
-        ),
-        (
-            {
-                CONF_RADIUS: 10.0,
-                CONF_LATITUDE: 10.0,
-                CONF_LONGITUDE: -100.0,
-            },
-            DEFAULT_NAME,
-            {
-                CONF_LATITUDE: 10.0,
-                CONF_LONGITUDE: -100.0,
-            },
-            {
-                CONF_RADIUS: 10000.0,
-                CONF_ALTITUDE: 0,
-            },
-        ),
-        (
-            {CONF_RADIUS: 10.0, CONF_ALTITUDE: 100.0},
-            DEFAULT_NAME,
-            {
-                CONF_LATITUDE: 32.87336,
-                CONF_LONGITUDE: -117.22743,
-            },
-            {
-                CONF_RADIUS: 10000.0,
-                CONF_ALTITUDE: 100.0,
-            },
-        ),
-    ],
-)
-async def test_import_flow(
-    hass: HomeAssistant,
-    config: dict[str, Any],
-    title: str,
-    data: dict[str, Any],
-    options: dict[str, Any],
-) -> None:
-    """Test the import flow."""
-    with patch_setup_entry():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
-        )
-        await hass.async_block_till_done()
-        assert result["type"] == FlowResultType.CREATE_ENTRY
-        assert result["title"] == title
-        assert result["options"] == options
-        assert result["data"] == data
-
-
-async def test_importing_already_exists_flow(hass: HomeAssistant) -> None:
-    """Test the import flow when same location already exists."""
-    MockConfigEntry(
-        domain=DOMAIN,
-        title=DEFAULT_NAME,
-        data={},
-        options={
-            CONF_LATITUDE: 32.87336,
-            CONF_LONGITUDE: -117.22743,
-            CONF_RADIUS: 10.0,
-            CONF_ALTITUDE: 100.0,
-        },
-    ).add_to_hass(hass)
-    with patch_setup_entry():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data={
-                CONF_LATITUDE: 32.87336,
-                CONF_LONGITUDE: -117.22743,
-                CONF_RADIUS: 10.0,
-                CONF_ALTITUDE: 100.0,
-            },
-        )
-        await hass.async_block_till_done()
-        assert result["type"] == FlowResultType.ABORT
-        assert result["reason"] == "already_configured"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/opensky/test_sensor.py
+++ b/tests/components/opensky/test_sensor.py
@@ -6,37 +6,15 @@ from freezegun.api import FrozenDateTimeFactory
 from syrupy import SnapshotAssertion
 
 from homeassistant.components.opensky.const import (
-    DOMAIN,
     EVENT_OPENSKY_ENTRY,
     EVENT_OPENSKY_EXIT,
 )
-from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_PLATFORM, CONF_RADIUS, Platform
 from homeassistant.core import Event, HomeAssistant
-from homeassistant.helpers import issue_registry as ir
-from homeassistant.setup import async_setup_component
 
 from . import get_states_response_fixture
 from .conftest import ComponentSetup
 
 from tests.common import MockConfigEntry, async_fire_time_changed
-
-LEGACY_CONFIG = {Platform.SENSOR: [{CONF_PLATFORM: DOMAIN, CONF_RADIUS: 10.0}]}
-
-
-async def test_legacy_migration(hass: HomeAssistant) -> None:
-    """Test migration from yaml to config flow."""
-    with patch(
-        "python_opensky.OpenSky.get_states",
-        return_value=get_states_response_fixture("opensky/states.json"),
-    ):
-        assert await async_setup_component(hass, Platform.SENSOR, LEGACY_CONFIG)
-        await hass.async_block_till_done()
-        entries = hass.config_entries.async_entries(DOMAIN)
-        assert len(entries) == 1
-        assert entries[0].state is ConfigEntryState.LOADED
-        issue_registry = ir.async_get(hass)
-        assert len(issue_registry.issues) == 1
 
 
 async def test_sensor(


### PR DESCRIPTION
## Breaking change
The YAML configuration was deprecated in release 2022.8. Support for it has now been completely removed. If you still have `opensky` in your YAML configuration, you should remove it completely.

## Proposed change
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
