### PR TITLE
Improve ergonomics of FlowManager.async_show_progress

### DIFF
--- a/homeassistant/components/github/config_flow.py
+++ b/homeassistant/components/github/config_flow.py
@@ -156,7 +156,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 "url": OAUTH_USER_LOGIN,
                 "code": self._login_device.user_code,
             },
-            progress_coro=_wait_for_login,
+            progress_coro=_wait_for_login() if not self.progress_fut else None,
         )
 
     async def async_step_repositories(

--- a/homeassistant/components/github/config_flow.py
+++ b/homeassistant/components/github/config_flow.py
@@ -140,8 +140,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 LOGGER.exception(exception)
                 return self.async_abort(reason="could_not_register")
 
-        if self.progress_fut and self.progress_fut.done():
-            if self.progress_fut.exception():
+        if self.progress_task and self.progress_task.done():
+            if self.progress_task.exception():
                 return self.async_show_progress_done(next_step_id="could_not_register")
             return self.async_show_progress_done(next_step_id="repositories")
 
@@ -156,7 +156,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 "url": OAUTH_USER_LOGIN,
                 "code": self._login_device.user_code,
             },
-            progress_coro=_wait_for_login() if not self.progress_fut else None,
+            progress_coro=_wait_for_login() if not self.progress_task else None,
         )
 
     async def async_step_repositories(

--- a/homeassistant/components/github/config_flow.py
+++ b/homeassistant/components/github/config_flow.py
@@ -140,8 +140,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 LOGGER.exception(exception)
                 return self.async_abort(reason="could_not_register")
 
-        if self.progress_task and self.progress_task.done():
-            if self.progress_task.exception():
+        if self.progress_fut and self.progress_fut.done():
+            if self.progress_fut.exception():
                 return self.async_show_progress_done(next_step_id="could_not_register")
             return self.async_show_progress_done(next_step_id="repositories")
 

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -129,7 +129,7 @@ class FlowResult(TypedDict, total=False):
     options: Mapping[str, Any]
     preview: str | None
     progress_action: str
-    progress_coro: Coroutine[Any, Any, None] | None
+    progress_coro: Coroutine[Any, Any, Any] | None
     reason: str
     required: bool
     result: Any
@@ -508,7 +508,7 @@ class FlowHandler:
     MINOR_VERSION = 1
 
     __progress_task: asyncio.Task | None = None
-    progress_task: asyncio.Task[None] | None = None
+    progress_task: asyncio.Task[Any] | None = None
 
     @property
     def source(self) -> str | None:
@@ -712,12 +712,12 @@ class FlowHandler:
     @callback
     def async_start_progress(
         self,
-        progress_job: Coroutine[Any, Any, None],
+        progress_job: Coroutine[Any, Any, Any],
         progress_done: Callable[..., Coroutine[Any, Any, Any]],
     ) -> None:
         """Start in progress task if not started."""
 
-        async def _send_event_when_done(fut: asyncio.Future[None]) -> None:
+        async def _send_event_when_done(fut: asyncio.Task[Any]) -> None:
             with suppress(BaseException):
                 await fut
             with suppress(UnknownFlow):

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -729,9 +729,6 @@ class FlowHandler:
             with suppress(UnknownFlow):
                 await progress_done(self.flow_id)
 
-        if not asyncio.iscoroutine(progress_job):
-            raise TypeError
-
         if not self.progress_task or self.progress_task.done():
             self.progress_task = self.hass.async_create_task(progress_job)
             self.__progress_task = self.hass.async_create_task(

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -456,7 +456,7 @@ class FlowManager(abc.ABC):
         elif result["type"] != FlowResultType.SHOW_PROGRESS:
             if flow.progress_task and not flow.progress_task.done():
                 flow.progress_task.cancel()
-                flow.progress_task = None
+            flow.progress_task = None
 
         if result["type"] in FLOW_NOT_COMPLETE_STEPS:
             self._raise_if_step_does_not_exist(flow, result["step_id"])

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -720,7 +720,8 @@ class FlowHandler:
         async def _send_event_when_done(fut: asyncio.Future[None]) -> None:
             with suppress(BaseException):
                 await fut
-            await progress_done(self.flow_id)
+            with suppress(UnknownFlow):
+                await progress_done(self.flow_id)
 
         if not asyncio.iscoroutine(progress_job):
             raise TypeError

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -450,7 +450,7 @@ class FlowManager(abc.ABC):
                 with suppress(UnknownFlow):
                     await self.async_configure(flow.flow_id)
 
-            def schedule_configure(_: asyncio.Future) -> None:
+            def schedule_configure(_: asyncio.Task) -> None:
                 self.hass.async_create_task(call_configure())
 
             progress_task.add_done_callback(schedule_configure)

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -440,7 +440,9 @@ class FlowManager(abc.ABC):
                 error_if_core=False,
             )
 
-        if result["type"] == FlowResultType.SHOW_PROGRESS and result["progress_coro"]:
+        if result["type"] == FlowResultType.SHOW_PROGRESS and (
+            progress_coro := result.pop("progress_coro", None)
+        ):
             flow_id = flow.flow_id
 
             async def _resume_flow_when_done(awt: Awaitable[None]) -> None:
@@ -449,7 +451,7 @@ class FlowManager(abc.ABC):
 
             if not flow.progress_task:
                 flow.progress_task = self.hass.async_create_task(
-                    _resume_flow_when_done(result["progress_coro"]())
+                    _resume_flow_when_done(progress_coro())
                 )
         elif result["type"] != FlowResultType.SHOW_PROGRESS:
             if flow.progress_task and not flow.progress_task.done():

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -715,7 +715,13 @@ class FlowHandler:
         progress_job: Coroutine[Any, Any, Any],
         progress_done: Callable[..., Coroutine[Any, Any, Any]],
     ) -> None:
