### PR TITLE
Raise ValueError if unit of measurement or state class is not valid for device classes

### DIFF
--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -129,28 +129,6 @@ async def test_temperature_conversion(
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == state_unit
 
 
-@pytest.mark.parametrize("device_class", [None, SensorDeviceClass.PRESSURE])
-async def test_temperature_conversion_wrong_device_class(
-    hass: HomeAssistant, device_class
-) -> None:
-    """Test temperatures are not converted if the sensor has wrong device class."""
-    entity0 = MockSensor(
-        name="Test",
-        native_value="0.0",
-        native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT,
-        device_class=device_class,
-    )
-    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
-
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
-    await hass.async_block_till_done()
-
-    # Check temperature is not converted
-    state = hass.states.get(entity0.entity_id)
-    assert state.state == "0.0"
-    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfTemperature.FAHRENHEIT
-
-
 @pytest.mark.parametrize("state_class", ["measurement", "total_increasing"])
 async def test_deprecated_last_reset(
     hass: HomeAssistant,

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -734,7 +734,7 @@ async def test_custom_unit(
             1.0,
             "1.0",
             "1.0",
-            SensorDeviceClass.POWER_FACTOR,
+            None,
         ),
         # Pressure
         # Smaller to larger unit, InHg is ~33x larger than hPa -> 1 more decimal


### PR DESCRIPTION
## Breaking change
It is no longer possible to use an invalid unit of measurement and/or status class in conjunction with a device class. Invalid use now results in an error instead of a warning.

## Proposed change
In December 2022, we introduced a validation for the unit of measurement (https://github.com/home-assistant/core/pull/84366) and for the state class (https://github.com/home-assistant/core/pull/84402), which checks whether the use is possible taking into account the device class. Since this only logged a warning, I think that now, one year later, it would be time to raise a "ValueError" (not mentioning the comment saying that this should have been done in 2023.6 :) ).

Removed the `test_temperature_conversion_wrong_device_class` test, as this should not be possible anymore.
Also need to change one of the device classes for the `test_custom_unit_change` test.

Do we need a post on the developer blog for this? 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
