### PR TITLE
Hide FlowResultType.SHOW_PROGRESS_DONE from frontend

### DIFF
--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -310,6 +310,15 @@ class FlowManager(abc.ABC):
         self, flow_id: str, user_input: dict | None = None
     ) -> FlowResult:
         """Continue a data entry flow."""
+        result: FlowResult | None = None
+        while not result or result["type"] == FlowResultType.SHOW_PROGRESS_DONE:
+            result = await self._async_configure(flow_id, user_input)
+        return result
+
+    async def _async_configure(
+        self, flow_id: str, user_input: dict | None = None
+    ) -> FlowResult:
+        """Continue a data entry flow."""
         if (flow := self._progress.get(flow_id)) is None:
             raise UnknownFlow
 
@@ -452,7 +461,7 @@ class FlowManager(abc.ABC):
             # The flow's progress task was changed, register a callback on it
             async def call_configure() -> None:
                 with suppress(UnknownFlow):
-                    await self.async_configure(flow.flow_id)
+                    await self._async_configure(flow.flow_id)
 
             def schedule_configure(_: asyncio.Task) -> None:
                 self.hass.async_create_task(call_configure())

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -619,7 +619,10 @@ async def test_show_progress_legacy(hass: HomeAssistant, manager, caplog) -> Non
     result = await manager.async_configure(
         result["flow_id"], {"task_finished": 2, "title": "Hello"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS_DONE
+    # Note: The SHOW_PROGRESS_DONE is hidden from frontend; FlowManager automatically
+    # calls the flow again
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Hello"
 
     await hass.async_block_till_done()
     assert len(events) == 2  # 1 for task one and 1 for task two
@@ -628,11 +631,6 @@ async def test_show_progress_legacy(hass: HomeAssistant, manager, caplog) -> Non
         "flow_id": result["flow_id"],
         "refresh": True,
     }
-
-    # Frontend refreshes the flow
-    result = await manager.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    assert result["title"] == "Hello"
 
     # Check for deprecation warning
     assert (

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -498,6 +498,54 @@ async def test_show_progress_error(hass: HomeAssistant, manager) -> None:
     assert result["reason"] == "error"
 
 
+async def test_show_progress_hidden_from_frontend(hass: HomeAssistant, manager) -> None:
+    """Test show progress done is not sent to frontend."""
+    manager.hass = hass
+    async_show_progress_done_called = False
+
+    @manager.mock_reg_handler("test")
+    class TestFlow(data_entry_flow.FlowHandler):
+        VERSION = 5
+        data = None
+        progress_task: asyncio.Task[None] | None = None
+
+        async def async_step_init(self, user_input=None):
+            async def long_running_job() -> None:
+                return
+
+            if not self.progress_task:
+                self.progress_task = hass.async_create_task(long_running_job())
+            if self.progress_task.done():
+                nonlocal async_show_progress_done_called
+                async_show_progress_done_called = True
+                return self.async_show_progress_done(next_step_id="finish")
+            return self.async_show_progress(
+                step_id="init",
+                progress_action="task",
+                # Set to None to simulate flow manager has not yet called when
+                # frontend loads
+                progress_task=None,
+            )
+
+        async def async_step_finish(self, user_input=None):
+            return self.async_create_entry(title=None, data=self.data)
+
+    result = await manager.async_init("test")
+    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert result["progress_action"] == "task"
+    assert len(manager.async_progress()) == 1
+    assert len(manager.async_progress_by_handler("test")) == 1
+    assert manager.async_get(result["flow_id"])["handler"] == "test"
+
+    await hass.async_block_till_done()
+    assert not async_show_progress_done_called
+
+    # Frontend refreshes the flow
+    result = await manager.async_configure(result["flow_id"])
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert async_show_progress_done_called
+
+
 async def test_show_progress_legacy(hass: HomeAssistant, manager, caplog) -> None:
     """Test show progress logic.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Hide `FlowResultType.SHOW_PROGRESS_DONE` from frontend

Rationale:
`FlowResultType.SHOW_PROGRESS_DONE` is meant as an internal result, returned when a long running task is completed to transition to the next step. Without the changes in this PR, we might send a `FlowResultType.SHOW_PROGRESS_DONE` result to frontend in case frontend refreshes the flow just when the long running task completed, before core has refreshed the flow.

This is not expected by frontend, frontend incorrectly interprets this as `FlowResultType.CREATE_ENTRY`:
https://github.com/home-assistant/frontend/blob/d441fafaab49c93f65e3781f076a762d4dad8287/src/dialogs/config-flow/dialog-data-entry-flow.ts#L271-L331

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
