### PR TITLE
Handle missing paths for integrations during test

### DIFF
--- a/homeassistant/components/blueprint/models.py
+++ b/homeassistant/components/blueprint/models.py
@@ -363,6 +363,7 @@ class DomainBlueprints:
             if self.blueprint_folder.exists():
                 return
 
+            assert integration.file_path
             shutil.copytree(
                 integration.file_path / BLUEPRINT_FOLDER,
                 self.blueprint_folder / HA_DOMAIN,

--- a/homeassistant/components/notify/legacy.py
+++ b/homeassistant/components/notify/legacy.py
@@ -279,6 +279,7 @@ class BaseNotificationService:
 
         # Load service descriptions from notify/services.yaml
         integration = await async_get_integration(hass, DOMAIN)
+        assert integration.file_path
         services_yaml = integration.file_path / "services.yaml"
         self.services_dict = await hass.async_add_executor_job(
             load_yaml_dict, str(services_yaml)

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -545,6 +545,9 @@ async def async_extract_config_entry_ids(
 
 def _load_services_file(hass: HomeAssistant, integration: Integration) -> JSON_TYPE:
     """Load services file for an integration."""
+    if integration.file_path is None:
+        return {}
+
     try:
         return cast(
             JSON_TYPE,

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -52,6 +52,10 @@ def component_translation_path(
     domain = parts[0]
     is_platform = len(parts) == 2
 
+    # When mocking integrations they might not have a path
+    if integration.file_path is None:
+        return None
+
     # If it's a component that is just one file, we don't support translations
     # Example custom_components/my_component.py
     if integration.file_path.name != domain:

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -631,7 +631,7 @@ class Integration:
         self,
         hass: HomeAssistant,
         pkg_path: str,
-        file_path: pathlib.Path,
+        file_path: pathlib.Path | None,
         manifest: Manifest,
     ) -> None:
         """Initialize an integration."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When we mock integrations during tests (https://github.com/home-assistant/core/blob/125161df6bad66152c53d2af47f90f005c62d77c/tests/common.py#L1056), they don't have any valid path to load translations from, so handle this case.


```
2024-01-11 00:13:33.278 INFO     MainThread homeassistant.helpers.entity_registry:entity_registry.py:714 Registered new sensor.test entity: sensor.test_very_unique
2024-01-11 00:13:33.278 DEBUG    MainThread homeassistant.core:core.py:1203 Bus:Handling <Event entity_registry_updated[L]: action=create, entity_id=sensor.test_very_unique>
2024-01-11 00:13:33.278 DEBUG    MainThread homeassistant.core:core.py:1203 Bus:Handling <Event entity_registry_updated[L]: action=update, entity_id=sensor.test_very_unique, changes=options=>
2024-01-11 00:13:33.280 INFO     SyncWorker_0 homeassistant.loader:loader.py:651 Loaded test from custom_components.test
2024-01-11 00:13:33.280 WARNING  SyncWorker_0 homeassistant.loader:loader.py:589 We found a custom integration test which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
2024-01-11 00:13:33.280 INFO     SyncWorker_0 homeassistant.loader:loader.py:651 Loaded test_embedded from custom_components.test_embedded
2024-01-11 00:13:33.280 WARNING  SyncWorker_0 homeassistant.loader:loader.py:589 We found a custom integration test_embedded which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
2024-01-11 00:13:33.280 INFO     SyncWorker_0 homeassistant.loader:loader.py:651 Loaded test_no_version from custom_components.test_no_version
2024-01-11 00:13:33.280 WARNING  SyncWorker_0 homeassistant.loader:loader.py:589 We found a custom integration test_no_version which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
2024-01-11 00:13:33.280 ERROR    SyncWorker_0 homeassistant.loader:loader.py:591 The custom integration 'test_no_version' does not have a version key in the manifest file and was blocked from loading. See https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes#versions for more details
2024-01-11 00:13:33.281 INFO     SyncWorker_0 homeassistant.loader:loader.py:651 Loaded test_bad_version from custom_components.test_bad_version
2024-01-11 00:13:33.281 WARNING  SyncWorker_0 homeassistant.loader:loader.py:589 We found a custom integration test_bad_version which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
2024-01-11 00:13:33.281 ERROR    SyncWorker_0 homeassistant.loader:loader.py:614 The custom integration 'test_bad_version' does not have a valid version key (bad) in the manifest file and was blocked from loading. See https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes#versions for more details
2024-01-11 00:13:33.281 INFO     SyncWorker_0 homeassistant.loader:loader.py:651 Loaded test_package from custom_components.test_package
2024-01-11 00:13:33.281 WARNING  SyncWorker_0 homeassistant.loader:loader.py:589 We found a custom integration test_package which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
2024-01-11 00:13:33.281 INFO     SyncWorker_0 homeassistant.loader:loader.py:651 Loaded test_integration_frame from custom_components.test_integration_frame
2024-01-11 00:13:33.281 WARNING  SyncWorker_0 homeassistant.loader:loader.py:589 We found a custom integration test_integration_frame which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
2024-01-11 00:13:33.282 INFO     SyncWorker_0 homeassistant.loader:loader.py:651 Loaded sensor from homeassistant.components.sensor
2024-01-11 00:13:33.282 INFO     MainThread homeassistant.setup:setup.py:301 Setting up sensor
2024-01-11 00:13:33.282 INFO     MainThread homeassistant.setup:setup.py:352 Setup of domain sensor took 0.0 seconds
2024-01-11 00:13:33.283 DEBUG    MainThread homeassistant.core:core.py:1203 Bus:Handling <Event component_loaded[L]: component=sensor>
2024-01-11 00:13:33.283 INFO     MainThread homeassistant.setup:setup.py:301 Setting up test
2024-01-11 00:13:33.283 INFO     MainThread homeassistant.setup:setup.py:352 Setup of domain test took 0.0 seconds
2024-01-11 00:13:33.284 DEBUG    MainThread homeassistant.core:core.py:1203 Bus:Handling <Event component_loaded[L]: component=test>
2024-01-11 00:13:33.284 DEBUG    MainThread homeassistant.helpers.translation:translation.py:222 Cache miss for en: sensor
2024-01-11 00:13:33.285 DEBUG    MainThread homeassistant.helpers.translation:translation.py:222 Cache miss for en: test
2024-01-11 00:13:33.285 DEBUG    MainThread homeassistant.helpers.entity_platform:entity_platform.py:328 Could not load translations for test
Traceback (most recent call last):
  File "/Users/joakim/src/hass/home-assistant/homeassistant/helpers/entity_platform.py", line 324, in get_translations
    return await translation.async_get_translations(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/joakim/src/hass/home-assistant/homeassistant/helpers/translation.py", line 363, in async_get_translations
    return await cache.async_fetch(language, category, components)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/joakim/src/hass/home-assistant/homeassistant/helpers/translation.py", line 212, in async_fetch
    await self._async_load(language, components_to_load)
  File "/Users/joakim/src/hass/home-assistant/homeassistant/helpers/translation.py", line 238, in _async_load
    for translation_strings in await asyncio.gather(
                               ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/joakim/src/hass/home-assistant/homeassistant/helpers/translation.py", line 161, in _async_get_component_strings
    path = component_translation_path(loaded, language, integration)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/joakim/src/hass/home-assistant/homeassistant/helpers/translation.py", line 57, in component_translation_path
    if integration.file_path.name != domain:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'name'
2024-01-11 00:13:33.286 INFO     MainThread homeassistant.components.sensor:entity_platform.py:352 Setting up test.sensor
2024-01-11 00:13:33.287 DEBUG    MainThread homeassistant.core:core.py:1203 Bus:Handling <Event entity_registry_updated[L]: action=update, entity_id=sensor.test_very_unique, changes=original_device_class=None, original_name=None, unit_of_measurement=None>
2024-01-11 00:13:33.287 DEBUG    MainThread homeassistant.core:core.py:1203 Bus:Handling <Event state_changed[L]: entity_id=sensor.test_very_unique, old_state=None, new_state=<state sensor.test_very_unique=0; unit_of_measurement=hPa, device_class=atmospheric_pressure, friendly_name=Test @ 2024-01-10T15:13:33.287640-08:00>>

```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
