### PR TITLE
Correct state class in `group` tests

### DIFF
--- a/tests/components/group/test_sensor.py
+++ b/tests/components/group/test_sensor.py
@@ -88,7 +88,7 @@ async def test_sensors(
             value,
             {
                 ATTR_DEVICE_CLASS: SensorDeviceClass.VOLUME,
-                ATTR_STATE_CLASS: SensorStateClass.MEASUREMENT,
+                ATTR_STATE_CLASS: SensorStateClass.TOTAL,
                 ATTR_UNIT_OF_MEASUREMENT: "L",
             },
         )
@@ -105,7 +105,7 @@ async def test_sensors(
         assert state.attributes.get(key) == value
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.VOLUME
     assert state.attributes.get(ATTR_ICON) is None
-    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
+    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.TOTAL
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "L"
 
     entity = entity_registry.async_get(f"sensor.sensor_group_{sensor_type}")
@@ -334,7 +334,7 @@ async def test_sensor_calculated_properties(hass: HomeAssistant) -> None:
         VALUES[0],
         {
             "device_class": SensorDeviceClass.ENERGY,
-            "state_class": SensorStateClass.MEASUREMENT,
+            "state_class": SensorStateClass.TOTAL_INCREASING,
             "unit_of_measurement": "kWh",
         },
     )
@@ -343,7 +343,7 @@ async def test_sensor_calculated_properties(hass: HomeAssistant) -> None:
         VALUES[1],
         {
             "device_class": SensorDeviceClass.ENERGY,
-            "state_class": SensorStateClass.MEASUREMENT,
+            "state_class": SensorStateClass.TOTAL_INCREASING,
             "unit_of_measurement": "kWh",
         },
     )
@@ -352,7 +352,7 @@ async def test_sensor_calculated_properties(hass: HomeAssistant) -> None:
     state = hass.states.get("sensor.test_sum")
     assert state.state == str(float(sum([VALUES[0], VALUES[1]])))
     assert state.attributes.get("device_class") == "energy"
-    assert state.attributes.get("state_class") == "measurement"
+    assert state.attributes.get("state_class") == "total_increasing"
     assert state.attributes.get("unit_of_measurement") == "kWh"
 
     hass.states.async_set(


### PR DESCRIPTION
## Proposed change
Use right state class in `group` tests. Noticed it while doing https://github.com/home-assistant/core/pull/107639

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
