### PR TITLE
Remove deprecated YAML support from litejet

### DIFF
--- a/homeassistant/components/litejet/__init__.py
+++ b/homeassistant/components/litejet/__init__.py
@@ -2,48 +2,15 @@
 import logging
 
 import pylitejet
-import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PORT, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_EXCLUDE_NAMES, CONF_INCLUDE_SWITCHES, DOMAIN, PLATFORMS
+from .const import DOMAIN, PLATFORMS
 
 _LOGGER = logging.getLogger(__name__)
-
-CONFIG_SCHEMA = vol.Schema(
-    vol.All(
-        cv.deprecated(DOMAIN),
-        {
-            DOMAIN: vol.Schema(
-                {
-                    vol.Required(CONF_PORT): cv.string,
-                    vol.Optional(CONF_EXCLUDE_NAMES): vol.All(
-                        cv.ensure_list, [cv.string]
-                    ),
-                    vol.Optional(CONF_INCLUDE_SWITCHES, default=False): cv.boolean,
-                }
-            )
-        },
-    ),
-    extra=vol.ALLOW_EXTRA,
-)
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the LiteJet component."""
-    if DOMAIN in config:
-        # Configuration.yaml config exists, trigger the import flow.
-        hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                DOMAIN, context={"source": SOURCE_IMPORT}, data=config[DOMAIN]
-            )
-        )
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/litejet/config_flow.py
+++ b/homeassistant/components/litejet/config_flow.py
@@ -9,10 +9,9 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_PORT
-from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, callback
-from homeassistant.data_entry_flow import FlowResult, FlowResultType
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 
 from .const import CONF_DEFAULT_TRANSITION, DOMAIN
 
@@ -54,21 +53,6 @@ class LiteJetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Create a LiteJet config entry based upon user input."""
         if self._async_current_entries():
-            if self.context["source"] == config_entries.SOURCE_IMPORT:
-                async_create_issue(
-                    self.hass,
-                    HOMEASSISTANT_DOMAIN,
-                    f"deprecated_yaml_{DOMAIN}",
-                    breaks_in_ha_version="2024.2.0",
-                    is_fixable=False,
-                    issue_domain=DOMAIN,
-                    severity=IssueSeverity.WARNING,
-                    translation_key="deprecated_yaml",
-                    translation_placeholders={
-                        "domain": DOMAIN,
-                        "integration_title": "LiteJet",
-                    },
-                )
             return self.async_abort(reason="single_instance_allowed")
 
         errors = {}
@@ -78,20 +62,6 @@ class LiteJetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 system = await pylitejet.open(port)
             except SerialException:
-                if self.context["source"] == config_entries.SOURCE_IMPORT:
-                    async_create_issue(
-                        self.hass,
-                        DOMAIN,
-                        "deprecated_yaml_serial_exception",
-                        breaks_in_ha_version="2024.2.0",
-                        is_fixable=False,
-                        issue_domain=DOMAIN,
-                        severity=IssueSeverity.ERROR,
-                        translation_key="deprecated_yaml_serial_exception",
-                        translation_placeholders={
-                            "url": "/config/integrations/dashboard/add?domain=litejet"
-                        },
-                    )
                 errors[CONF_PORT] = "open_failed"
             else:
                 await system.close()
@@ -105,27 +75,6 @@ class LiteJetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema({vol.Required(CONF_PORT): str}),
             errors=errors,
         )
-
-    async def async_step_import(self, import_data: dict[str, Any]) -> FlowResult:
-        """Import litejet config from configuration.yaml."""
-        new_data = {CONF_PORT: import_data[CONF_PORT]}
-        result = await self.async_step_user(new_data)
-        if result["type"] == FlowResultType.CREATE_ENTRY:
-            async_create_issue(
-                self.hass,
-                HOMEASSISTANT_DOMAIN,
-                f"deprecated_yaml_{DOMAIN}",
-                breaks_in_ha_version="2024.2.0",
-                is_fixable=False,
-                issue_domain=DOMAIN,
-                severity=IssueSeverity.WARNING,
-                translation_key="deprecated_yaml",
-                translation_placeholders={
-                    "domain": DOMAIN,
-                    "integration_title": "LiteJet",
-                },
-            )
-        return result
 
     @staticmethod
     @callback

