### PR TITLE
Improve debug logs in Minecraft Server

### DIFF
--- a/homeassistant/components/minecraft_server/api.py
+++ b/homeassistant/components/minecraft_server/api.py
@@ -89,7 +89,7 @@ class MinecraftServer:
         self._server.timeout = DATA_UPDATE_TIMEOUT
 
         _LOGGER.debug(
-            "%s server instance created with address '%s'",
+            "Initialized %s server instance with address '%s'",
             self._server_type,
             self._address,
         )
@@ -98,7 +98,15 @@ class MinecraftServer:
         """Check if the server is online, supporting both Java and Bedrock Edition servers."""
         try:
             await self.async_get_data()
-        except (MinecraftServerConnectionError, MinecraftServerNotInitializedError):
+        except (
+            MinecraftServerConnectionError,
+            MinecraftServerNotInitializedError,
+        ) as error:
+            _LOGGER.debug(
+                "Connection check of %s server failed: %s",
+                self._server_type,
+                self._get_error_message(error),
+            )
             return False
 
         return True
@@ -108,7 +116,9 @@ class MinecraftServer:
         status_response: BedrockStatusResponse | JavaStatusResponse
 
         if self._server is None:
-            raise MinecraftServerNotInitializedError()
+            raise MinecraftServerNotInitializedError(
+                f"Server instance with address '{self._address}' is not initialized"
+            )
 
         try:
             status_response = await self._server.async_status(tries=DATA_UPDATE_RETRIES)

--- a/homeassistant/components/minecraft_server/config_flow.py
+++ b/homeassistant/components/minecraft_server/config_flow.py
@@ -44,16 +44,16 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
 
                 try:
                     await api.async_initialize()
-                except MinecraftServerAddressError:
-                    pass
+                except MinecraftServerAddressError as error:
+                    _LOGGER.debug(
+                        "Initialization of %s server failed: %s",
+                        server_type,
+                        error,
+                    )
                 else:
                     if await api.async_is_online():
                         config_data[CONF_TYPE] = server_type
                         return self.async_create_entry(title=address, data=config_data)
-
-                _LOGGER.debug(
-                    "Connection check to %s server '%s' failed", server_type, address
-                )
 
             # Host or port invalid or server not reachable.
             errors["base"] = "cannot_connect"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After 2 reported issues I noticed that some debug logs are missing important information. This PR improves those debug logs:
- Move failed connection check log from `config_flow` to `api` with more information.
- Add log for failed init in `config_flow`.
- Add error text while raising `MinecraftServerNotInitializedError`.
- Remove duplicate server address in some logs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: n.a.
- This PR is related to issue: #106631, #106971
- Link to documentation pull request: n.a.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
