### PR TITLE
Remove deprecated services from Litterrobot

### DIFF
--- a/homeassistant/components/litterrobot/strings.json
+++ b/homeassistant/components/litterrobot/strings.json
@@ -25,30 +25,6 @@
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
-  "issues": {
-    "service_deprecation_turn_off": {
-      "title": "Litter-Robot vaccum support for {old_service} is being removed",
-      "fix_flow": {
-        "step": {
-          "confirm": {
-            "title": "[%key:component::litterrobot::issues::service_deprecation_turn_off::title%]",
-            "description": "Litter-Robot vaccum support for the {old_service} service is deprecated and will be removed in Home Assistant 2024.2; Please adjust any automation or script that uses the service to instead call {new_service} and select submit below to mark this issue as resolved."
-          }
-        }
-      }
-    },
-    "service_deprecation_turn_on": {
-      "title": "[%key:component::litterrobot::issues::service_deprecation_turn_off::title%]",
-      "fix_flow": {
-        "step": {
-          "confirm": {
-            "title": "[%key:component::litterrobot::issues::service_deprecation_turn_off::title%]",
-            "description": "[%key:component::litterrobot::issues::service_deprecation_turn_off::fix_flow::step::confirm::description%]"
-          }
-        }
-      }
-    }
-  },
   "entity": {
     "binary_sensor": {
       "sleeping": {

--- a/homeassistant/components/litterrobot/vacuum.py
+++ b/homeassistant/components/litterrobot/vacuum.py
@@ -75,11 +75,7 @@ class LitterRobotCleaner(LitterRobotEntity[LitterRobot], StateVacuumEntity):
     """Litter-Robot "Vacuum" Cleaner."""
 
     _attr_supported_features = (
-        VacuumEntityFeature.START
-        | VacuumEntityFeature.STATE
-        | VacuumEntityFeature.STOP
-        | VacuumEntityFeature.TURN_OFF
-        | VacuumEntityFeature.TURN_ON
+        VacuumEntityFeature.START | VacuumEntityFeature.STATE | VacuumEntityFeature.STOP
     )
 
     @property

--- a/homeassistant/components/litterrobot/vacuum.py
+++ b/homeassistant/components/litterrobot/vacuum.py
@@ -20,11 +20,7 @@ from homeassistant.components.vacuum import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import (
-    config_validation as cv,
-    entity_platform,
-    issue_registry as ir,
-)
+from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
 
@@ -96,42 +92,6 @@ class LitterRobotCleaner(LitterRobotEntity[LitterRobot], StateVacuumEntity):
         """Return the status of the cleaner."""
         return (
             f"{self.robot.status.text}{' (Sleeping)' if self.robot.is_sleeping else ''}"
-        )
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the cleaner on, starting a clean cycle."""
-        await self.robot.set_power_status(True)
-        ir.async_create_issue(
-            self.hass,
-            DOMAIN,
-            "service_deprecation_turn_on",
-            breaks_in_ha_version="2024.2.0",
-            is_fixable=True,
-            is_persistent=True,
-            severity=ir.IssueSeverity.WARNING,
-            translation_key="service_deprecation_turn_on",
-            translation_placeholders={
-                "old_service": "vacuum.turn_on",
-                "new_service": "vacuum.start",
-            },
-        )
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the unit off, stopping any cleaning in progress as is."""
-        await self.robot.set_power_status(False)
-        ir.async_create_issue(
-            self.hass,
-            DOMAIN,
-            "service_deprecation_turn_off",
-            breaks_in_ha_version="2024.2.0",
-            is_fixable=True,
-            is_persistent=True,
-            severity=ir.IssueSeverity.WARNING,
-            translation_key="service_deprecation_turn_off",
-            translation_placeholders={
-                "old_service": "vacuum.turn_off",
-                "new_service": "vacuum.stop",
-            },
         )
 
     async def async_start(self) -> None:

--- a/tests/components/litterrobot/test_vacuum.py
+++ b/tests/components/litterrobot/test_vacuum.py
@@ -13,8 +13,6 @@ from homeassistant.components.vacuum import (
     DOMAIN as PLATFORM_DOMAIN,
     SERVICE_START,
     SERVICE_STOP,
-    SERVICE_TURN_OFF,
-    SERVICE_TURN_ON,
     STATE_DOCKED,
     STATE_ERROR,
 )
@@ -103,16 +101,6 @@ async def test_vacuum_with_error(
         (SERVICE_START, "start_cleaning", None),
         (SERVICE_STOP, "set_power_status", None),
         (
-            SERVICE_TURN_OFF,
-            "set_power_status",
-            {"issues": {(DOMAIN, "service_deprecation_turn_off")}},
-        ),
-        (
-            SERVICE_TURN_ON,
-            "set_power_status",
-            {"issues": {(DOMAIN, "service_deprecation_turn_on")}},
-        ),
-        (
             SERVICE_SET_SLEEP_MODE,
             "set_sleep_mode",
             {"data": {"enabled": True, "start_time": "22:30"}},
@@ -150,53 +138,3 @@ async def test_commands(
 
     issue_registry = ir.async_get(hass)
     assert set(issue_registry.issues.keys()) == issues
-
-
-@pytest.mark.parametrize(
-    ("service", "issue_id", "placeholders"),
-    [
-        (
-            SERVICE_TURN_OFF,
-            "service_deprecation_turn_off",
-            {
-                "old_service": "vacuum.turn_off",
-                "new_service": "vacuum.stop",
-            },
-        ),
-        (
-            SERVICE_TURN_ON,
-            "service_deprecation_turn_on",
-            {
-                "old_service": "vacuum.turn_on",
-                "new_service": "vacuum.start",
-            },
-        ),
-    ],
-)
-async def test_issues(
-    hass: HomeAssistant,
-    mock_account: MagicMock,
-    caplog: pytest.LogCaptureFixture,
-    service: str,
-    issue_id: str,
-    placeholders: dict[str, str],
-) -> None:
-    """Test issues raised by calling deprecated services."""
-    await setup_integration(hass, mock_account, PLATFORM_DOMAIN)
-
-    vacuum = hass.states.get(VACUUM_ENTITY_ID)
-    assert vacuum
-    assert vacuum.state == STATE_DOCKED
-
-    await hass.services.async_call(
-        PLATFORM_DOMAIN,
-        service,
-        {ATTR_ENTITY_ID: VACUUM_ENTITY_ID},
-        blocking=True,
-    )
-
-    issue_registry = ir.async_get(hass)
-    issue = issue_registry.async_get_issue(DOMAIN, issue_id)
-    assert issue.is_fixable is True
-    assert issue.is_persistent is True
-    assert issue.translation_placeholders == placeholders


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The services `vacuum.turn_on` and `vacuum.turn_off` were deprecated in  2023.11. Support for the deprecated services has now been completely removed. If you are still using them, please adjust your automations and scripts and use `vacuum.start` and `vacuum.stop` instead.

## Proposed change
Remove deprecated services `vacuum.turn_on` and `vacuum.turn_off` completely.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
