### PR TITLE
Fix ZHA handling of power factor ElectricalMeasurement attribute sensor

### DIFF
--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -342,7 +342,7 @@ class ElectricalMeasurement(PollableSensor):
 
     def formatter(self, value: int) -> int | float:
         """Return 'normalized' value."""
-        if self._div_mul_prefix != None:
+        if self._div_mul_prefix:
             multiplier = getattr(
                 self._cluster_handler, f"{self._div_mul_prefix}_multiplier"
             )

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -342,12 +342,16 @@ class ElectricalMeasurement(PollableSensor):
 
     def formatter(self, value: int) -> int | float:
         """Return 'normalized' value."""
-        multiplier = getattr(
-            self._cluster_handler, f"{self._div_mul_prefix}_multiplier", self._multiplier
-        )
-        divisor = getattr(
-            self._cluster_handler, f"{self._div_mul_prefix}_divisor", self._divisor
-        )
+        if _div_mul_prefix != None:
+            multiplier = getattr(
+                self._cluster_handler, f"{self._div_mul_prefix}_multiplier"
+            )
+            divisor = getattr(
+                self._cluster_handler, f"{self._div_mul_prefix}_divisor"
+            )
+        else:
+            multiplier = self._multiplier
+            divisor = self._divisor
         value = float(value * multiplier) / divisor
         if value < 100 and divisor > 1:
             return round(value, self._decimals)

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -342,7 +342,7 @@ class ElectricalMeasurement(PollableSensor):
 
     def formatter(self, value: int) -> int | float:
         """Return 'normalized' value."""
-        if _div_mul_prefix != None:
+        if self._div_mul_prefix != None:
             multiplier = getattr(
                 self._cluster_handler, f"{self._div_mul_prefix}_multiplier"
             )

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -7,7 +7,7 @@ import enum
 import functools
 import numbers
 import random
-from typing import TYPE_CHECKING, Any, Self, Union
+from typing import TYPE_CHECKING, Any, Self
 
 from zigpy import types
 
@@ -319,7 +319,7 @@ class ElectricalMeasurement(PollableSensor):
     _attr_device_class: SensorDeviceClass = SensorDeviceClass.POWER
     _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement: str = UnitOfPower.WATT
-    _div_mul_prefix: Union[str, None] = "ac_power"
+    _div_mul_prefix: str | None = "ac_power"
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -7,7 +7,7 @@ import enum
 import functools
 import numbers
 import random
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any, Self, Union
 
 from zigpy import types
 
@@ -319,7 +319,7 @@ class ElectricalMeasurement(PollableSensor):
     _attr_device_class: SensorDeviceClass = SensorDeviceClass.POWER
     _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement: str = UnitOfPower.WATT
-    _div_mul_prefix = "ac_power"
+    _div_mul_prefix: Union[str, None] = "ac_power"
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -346,9 +346,7 @@ class ElectricalMeasurement(PollableSensor):
             multiplier = getattr(
                 self._cluster_handler, f"{self._div_mul_prefix}_multiplier"
             )
-            divisor = getattr(
-                self._cluster_handler, f"{self._div_mul_prefix}_divisor"
-            )
+            divisor = getattr(self._cluster_handler, f"{self._div_mul_prefix}_divisor")
         else:
             multiplier = self._multiplier
             divisor = self._divisor

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -343,9 +343,11 @@ class ElectricalMeasurement(PollableSensor):
     def formatter(self, value: int) -> int | float:
         """Return 'normalized' value."""
         multiplier = getattr(
-            self._cluster_handler, f"{self._div_mul_prefix}_multiplier"
+            self._cluster_handler, f"{self._div_mul_prefix}_multiplier", self._multiplier
         )
-        divisor = getattr(self._cluster_handler, f"{self._div_mul_prefix}_divisor")
+        divisor = getattr(
+            self._cluster_handler, f"{self._div_mul_prefix}_divisor", self._divisor
+        )
         value = float(value * multiplier) / divisor
         if value < 100 and divisor > 1:
             return round(value, self._decimals)
@@ -419,13 +421,14 @@ class ElectricalMeasurementFrequency(PolledElectricalMeasurement):
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT)
 # pylint: disable-next=hass-invalid-inheritance # needs fixing
 class ElectricalMeasurementPowerFactor(PolledElectricalMeasurement):
