### PR TITLE
Correct state class in `mobile_app` tests

### DIFF
--- a/tests/components/mobile_app/test_sensor.py
+++ b/tests/components/mobile_app/test_sensor.py
@@ -53,7 +53,7 @@ async def test_sensor(
                 "type": "sensor",
                 "entity_category": "diagnostic",
                 "unique_id": "battery_temp",
-                "state_class": "total",
+                "state_class": "measurement",
                 "unit_of_measurement": UnitOfTemperature.CELSIUS,
             },
         },
@@ -73,7 +73,7 @@ async def test_sensor(
     # unit of temperature sensor is automatically converted to the system UoM
     assert entity.attributes["unit_of_measurement"] == state_unit
     assert entity.attributes["foo"] == "bar"
-    assert entity.attributes["state_class"] == "total"
+    assert entity.attributes["state_class"] == "measurement"
     assert entity.domain == "sensor"
     assert entity.name == "Test 1 Battery Temperature"
     assert entity.state == state1
@@ -175,7 +175,7 @@ async def test_sensor_migration(
                 "type": "sensor",
                 "entity_category": "diagnostic",
                 "unique_id": unique_id,
-                "state_class": "total",
+                "state_class": "measurement",
                 "unit_of_measurement": UnitOfTemperature.CELSIUS,
             },
         },
@@ -195,7 +195,7 @@ async def test_sensor_migration(
     # unit of temperature sensor is automatically converted to the system UoM
     assert entity.attributes["unit_of_measurement"] == state_unit
     assert entity.attributes["foo"] == "bar"
-    assert entity.attributes["state_class"] == "total"
+    assert entity.attributes["state_class"] == "measurement"
     assert entity.domain == "sensor"
     assert entity.name == "Test 1 Battery Temperature"
     assert entity.state == state1

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -962,7 +962,7 @@ async def test_reregister_sensor(
                 "state": 100,
                 "type": "sensor",
                 "unique_id": "abcd",
-                "state_class": "total",
+                "state_class": "measurement",
                 "device_class": "battery",
                 "entity_category": "diagnostic",
                 "icon": "mdi:new-icon",


### PR DESCRIPTION
## Proposed change
Use the right state class in `mobile_app` tests for the `battery` and `battery_level`. Noticed this while doing https://github.com/home-assistant/core/pull/107639

Need to check if the App itself does this right

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