--- a/homeassistant/components/litejet/strings.json
+++ b/homeassistant/components/litejet/strings.json
@@ -25,11 +25,5 @@
         }
       }
     }
-  },
-  "issues": {
-    "deprecated_yaml_serial_exception": {
-      "title": "The LiteJet YAML configuration import failed",
-      "description": "Configuring LiteJet using YAML is being removed but there was an error opening the serial port when importing your YAML configuration.\n\nCorrect the YAML configuration and restart Home Assistant to try again or manually continue to [set up the integration]({url})."
-    }
   }
 }

--- a/tests/components/litejet/test_config_flow.py
+++ b/tests/components/litejet/test_config_flow.py
@@ -6,8 +6,7 @@ from serial import SerialException
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.litejet.const import CONF_DEFAULT_TRANSITION, DOMAIN
 from homeassistant.const import CONF_PORT
-from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
-import homeassistant.helpers.issue_registry as ir
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -66,63 +65,6 @@ async def test_flow_open_failed(hass: HomeAssistant) -> None:
 
     assert result["type"] == "form"
     assert result["errors"][CONF_PORT] == "open_failed"
-
-
-async def test_import_step(hass: HomeAssistant, mock_litejet) -> None:
-    """Test initializing via import step."""
-    test_data = {CONF_PORT: "/dev/imported"}
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=test_data
-    )
-
-    assert result["type"] == "create_entry"
-    assert result["title"] == test_data[CONF_PORT]
-    assert result["data"] == test_data
-
-    issue_registry = ir.async_get(hass)
-    issue = issue_registry.async_get_issue(
-        HOMEASSISTANT_DOMAIN, "deprecated_yaml_litejet"
-    )
-    assert issue.translation_key == "deprecated_yaml"
-
-
-async def test_import_step_fails(hass: HomeAssistant) -> None:
-    """Test initializing via import step fails due to can't open port."""
-    test_data = {CONF_PORT: "/dev/test"}
-    with patch("pylitejet.LiteJet") as mock_pylitejet:
-        mock_pylitejet.side_effect = SerialException
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=test_data
-        )
-
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["errors"] == {"port": "open_failed"}
-
-    issue_registry = ir.async_get(hass)
-    assert issue_registry.async_get_issue(DOMAIN, "deprecated_yaml_serial_exception")
-
-
-async def test_import_step_already_exist(hass: HomeAssistant) -> None:
-    """Test initializing via import step when entry already exist."""
-    first_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_PORT: "/dev/imported"},
-    )
-    first_entry.add_to_hass(hass)
-
-    test_data = {CONF_PORT: "/dev/imported"}
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=test_data
-    )
-
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
-    assert result["reason"] == "single_instance_allowed"
-
-    issue_registry = ir.async_get(hass)
-    issue = issue_registry.async_get_issue(
-        HOMEASSISTANT_DOMAIN, "deprecated_yaml_litejet"
-    )
-    assert issue.translation_key == "deprecated_yaml"
 
 
 async def test_options(hass: HomeAssistant) -> None:

--- a/tests/components/litejet/test_init.py
+++ b/tests/components/litejet/test_init.py
@@ -1,7 +1,6 @@
 """The tests for the litejet component."""
 from homeassistant.components import litejet
 from homeassistant.components.litejet.const import DOMAIN
-from homeassistant.const import CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -12,15 +11,6 @@ async def test_setup_with_no_config(hass: HomeAssistant) -> None:
     """Test that nothing happens."""
     assert await async_setup_component(hass, DOMAIN, {}) is True
     assert DOMAIN not in hass.data
-
-
-async def test_setup_with_config_to_import(hass: HomeAssistant, mock_litejet) -> None:
-    """Test that import happens."""
-    assert (
-        await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PORT: "/dev/hello"}})
-        is True
-    )
-    assert DOMAIN in hass.data
 
 
 async def test_unload_entry(hass: HomeAssistant, mock_litejet) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The YAML configuration was deprecated in release 2022.9. Support for it has now been completely removed. If you still have `litejet` in your YAML configuration, you should remove it completely.

## Proposed change
Remove the deprecated YAML configuration completely from `litejet`. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
