### PR TITLE
Dynamically map state class, device class and UoM in ZHA smart energy metering sensor

### DIFF
--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -494,7 +494,7 @@ class SmartEnergyMeteringEntityDescription(SensorEntityDescription):
 
     key: str = "instantaneous_demand"
     state_class: SensorStateClass | None = SensorStateClass.MEASUREMENT
-    scale: int | None = None
+    scale: int = 1
 
 
 @MULTI_MATCH(
@@ -608,7 +608,7 @@ class SmartEnergyMetering(PollableSensor):
         description = self._ENTITY_DESCRIPTION_MAP.get(
             self._cluster_handler.unit_of_measurement
         )
-        if description and description.scale and state:
+        if description is not None and state is not None:
             return float(state) * description.scale
 
         return state

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -605,11 +605,11 @@ class SmartEnergyMetering(PollableSensor):
     def native_value(self) -> StateType:
         """Return the state of the entity."""
         state = super().native_value
-        class_map = self._ENTITY_DESCRIPTION_MAP.get(
+        description = self._ENTITY_DESCRIPTION_MAP.get(
             self._cluster_handler.unit_of_measurement
         )
-        if class_map is not None and state is not None:
-            return float(state) * class_map.scale
+        if description is not None and state is not None:
+            return float(state) * description.scale
 
         return state
 

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -494,7 +494,7 @@ class SmartEnergyMeteringEntityDescription(SensorEntityDescription):
 
     key: str = "instantaneous_demand"
     state_class: SensorStateClass | None = SensorStateClass.MEASUREMENT
-    scale: int = 1
+    scale: int | None = None
 
 
 @MULTI_MATCH(
@@ -608,7 +608,7 @@ class SmartEnergyMetering(PollableSensor):
         description = self._ENTITY_DESCRIPTION_MAP.get(
             self._cluster_handler.unit_of_measurement
         )
-        if description is not None and state is not None:
+        if description and description.scale and state:
             return float(state) * description.scale
 
         return state

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -505,6 +505,7 @@ class SmartEnergyMeteringEntityDescription(SensorEntityDescription):
 class SmartEnergyMetering(PollableSensor):
     """Metering sensor."""
 
+    entity_description: SmartEnergyMeteringEntityDescription
     _use_custom_polling: bool = False
     _attribute_name = "instantaneous_demand"
     _attr_translation_key: str = "instantaneous_demand"
@@ -605,11 +606,8 @@ class SmartEnergyMetering(PollableSensor):
     def native_value(self) -> StateType:
         """Return the state of the entity."""
         state = super().native_value
-        description = self._ENTITY_DESCRIPTION_MAP.get(
-            self._cluster_handler.unit_of_measurement
-        )
-        if description is not None and state is not None:
-            return float(state) * description.scale
+        if hasattr(self, "entity_description") and state is not None:
+            return float(state) * self.entity_description.scale
 
         return state
 
@@ -630,6 +628,7 @@ class SmartEnergySummationEntityDescription(SmartEnergyMeteringEntityDescription
 class SmartEnergySummation(SmartEnergyMetering):
     """Smart Energy Metering summation sensor."""
 
+    entity_description: SmartEnergySummationEntityDescription
     _attribute_name = "current_summ_delivered"
     _unique_id_suffix = "summation_delivered"
     _attr_translation_key: str = "summation_delivered"

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -169,7 +169,7 @@ async def async_test_smart_energy_summation(hass, cluster, entity_id):
     assert hass.states.get(entity_id).attributes["device_type"] == "Electric Metering"
     assert (
         hass.states.get(entity_id).attributes[ATTR_DEVICE_CLASS]
-        == SensorDeviceClass.ENERGY
+        == SensorDeviceClass.VOLUME
     )
 
 

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -779,7 +779,7 @@ async def test_unsupported_attributes_sensor(
         (
             1,
             1232000,
-            "123.20",
+            "123.2",
             UnitOfVolume.CUBIC_METERS,
         ),
         (

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -164,12 +164,12 @@ async def async_test_smart_energy_summation(hass, cluster, entity_id):
     await send_attributes_report(
         hass, cluster, {1025: 1, "current_summ_delivered": 12321, 1026: 100}
     )
-    assert_state(hass, entity_id, "12.32", UnitOfVolume.CUBIC_METERS)
+    assert_state(hass, entity_id, "12.321", UnitOfEnergy.KILO_WATT_HOUR)
     assert hass.states.get(entity_id).attributes["status"] == "NO_ALARMS"
     assert hass.states.get(entity_id).attributes["device_type"] == "Electric Metering"
     assert (
         hass.states.get(entity_id).attributes[ATTR_DEVICE_CLASS]
-        == SensorDeviceClass.VOLUME
+        == SensorDeviceClass.ENERGY
     )
 
 
@@ -346,7 +346,7 @@ async def async_test_device_temperature(hass, cluster, entity_id):
                 "multiplier": 1,
                 "status": 0x00,
                 "summation_formatting": 0b1_0111_010,
-                "unit_of_measure": 0x01,
+                "unit_of_measure": 0x00,
             },
             {"instaneneous_demand"},
         ),

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -779,7 +779,7 @@ async def test_unsupported_attributes_sensor(
         (
             1,
             1232000,
-            "123.2",
+            "123.20",
             UnitOfVolume.CUBIC_METERS,
         ),
         (

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -848,6 +848,12 @@ async def test_unsupported_attributes_sensor(
             "10.25",
             "IMP gal",
         ),
+        (
+            7,
+            50124,
+            "5.01",
+            UnitOfVolume.LITERS,
+        ),
     ),
 )
 async def test_se_summation_uom(

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -845,8 +845,8 @@ async def test_unsupported_attributes_sensor(
         (
             5,
             102456,
-            "10.246",
-            UnitOfEnergy.KILO_WATT_HOUR,
+            "10.25",
+            "IMP gal",
         ),
     ),
 )

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -779,26 +779,26 @@ async def test_unsupported_attributes_sensor(
         (
             1,
             1232000,
-            "123.20",
+            "123.2",
             UnitOfVolume.CUBIC_METERS,
         ),
         (
             3,
             2340,
-            "0.23",
-            f"100 {UnitOfVolume.CUBIC_FEET}",
+            "0.65",
+            UnitOfVolume.CUBIC_METERS,
         ),
         (
             3,
             2360,
-            "0.24",
-            f"100 {UnitOfVolume.CUBIC_FEET}",
+            "0.68",
+            UnitOfVolume.CUBIC_METERS,
         ),
         (
             8,
             23660,
             "2.37",
-            "kPa",
+            UnitOfPressure.KPA,
         ),
         (
             0,
@@ -838,6 +838,12 @@ async def test_unsupported_attributes_sensor(
         ),
         (
             0,
+            102456,
+            "10.246",
+            UnitOfEnergy.KILO_WATT_HOUR,
+        ),
+        (
+            5,
             102456,
             "10.246",
             UnitOfEnergy.KILO_WATT_HOUR,


### PR DESCRIPTION
## Proposed change
Currently, the status class and the device class are statically assigned for the ZHA sensors 'SmartEnergyMetering' and 'SmartEnergySummation', which leads to inadmissible use, e.g. the device class 'Energy' is assigned for a sensor measuring liters.

This PR creates a additional mapping for state class and device class besides the unit of measurement. 
Noticed while doing https://github.com/home-assistant/core/pull/107639

In addition, these attributes are set in the `__init__` to prevent them from being looked up again and again.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #85554
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
