### PR TITLE
Add unique_id for ZoneMinder cameras

### DIFF
--- a/homeassistant/components/zoneminder/camera.py
+++ b/homeassistant/components/zoneminder/camera.py
@@ -46,18 +46,17 @@ class ZoneMinderCamera(MjpegCamera):
 
     def __init__(self, monitor: Monitor, verify_ssl: bool) -> None:
         """Initialize as a subclass of MjpegCamera."""
+        zmname = monitor.name.casefold().replace(" ", "")
         super().__init__(
             name=monitor.name,
             mjpeg_url=monitor.mjpeg_image_url,
             still_image_url=monitor.still_image_url,
             verify_ssl=verify_ssl,
+            unique_id=f"{ZONEMINDER_DOMAIN}-{zmname}-{monitor.id}",
         )
         self._attr_is_recording = False
         self._attr_available = False
         self._monitor = monitor
-
-        zmname = monitor.name.casefold().replace(" ", "")
-        self._attr_unique_id = f"{ZONEMINDER_DOMAIN}-{zmname}-mid{monitor.id}"
 
     def update(self) -> None:
         """Update our recording state from the ZM API."""

--- a/homeassistant/components/zoneminder/camera.py
+++ b/homeassistant/components/zoneminder/camera.py
@@ -56,6 +56,9 @@ class ZoneMinderCamera(MjpegCamera):
         self._attr_available = False
         self._monitor = monitor
 
+        zmname = monitor.name.casefold().replace(" ", "")
+        self._attr_unique_id = f"{ZONEMINDER_DOMAIN}-{zmname}-mid{monitor.id}"
+
     def update(self) -> None:
         """Update our recording state from the ZM API."""
         _LOGGER.debug("Updating camera state for monitor %i", self._monitor.id)


### PR DESCRIPTION
This generates unique_id for ZoneMinder camera discovery as:
 "zoneminder-<ZM_monitor_name>-mid<ZM_monitor_id>"


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Existing ZoneMinder deployments will import cameras as new Entity ID's.

This behavior occurs because previous ZM cameras were created without an
internal unique_id. This change was made to allow additional configuration to be
set by users from the HA UI.

Any configuration referencing those previous names will need to be remapped,
or you can re-attempt the discovery process by purging the previous non-uniqiue_id
entities and restarting HA to continue using the original default names.

1. [Backup Home Assistant](https://www.home-assistant.io/integrations/backup/)
2. Search "camera" under Settings > Devices & Service > Entities
3. Remove Selected, the old non-connected camera entities
4. Restart HA


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes #107208

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->
Unless someone has a trick when migrating from unique_id null to string,
I'm listing this as breaking change.

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #107208

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
