### PR TITLE
Support smartthings multiple component devices

### DIFF
--- a/homeassistant/components/smartthings/binary_sensor.py
+++ b/homeassistant/components/smartthings/binary_sensor.py
@@ -60,7 +60,7 @@ async def async_setup_entry(
         capabilities = broker.get_assigned(device.device_id, Platform.BINARY_SENSOR)
         device_components = get_device_attributes(device)
 
-        for component_id in device_components:
+        for component_id in list(device_components.keys()):
             attributes = device_components[component_id]
 
             for capability in capabilities:
@@ -84,7 +84,7 @@ def get_capabilities(capabilities: Sequence[str]) -> Sequence[str] | None:
 class SmartThingsBinarySensor(SmartThingsEntity, BinarySensorEntity):
     """Define a SmartThings Binary Sensor."""
 
-    def __init__(self, device, attribute, component_id: str | None = None):
+    def __init__(self, device, attribute, component_id: str | None = None) -> None:
         """Init the class."""
         super().__init__(device)
         self._attribute = attribute

--- a/homeassistant/components/smartthings/binary_sensor.py
+++ b/homeassistant/components/smartthings/binary_sensor.py
@@ -103,4 +103,8 @@ class SmartThingsBinarySensor(SmartThingsEntity, BinarySensorEntity):
         """Return true if the binary sensor is on."""
         status = get_device_status(self._device, self._component_id)
 
-        return status.is_on(self._attribute)
+        if status is None:
+            return False
+
+        else:
+            return status.is_on(self._attribute)

--- a/homeassistant/components/smartthings/binary_sensor.py
+++ b/homeassistant/components/smartthings/binary_sensor.py
@@ -106,5 +106,4 @@ class SmartThingsBinarySensor(SmartThingsEntity, BinarySensorEntity):
         if status is None:
             return False
 
-        else:
-            return status.is_on(self._attribute)
+        return status.is_on(self._attribute)

--- a/homeassistant/components/smartthings/binary_sensor.py
+++ b/homeassistant/components/smartthings/binary_sensor.py
@@ -10,12 +10,13 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
+from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import SmartThingsEntity
 from .const import DATA_BROKERS, DOMAIN
+from .utils import format_component_name, get_device_attributes, get_device_status
 
 CAPABILITY_TO_ATTRIB = {
     Capability.acceleration_sensor: Attribute.acceleration,
@@ -24,6 +25,7 @@ CAPABILITY_TO_ATTRIB = {
     Capability.motion_sensor: Attribute.motion,
     Capability.presence_sensor: Attribute.presence,
     Capability.sound_sensor: Attribute.sound,
+    Capability.switch: Attribute.power,
     Capability.tamper_alert: Attribute.tamper,
     Capability.valve: Attribute.valve,
     Capability.water_sensor: Attribute.water,
@@ -34,6 +36,7 @@ ATTRIB_TO_CLASS = {
     Attribute.filter_status: BinarySensorDeviceClass.PROBLEM,
     Attribute.motion: BinarySensorDeviceClass.MOTION,
     Attribute.presence: BinarySensorDeviceClass.PRESENCE,
+    Attribute.power: BinarySensorDeviceClass.POWER,
     Attribute.sound: BinarySensorDeviceClass.SOUND,
     Attribute.tamper: BinarySensorDeviceClass.PROBLEM,
     Attribute.valve: BinarySensorDeviceClass.OPENING,
@@ -52,10 +55,22 @@ async def async_setup_entry(
     """Add binary sensors for a config entry."""
     broker = hass.data[DOMAIN][DATA_BROKERS][config_entry.entry_id]
     sensors = []
+
     for device in broker.devices.values():
-        for capability in broker.get_assigned(device.device_id, "binary_sensor"):
-            attrib = CAPABILITY_TO_ATTRIB[capability]
-            sensors.append(SmartThingsBinarySensor(device, attrib))
+        capabilities = broker.get_assigned(device.device_id, Platform.BINARY_SENSOR)
+        device_components = get_device_attributes(device)
+
+        for component_id in device_components:
+            attributes = device_components[component_id]
+
+            for capability in capabilities:
+                attrib = CAPABILITY_TO_ATTRIB[capability]
+
+                if attributes is None or attrib in attributes:
+                    sensors.append(
+                        SmartThingsBinarySensor(device, attrib, component_id)
+                    )
+
     async_add_entities(sensors)
 
 
@@ -69,16 +84,23 @@ def get_capabilities(capabilities: Sequence[str]) -> Sequence[str] | None:
 class SmartThingsBinarySensor(SmartThingsEntity, BinarySensorEntity):
     """Define a SmartThings Binary Sensor."""
 
-    def __init__(self, device, attribute):
+    def __init__(self, device, attribute, component_id: str | None = None):
         """Init the class."""
         super().__init__(device)
         self._attribute = attribute
-        self._attr_name = f"{device.label} {attribute}"
-        self._attr_unique_id = f"{device.device_id}.{attribute}"
+        self._component_id = component_id
+
+        self._attr_name = format_component_name(device.label, attribute, component_id)
+        self._attr_unique_id = format_component_name(
+            device.device_id, attribute, component_id, "."
+        )
+
         self._attr_device_class = ATTRIB_TO_CLASS[attribute]
         self._attr_entity_category = ATTRIB_TO_ENTTIY_CATEGORY.get(attribute)
 
     @property
     def is_on(self):
         """Return true if the binary sensor is on."""
-        return self._device.status.is_on(self._attribute)
+        status = get_device_status(self._device, self._component_id)
+
+        return status.is_on(self._attribute)

--- a/homeassistant/components/smartthings/light.py
+++ b/homeassistant/components/smartthings/light.py
@@ -248,5 +248,4 @@ class SmartThingsLight(SmartThingsEntity, LightEntity):
         if status is None:
             return False
 
-        else:
-            return status.switch
+        return status.switch

--- a/homeassistant/components/smartthings/light.py
+++ b/homeassistant/components/smartthings/light.py
@@ -183,21 +183,21 @@ class SmartThingsLight(SmartThingsEntity, LightEntity):
 
     async def async_update(self) -> None:
         """Update entity attributes when the device status has changed."""
+        status = get_device_status(self._device, self._component_id)
+
         # Brightness and transition
         if brightness_supported(self._attr_supported_color_modes):
-            self._attr_brightness = int(
-                convert_scale(self._device.status.level, 100, 255, 0)
-            )
+            self._attr_brightness = int(convert_scale(status.level, 100, 255, 0))
         # Color Temperature
         if ColorMode.COLOR_TEMP in self._attr_supported_color_modes:
             self._attr_color_temp = color_util.color_temperature_kelvin_to_mired(
-                self._device.status.color_temperature
+                status.color_temperature
             )
         # Color
         if ColorMode.HS in self._attr_supported_color_modes:
             self._attr_hs_color = (
-                convert_scale(self._device.status.hue, 100, 360),
-                self._device.status.saturation,
+                convert_scale(status.hue, 100, 360),
+                status.saturation,
             )
 
     async def async_set_color(self, hs_color):

--- a/homeassistant/components/smartthings/light.py
+++ b/homeassistant/components/smartthings/light.py
@@ -103,12 +103,13 @@ class SmartThingsLight(SmartThingsEntity, LightEntity):
         self._component_id = component_id
         self._external_component_id = "main" if component_id is None else component_id
 
-        self._attr_name = format_component_name(
-            device.label, Platform.LIGHT, component_id
-        )
-        self._attr_unique_id = format_component_name(
-            device.device_id, Platform.LIGHT, component_id, "."
-        )
+        if component_id is not None:
+            self._attr_name = format_component_name(
+                device.label, Platform.LIGHT, component_id
+            )
+            self._attr_unique_id = format_component_name(
+                device.device_id, Platform.LIGHT, component_id, "."
+            )
 
         self._attr_supported_color_modes = self._determine_color_modes()
         self._attr_supported_features = self._determine_features()

--- a/homeassistant/components/smartthings/light.py
+++ b/homeassistant/components/smartthings/light.py
@@ -46,7 +46,7 @@ async def async_setup_entry(
 
         device_components = get_device_attributes(device)
 
-        for component_id in device_components:
+        for component_id in list(device_components.keys()):
             attributes = device_components[component_id]
 
             if attributes is None or Platform.SWITCH in attributes:
@@ -97,7 +97,7 @@ class SmartThingsLight(SmartThingsEntity, LightEntity):
     # highest kelvin found supported across 20+ handlers.
     _attr_min_mireds = 111  # 9000K
 
-    def __init__(self, device, component_id: str | None = None):
+    def __init__(self, device, component_id: str | None = None) -> None:
         """Init the class."""
         super().__init__(device)
         self._component_id = component_id

--- a/homeassistant/components/smartthings/light.py
+++ b/homeassistant/components/smartthings/light.py
@@ -185,6 +185,9 @@ class SmartThingsLight(SmartThingsEntity, LightEntity):
         """Update entity attributes when the device status has changed."""
         status = get_device_status(self._device, self._component_id)
 
+        if status is None:
+            return
+
         # Brightness and transition
         if brightness_supported(self._attr_supported_color_modes):
             self._attr_brightness = int(convert_scale(status.level, 100, 255, 0))
@@ -205,17 +208,30 @@ class SmartThingsLight(SmartThingsEntity, LightEntity):
         hue = convert_scale(float(hs_color[0]), 360, 100)
         hue = max(min(hue, 100.0), 0.0)
         saturation = max(min(float(hs_color[1]), 100.0), 0.0)
-        await self._device.set_color(
-            hue, saturation, set_status=True, component_id=self._external_component_id
-        )
+
+        if self._component_id is None:
+            await self._device.set_color(hue, saturation, set_status=True)
+
+        else:
+            await self._device.set_color(
+                hue,
+                saturation,
+                set_status=True,
+                component_id=self._external_component_id,
+            )
 
     async def async_set_color_temp(self, value: float):
         """Set the color temperature of the device."""
         kelvin = color_util.color_temperature_mired_to_kelvin(value)
         kelvin = max(min(kelvin, 30000), 1)
-        await self._device.set_color_temperature(
-            kelvin, set_status=True, component_id=self._external_component_id
-        )
+
+        if self._component_id is None:
+            await self._device.set_color_temperature(kelvin, set_status=True)
+
+        else:
+            await self._device.set_color_temperature(
+                kelvin, set_status=True, component_id=self._external_component_id
+            )
 
     async def async_set_level(self, brightness: int, transition: int):
         """Set the brightness of the light over transition."""
@@ -225,9 +241,17 @@ class SmartThingsLight(SmartThingsEntity, LightEntity):
         level = 1 if level == 0 and brightness > 0 else level
         level = max(min(level, 100), 0)
         duration = int(transition)
-        await self._device.set_level(
-            level, duration, set_status=True, component_id=self._external_component_id
-        )
+
+        if self._component_id is None:
+            await self._device.set_level(level, duration, set_status=True)
+
+        else:
+            await self._device.set_level(
+                level,
+                duration,
+                set_status=True,
+                component_id=self._external_component_id,
+            )
 
     @property
     def color_mode(self) -> ColorMode:

--- a/homeassistant/components/smartthings/light.py
+++ b/homeassistant/components/smartthings/light.py
@@ -52,7 +52,7 @@ async def async_setup_entry(
             if attributes is None or Platform.SWITCH in attributes:
                 entities.append(SmartThingsLight(device, component_id))
 
-    async_add_entities(entities)
+    async_add_entities(entities, True)
 
 
 def get_capabilities(capabilities: Sequence[str]) -> Sequence[str] | None:

--- a/homeassistant/components/smartthings/light.py
+++ b/homeassistant/components/smartthings/light.py
@@ -245,4 +245,8 @@ class SmartThingsLight(SmartThingsEntity, LightEntity):
         """Return true if light is on."""
         status = get_device_status(self._device, self._component_id)
 
-        return status.switch
+        if status is None:
+            return False
+
+        else:
+            return status.switch

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -780,7 +780,11 @@ class SmartThingsPowerConsumptionSensor(SmartThingsEntity, SensorEntity):
         """Return the state of the sensor."""
         status = get_device_status(self._device, self._component_id)
 
-        value = None if status is None else status.attributes[Attribute.power_consumption].value
+        value = (
+            None
+            if status is None
+            else status.attributes[Attribute.power_consumption].value
+        )
         if value is None or value.get(self.report_name) is None:
             return None
         if self.report_name == "power":

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -569,16 +569,16 @@ async def async_setup_entry(
             attributes = device_components[component_id]
 
             entities.extend(
-                get_device_sensor_entities(broker, device, component_id, attributes)
+                _get_device_sensor_entities(broker, device, component_id, attributes)
             )
             entities.extend(
-                get_device_switch_entities(broker, device, component_id, attributes)
+                _get_device_switch_entities(broker, device, component_id, attributes)
             )
 
     async_add_entities(entities)
 
 
-def get_device_sensor_entities(
+def _get_device_sensor_entities(
     broker, device, component_id: str | None, component_attributes: list[str] | None
 ) -> list[SensorEntity]:
     entities = []
@@ -632,7 +632,7 @@ def get_device_sensor_entities(
     return entities
 
 
-def get_device_switch_entities(
+def _get_device_switch_entities(
     broker, device, component_id: str | None, component_attributes: list[str] | None
 ) -> list[SensorEntity]:
     entities = []

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -779,6 +779,8 @@ class SmartThingsPowerConsumptionSensor(SmartThingsEntity, SensorEntity):
     def native_value(self):
         """Return the state of the sensor."""
         status = get_device_status(self._device, self._component_id)
+        if status is None:
+            return None
 
         value = status.attributes[Attribute.power_consumption].value
         if value is None or value.get(self.report_name) is None:
@@ -793,14 +795,15 @@ class SmartThingsPowerConsumptionSensor(SmartThingsEntity, SensorEntity):
         if self.report_name == "power":
             status = get_device_status(self._device, self._component_id)
 
-            attributes = [
-                "power_consumption_start",
-                "power_consumption_end",
-            ]
-            state_attributes = {}
-            for attribute in attributes:
-                value = getattr(status, attribute)
-                if value is not None:
-                    state_attributes[attribute] = value
-            return state_attributes
+            if status is not None:
+                attributes = [
+                    "power_consumption_start",
+                    "power_consumption_end",
+                ]
+                state_attributes = {}
+                for attribute in attributes:
+                    value = getattr(status, attribute)
+                    if value is not None:
+                        state_attributes[attribute] = value
+                return state_attributes
         return None

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     LIGHT_LUX,
     PERCENTAGE,
     EntityCategory,
+    Platform,
     UnitOfElectricPotential,
     UnitOfEnergy,
     UnitOfMass,
@@ -32,6 +33,7 @@ from homeassistant.util import dt as dt_util
 
 from . import SmartThingsEntity
 from .const import DATA_BROKERS, DOMAIN
+from .utils import format_component_name, get_device_attributes, get_device_status
 
 Map = namedtuple(
     "Map", "attribute name default_unit device_class state_class entity_category"
@@ -559,58 +561,104 @@ async def async_setup_entry(
     """Add sensors for a config entry."""
     broker = hass.data[DOMAIN][DATA_BROKERS][config_entry.entry_id]
     entities: list[SensorEntity] = []
-    for device in broker.devices.values():
-        for capability in broker.get_assigned(device.device_id, "sensor"):
-            if capability == Capability.three_axis:
-                entities.extend(
-                    [
-                        SmartThingsThreeAxisSensor(device, index)
-                        for index in range(len(THREE_AXIS_NAMES))
-                    ]
-                )
-            elif capability == Capability.power_consumption_report:
-                entities.extend(
-                    [
-                        SmartThingsPowerConsumptionSensor(device, report_name)
-                        for report_name in POWER_CONSUMPTION_REPORT_NAMES
-                    ]
-                )
-            else:
-                maps = CAPABILITY_TO_SENSORS[capability]
-                entities.extend(
-                    [
-                        SmartThingsSensor(
-                            device,
-                            m.attribute,
-                            m.name,
-                            m.default_unit,
-                            m.device_class,
-                            m.state_class,
-                            m.entity_category,
-                        )
-                        for m in maps
-                    ]
-                )
 
-        if broker.any_assigned(device.device_id, "switch"):
-            for capability in (Capability.energy_meter, Capability.power_meter):
-                maps = CAPABILITY_TO_SENSORS[capability]
-                entities.extend(
-                    [
-                        SmartThingsSensor(
-                            device,
-                            m.attribute,
-                            m.name,
-                            m.default_unit,
-                            m.device_class,
-                            m.state_class,
-                            m.entity_category,
-                        )
-                        for m in maps
-                    ]
-                )
+    for device in broker.devices.values():
+        device_components = get_device_attributes(device)
+
+        for component_id in device_components:
+            attributes = device_components[component_id]
+
+            entities.extend(
+                get_device_sensor_entities(broker, device, component_id, attributes)
+            )
+            entities.extend(
+                get_device_switch_entities(broker, device, component_id, attributes)
+            )
 
     async_add_entities(entities)
+
+
+def get_device_sensor_entities(
+    broker, device, component_id: str | None, component_attributes: list[str] | None
+) -> list[SensorEntity]:
+    entities = []
+    for capability in broker.get_assigned(device.device_id, Platform.SENSOR):
+        if capability == Capability.three_axis:
+            entities.extend(
+                [
+                    SmartThingsThreeAxisSensor(device, index, component_id)
+                    for index in range(len(THREE_AXIS_NAMES))
+                    if component_attributes is None or index in component_attributes
+                ]
+            )
+        elif capability == Capability.power_consumption_report:
+            entities.extend(
+                [
+                    SmartThingsPowerConsumptionSensor(device, report_name, component_id)
+                    for report_name in POWER_CONSUMPTION_REPORT_NAMES
+                    if component_attributes is None
+                    or report_name in component_attributes
+                ]
+            )
+        else:
+            maps = CAPABILITY_TO_SENSORS[capability]
+
+            for m in maps:
+                if (
+                    component_attributes is not None
+                    and m.attribute not in component_attributes
+                ):
+                    continue
+
+                if component_id is None and m.attribute in [
+                    Attribute.temperature,
+                    Attribute.cooling_setpoint,
+                ]:
+                    continue
+
+                entity = SmartThingsSensor(
+                    device,
+                    m.attribute,
+                    m.name,
+                    m.default_unit,
+                    m.device_class,
+                    m.state_class,
+                    m.entity_category,
+                    component_id,
+                )
+
+                entities.append(entity)
+
+    return entities
+
+
+def get_device_switch_entities(
+    broker, device, component_id: str | None, component_attributes: list[str] | None
+) -> list[SensorEntity]:
+    entities = []
+
+    if broker.any_assigned(device.device_id, Platform.SWITCH):
+        for capability in (Capability.energy_meter, Capability.power_meter):
+            maps = CAPABILITY_TO_SENSORS[capability]
+            entities.extend(
+                [
+                    SmartThingsSensor(
+                        device,
+                        m.attribute,
+                        m.name,
+                        m.default_unit,
+                        m.device_class,
+                        m.state_class,
+                        m.entity_category,
+                        component_id,
+                    )
+                    for m in maps
+                    if component_attributes is None
+                    or m.attribute in component_attributes
+                ]
+            )
+
+    return entities
 
 
 def get_capabilities(capabilities: Sequence[str]) -> Sequence[str] | None:
@@ -632,12 +680,20 @@ class SmartThingsSensor(SmartThingsEntity, SensorEntity):
         device_class: SensorDeviceClass,
         state_class: str | None,
         entity_category: EntityCategory | None,
+        component_id: str | None,
     ) -> None:
         """Init the class."""
         super().__init__(device)
+
+        self._component_id = component_id
         self._attribute = attribute
-        self._attr_name = f"{device.label} {name}"
-        self._attr_unique_id = f"{device.device_id}.{attribute}"
+        self._component_id = component_id
+
+        self._attr_name = format_component_name(device.label, name, component_id)
+        self._attr_unique_id = format_component_name(
+            device.device_id, attribute, component_id, "."
+        )
+
         self._attr_device_class = device_class
         self._default_unit = default_unit
         self._attr_state_class = state_class
@@ -646,7 +702,8 @@ class SmartThingsSensor(SmartThingsEntity, SensorEntity):
     @property
     def native_value(self):
         """Return the state of the sensor."""
-        value = self._device.status.attributes[self._attribute].value
+        status = get_device_status(self._device, self._component_id)
+        value = status.attributes[self._attribute].value
 
         if self.device_class != SensorDeviceClass.TIMESTAMP:
             return value
@@ -656,24 +713,34 @@ class SmartThingsSensor(SmartThingsEntity, SensorEntity):
     @property
     def native_unit_of_measurement(self):
         """Return the unit this state is expressed in."""
-        unit = self._device.status.attributes[self._attribute].unit
+        status = get_device_status(self._device, self._component_id)
+        unit = status.attributes[self._attribute].unit
         return UNITS.get(unit, unit) if unit else self._default_unit
 
 
 class SmartThingsThreeAxisSensor(SmartThingsEntity, SensorEntity):
     """Define a SmartThings Three Axis Sensor."""
 
-    def __init__(self, device, index):
+    def __init__(self, device, index, component_id: str | None):
         """Init the class."""
         super().__init__(device)
+
         self._index = index
-        self._attr_name = f"{device.label} {THREE_AXIS_NAMES[index]}"
-        self._attr_unique_id = f"{device.device_id} {THREE_AXIS_NAMES[index]}"
+        self._component_id = component_id
+
+        attribute = THREE_AXIS_NAMES[index]
+
+        self._attr_name = format_component_name(device.label, attribute, component_id)
+        self._attr_unique_id = format_component_name(
+            device.device_id, attribute, component_id, "."
+        )
 
     @property
     def native_value(self):
         """Return the state of the sensor."""
-        three_axis = self._device.status.attributes[Attribute.three_axis].value
+        status = get_device_status(self._device, self._component_id)
+
+        three_axis = status.attributes[Attribute.three_axis].value
         try:
             return three_axis[self._index]
         except (TypeError, IndexError):
@@ -684,15 +751,20 @@ class SmartThingsPowerConsumptionSensor(SmartThingsEntity, SensorEntity):
     """Define a SmartThings Sensor."""
 
     def __init__(
-        self,
-        device: DeviceEntity,
-        report_name: str,
+        self, device: DeviceEntity, report_name: str, component_id: str | None
     ) -> None:
         """Init the class."""
         super().__init__(device)
         self.report_name = report_name
-        self._attr_name = f"{device.label} {report_name}"
-        self._attr_unique_id = f"{device.device_id}.{report_name}_meter"
+        self._component_id = component_id
+
+        unique_id = format_component_name(
+            device.device_id, report_name, component_id, "."
+        )
+
+        self._attr_name = format_component_name(device.label, report_name, component_id)
+        self._attr_unique_id = f"{unique_id}_meter"
+
         if self.report_name == "power":
             self._attr_state_class = SensorStateClass.MEASUREMENT
             self._attr_device_class = SensorDeviceClass.POWER
@@ -705,7 +777,9 @@ class SmartThingsPowerConsumptionSensor(SmartThingsEntity, SensorEntity):
     @property
     def native_value(self):
         """Return the state of the sensor."""
-        value = self._device.status.attributes[Attribute.power_consumption].value
+        status = get_device_status(self._device, self._component_id)
+
+        value = status.attributes[Attribute.power_consumption].value
         if value is None or value.get(self.report_name) is None:
             return None
         if self.report_name == "power":
@@ -716,13 +790,15 @@ class SmartThingsPowerConsumptionSensor(SmartThingsEntity, SensorEntity):
     def extra_state_attributes(self):
         """Return specific state attributes."""
         if self.report_name == "power":
+            status = get_device_status(self._device, self._component_id)
+
             attributes = [
                 "power_consumption_start",
                 "power_consumption_end",
             ]
             state_attributes = {}
             for attribute in attributes:
-                value = getattr(self._device.status, attribute)
+                value = getattr(status, attribute)
                 if value is not None:
                     state_attributes[attribute] = value
             return state_attributes

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -565,7 +565,7 @@ async def async_setup_entry(
     for device in broker.devices.values():
         device_components = get_device_attributes(device)
 
-        for component_id in device_components:
+        for component_id in list(device_components.keys()):
             attributes = device_components[component_id]
 
             entities.extend(
@@ -581,14 +581,15 @@ async def async_setup_entry(
 def _get_device_sensor_entities(
     broker, device, component_id: str | None, component_attributes: list[str] | None
 ) -> list[SensorEntity]:
-    entities = []
+    entities: list[SensorEntity] = []
     for capability in broker.get_assigned(device.device_id, Platform.SENSOR):
         if capability == Capability.three_axis:
             entities.extend(
                 [
                     SmartThingsThreeAxisSensor(device, index, component_id)
                     for index in range(len(THREE_AXIS_NAMES))
-                    if component_attributes is None or index in component_attributes
+                    if component_attributes is None
+                    or THREE_AXIS_NAMES[index] in component_attributes
                 ]
             )
         elif capability == Capability.power_consumption_report:
@@ -635,7 +636,7 @@ def _get_device_sensor_entities(
 def _get_device_switch_entities(
     broker, device, component_id: str | None, component_attributes: list[str] | None
 ) -> list[SensorEntity]:
-    entities = []
+    entities: list[SensorEntity] = []
 
     if broker.any_assigned(device.device_id, Platform.SWITCH):
         for capability in (Capability.energy_meter, Capability.power_meter):
@@ -721,7 +722,7 @@ class SmartThingsSensor(SmartThingsEntity, SensorEntity):
 class SmartThingsThreeAxisSensor(SmartThingsEntity, SensorEntity):
     """Define a SmartThings Three Axis Sensor."""
 
-    def __init__(self, device, index, component_id: str | None):
+    def __init__(self, device, index, component_id: str | None) -> None:
         """Init the class."""
         super().__init__(device)
 

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -779,10 +779,8 @@ class SmartThingsPowerConsumptionSensor(SmartThingsEntity, SensorEntity):
     def native_value(self):
         """Return the state of the sensor."""
         status = get_device_status(self._device, self._component_id)
-        if status is None:
-            return None
 
-        value = status.attributes[Attribute.power_consumption].value
+        value = None if status is None else status.attributes[Attribute.power_consumption].value
         if value is None or value.get(self.report_name) is None:
             return None
         if self.report_name == "power":

--- a/homeassistant/components/smartthings/switch.py
+++ b/homeassistant/components/smartthings/switch.py
@@ -61,12 +61,13 @@ class SmartThingsSwitch(SmartThingsEntity, SwitchEntity):
         self._component_id = component_id
         self._external_component_id = "main" if component_id is None else component_id
 
-        self._attr_name = format_component_name(
-            device.label, Platform.SWITCH, component_id
-        )
-        self._attr_unique_id = format_component_name(
-            device.device_id, Platform.SWITCH, component_id, "."
-        )
+        if component_id is not None:
+            self._attr_name = format_component_name(
+                device.label, Platform.SWITCH, component_id
+            )
+            self._attr_unique_id = format_component_name(
+                device.device_id, Platform.SWITCH, component_id, "."
+            )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""

--- a/homeassistant/components/smartthings/switch.py
+++ b/homeassistant/components/smartthings/switch.py
@@ -94,5 +94,4 @@ class SmartThingsSwitch(SmartThingsEntity, SwitchEntity):
         if status is None:
             return False
 
-        else:
-            return status.switch
+        return status.switch

--- a/homeassistant/components/smartthings/switch.py
+++ b/homeassistant/components/smartthings/switch.py
@@ -91,4 +91,8 @@ class SmartThingsSwitch(SmartThingsEntity, SwitchEntity):
         """Return true if light is on."""
         status = get_device_status(self._device, self._component_id)
 
-        return status.switch
+        if status is None:
+            return False
+
+        else:
+            return status.switch

--- a/homeassistant/components/smartthings/switch.py
+++ b/homeassistant/components/smartthings/switch.py
@@ -35,7 +35,7 @@ async def async_setup_entry(
 
         device_components = get_device_attributes(device)
 
-        for component_id in device_components:
+        for component_id in list(device_components.keys()):
             attributes = device_components[component_id]
 
             if attributes is None or Platform.SWITCH in attributes:
@@ -55,7 +55,7 @@ def get_capabilities(capabilities: Sequence[str]) -> Sequence[str] | None:
 class SmartThingsSwitch(SmartThingsEntity, SwitchEntity):
     """Define a SmartThings switch."""
 
-    def __init__(self, device, component_id: str | None = None):
+    def __init__(self, device, component_id: str | None = None) -> None:
         """Init the class."""
         super().__init__(device)
         self._component_id = component_id

--- a/homeassistant/components/smartthings/switch.py
+++ b/homeassistant/components/smartthings/switch.py
@@ -28,18 +28,14 @@ async def async_setup_entry(
     entities = []
 
     for device in broker.devices.values():
-        has_switch = broker.any_assigned(device.device_id, Platform.SWITCH)
+        if broker.any_assigned(device.device_id, Platform.SWITCH):
+            device_components = get_device_attributes(device)
 
-        if not has_switch:
-            continue
+            for component_id in list(device_components.keys()):
+                attributes = device_components[component_id]
 
-        device_components = get_device_attributes(device)
-
-        for component_id in list(device_components.keys()):
-            attributes = device_components[component_id]
-
-            if attributes is None or Platform.SWITCH in attributes:
-                entities.append(SmartThingsSwitch(device, component_id))
+                if attributes is None or Platform.SWITCH in attributes:
+                    entities.append(SmartThingsSwitch(device, component_id))
 
     async_add_entities(entities)
 
@@ -92,7 +88,4 @@ class SmartThingsSwitch(SmartThingsEntity, SwitchEntity):
         """Return true if light is on."""
         status = get_device_status(self._device, self._component_id)
 
-        if status is None:
-            return False
-
-        return status.switch
+        return False if status is None else status.switch

--- a/homeassistant/components/smartthings/switch.py
+++ b/homeassistant/components/smartthings/switch.py
@@ -8,11 +8,13 @@ from pysmartthings import Capability
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import SmartThingsEntity
 from .const import DATA_BROKERS, DOMAIN
+from .utils import format_component_name, get_device_attributes, get_device_status
 
 
 async def async_setup_entry(
@@ -22,13 +24,24 @@ async def async_setup_entry(
 ) -> None:
     """Add switches for a config entry."""
     broker = hass.data[DOMAIN][DATA_BROKERS][config_entry.entry_id]
-    async_add_entities(
-        [
-            SmartThingsSwitch(device)
-            for device in broker.devices.values()
-            if broker.any_assigned(device.device_id, "switch")
-        ]
-    )
+
+    entities = []
+
+    for device in broker.devices.values():
+        has_switch = broker.any_assigned(device.device_id, Platform.SWITCH)
+
+        if not has_switch:
+            continue
+
+        device_components = get_device_attributes(device)
+
+        for component_id in device_components:
+            attributes = device_components[component_id]
+
+            if attributes is None or Platform.SWITCH in attributes:
+                entities.append(SmartThingsSwitch(device, component_id))
+
+    async_add_entities(entities)
 
 
 def get_capabilities(capabilities: Sequence[str]) -> Sequence[str] | None:
@@ -42,16 +55,33 @@ def get_capabilities(capabilities: Sequence[str]) -> Sequence[str] | None:
 class SmartThingsSwitch(SmartThingsEntity, SwitchEntity):
     """Define a SmartThings switch."""
 
+    def __init__(self, device, component_id: str | None = None):
+        """Init the class."""
+        super().__init__(device)
+        self._component_id = component_id
+        self._external_component_id = "main" if component_id is None else component_id
+
+        self._attr_name = format_component_name(
+            device.label, Platform.SWITCH, component_id
+        )
+        self._attr_unique_id = format_component_name(
+            device.device_id, Platform.SWITCH, component_id, "."
+        )
+
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        await self._device.switch_off(set_status=True)
+        await self._device.switch_off(
+            set_status=True, component_id=self._external_component_id
+        )
         # State is set optimistically in the command above, therefore update
         # the entity state ahead of receiving the confirming push updates
         self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        await self._device.switch_on(set_status=True)
+        await self._device.switch_on(
+            set_status=True, component_id=self._external_component_id
+        )
         # State is set optimistically in the command above, therefore update
         # the entity state ahead of receiving the confirming push updates
         self.async_write_ha_state()
@@ -59,4 +89,6 @@ class SmartThingsSwitch(SmartThingsEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return true if light is on."""
-        return self._device.status.switch
+        status = get_device_status(self._device, self._component_id)
+
+        return status.switch

--- a/homeassistant/components/smartthings/utils.py
+++ b/homeassistant/components/smartthings/utils.py
@@ -1,0 +1,53 @@
+from pysmartthings import DeviceStatusBase
+
+
+def format_component_name(
+    prefix: str, suffix: str, component_id: str | None, delimiter: str = " "
+) -> str:
+    parts = [prefix]
+
+    if component_id is not None:
+        parts.append(component_id)
+
+    parts.append(suffix)
+
+    component_name = delimiter.join(parts)
+
+    return component_name
+
+
+def get_device_status(device, component_id: str | None) -> DeviceStatusBase:
+    status = device.status
+
+    if component_id is not None:
+        status = status.components[component_id]
+
+    return status
+
+
+def get_device_attributes(device) -> dict[str, list[str]]:
+    result = {}
+    device_components_keys = list(device.status.components.keys())
+
+    components_keys = [None]
+
+    if len(device_components_keys) > 1:
+        components_keys.extend(device_components_keys)
+
+    disabled_components = device.status.attributes["disabledComponents"]
+
+    for component_key in components_keys:
+        if component_key is not None and component_key in disabled_components:
+            continue
+
+        component_id = None
+        component_attributes = None
+
+        if component_key is not None:
+            component = device.status.components[component_key]
+            component_id = component.component_id
+            component_attributes = list(component.attributes.keys())
+
+        result[component_id] = component_attributes
+
+    return result

--- a/homeassistant/components/smartthings/utils.py
+++ b/homeassistant/components/smartthings/utils.py
@@ -1,9 +1,11 @@
+"""Shared functionality to serve multiple HA components."""
 from pysmartthings import DeviceStatusBase
 
 
 def format_component_name(
     prefix: str, suffix: str, component_id: str | None, delimiter: str = " "
 ) -> str:
+    """Format component name according to convention."""
     parts = [prefix]
 
     if component_id is not None:
@@ -17,6 +19,7 @@ def format_component_name(
 
 
 def get_device_status(device, component_id: str | None) -> DeviceStatusBase:
+    """Choose the status object based on device and component id."""
     status = device.status
 
     if component_id is not None:
@@ -26,6 +29,7 @@ def get_device_status(device, component_id: str | None) -> DeviceStatusBase:
 
 
 def get_device_attributes(device) -> dict[str, list[str]]:
+    """Construct list of components related to a device."""
     result = {}
     device_components_keys = list(device.status.components.keys())
 

--- a/homeassistant/components/smartthings/utils.py
+++ b/homeassistant/components/smartthings/utils.py
@@ -28,9 +28,9 @@ def get_device_status(device, component_id: str | None) -> DeviceStatusBase:
     return status
 
 
-def get_device_attributes(device) -> dict[str, list[str]]:
+def get_device_attributes(device) -> dict[str | None, list[str] | None]:
     """Construct list of components related to a device."""
-    result = {}
+    result: dict[str | None, list[str] | None] = {}
     device_components_keys = list(device.status.components.keys())
 
     components_keys = [None]

--- a/tests/components/smartthings/conftest.py
+++ b/tests/components/smartthings/conftest.py
@@ -274,26 +274,28 @@ def device_factory_fixture():
         }
 
         if label == "Dimmer 1":
-            device_data["components"].extend([
-                {
-                    "id": "secondary",
-                    "capabilities": [
-                        {"id": capability, "version": 1} for capability in capabilities
-                    ],
-                },
-                {
-                    "id": "with_unsupported_capabilities",
-                    "capabilities": [
-                        {"id": f"{capability}_other", "version": 1} for capability in capabilities
-                    ],
-                },
-                {
-                    "id": "with_unsupported_capabilities",
-                    "capabilities": [
-                        {"id": "temperature", "version": 1}
-                    ],
-                },
-            ])
+            device_data["components"].extend(
+                [
+                    {
+                        "id": "secondary",
+                        "capabilities": [
+                            {"id": capability, "version": 1}
+                            for capability in capabilities
+                        ],
+                    },
+                    {
+                        "id": "with_unsupported_capabilities",
+                        "capabilities": [
+                            {"id": f"{capability}_other", "version": 1}
+                            for capability in capabilities
+                        ],
+                    },
+                    {
+                        "id": "with_unsupported_capabilities",
+                        "capabilities": [{"id": "temperature", "version": 1}],
+                    },
+                ]
+            )
 
         device = DeviceEntity(api, data=device_data)
         if status:

--- a/tests/components/smartthings/conftest.py
+++ b/tests/components/smartthings/conftest.py
@@ -263,6 +263,12 @@ def device_factory_fixture():
                     "capabilities": [
                         {"id": capability, "version": 1} for capability in capabilities
                     ],
+                },
+                {
+                    "id": "secondary",
+                    "capabilities": [
+                        {"id": capability, "version": 1} for capability in capabilities
+                    ],
                 }
             ],
             "dth": {

--- a/tests/components/smartthings/conftest.py
+++ b/tests/components/smartthings/conftest.py
@@ -263,13 +263,7 @@ def device_factory_fixture():
                     "capabilities": [
                         {"id": capability, "version": 1} for capability in capabilities
                     ],
-                },
-                {
-                    "id": "secondary",
-                    "capabilities": [
-                        {"id": capability, "version": 1} for capability in capabilities
-                    ],
-                },
+                }
             ],
             "dth": {
                 "deviceTypeId": "b678b29d-2726-4e4f-9c3f-7aa05bd08964",
@@ -278,10 +272,34 @@ def device_factory_fixture():
             },
             "type": "DTH",
         }
+
+        if label == "Dimmer 1":
+            device_data["components"].extend([
+                {
+                    "id": "secondary",
+                    "capabilities": [
+                        {"id": capability, "version": 1} for capability in capabilities
+                    ],
+                },
+                {
+                    "id": "with_unsupported_capabilities",
+                    "capabilities": [
+                        {"id": f"{capability}_other", "version": 1} for capability in capabilities
+                    ],
+                },
+                {
+                    "id": "with_unsupported_capabilities",
+                    "capabilities": [
+                        {"id": "temperature", "version": 1}
+                    ],
+                },
+            ])
+
         device = DeviceEntity(api, data=device_data)
         if status:
             for attribute, value in status.items():
                 device.status.apply_attribute_update("main", "", attribute, value)
+
         return device
 
     return _factory

--- a/tests/components/smartthings/conftest.py
+++ b/tests/components/smartthings/conftest.py
@@ -269,7 +269,7 @@ def device_factory_fixture():
                     "capabilities": [
                         {"id": capability, "version": 1} for capability in capabilities
                     ],
-                }
+                },
             ],
             "dth": {
                 "deviceTypeId": "b678b29d-2726-4e4f-9c3f-7aa05bd08964",

--- a/tests/components/smartthings/test_utils.py
+++ b/tests/components/smartthings/test_utils.py
@@ -1,0 +1,110 @@
+"""Tests for the utils module."""
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import uuid4
+
+from pysmartthings import CAPABILITIES, AppEntity, Capability, Attribute
+import pytest
+
+from homeassistant.components.smartthings import utils
+from homeassistant.components.smartthings.const import (
+    CONF_REFRESH_TOKEN,
+    DATA_MANAGER,
+    DOMAIN,
+)
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_format_component_name_with_component_id(hass: HomeAssistant, app) -> None:
+    """Test format component name with component id."""
+    # Act
+    text = utils.format_component_name("test", "test", "test")
+
+    # Assert
+    assert text == "test test test"
+
+
+async def test_format_component_name_without_component_id(hass: HomeAssistant, app) -> None:
+    """Test format component name without component id."""
+    # Act
+    text = utils.format_component_name("test", "test", None)
+
+    # Assert
+    assert text == "test test"
+
+
+async def get_device_status_with_component_id(
+    hass: HomeAssistant, smartthings_mock, location, device_factory
+) -> None:
+    """Test the utils get device status with component id."""
+    # Arrange
+    device = {
+        "status": {
+            "secondary": {
+                "status": "test"
+            }
+        }
+    }
+
+    # Act
+    device_status = utils.get_device_status(device, "secondary")
+    # Assert
+    assert device_status == "test"
+
+
+async def get_device_status_without_component_id(
+    hass: HomeAssistant, smartthings_mock, location, device_factory
+) -> None:
+    """Test the utils get device status without component id."""
+    # Arrange
+    device = {
+        "status": "test"
+    }
+
+    # Act
+    device_status = utils.get_device_status(device, None)
+    # Assert
+    assert device_status == "test"
+
+
+async def get_device_attributes_single_components(device_factory) -> None:
+    """Test the utils get device attribute with single component."""
+    device = device_factory(
+        "Color Dimmer 1",
+        capabilities=[Capability.switch, Capability.switch_level],
+        status={Attribute.switch: "on", Attribute.level: 100},
+    )
+
+    # Act
+    device_status = utils.get_device_attributes(device)
+    # Assert
+    assert device_status is not None
+
+
+async def get_device_attributes_multiple_components(device_factory) -> None:
+    """Test the utils get device attribute with multiple component."""
+    device = device_factory(
+        "Dimmer 1",
+        capabilities=[Capability.switch, Capability.switch_level],
+        status={Attribute.switch: "on", Attribute.level: 100},
+    )
+
+    # Act
+    device_status = utils.get_device_attributes(device)
+    # Assert
+    assert device_status is not None
+
+
+async def get_device_attr_multiple_components_and_disabled_components(device_factory) -> None:
+    """Test the utils get device attribute with multiple component with disabled components."""
+    device = device_factory(
+        "Dimmer 1",
+        capabilities=[Capability.switch, Capability.switch_level],
+        status={Attribute.switch: "on", Attribute.level: 100, "disabledComponents": ["with_unsupported_capabilities"]},
+    )
+
+    # Act
+    device_status = utils.get_device_attributes(device)
+    # Assert
+    assert device_status is not None

--- a/tests/components/smartthings/test_utils.py
+++ b/tests/components/smartthings/test_utils.py
@@ -1,22 +1,14 @@
 """Tests for the utils module."""
-from unittest.mock import AsyncMock, Mock, patch
-from uuid import uuid4
 
-from pysmartthings import CAPABILITIES, AppEntity, Capability, Attribute
-import pytest
+from pysmartthings import Attribute, Capability
 
 from homeassistant.components.smartthings import utils
-from homeassistant.components.smartthings.const import (
-    CONF_REFRESH_TOKEN,
-    DATA_MANAGER,
-    DOMAIN,
-)
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry
 
-
-async def test_format_component_name_with_component_id(hass: HomeAssistant, app) -> None:
+async def test_format_component_name_with_component_id(
+    hass: HomeAssistant, app
+) -> None:
     """Test format component name with component id."""
     # Act
     text = utils.format_component_name("test", "test", "test")
@@ -25,7 +17,9 @@ async def test_format_component_name_with_component_id(hass: HomeAssistant, app)
     assert text == "test test test"
 
 
-async def test_format_component_name_without_component_id(hass: HomeAssistant, app) -> None:
+async def test_format_component_name_without_component_id(
+    hass: HomeAssistant, app
+) -> None:
     """Test format component name without component id."""
     # Act
     text = utils.format_component_name("test", "test", None)
@@ -39,13 +33,7 @@ async def get_device_status_with_component_id(
 ) -> None:
     """Test the utils get device status with component id."""
     # Arrange
-    device = {
-        "status": {
-            "secondary": {
-                "status": "test"
-            }
-        }
-    }
+    device = {"status": {"secondary": {"status": "test"}}}
 
     # Act
     device_status = utils.get_device_status(device, "secondary")
@@ -58,9 +46,7 @@ async def get_device_status_without_component_id(
 ) -> None:
     """Test the utils get device status without component id."""
     # Arrange
-    device = {
-        "status": "test"
-    }
+    device = {"status": "test"}
 
     # Act
     device_status = utils.get_device_status(device, None)
@@ -96,12 +82,18 @@ async def get_device_attributes_multiple_components(device_factory) -> None:
     assert device_status is not None
 
 
-async def get_device_attr_multiple_components_and_disabled_components(device_factory) -> None:
+async def get_device_attr_multiple_components_and_disabled_components(
+    device_factory,
+) -> None:
     """Test the utils get device attribute with multiple component with disabled components."""
     device = device_factory(
         "Dimmer 1",
         capabilities=[Capability.switch, Capability.switch_level],
-        status={Attribute.switch: "on", Attribute.level: 100, "disabledComponents": ["with_unsupported_capabilities"]},
+        status={
+            Attribute.switch: "on",
+            Attribute.level: 100,
+            "disabledComponents": ["with_unsupported_capabilities"],
+        },
     )
 
     # Act


### PR DESCRIPTION
add support for devices with multiple components to be used as binar_sensor, light, sensor and switch

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support multiple components for SmartThings devices for following HA components:
- binary sensor
- light
- sensor
- switch

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #61075 
- This PR is related to issue: #61075 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