-        """Start in progress task if not started."""
+        """Start in progress task if not started.
+
+        We need to keep track of both the task passed to us from a flow, and the
+        outer task which awaits that task and then notifies frontend. If we only
+        keep track of the outer task, we introduce a race where frontend calls
+        configure before the outer task is done.
+        """
 
         async def _send_event_when_done(fut: asyncio.Task[Any]) -> None:
             with suppress(BaseException):

--- a/tests/components/github/test_config_flow.py
+++ b/tests/components/github/test_config_flow.py
@@ -123,8 +123,8 @@ async def test_flow_with_activation_failure(
     assert result["type"] == FlowResultType.SHOW_PROGRESS
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.SHOW_PROGRESS_DONE
-    assert result["step_id"] == "could_not_register"
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "could_not_register"
 
 
 async def test_flow_with_remove_while_activating(

--- a/tests/components/github/test_config_flow.py
+++ b/tests/components/github/test_config_flow.py
@@ -121,6 +121,7 @@ async def test_flow_with_activation_failure(
     )
     assert result["step_id"] == "device"
     assert result["type"] == FlowResultType.SHOW_PROGRESS
+    await hass.async_block_till_done()
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
     assert result["type"] == FlowResultType.ABORT

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -368,7 +368,7 @@ async def test_show_progress(hass: HomeAssistant, manager) -> None:
             progress_coro: Coroutine | None = None
             if not task_one_evt.is_set():
                 progress_action = "task_one"
-                if not self.progress_fut:
+                if not self.progress_task:
                     progress_coro = long_running_task_one()
             elif not task_two_evt.is_set():
                 progress_action = "task_two"
@@ -455,10 +455,10 @@ async def test_show_progress_error(hass: HomeAssistant, manager) -> None:
                 raise TypeError
 
             progress_coro: Coroutine | None = None
-            if not self.progress_fut:
+            if not self.progress_task:
                 progress_coro = long_running_task()
-            if self.progress_fut and self.progress_fut.done():
-                if self.progress_fut.exception():
+            if self.progress_task and self.progress_task.done():
+                if self.progress_task.exception():
                     return self.async_show_progress_done(next_step_id="error")
                 return self.async_show_progress_done(next_step_id="no_error")
             return self.async_show_progress(

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -1,4 +1,6 @@
 """Test the flow classes."""
+import asyncio
+from collections.abc import Coroutine
 import dataclasses
 import logging
 from unittest.mock import Mock, patch
@@ -7,7 +9,7 @@ import pytest
 import voluptuous as vol
 
 from homeassistant import config_entries, data_entry_flow
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.util.decorator import Registry
 
 from .common import async_capture_events, import_and_test_deprecated_constant_enum
@@ -337,6 +339,170 @@ async def test_external_step(hass: HomeAssistant, manager) -> None:
 
 async def test_show_progress(hass: HomeAssistant, manager) -> None:
     """Test show progress logic."""
+    manager.hass = hass
+    events = []
+    task_one_evt = asyncio.Event()
+    task_two_evt = asyncio.Event()
+    event_received_evt = asyncio.Event()
+
+    @callback
+    def capture_events(event: Event) -> None:
+        events.append(event)
+        event_received_evt.set()
+
+    @manager.mock_reg_handler("test")
+    class TestFlow(data_entry_flow.FlowHandler):
+        VERSION = 5
+        data = None
+        start_task_two = False
+
+        async def async_step_init(self, user_input=None):
+            async def long_running_task_one() -> None:
+                await task_one_evt.wait()
+                self.start_task_two = True
+
+            async def long_running_task_two() -> None:
+                await task_two_evt.wait()
+                self.data = {"title": "Hello"}
+
+            progress_coro: Coroutine | None = None
+            if not task_one_evt.is_set():
+                progress_action = "task_one"
+                if not self.progress_fut:
+                    progress_coro = long_running_task_one()
+            elif not task_two_evt.is_set():
+                progress_action = "task_two"
+                if self.start_task_two:
+                    progress_coro = long_running_task_two()
+                    self.start_task_two = False
+            if not task_one_evt.is_set() or not task_two_evt.is_set():
+                return self.async_show_progress(
+                    step_id="init",
+                    progress_action=progress_action,
+                    progress_coro=progress_coro,
+                )
+
+            return self.async_show_progress_done(next_step_id="finish")
+
+        async def async_step_finish(self, user_input=None):
+            return self.async_create_entry(title=self.data["title"], data=self.data)
+
+    hass.bus.async_listen(
+        data_entry_flow.EVENT_DATA_ENTRY_FLOW_PROGRESSED,
+        capture_events,
+        run_immediately=True,
+    )
+
+    result = await manager.async_init("test")
+    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert result["progress_action"] == "task_one"
+    assert len(manager.async_progress()) == 1
+    assert len(manager.async_progress_by_handler("test")) == 1
+    assert manager.async_get(result["flow_id"])["handler"] == "test"
+
+    # Set task one done and wait for event
+    task_one_evt.set()
+    await event_received_evt.wait()
+    event_received_evt.clear()
+    assert len(events) == 1
+    assert events[0].data == {
+        "handler": "test",
+        "flow_id": result["flow_id"],
+        "refresh": True,
+    }
+
+    # Frontend refreshes the flow
+    result = await manager.async_configure(result["flow_id"])
+    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert result["progress_action"] == "task_two"
+
+    # Set task two done and wait for event
+    task_two_evt.set()
+    await event_received_evt.wait()
+    event_received_evt.clear()
+    assert len(events) == 2  # 1 for task one and 1 for task two
+    assert events[1].data == {
+        "handler": "test",
+        "flow_id": result["flow_id"],
+        "refresh": True,
+    }
+
+    # Frontend refreshes the flow
+    result = await manager.async_configure(result["flow_id"])
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Hello"
+
+
+async def test_show_progress_error(hass: HomeAssistant, manager) -> None:
+    """Test show progress logic."""
+    manager.hass = hass
+    events = []
+    event_received_evt = asyncio.Event()
+
+    @callback
+    def capture_events(event: Event) -> None:
+        events.append(event)
+        event_received_evt.set()
+
+    @manager.mock_reg_handler("test")
+    class TestFlow(data_entry_flow.FlowHandler):
+        VERSION = 5
+        data = None
+        start_task_two = False
+
+        async def async_step_init(self, user_input=None):
+            async def long_running_task() -> None:
+                raise TypeError
+
+            progress_coro: Coroutine | None = None
+            if not self.progress_fut:
+                progress_coro = long_running_task()
+            if self.progress_fut and self.progress_fut.done():
+                if self.progress_fut.exception():
+                    return self.async_show_progress_done(next_step_id="error")
+                return self.async_show_progress_done(next_step_id="no_error")
+            return self.async_show_progress(
+                step_id="init", progress_action="task", progress_coro=progress_coro
+            )
+
+        async def async_step_error(self, user_input=None):
+            return self.async_abort(reason="error")
+
+    hass.bus.async_listen(
+        data_entry_flow.EVENT_DATA_ENTRY_FLOW_PROGRESSED,
+        capture_events,
+        run_immediately=True,
+    )
+
+    result = await manager.async_init("test")
+    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert result["progress_action"] == "task"
+    assert len(manager.async_progress()) == 1
+    assert len(manager.async_progress_by_handler("test")) == 1
+    assert manager.async_get(result["flow_id"])["handler"] == "test"
+
+    # Set task one done and wait for event
+    await event_received_evt.wait()
+    event_received_evt.clear()
+    assert len(events) == 1
+    assert events[0].data == {
+        "handler": "test",
+        "flow_id": result["flow_id"],
+        "refresh": True,
+    }
+
+    # Frontend refreshes the flow
+    result = await manager.async_configure(result["flow_id"])
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "error"
+
+
+async def test_show_progress_legacy(hass: HomeAssistant, manager) -> None:
+    """Test show progress logic.
+
+    This tests the deprecated version where the config flow is responsible for
+    resuming the flow.
+    """
     manager.hass = hass
 
     @manager.mock_reg_handler("test")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve ergonomics of `FlowManager.async_show_progress`

### Details:
`FlowHandler.async_show_progress` has a new argument `progress_task`.

`FlowManager` will:
- send an event to fronted once the task has finished
- cancel the `progress_task` if the user closes the config flow dialog before the task is done

This means derived classes are no longer responsible for interaction between the progress task state and the UI.

In a follow-up PR, `FlowHandler.async_show_progress` will log a warning if it's called without a `progress_task`. In a future release, the call will instead fail.

### Rationale:
Make it easier to use `FlowManager.async_show_progress` in config flows by moving the tracking of progress tasks etc. to `FlowManager`. This PR uses the new functionality in the `github` integration as a proof of concept.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2037

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
