### PR TITLE
Remove deprecated vacuum service from roborock

### DIFF
--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -276,18 +276,5 @@
         }
       }
     }
-  },
-  "issues": {
-    "service_deprecation_start_pause": {
-      "title": "Roborock vacuum support for vacuum.start_pause is being removed",
-      "fix_flow": {
-        "step": {
-          "confirm": {
-            "title": "[%key:component::roborock::issues::service_deprecation_start_pause::title%]",
-            "description": "Roborock vacuum support for the vacuum.start_pause service is deprecated and will be removed in Home Assistant 2024.2; Please adjust any automation or script that uses the service to instead call vacuum.pause or vacuum.start and select submit below to mark this issue as resolved."
-          }
-        }
-      }
-    }
   }
 }

--- a/homeassistant/components/roborock/vacuum.py
+++ b/homeassistant/components/roborock/vacuum.py
@@ -17,7 +17,6 @@ from homeassistant.components.vacuum import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import slugify
 
@@ -147,23 +146,6 @@ class RoborockVacuum(RoborockCoordinatedEntity, StateVacuumEntity):
         await self.send(
             RoborockCommand.SET_CUSTOM_MODE,
             [self._device_status.get_fan_speed_code(fan_speed)],
-        )
-
-    async def async_start_pause(self) -> None:
-        """Start, pause or resume the cleaning task."""
-        if self.state == STATE_CLEANING:
-            await self.async_pause()
-        else:
-            await self.async_start()
-        ir.async_create_issue(
-            self.hass,
-            DOMAIN,
-            "service_deprecation_start_pause",
-            breaks_in_ha_version="2024.2.0",
-            is_fixable=True,
-            is_persistent=True,
-            severity=ir.IssueSeverity.WARNING,
-            translation_key="service_deprecation_start_pause",
         )
 
     async def async_send_command(

--- a/tests/components/roborock/test_vacuum.py
+++ b/tests/components/roborock/test_vacuum.py
@@ -15,12 +15,11 @@ from homeassistant.components.vacuum import (
     SERVICE_SEND_COMMAND,
     SERVICE_SET_FAN_SPEED,
     SERVICE_START,
-    SERVICE_START_PAUSE,
     SERVICE_STOP,
 )
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry
 
@@ -46,7 +45,6 @@ async def test_registry_entries(
         (SERVICE_RETURN_TO_BASE, RoborockCommand.APP_CHARGE, None, None),
         (SERVICE_CLEAN_SPOT, RoborockCommand.APP_SPOT, None, None),
         (SERVICE_LOCATE, RoborockCommand.FIND_ME, None, None),
-        (SERVICE_START_PAUSE, RoborockCommand.APP_START, None, None),
         (
             SERVICE_SET_FAN_SPEED,
             RoborockCommand.SET_CUSTOM_MODE,
@@ -88,37 +86,3 @@ async def test_commands(
         assert mock_send_command.call_count == 1
         assert mock_send_command.call_args[0][0] == command
         assert mock_send_command.call_args[0][1] == called_params
-
-
-@pytest.mark.parametrize(
-    ("service", "issue_id"),
-    [
-        (SERVICE_START_PAUSE, "service_deprecation_start_pause"),
-    ],
-)
-async def test_issues(
-    hass: HomeAssistant,
-    bypass_api_fixture,
-    setup_entry: MockConfigEntry,
-    service: str,
-    issue_id: str,
-) -> None:
-    """Test issues raised by calling deprecated services."""
-    vacuum = hass.states.get(ENTITY_ID)
-    assert vacuum
-
-    data = {ATTR_ENTITY_ID: ENTITY_ID}
-    with patch(
-        "homeassistant.components.roborock.coordinator.RoborockLocalClient.send_command"
-    ):
-        await hass.services.async_call(
-            Platform.VACUUM,
-            service,
-            data,
-            blocking=True,
-        )
-
-    issue_registry = ir.async_get(hass)
-    issue = issue_registry.async_get_issue("roborock", issue_id)
-    assert issue.is_fixable is True
-    assert issue.is_persistent is True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The services `vacuum.start_pause` was deprecated in 2023.8. Support for the deprecated services has now been completely removed. If you are still using them, please adjust your automations and scripts and use `vacuum.pause` or `vacuum.start` instead.

## Proposed change
Remove deprecated `vacuum.start_pause` service from roborock.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
