### PR TITLE
Fix Tado unique mobile device dispatcher

### DIFF
--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -245,8 +245,9 @@ class TadoConnector:
             _LOGGER.debug("No linked devices found for home ID %s", self.home_id)
             return
 
-        # Make request at PyTado the library should fix it, so this can be removed
-        if "errors" in devices and len(devices["errors"]) > 0:
+        # Errors are planned to be converted to exceptions
+        # in PyTado library, so this can be removed
+        if "errors" in devices and devices["errors"]:
             _LOGGER.error(
                 "Error for home ID %s while updating devices: %s",
                 self.home_id,

--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -209,6 +209,7 @@ class TadoConnector:
             _LOGGER.debug("No linked mobile devices found for home ID %s", self.home_id)
             return
 
+        # Make request at PyTado the library should fix it, so this can be removed
         if "errors" in mobile_devices and len(mobile_devices["errors"]) > 0:
             _LOGGER.error(
                 "Error for home ID %s while updating mobile devices: %s",
@@ -243,6 +244,7 @@ class TadoConnector:
             _LOGGER.debug("No linked devices found for home ID %s", self.home_id)
             return
 
+        # Make request at PyTado the library should fix it, so this can be removed
         if "errors" in devices and len(devices["errors"]) > 0:
             _LOGGER.error(
                 "Error for home ID %s while updating devices: %s",

--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -226,10 +226,11 @@ class TadoConnector:
                 self.home_id,
                 mobile_device,
             )
-            dispatcher_send(
-                self.hass,
-                SIGNAL_TADO_MOBILE_DEVICE_UPDATE_RECEIVED.format(self.home_id),
-            )
+
+        dispatcher_send(
+            self.hass,
+            SIGNAL_TADO_MOBILE_DEVICE_UPDATE_RECEIVED.format(self.home_id),
+        )
 
         dispatcher_send(self.hass, SIGNAL_TADO_MOBILE_DEVICES_UPDATE)
 

--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -195,6 +195,7 @@ class TadoConnector:
     def update(self):
         """Update the registered zones."""
         self.update_devices()
+        self.update_mobile_devices()
         self.update_zones()
         self.update_home()
 

--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -27,7 +27,6 @@ from .const import (
     INSIDE_TEMPERATURE_MEASUREMENT,
     PRESET_AUTO,
     SIGNAL_TADO_MOBILE_DEVICE_UPDATE_RECEIVED,
-    SIGNAL_TADO_MOBILE_DEVICES_UPDATE,
     SIGNAL_TADO_UPDATE_RECEIVED,
     TEMP_OFFSET,
     UPDATE_LISTENER,
@@ -231,8 +230,6 @@ class TadoConnector:
             self.hass,
             SIGNAL_TADO_MOBILE_DEVICE_UPDATE_RECEIVED.format(self.home_id),
         )
-
-        dispatcher_send(self.hass, SIGNAL_TADO_MOBILE_DEVICES_UPDATE)
 
     def update_devices(self):
         """Update the device data from Tado."""

--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -204,7 +204,7 @@ class TadoConnector:
             _LOGGER.error("Unable to connect to Tado while updating mobile devices")
             return
 
-        if len(mobile_devices) == 0:
+        if not mobile_devices:
             _LOGGER.debug("No linked mobile devices found for home ID %s", self.home_id)
             return
 
@@ -239,7 +239,7 @@ class TadoConnector:
             _LOGGER.error("Unable to connect to Tado while updating devices")
             return
 
-        if len(devices) == 0:
+        if not devices:
             _LOGGER.debug("No linked devices found for home ID %s", self.home_id)
             return
 

--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -210,7 +210,7 @@ class TadoConnector:
             return
 
         # Make request at PyTado the library should fix it, so this can be removed
-        if "errors" in mobile_devices and len(mobile_devices["errors"]) > 0:
+        if "errors" in mobile_devices and mobile_devices["errors"]:
             _LOGGER.error(
                 "Error for home ID %s while updating mobile devices: %s",
                 self.home_id,

--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -213,6 +213,14 @@ class TadoConnector:
             )
             return
 
+        if mobile_devices.get("errors"):
+            _LOGGER.error(
+                "Error for home ID %s while updating mobile devices: %s",
+                self.home_id,
+                mobile_devices["errors"],
+            )
+            return
+
         for mobile_device in mobile_devices:
             self.data["mobile_device"][mobile_device["id"]] = mobile_device
             _LOGGER.debug(
@@ -239,6 +247,14 @@ class TadoConnector:
 
         if len(devices) == 0:
             _LOGGER.warning("No linked devices found for home ID %s", self.home_id)
+            return
+
+        if devices.get("errors"):
+            _LOGGER.error(
+                "Error for home ID %s while updating devices: %s",
+                self.home_id,
+                devices["errors"],
+            )
             return
 
         for device in devices:

--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -162,7 +162,6 @@ class TadoConnector:
         self.tado = None
         self.zones = None
         self.devices = None
-        self.mobile_devices = None
         self.data = {
             "device": {},
             "mobile_device": {},
@@ -182,7 +181,6 @@ class TadoConnector:
         # Load zones and devices
         self.zones = self.tado.get_zones()
         self.devices = self.tado.get_devices()
-        self.mobile_devices = self.tado.get_mobile_devices()
         tado_home = self.tado.get_me()["homes"][0]
         self.home_id = tado_home["id"]
         self.home_name = tado_home["name"]
@@ -208,9 +206,7 @@ class TadoConnector:
             return
 
         if len(mobile_devices) == 0:
-            _LOGGER.warning(
-                "No linked mobile devices found for home ID %s", self.home_id
-            )
+            _LOGGER.debug("No linked mobile devices found for home ID %s", self.home_id)
             return
 
         if "errors" in mobile_devices and len(mobile_devices["errors"]) > 0:
@@ -230,9 +226,7 @@ class TadoConnector:
             )
             dispatcher_send(
                 self.hass,
-                SIGNAL_TADO_MOBILE_DEVICE_UPDATE_RECEIVED.format(
-                    self.home_id, mobile_device["id"]
-                ),
+                SIGNAL_TADO_MOBILE_DEVICE_UPDATE_RECEIVED.format(self.home_id),
             )
 
         dispatcher_send(self.hass, SIGNAL_TADO_MOBILE_DEVICES_UPDATE)
@@ -246,7 +240,7 @@ class TadoConnector:
             return
 
         if len(devices) == 0:
-            _LOGGER.warning("No linked devices found for home ID %s", self.home_id)
+            _LOGGER.debug("No linked devices found for home ID %s", self.home_id)
             return
 
         if "errors" in devices and len(devices["errors"]) > 0:

--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -213,7 +213,7 @@ class TadoConnector:
             )
             return
 
-        if mobile_devices.get("errors"):
+        if "errors" in mobile_devices and len(mobile_devices["errors"]) > 0:
             _LOGGER.error(
                 "Error for home ID %s while updating mobile devices: %s",
                 self.home_id,
@@ -249,7 +249,7 @@ class TadoConnector:
             _LOGGER.warning("No linked devices found for home ID %s", self.home_id)
             return
 
-        if devices.get("errors"):
+        if "errors" in devices and len(devices["errors"]) > 0:
             _LOGGER.error(
                 "Error for home ID %s while updating devices: %s",
                 self.home_id,

--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -209,7 +209,8 @@ class TadoConnector:
             _LOGGER.debug("No linked mobile devices found for home ID %s", self.home_id)
             return
 
-        # Make request at PyTado the library should fix it, so this can be removed
+        # Errors are planned to be converted to exceptions
+        # in PyTado library, so this can be removed
         if "errors" in mobile_devices and mobile_devices["errors"]:
             _LOGGER.error(
                 "Error for home ID %s while updating mobile devices: %s",

--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -207,6 +207,12 @@ class TadoConnector:
             _LOGGER.error("Unable to connect to Tado while updating mobile devices")
             return
 
+        if len(mobile_devices) == 0:
+            _LOGGER.warning(
+                "No linked mobile devices found for home ID %s", self.home_id
+            )
+            return
+
         for mobile_device in mobile_devices:
             self.data["mobile_device"][mobile_device["id"]] = mobile_device
             _LOGGER.debug(
@@ -229,6 +235,10 @@ class TadoConnector:
             devices = self.tado.get_devices()
         except RuntimeError:
             _LOGGER.error("Unable to connect to Tado while updating devices")
+            return
+
+        if len(devices) == 0:
+            _LOGGER.warning("No linked devices found for home ID %s", self.home_id)
             return
 
         for device in devices:

--- a/homeassistant/components/tado/const.py
+++ b/homeassistant/components/tado/const.py
@@ -180,7 +180,6 @@ DOMAIN = "tado"
 
 SIGNAL_TADO_UPDATE_RECEIVED = "tado_update_received_{}_{}_{}"
 SIGNAL_TADO_MOBILE_DEVICE_UPDATE_RECEIVED = "tado_mobile_device_update_received_{}"
-SIGNAL_TADO_MOBILE_DEVICES_UPDATE = "tado_mobile_devices_update"
 UNIQUE_ID = "unique_id"
 
 DEFAULT_NAME = "Tado"

--- a/homeassistant/components/tado/const.py
+++ b/homeassistant/components/tado/const.py
@@ -179,7 +179,8 @@ TADO_TO_HA_SWING_MODE_MAP = {
 DOMAIN = "tado"
 
 SIGNAL_TADO_UPDATE_RECEIVED = "tado_update_received_{}_{}_{}"
-SIGNAL_TADO_MOBILE_DEVICE_UPDATE_RECEIVED = "tado_mobile_device_update_received"
+SIGNAL_TADO_MOBILE_DEVICE_UPDATE_RECEIVED = "tado_mobile_device_update_received_{}_{}"
+SIGNAL_TADO_MOBILE_DEVICES_UPDATE = "tao_mobile_devices_update"
 UNIQUE_ID = "unique_id"
 
 DEFAULT_NAME = "Tado"

--- a/homeassistant/components/tado/const.py
+++ b/homeassistant/components/tado/const.py
@@ -180,7 +180,7 @@ DOMAIN = "tado"
 
 SIGNAL_TADO_UPDATE_RECEIVED = "tado_update_received_{}_{}_{}"
 SIGNAL_TADO_MOBILE_DEVICE_UPDATE_RECEIVED = "tado_mobile_device_update_received_{}"
-SIGNAL_TADO_MOBILE_DEVICES_UPDATE = "tao_mobile_devices_update"
+SIGNAL_TADO_MOBILE_DEVICES_UPDATE = "tado_mobile_devices_update"
 UNIQUE_ID = "unique_id"
 
 DEFAULT_NAME = "Tado"

--- a/homeassistant/components/tado/const.py
+++ b/homeassistant/components/tado/const.py
@@ -179,7 +179,7 @@ TADO_TO_HA_SWING_MODE_MAP = {
 DOMAIN = "tado"
 
 SIGNAL_TADO_UPDATE_RECEIVED = "tado_update_received_{}_{}_{}"
-SIGNAL_TADO_MOBILE_DEVICE_UPDATE_RECEIVED = "tado_mobile_device_update_received_{}_{}"
+SIGNAL_TADO_MOBILE_DEVICE_UPDATE_RECEIVED = "tado_mobile_device_update_received_{}"
 SIGNAL_TADO_MOBILE_DEVICES_UPDATE = "tao_mobile_devices_update"
 UNIQUE_ID = "unique_id"
 

--- a/homeassistant/components/tado/device_tracker.py
+++ b/homeassistant/components/tado/device_tracker.py
@@ -22,13 +22,7 @@ from homeassistant.helpers.issue_registry import IssueSeverity, async_create_iss
 from homeassistant.helpers.typing import ConfigType
 
 from . import TadoConnector
-from .const import (
-    CONF_HOME_ID,
-    DATA,
-    DOMAIN,
-    SIGNAL_TADO_MOBILE_DEVICE_UPDATE_RECEIVED,
-    SIGNAL_TADO_MOBILE_DEVICES_UPDATE,
-)
+from .const import CONF_HOME_ID, DATA, DOMAIN, SIGNAL_TADO_MOBILE_DEVICE_UPDATE_RECEIVED
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -96,7 +90,7 @@ async def async_setup_entry(
     entry.async_on_unload(
         async_dispatcher_connect(
             hass,
-            SIGNAL_TADO_MOBILE_DEVICES_UPDATE,
+            SIGNAL_TADO_MOBILE_DEVICE_UPDATE_RECEIVED.format(tado.home_id),
             update_devices,
         )
     )

--- a/homeassistant/components/tado/device_tracker.py
+++ b/homeassistant/components/tado/device_tracker.py
@@ -175,9 +175,7 @@ class TadoDeviceTrackerEntity(TrackerEntity):
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,
-                SIGNAL_TADO_MOBILE_DEVICE_UPDATE_RECEIVED.format(
-                    self._tado.home_id, self._device_id
-                ),
+                SIGNAL_TADO_MOBILE_DEVICE_UPDATE_RECEIVED.format(self._tado.home_id),
                 self.on_demand_update,
             )
         )

--- a/tests/components/tado/fixtures/mobile_devices.json
+++ b/tests/components/tado/fixtures/mobile_devices.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "Home",
+    "id": 123456,
+    "settings": {
+      "geoTrackingEnabled": false,
+      "specialOffersEnabled": false,
+      "onDemandLogRetrievalEnabled": false,
+      "pushNotifications": {
+        "lowBatteryReminder": true,
+        "awayModeReminder": true,
+        "homeModeReminder": true,
+        "openWindowReminder": true,
+        "energySavingsReportReminder": true,
+        "incidentDetection": true,
+        "energyIqReminder": false
+      }
+    },
+    "deviceMetadata": {
+      "platform": "Android",
+      "osVersion": "14",
+      "model": "Samsung",
+      "locale": "nl"
+    }
+  }
+]

--- a/tests/components/tado/util.py
+++ b/tests/components/tado/util.py
@@ -17,6 +17,7 @@ async def async_init_integration(
 
     token_fixture = "tado/token.json"
     devices_fixture = "tado/devices.json"
+    mobile_devices_fixture = "tado/mobile_devices.json"
     me_fixture = "tado/me.json"
     weather_fixture = "tado/weather.json"
     home_state_fixture = "tado/home_state.json"
@@ -69,6 +70,10 @@ async def async_init_integration(
         m.get(
             "https://my.tado.com/api/v2/homes/1/devices",
             text=load_fixture(devices_fixture),
+        )
+        m.get(
+            "https://my.tado.com/api/v2/homes/1/mobileDevices",
+            text=load_fixture(mobile_devices_fixture),
         )
         m.get(
             "https://my.tado.com/api/v2/devices/WR1/",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a unique dispatcher per mobile device, instead of running it on the generic dispatcher. This caused issues when users have multiple homes and multiple installations running on one HA installation.
Having an unique dispatcher per mobile device, based on the underlying home ID, will prevent a too generic dispatcher for all mobile devices. The generic dispatcher would load only the mobile devices known per home, and missed the mobile devices linked to a different entry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #107544, fixes #105890 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
