### PR TITLE
Add additional template render tests

### DIFF
--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -1311,7 +1311,7 @@ async def test_render_template_renders_template(
 
 @pytest.mark.xfail(reason="Entities are missing when using a filter")
 async def test_render_template_with_filter(
-    hass: HomeAssistant, websocket_client
+    hass: HomeAssistant, websocket_client: MockHAClientWebSocket
 ) -> None:
     """Test simple template with a filter is rendered and updated."""
     hass.states.async_set("light.test", "on")

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -1048,6 +1048,102 @@ async def test_track_template_result(hass: HomeAssistant) -> None:
     assert len(wildercard_runs) == 4
 
 
+@pytest.mark.xfail(reason="unknown")
+async def test_track_template_result_with_filter(hass: HomeAssistant) -> None:
+    """Test tracking template where the state comes in via a filter."""
+    specific_runs = []
+    wildcard_runs = []
+    wildercard_runs = []
+
+    template_condition = Template("{{ 'test.state' | states }}", hass)
+    template_condition_var = Template(
+        "{{ ('test.state' | states | int(default=0)) + test }}", hass
+    )
+
+    def specific_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
+        track_result = updates.pop()
+        specific_runs.append(int(track_result.result))
+
+    async_track_template_result(
+        hass, [TrackTemplate(template_condition, None)], specific_run_callback
+    )
+
+    @ha.callback
+    def wildcard_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
+        track_result = updates.pop()
+        wildcard_runs.append(
+            (int(track_result.last_result or 0), int(track_result.result))
+        )
+
+    async_track_template_result(
+        hass, [TrackTemplate(template_condition, None)], wildcard_run_callback
+    )
+
+    async def wildercard_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
+        track_result = updates.pop()
+        wildercard_runs.append(
+            (int(track_result.last_result or 0), int(track_result.result))
+        )
+
+    async_track_template_result(
+        hass,
+        [TrackTemplate(template_condition_var, {"test": 5})],
+        wildercard_run_callback,
+    )
+    await hass.async_block_till_done()
+
+    hass.states.async_set("sensor.test", 5)
+    await hass.async_block_till_done()
+
+    assert specific_runs == [5]
+    assert wildcard_runs == [(0, 5)]
+    assert wildercard_runs == [(0, 10)]
+
+    hass.states.async_set("sensor.test", 30)
+    await hass.async_block_till_done()
+
+    assert specific_runs == [5, 30]
+    assert wildcard_runs == [(0, 5), (5, 30)]
+    assert wildercard_runs == [(0, 10), (10, 35)]
+
+    hass.states.async_set("sensor.test", 30)
+    await hass.async_block_till_done()
+
+    assert len(specific_runs) == 2
+    assert len(wildcard_runs) == 2
+    assert len(wildercard_runs) == 2
+
+    hass.states.async_set("sensor.test", 5)
+    await hass.async_block_till_done()
+
+    assert len(specific_runs) == 3
+    assert len(wildcard_runs) == 3
+    assert len(wildercard_runs) == 3
+
+    hass.states.async_set("sensor.test", 5)
+    await hass.async_block_till_done()
+
+    assert len(specific_runs) == 3
+    assert len(wildcard_runs) == 3
+    assert len(wildercard_runs) == 3
+
+    hass.states.async_set("sensor.test", 20)
+    await hass.async_block_till_done()
+
+    assert len(specific_runs) == 4
+    assert len(wildcard_runs) == 4
+    assert len(wildercard_runs) == 4
+
+
 async def test_track_template_result_none(hass: HomeAssistant) -> None:
     """Test tracking template."""
     specific_runs = []

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -3968,6 +3968,43 @@ def test_closest_function_to_state(hass: HomeAssistant) -> None:
     )
 
 
+def test_async_render_to_info_with_compare_is_is_state(hass: HomeAssistant) -> None:
+    """Test async_render_to_info with compare to is_state."""
+    hass.states.async_set("light.a", "off")
+
+    info = render_to_info(
+        hass,
+        """
+{{ "light.a" is is_state("off") }}
+""",
+    )
+
+    assert_result_info(info, True, {"light.a"}, set())
+
+    info = render_to_info(
+        hass,
+        """
+{{ "light.a" is is_state("on") }}
+""",
+    )
+
+    assert_result_info(info, False, {"light.a"}, set())
+
+
+def test_async_render_to_info_with_filter(hass: HomeAssistant) -> None:
+    """Test async_render_to_info with filter."""
+    hass.states.async_set("light.a", "off")
+
+    info = render_to_info(
+        hass,
+        """
+{{ "light.a" | states }}
+""",
+    )
+
+    assert_result_info(info, "off", {"light.a"}, set())
+
+
 def test_closest_function_invalid_state(hass: HomeAssistant) -> None:
     """Test closest function invalid state."""
     hass.states.async_set(

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -4003,7 +4003,7 @@ def test_async_render_to_info_with_filter(hass: HomeAssistant) -> None:
     assert_result_info(info, "off", {"light.a"}, set())
 
 
-# @pytest.mark.xfail(reason="fails on second render")
+@pytest.mark.xfail(reason="fails on second render")
 def test_async_render_to_info_with_filter_multiple_times(hass: HomeAssistant) -> None:
     """Test async_render_to_info with filter multiple times."""
     hass.states.async_set("light.a", "off")

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -4003,15 +4003,19 @@ def test_async_render_to_info_with_filter(hass: HomeAssistant) -> None:
     assert_result_info(info, "off", {"light.a"}, set())
 
 
-@pytest.mark.xfail(reason="fails on second render")
+# @pytest.mark.xfail(reason="fails on second render")
 def test_async_render_to_info_with_filter_multiple_times(hass: HomeAssistant) -> None:
     """Test async_render_to_info with filter multiple times."""
+    hass.states.async_set("light.a", "off")
     template_str = '{{ "light.a" | states }}'
     tmp = template.Template(template_str, hass)
     info = tmp.async_render_to_info()
     assert info.entities == {"light.a"}
+    assert info.result() == "off"
+    hass.states.async_set("light.a", "on")
     info2 = tmp.async_render_to_info()
     assert info2.entities == {"light.a"}
+    assert info2.result() == "on"
 
 
 def test_closest_function_invalid_state(hass: HomeAssistant) -> None:

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -3994,15 +3994,24 @@ def test_async_render_to_info_with_compare_is_is_state(hass: HomeAssistant) -> N
 def test_async_render_to_info_with_filter(hass: HomeAssistant) -> None:
     """Test async_render_to_info with filter."""
     hass.states.async_set("light.a", "off")
-
+    template_str = '{{ "light.a" | states }}'
     info = render_to_info(
         hass,
-        """
-{{ "light.a" | states }}
-""",
+        template_str,
     )
 
     assert_result_info(info, "off", {"light.a"}, set())
+
+
+@pytest.mark.xfail(reason="fails on second render")
+def test_async_render_to_info_with_filter_multiple_times(hass: HomeAssistant) -> None:
+    """Test async_render_to_info with filter multiple times."""
+    template_str = '{{ "light.a" | states }}'
+    tmp = template.Template(template_str, hass)
+    info = tmp.async_render_to_info()
+    assert info.entities == {"light.a"}
+    info2 = tmp.async_render_to_info()
+    assert info2.entities == {"light.a"}
 
 
 def test_closest_function_invalid_state(hass: HomeAssistant) -> None:


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add additional template render tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
