### PR TITLE
Fix Netatmo camera name does not show under Media -> Media sources -> Camera

### DIFF
--- a/homeassistant/components/netatmo/camera.py
+++ b/homeassistant/components/netatmo/camera.py
@@ -83,7 +83,7 @@ class NetatmoCamera(NetatmoBase, Camera):
     """Representation of a Netatmo camera."""
 
     _attr_brand = MANUFACTURER
-    _attr_has_entity_name = True
+    _attr_has_entity_name = False
     _attr_supported_features = CameraEntityFeature.STREAM
 
     def __init__(
@@ -97,8 +97,7 @@ class NetatmoCamera(NetatmoBase, Camera):
         self._camera = cast(NaModules.Camera, netatmo_device.device)
         self._id = self._camera.entity_id
         self._home_id = self._camera.home.entity_id
-        self._attr_name = self._camera.name
-        self._device_name = self._camera.name
+        self._device_name = self._attr_name = self._camera.name
         self._model = self._camera.device_type
         self._config_url = CONF_URL_SECURITY
         self._attr_unique_id = f"{self._id}-{self._model}"

--- a/homeassistant/components/netatmo/camera.py
+++ b/homeassistant/components/netatmo/camera.py
@@ -97,6 +97,7 @@ class NetatmoCamera(NetatmoBase, Camera):
         self._camera = cast(NaModules.Camera, netatmo_device.device)
         self._id = self._camera.entity_id
         self._home_id = self._camera.home.entity_id
+        self._attr_name = self._camera.name
         self._device_name = self._camera.name
         self._model = self._camera.device_type
         self._config_url = CONF_URL_SECURITY


### PR DESCRIPTION
## Proposed change
Fixes issue #105268 where Netatmo camera name does not show under Media -> Media sources -> Camera

### Before
![image](https://github.com/home-assistant/core/assets/50791984/c83abbfc-d479-4329-ac48-1950ce31a714)

### After
![image](https://github.com/home-assistant/core/assets/50791984/85f4dba6-8541-44bb-bea8-b38a209f335f)

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #105268 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.