### PR TITLE
Fix cloud tts loading

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -294,7 +294,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     }
 
     async def _on_start() -> None:
-        """Discover platforms."""
+        """Handle cloud started after login."""
         nonlocal loaded
 
         # Prevent multiple discovery
@@ -302,14 +302,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             return
         loaded = True
 
-        tts_info = {"platform_loaded": tts_platform_loaded}
-
-        await async_load_platform(hass, Platform.TTS, DOMAIN, tts_info, config)
-        await tts_platform_loaded.wait()
-
-        # The config entry should be loaded after the legacy tts platform is loaded
-        # to make sure that the tts integration is setup before we try to migrate
-        # old assist pipelines in the cloud stt entity.
         await hass.config_entries.flow.async_init(DOMAIN, context={"source": "system"})
 
     async def _on_connect() -> None:
@@ -337,6 +329,16 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     http_api.async_setup(hass)
 
     account_link.async_setup(hass)
+
+    hass.async_create_task(
+        async_load_platform(
+            hass,
+            Platform.TTS,
+            DOMAIN,
+            {"platform_loaded": tts_platform_loaded},
+            config,
+        )
+    )
 
     async_call_later(
         hass=hass,

--- a/tests/components/cloud/test_http_api.py
+++ b/tests/components/cloud/test_http_api.py
@@ -113,8 +113,8 @@ async def setup_cloud_fixture(hass: HomeAssistant, cloud: MagicMock) -> None:
         },
     )
     await hass.async_block_till_done()
-    on_start_callback = cloud.register_on_start.call_args[0][0]
-    await on_start_callback()
+    await cloud.login("test-user", "test-pass")
+    cloud.login.reset_mock()
 
 
 async def test_google_actions_sync(

--- a/tests/components/cloud/test_init.py
+++ b/tests/components/cloud/test_init.py
@@ -230,6 +230,7 @@ async def test_async_get_or_create_cloudhook(
     """Test async_get_or_create_cloudhook."""
     assert await async_setup_component(hass, "cloud", {"cloud": {}})
     await hass.async_block_till_done()
+    await cloud.login("test-user", "test-pass")
 
     webhook_id = "mock-webhook-id"
     cloudhook_url = "https://cloudhook.nabu.casa/abcdefg"
@@ -262,7 +263,7 @@ async def test_async_get_or_create_cloudhook(
         async_create_cloudhook_mock.assert_not_called()
 
     # Simulate logged out
-    cloud.id_token = None
+    await cloud.logout()
 
     # Not logged in
     with pytest.raises(CloudNotAvailable):

--- a/tests/components/cloud/test_init.py
+++ b/tests/components/cloud/test_init.py
@@ -19,7 +19,7 @@ from homeassistant.core import Context, HomeAssistant
 from homeassistant.exceptions import Unauthorized
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockUser
+from tests.common import MockConfigEntry, MockUser
 
 
 async def test_constructor_loads_info_from_config(hass: HomeAssistant) -> None:
@@ -275,3 +275,18 @@ async def test_async_get_or_create_cloudhook(
     # Not connected
     with pytest.raises(CloudNotConnected):
         await async_get_or_create_cloudhook(hass, webhook_id)
+
+
+async def test_cloud_logout(
+    hass: HomeAssistant,
+    cloud: MagicMock,
+) -> None:
+    """Test cloud setup with existing config entry when user is logged out."""
+    assert cloud.is_logged_in is False
+
+    mock_config_entry = MockConfigEntry(domain=DOMAIN)
+    mock_config_entry.add_to_hass(hass)
+    assert await async_setup_component(hass, DOMAIN, {"cloud": {}})
+    await hass.async_block_till_done()
+
+    assert cloud.is_logged_in is False

--- a/tests/components/cloud/test_system_health.py
+++ b/tests/components/cloud/test_system_health.py
@@ -42,6 +42,7 @@ async def test_cloud_system_health(
         },
     )
     await hass.async_block_till_done()
+    await cloud.login("test-user", "test-pass")
 
     cloud.remote.snitun_server = "us-west-1"
     cloud.remote.certificate_status = CertificateStatus.READY


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- There was a deadlock if the user was logged out with an existing config entry. The stt platform was waiting for the tts platform which only loaded if the user was logged in.
- Fix this now by always loading the tts platform. Later we'll replace the legacy platform with a config entry based platform.
- Add tests. The first commit is a test refactor to be able to test logged out state better.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
