### PR TITLE
Fix missing timeout exception check in powerwall config flow

### DIFF
--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -166,7 +166,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         description_placeholders: dict[str, str] = {}
         try:
             info = await validate_input(self.hass, user_input)
-        except PowerwallUnreachableError as ex:
+        except (PowerwallUnreachableError, asyncio.TimeoutError) as ex:
             errors[CONF_IP_ADDRESS] = "cannot_connect"
             description_placeholders = {"error": str(ex)}
         except WrongVersion as ex:

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -4,6 +4,7 @@ import asyncio
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
+import pytest
 from tesla_powerwall import (
     AccessDeniedError,
     MissingAttributeError,
@@ -60,15 +61,14 @@ async def test_form_source_user(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_cannot_connect(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize("exc", (PowerwallUnreachableError, asyncio.TimeoutError))
+async def test_form_cannot_connect(hass: HomeAssistant, exc: Exception) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    mock_powerwall = await _mock_powerwall_side_effect(
-        site_info=PowerwallUnreachableError
-    )
+    mock_powerwall = await _mock_powerwall_side_effect(site_info=exc)
 
     with patch(
         "homeassistant.components.powerwall.config_flow.Powerwall",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix missing timeout exception check in powerwall config flow

Powerwall recently went asyncio. Any place where we check for unreachable, we need to check asyncio.TimeoutError as well. One of them was missed

```
09:08 homeassistant homeassistant[546]: 2024-01-12 10:09:08.899 ERROR (MainThread) [homeassistant.components.powerwall.config_flow] Unexpected exception
Jan 12 20:09:08 homeassistant homeassistant[546]: Traceback (most recent call last):
Jan 12 20:09:08 homeassistant homeassistant[546]:   File "/usr/src/homeassistant/homeassistant/components/powerwall/config_flow.py", line 168, in _async_try_connect
Jan 12 20:09:08 homeassistant homeassistant[546]:     info = await validate_input(self.hass, user_input)
Jan 12 20:09:08 homeassistant homeassistant[546]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jan 12 20:09:08 homeassistant homeassistant[546]:   File "/usr/src/homeassistant/homeassistant/components/powerwall/config_flow.py", line 76, in validate_input
Jan 12 20:09:08 homeassistant homeassistant[546]:     site_info, gateway_din = await _login_and_fetch_site_info(
Jan 12 20:09:08 homeassistant homeassistant[546]:                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jan 12 20:09:08 homeassistant homeassistant[546]:   File "/usr/src/homeassistant/homeassistant/components/powerwall/config_flow.py", line 43, in _login_and_fetch_site_info
Jan 12 20:09:08 homeassistant homeassistant[546]:     await power_wall.login(password)
Jan 12 20:09:08 homeassistant homeassistant[546]:   File "/usr/local/lib/python3.12/site-packages/tesla_powerwall/powerwall.py", line 58, in login
Jan 12 20:09:08 homeassistant homeassistant[546]:     return await self.login_as(User.CUSTOMER, password, email, force_sm_off)
Jan 12 20:09:08 homeassistant homeassistant[546]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jan 12 20:09:08 homeassistant homeassistant[546]:   File "/usr/local/lib/python3.12/site-packages/tesla_powerwall/powerwall.py", line 49, in login_as
Jan 12 20:09:08 homeassistant homeassistant[546]:     response = await self._api.login(user, email, password, force_sm_off)
Jan 12 20:09:08 homeassistant homeassistant[546]:                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jan 12 20:09:08 homeassistant homeassistant[546]:   File "/usr/local/lib/python3.12/site-packages/tesla_powerwall/api.py", line 172, in login
Jan 12 20:09:08 homeassistant homeassistant[546]:     return await self.post(
Jan 12 20:09:08 homeassistant homeassistant[546]:            ^^^^^^^^^^^^^^^^
Jan 12 20:09:08 homeassistant homeassistant[546]:   File "/usr/local/lib/python3.12/site-packages/tesla_powerwall/api.py", line 146, in post
Jan 12 20:09:08 homeassistant homeassistant[546]:     response = await self._http_session.post(
Jan 12 20:09:08 homeassistant homeassistant[546]:                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jan 12 20:09:08 homeassistant homeassistant[546]:   File "/usr/local/lib/python3.12/site-packages/aiohttp/client.py", line 601, in _request
Jan 12 20:09:08 homeassistant homeassistant[546]:     await resp.start(conn)
Jan 12 20:09:08 homeassistant homeassistant[546]:   File "/usr/local/lib/python3.12/site-packages/aiohttp/client_reqrep.py", line 960, in start
Jan 12 20:09:08 homeassistant homeassistant[546]:     with self._timer:
Jan 12 20:09:08 homeassistant homeassistant[546]:   File "/usr/local/lib/python3.12/site-packages/aiohttp/helpers.py", line 735, in __exit__
Jan 12 20:09:08 homeassistant homeassistant[546]:     raise asyncio.TimeoutError from None
Jan 12 20:09:08 homeassistant homeassistant[546]: TimeoutError
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