-    """Frequency measurement."""
+    """Power Factor measurement."""
 
     _attribute_name = "power_factor"
     _unique_id_suffix = "power_factor"
     _use_custom_polling = False  # Poll indirectly by ElectricalMeasurementSensor
     _attr_device_class: SensorDeviceClass = SensorDeviceClass.POWER_FACTOR
     _attr_native_unit_of_measurement = PERCENTAGE
+    _div_mul_prefix = None
 
 
 @MULTI_MATCH(

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -219,6 +219,24 @@ async def async_test_em_apparent_power(hass, cluster, entity_id):
     assert_state(hass, entity_id, "9.9", UnitOfApparentPower.VOLT_AMPERE)
 
 
+async def async_test_em_power_factor(hass: HomeAssistant, cluster, entity_id):
+    """Test electrical measurement Power Factor sensor."""
+    # update divisor cached value
+    await send_attributes_report(hass, cluster, {"ac_power_divisor": 1})
+    await send_attributes_report(hass, cluster, {0: 1, 0x0510: 100, 10: 1000})
+    assert_state(hass, entity_id, "100", PERCENTAGE)
+
+    await send_attributes_report(hass, cluster, {0: 1, 0x0510: 99, 10: 1000})
+    assert_state(hass, entity_id, "99", PERCENTAGE)
+
+    await send_attributes_report(hass, cluster, {"ac_power_divisor": 10})
+    await send_attributes_report(hass, cluster, {0: 1, 0x0510: 100, 10: 5000})
+    assert_state(hass, entity_id, "100", PERCENTAGE)
+
+    await send_attributes_report(hass, cluster, {0: 1, 0x0510: 99, 10: 5000})
+    assert_state(hass, entity_id, "99", PERCENTAGE)
+
+
 async def async_test_em_rms_current(hass, cluster, entity_id):
     """Test electrical measurement RMS Current sensor."""
 
@@ -371,6 +389,14 @@ async def async_test_device_temperature(hass, cluster, entity_id):
             7,
             {"ac_power_divisor": 1000, "ac_power_multiplier": 1},
             {"active_power", "rms_current", "rms_voltage"},
+        ),
+        (
+            homeautomation.ElectricalMeasurement.cluster_id,
+            "power_factor",
+            async_test_em_power_factor,
+            7,
+            {"ac_power_divisor": 1000, "ac_power_multiplier": 1},
+            {"active_power", "apparent_power", "rms_current", "rms_voltage"},
         ),
         (
             homeautomation.ElectricalMeasurement.cluster_id,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Zigbee Cluster Library defines PowerFactor as an int8 with value supported from -100 to 100.

Currently the zha sensor handler defaults to applying the ac_power_divisor and ac_power_multiplier formatters against the power_factor attribute value as _div_mul_prefix is not set for the sensor.

The Cluster Library spec outlines that this should not be the case, the native Zigbee attribute value provides with a % value out of 100.
This change updates the formatter method for sensor class ElectricalMeasurement and ElectricalMeasurementPowerFactor sensor handler to address this.

https://zigbeealliance.org/wp-content/uploads/2021/10/07-5123-08-Zigbee-Cluster-Library.pdf
See:  4.9.2.2.6,  4.9.2.2.6.15,  4.9.2.2.7.5

<img width="642" alt="image" src="https://github.com/home-assistant/core/assets/46714706/64938ed8-846a-4f48-8bb5-b5ef5de3dd8c">

<img width="419" alt="image" src="https://github.com/home-assistant/core/assets/46714706/8253a122-6132-45fa-b3d2-6d15e40a5b5e">

<img width="654" alt="image" src="https://github.com/home-assistant/core/assets/46714706/96e315cd-72d7-4d34-acdb-d21c06838ed9">

The impact of the existing implementation is that quirks not using the default power divisor/multiplier values of 1 are having to multiply power factor prior to updating the cluster attribute, i.e. if the ac_power_divisor is 10, the quirk would multiply the power factor of 100 to 1000.
This results in an out of spec power_factor value.


Reviewing zha-cluster-handlers only one quirk currently use this workaround so impact of this fix should be minimal.
 * [ts0601_rcbo.py](https://github.com/zigpy/zha-device-handlers/blob/dev/zhaquirks/tuya/ts0601_rcbo.py) (currently multiplies power_factor by an additional 10, giving 1000 for 100%).

zha-quirks had one quirk updated, so this change is no longer breaking.
PR:
- https://github.com/zigpy/zha-device-handlers/pull/2896

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/zigpy/zha-device-handlers/pull/2896
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
