### PR TITLE
Add GeoJSON properties in the entities extra attributes

### DIFF
--- a/homeassistant/components/geo_json_events/geo_location.py
+++ b/homeassistant/components/geo_json_events/geo_location.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 import logging
-from typing import Any
 
 from aio_geojson_generic_client.feed_entry import GenericFeedEntry
 
@@ -108,10 +107,6 @@ class GeoJsonLocationEvent(GeolocationEvent):
         self._attr_distance = feed_entry.distance_to_home
         self._attr_latitude = feed_entry.coordinates[0]
         self._attr_longitude = feed_entry.coordinates[1]
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return the device state attributes."""
-        if not self._external_id:
-            return {}
-        return {ATTR_EXTERNAL_ID: self._external_id}
+        self._attr_extra_state_attributes = feed_entry.properties
+        if self._external_id:
+            self._attr_extra_state_attributes[ATTR_EXTERNAL_ID] = self._external_id

--- a/tests/components/geo_json_events/test_geo_location.py
+++ b/tests/components/geo_json_events/test_geo_location.py
@@ -4,10 +4,7 @@ from unittest.mock import patch
 
 from freezegun import freeze_time
 
-from homeassistant.components.geo_json_events.const import (
-    ATTR_EXTERNAL_ID,
-    DEFAULT_UPDATE_INTERVAL,
-)
+from homeassistant.components.geo_json_events.const import DEFAULT_UPDATE_INTERVAL
 from homeassistant.components.geo_location import (
     ATTR_SOURCE,
     DOMAIN as GEO_LOCATION_DOMAIN,
@@ -73,7 +70,6 @@ async def test_entity_lifecycle(
         assert state is not None
         assert state.name == "Title 1"
         assert state.attributes == {
-            ATTR_EXTERNAL_ID: "1234",
             ATTR_LATITUDE: -31.0,
             ATTR_LONGITUDE: 150.0,
             ATTR_FRIENDLY_NAME: "Title 1",
@@ -86,7 +82,6 @@ async def test_entity_lifecycle(
         assert state is not None
         assert state.name == "Title 2"
         assert state.attributes == {
-            ATTR_EXTERNAL_ID: "2345",
             ATTR_LATITUDE: -31.1,
             ATTR_LONGITUDE: 150.1,
             ATTR_FRIENDLY_NAME: "Title 2",
@@ -99,7 +94,6 @@ async def test_entity_lifecycle(
         assert state is not None
         assert state.name == "Title 3"
         assert state.attributes == {
-            ATTR_EXTERNAL_ID: "3456",
             ATTR_LATITUDE: -31.2,
             ATTR_LONGITUDE: 150.2,
             ATTR_FRIENDLY_NAME: "Title 3",


### PR DESCRIPTION
## Proposed change
Adds support for storing GeoJSON properties in the entities extra attributes. Previously, an entity would only otherwise show latitude and longitude.

This makes the GeoJSON integration actually useful for me because I can now use it for checking:

1. Community Incidents
2. Power Outages
3. Water Chlorination
4. Water Outages

### Example of EV Charging Locations

GeoJSON file - https://opendata-nzta.opendata.arcgis.com/datasets/NZTA::ev-roam-charging-stations.geojson

![image](https://github.com/home-assistant/core/assets/50791984/3ae6fd2e-e59e-4a54-8419-0fcd4bce8535)

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.