### PR TITLE
Add absolute() template function

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1666,9 +1666,7 @@ def multiply(value, amount, default=_SENTINEL):
 def absolute(value, default=_SENTINEL):
     """Filter and function to get absolute value."""
     try:
-        # abs() is defined for integers, floating point values,
-        # and complex numbers. Other types will raise a TyperError.
-        return abs(value)
+        return abs(float(value))
     except (ValueError, TypeError):
         if default is _SENTINEL:
             raise_no_default("abs", value)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -158,7 +158,7 @@ ORJSON_PASSTHROUGH_OPTIONS = (
 
 def _template_state_no_collect(hass: HomeAssistant, state: State) -> TemplateState:
     """Return a TemplateState for a state without collecting."""
-    template_state: TemplateState = CACHED_TEMPLATE_NO_COLLECT_LRU.get(state)
+    template_state: TemplateState | None = CACHED_TEMPLATE_NO_COLLECT_LRU.get(state)
     if template_state:
         return template_state
     template_state = _create_template_state_no_collect(hass, state)
@@ -168,7 +168,7 @@ def _template_state_no_collect(hass: HomeAssistant, state: State) -> TemplateSta
 
 def _template_state(hass: HomeAssistant, state: State) -> TemplateState:
     """Return a TemplateState for a state that collects."""
-    template_state: TemplateState = CACHED_TEMPLATE_LRU.get(state)
+    template_state: TemplateState | None = CACHED_TEMPLATE_LRU.get(state)
     if template_state:
         return template_state
     template_state = TemplateState(hass, state)

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -718,7 +718,15 @@ def test_multiply(hass: HomeAssistant) -> None:
 
 def test_absolute(hass: HomeAssistant) -> None:
     """Test absolute."""
-    tests = [(5, 5), (0, 0), (-5, 5), (5.0, 5.0), (0.0, 0.0), (-5.0, 5.0)]
+    tests = [
+        (5, 5),
+        (0, 0),
+        (-5, 5),
+        (5.0, 5.0),
+        (0.0, 0.0),
+        (-5.0, 5.0),
+        ("-5.0", 5.0),
+    ]
 
     for value, expected in tests:
         assert (

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -744,6 +744,8 @@ def test_absolute(hass: HomeAssistant) -> None:
         template.Template("{{ invalid | abs }}", hass).async_render()
     with pytest.raises(TemplateError):
         template.Template("{{ abs(invalid) }}", hass).async_render()
+    with pytest.raises(TemplateError, match="no default was specified"):
+        render(hass, "{{ 'no_number' | abs }}")
 
     # Test handling of default return value
     assert render(hass, "{{ 'no_number' | abs(1) }}") == 1

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -716,6 +716,36 @@ def test_multiply(hass: HomeAssistant) -> None:
     assert render(hass, "{{ 'no_number' | multiply(10, default=1) }}") == 1
 
 
+def test_absolute(hass: HomeAssistant) -> None:
+    """Test absolute."""
+    tests = [(5, 5), (0, 0), (-5, 5), (5.0, 5.0), (0.0, 0.0), (-5.0, 5.0)]
+
+    for value, expected in tests:
+        assert (
+            template.Template(f"{{{{ {value} | abs }}}}", hass).async_render()
+            == expected
+        )
+
+        assert (
+            template.Template(f"{{{{ abs({value}) }}}}", hass).async_render()
+            == expected
+        )
+
+    # Test handling of invalid input
+    with pytest.raises(TemplateError):
+        template.Template("{{ invalid | abs }}", hass).async_render()
+    with pytest.raises(TemplateError):
+        template.Template("{{ abs(invalid) }}", hass).async_render()
+
+    # Test handling of default return value
+    assert render(hass, "{{ 'no_number' | abs(1) }}") == 1
+    assert render(hass, "{{ 'no_number' | abs(default=1) }}") == 1
+    assert render(hass, "{{ abs('no_number', 1) }}") == 1
+    assert render(hass, "{{ abs('no_number', default=1) }}") == 1
+    assert render(hass, "{{ abs(5, 1) }}") == 5
+    assert render(hass, "{{ abs(5, default=1) }}") == 5
+
+
 def test_logarithm(hass: HomeAssistant) -> None:
     """Test logarithm."""
     tests = [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
N/A

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `absolute()` template filter and function.

The additional changes on lines 43, 161 and 171 are necessary to make `pylint` and
`mypy` pass. They are not related to my change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30735

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
