### PR TITLE
Clamp tplink color temp to valid range

### DIFF
--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -225,18 +225,19 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
     async def _async_set_color_temp(
         self, color_temp: float | int, brightness: int | None, transition: int | None
     ) -> None:
+        device = self.device
+        valid_temperature_range = device.valid_temperature_range
+        requested_color_temp = round(color_temp)
         # Clamp color temp to valid range
         # since if the light in a group we will
         # get requests for color temps for the range
         # of the group and not the light
-        device = self.device
-        valid_temperature_range = device.valid_temperature_range
-        requested_color_temp = round(color_temp)
+        clamped_color_temp = min(
+            valid_temperature_range.max,
+            max(valid_temperature_range.min, requested_color_temp),
+        )
         await device.set_color_temp(
-            min(
-                valid_temperature_range.max,
-                max(valid_temperature_range.min, requested_color_temp),
-            ),
+            clamped_color_temp,
             brightness=brightness,
             transition=transition,
         )

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -222,6 +222,25 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
         hue, sat = tuple(int(val) for val in hs_color)
         await self.device.set_hsv(hue, sat, brightness, transition=transition)
 
+    async def _async_set_color_temp(
+        self, color_temp: float | int, brightness: int | None, transition: int | None
+    ) -> None:
+        # Clamp color temp to valid range
+        # since if the light in a group we will
+        # get requests for color temps for the range
+        # of the group and not the light
+        device = self.device
+        valid_temperature_range = device.valid_temperature_range
+        requested_color_temp = round(color_temp)
+        await device.set_color_temp(
+            min(
+                valid_temperature_range.max,
+                max(valid_temperature_range.min, requested_color_temp),
+            ),
+            brightness=brightness,
+            transition=transition,
+        )
+
     async def _async_turn_on_with_brightness(
         self, brightness: int | None, transition: int | None
     ) -> None:
@@ -236,10 +255,8 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
         """Turn the light on."""
         brightness, transition = self._async_extract_brightness_transition(**kwargs)
         if ATTR_COLOR_TEMP_KELVIN in kwargs:
-            await self.device.set_color_temp(
-                int(kwargs[ATTR_COLOR_TEMP_KELVIN]),
-                brightness=brightness,
-                transition=transition,
+            await self._async_set_color_temp(
+                kwargs[ATTR_COLOR_TEMP_KELVIN], brightness, transition
             )
         if ATTR_HS_COLOR in kwargs:
             await self._async_set_hsv(kwargs[ATTR_HS_COLOR], brightness, transition)
@@ -316,10 +333,8 @@ class TPLinkSmartLightStrip(TPLinkSmartBulb):
                 # we have to set an HSV value to clear the effect
                 # before we can set a color temp
                 await self.device.set_hsv(0, 0, brightness)
-            await self.device.set_color_temp(
-                int(kwargs[ATTR_COLOR_TEMP_KELVIN]),
-                brightness=brightness,
-                transition=transition,
+            await self._async_set_color_temp(
+                kwargs[ATTR_COLOR_TEMP_KELVIN], brightness, transition
             )
         elif ATTR_HS_COLOR in kwargs:
             await self._async_set_hsv(kwargs[ATTR_HS_COLOR], brightness, transition)

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -264,6 +264,26 @@ async def test_color_temp_light(
     bulb.set_color_temp.assert_called_with(6666, brightness=None, transition=None)
     bulb.set_color_temp.reset_mock()
 
+    # Verify color temp is clamped to the valid range
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP_KELVIN: 20000},
+        blocking=True,
+    )
+    bulb.set_color_temp.assert_called_with(9000, brightness=None, transition=None)
+    bulb.set_color_temp.reset_mock()
+
+    # Verify color temp is clamped to the valid range
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP_KELVIN: 1},
+        blocking=True,
+    )
+    bulb.set_color_temp.assert_called_with(4000, brightness=None, transition=None)
+    bulb.set_color_temp.reset_mock()
+
 
 async def test_brightness_only_light(hass: HomeAssistant) -> None:
     """Test a light."""


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
fixes #100618

If the light is part of a group and gets a color temp for the group it may be outside the valid range. Clamp the value to the top and bottom of the range

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/100618
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
