### PR TITLE
Add readable state for tesla wall connector

### DIFF
--- a/homeassistant/components/tesla_wall_connector/sensor.py
+++ b/homeassistant/components/tesla_wall_connector/sensor.py
@@ -29,6 +29,19 @@ from .const import DOMAIN, WALLCONNECTOR_DATA_LIFETIME, WALLCONNECTOR_DATA_VITAL
 
 _LOGGER = logging.getLogger(__name__)
 
+EVSE_STATE = {
+    0: "booting",
+    1: "not_connected",
+    2: "connected",
+    4: "ready",
+    6: "negotiating",
+    7: "error",
+    8: "charging_finished",
+    9: "waiting_car",
+    10: "charging_reduced",
+    11: "charging",
+}
+
 
 @dataclass(frozen=True)
 class WallConnectorSensorDescription(
@@ -43,6 +56,16 @@ WALL_CONNECTOR_SENSORS = [
         translation_key="evse_state",
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data[WALLCONNECTOR_DATA_VITALS].evse_state,
+    ),
+    WallConnectorSensorDescription(
+        key="state",
+        translation_key="state",
+        device_class=SensorDeviceClass.ENUM,
+        value_fn=lambda data: EVSE_STATE.get(
+            data[WALLCONNECTOR_DATA_VITALS].evse_state, "unknown"
+        ),
+        options=list(EVSE_STATE.values()) + ["unknown"],
+        icon="mdi:ev-station",
     ),
     WallConnectorSensorDescription(
         key="handle_temp_c",

--- a/homeassistant/components/tesla_wall_connector/sensor.py
+++ b/homeassistant/components/tesla_wall_connector/sensor.py
@@ -56,6 +56,7 @@ WALL_CONNECTOR_SENSORS = [
         translation_key="evse_state",
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data[WALLCONNECTOR_DATA_VITALS].evse_state,
+        entity_registry_enabled_default=False,
     ),
     WallConnectorSensorDescription(
         key="state",

--- a/homeassistant/components/tesla_wall_connector/sensor.py
+++ b/homeassistant/components/tesla_wall_connector/sensor.py
@@ -63,9 +63,9 @@ WALL_CONNECTOR_SENSORS = [
         translation_key="state",
         device_class=SensorDeviceClass.ENUM,
         value_fn=lambda data: EVSE_STATE.get(
-            data[WALLCONNECTOR_DATA_VITALS].evse_state, "unknown"
+            data[WALLCONNECTOR_DATA_VITALS].evse_state
         ),
-        options=list(EVSE_STATE.values()) + ["unknown"],
+        options=list(EVSE_STATE.values()),
         icon="mdi:ev-station",
     ),
     WallConnectorSensorDescription(

--- a/homeassistant/components/tesla_wall_connector/sensor.py
+++ b/homeassistant/components/tesla_wall_connector/sensor.py
@@ -53,14 +53,14 @@ class WallConnectorSensorDescription(
 WALL_CONNECTOR_SENSORS = [
     WallConnectorSensorDescription(
         key="evse_state",
-        translation_key="evse_state",
+        translation_key="status_code",
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data[WALLCONNECTOR_DATA_VITALS].evse_state,
         entity_registry_enabled_default=False,
     ),
     WallConnectorSensorDescription(
-        key="state",
-        translation_key="state",
+        key="status",
+        translation_key="status",
         device_class=SensorDeviceClass.ENUM,
         value_fn=lambda data: EVSE_STATE.get(
             data[WALLCONNECTOR_DATA_VITALS].evse_state

--- a/homeassistant/components/tesla_wall_connector/strings.json
+++ b/homeassistant/components/tesla_wall_connector/strings.json
@@ -30,8 +30,23 @@
       }
     },
     "sensor": {
+      "state": {
+        "name": "Status",
+        "state": {
+          "booting": "Booting",
+          "not_connected": "Vehicule not connected",
+          "connected": "Vehicule connected",
+          "ready": "Ready to charge",
+          "negociating": "Negociating connection",
+          "error": "Error",
+          "charging_finished": "Charging finished",
+          "waiting_car": "Waiting for car",
+          "charging_reduced": "Charging (reduced)",
+          "charging": "Charging"
+        }
+      },
       "evse_state": {
-        "name": "State"
+        "name": "Raw state"
       },
       "handle_temp_c": {
         "name": "Handle temperature"

--- a/homeassistant/components/tesla_wall_connector/strings.json
+++ b/homeassistant/components/tesla_wall_connector/strings.json
@@ -34,8 +34,8 @@
         "name": "Status",
         "state": {
           "booting": "Booting",
-          "not_connected": "Vehicule not connected",
-          "connected": "Vehicule connected",
+          "not_connected": "Vehicle not connected",
+          "connected": "Vehicle connected",
           "ready": "Ready to charge",
           "negociating": "Negociating connection",
           "error": "Error",

--- a/homeassistant/components/tesla_wall_connector/strings.json
+++ b/homeassistant/components/tesla_wall_connector/strings.json
@@ -30,7 +30,7 @@
       }
     },
     "sensor": {
-      "state": {
+      "status": {
         "name": "Status",
         "state": {
           "booting": "Booting",
@@ -45,8 +45,8 @@
           "charging": "Charging"
         }
       },
-      "evse_state": {
-        "name": "Raw state"
+      "status_code": {
+        "name": "Status code"
       },
       "handle_temp_c": {
         "name": "Handle temperature"

--- a/tests/components/tesla_wall_connector/test_sensor.py
+++ b/tests/components/tesla_wall_connector/test_sensor.py
@@ -13,7 +13,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     """Test all sensors."""
 
     entity_and_expected_values = [
-        EntityAndExpectedValues("sensor.tesla_wall_connector_state", "1", "2"),
+        EntityAndExpectedValues("sensor.tesla_wall_connector_raw_state", "1", "2"),
         EntityAndExpectedValues(
             "sensor.tesla_wall_connector_handle_temperature", "25.5", "-1.4"
         ),
@@ -43,6 +43,9 @@ async def test_sensors(hass: HomeAssistant) -> None:
         ),
         EntityAndExpectedValues(
             "sensor.tesla_wall_connector_phase_c_voltage", "232.1", "230"
+        ),
+        EntityAndExpectedValues(
+            "sensor.tesla_wall_connector_status", "not_connected", "connected"
         ),
     ]
 

--- a/tests/components/tesla_wall_connector/test_sensor.py
+++ b/tests/components/tesla_wall_connector/test_sensor.py
@@ -14,7 +14,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
 
     entity_and_expected_values = [
         EntityAndExpectedValues(
-            "sensor.tesla_wall_connector_status", "not_connected", "connected"
+            "sensor.tesla_wall_connector_status", "not_connected", "unknown"
         ),
         EntityAndExpectedValues(
             "sensor.tesla_wall_connector_handle_temperature", "25.5", "-1.4"
@@ -61,7 +61,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     mock_vitals_first_update.currentC_a = 12
 
     mock_vitals_second_update = get_vitals_mock()
-    mock_vitals_second_update.evse_state = 2
+    mock_vitals_second_update.evse_state = 3
     mock_vitals_second_update.handle_temp_c = -1.42
     mock_vitals_second_update.grid_v = 229.21
     mock_vitals_second_update.grid_hz = 49.981

--- a/tests/components/tesla_wall_connector/test_sensor.py
+++ b/tests/components/tesla_wall_connector/test_sensor.py
@@ -13,7 +13,9 @@ async def test_sensors(hass: HomeAssistant) -> None:
     """Test all sensors."""
 
     entity_and_expected_values = [
-        EntityAndExpectedValues("sensor.tesla_wall_connector_raw_state", "1", "2"),
+        EntityAndExpectedValues(
+            "sensor.tesla_wall_connector_status", "not_connected", "connected"
+        ),
         EntityAndExpectedValues(
             "sensor.tesla_wall_connector_handle_temperature", "25.5", "-1.4"
         ),
@@ -43,9 +45,6 @@ async def test_sensors(hass: HomeAssistant) -> None:
         ),
         EntityAndExpectedValues(
             "sensor.tesla_wall_connector_phase_c_voltage", "232.1", "230"
-        ),
-        EntityAndExpectedValues(
-            "sensor.tesla_wall_connector_status", "not_connected", "connected"
         ),
     ]
 


### PR DESCRIPTION
## Proposed change

Adds new state sensor with translated state. The old state sensor which contained the raw data (a number) has been renamed to `status_code` and disabled by default.

I looked at tesla wall connector third party app for state mapping (https://apps.apple.com/us/app/wall-monitor-for-tesla/id1635414689) and tested with my device.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
