### PR TITLE
Deprecate passing step_id to FlowHandler methods

### DIFF
--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -575,25 +575,30 @@ class FlowHandler:
     def async_show_form(
         self,
         *,
-        step_id: str,
+        step_id: str | None = None,
         data_schema: vol.Schema | None = None,
         errors: dict[str, str] | None = None,
         description_placeholders: Mapping[str, str | None] | None = None,
         last_step: bool | None = None,
         preview: str | None = None,
     ) -> FlowResult:
-        """Return the definition of a form to gather user input."""
-        return FlowResult(
+        """Return the definition of a form to gather user input.
+
+        The step_id parameter is deprecated and will be removed in a future release.
+        """
+        flow_result = FlowResult(
             type=FlowResultType.FORM,
             flow_id=self.flow_id,
             handler=self.handler,
-            step_id=step_id,
             data_schema=data_schema,
             errors=errors,
             description_placeholders=description_placeholders,
             last_step=last_step,  # Display next or submit button in frontend
             preview=preview,  # Display preview component in frontend
         )
+        if step_id is not None:
+            flow_result["step_id"] = step_id
+        return flow_result
 
     @callback
     def async_create_entry(
@@ -636,19 +641,24 @@ class FlowHandler:
     def async_external_step(
         self,
         *,
-        step_id: str,
+        step_id: str | None = None,
         url: str,
         description_placeholders: Mapping[str, str] | None = None,
     ) -> FlowResult:
-        """Return the definition of an external step for the user to take."""
-        return FlowResult(
+        """Return the definition of an external step for the user to take.
+
+        The step_id parameter is deprecated and will be removed in a future release.
+        """
+        flow_result = FlowResult(
             type=FlowResultType.EXTERNAL_STEP,
             flow_id=self.flow_id,
             handler=self.handler,
-            step_id=step_id,
             url=url,
             description_placeholders=description_placeholders,
         )
+        if step_id is not None:
+            flow_result["step_id"] = step_id
+        return flow_result
 
     @callback
     def async_external_step_done(self, *, next_step_id: str) -> FlowResult:
@@ -669,7 +679,10 @@ class FlowHandler:
         description_placeholders: Mapping[str, str] | None = None,
         progress_task: asyncio.Task[Any] | None = None,
     ) -> FlowResult:
-        """Show a progress message to the user, without user input allowed."""
+        """Show a progress message to the user, without user input allowed.
+
+        The step_id parameter is deprecated and will be removed in a future release.
+        """
         if progress_task is None and not self.__no_progress_task_reported:
             self.__no_progress_task_reported = True
             cls = self.__class__
@@ -685,7 +698,7 @@ class FlowHandler:
                 report_issue,
             )
 
-        result = FlowResult(
+        flow_result = FlowResult(
             type=FlowResultType.SHOW_PROGRESS,
             flow_id=self.flow_id,
             handler=self.handler,
@@ -694,8 +707,8 @@ class FlowHandler:
             progress_task=progress_task,
         )
         if step_id is not None:
-            result["step_id"] = step_id
-        return result
+            flow_result["step_id"] = step_id
+        return flow_result
 
     @callback
     def async_show_progress_done(self, *, next_step_id: str) -> FlowResult:
@@ -711,23 +724,26 @@ class FlowHandler:
     def async_show_menu(
         self,
         *,
-        step_id: str,
+        step_id: str | None = None,
         menu_options: list[str] | dict[str, str],
         description_placeholders: Mapping[str, str] | None = None,
     ) -> FlowResult:
         """Show a navigation menu to the user.
 
         Options dict maps step_id => i18n label
+        The step_id parameter is deprecated and will be removed in a future release.
         """
-        return FlowResult(
+        flow_result = FlowResult(
             type=FlowResultType.MENU,
             flow_id=self.flow_id,
             handler=self.handler,
-            step_id=step_id,
             data_schema=vol.Schema({"next_step_id": vol.In(menu_options)}),
             menu_options=menu_options,
             description_placeholders=description_placeholders,
         )
+        if step_id is not None:
+            flow_result["step_id"] = step_id
+        return flow_result
 
     @callback
     def async_remove(self) -> None:

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -76,6 +76,9 @@ FLOW_NOT_COMPLETE_STEPS = {
 }
 
 STEP_ID_OPTIONAL_STEPS = {
+    FlowResultType.EXTERNAL_STEP,
+    FlowResultType.FORM,
+    FlowResultType.MENU,
     FlowResultType.SHOW_PROGRESS,
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate passing `step_id` to `FlowHandler` methods

Rationale:
Changing flow steps should not be done by calling either of the methods `async_show_form`, `async_external_step` or `async_show_menu`; doing so often causes bugs where the flow is in an ambiguous state.

Note that passing `step_id` to `async_show_progress` is already deprecated; in this PR this is also mentioned in the docstring.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
