### PR TITLE
Add support for Uonet+ Vulcan integration on Python 3.12

### DIFF
--- a/homeassistant/components/vulcan/__init__.py
+++ b/homeassistant/components/vulcan/__init__.py
@@ -1,32 +1,21 @@
 """The Vulcan component."""
-import sys
 
 from aiohttp import ClientConnectorError
+from vulcan import Account, Keystore, UnauthorizedCertificateException, Vulcan
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import (
-    ConfigEntryAuthFailed,
-    ConfigEntryNotReady,
-    HomeAssistantError,
-)
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN
-
-if sys.version_info < (3, 12):
-    from vulcan import Account, Keystore, UnauthorizedCertificateException, Vulcan
 
 PLATFORMS = [Platform.CALENDAR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Uonet+ Vulcan integration."""
-    if sys.version_info >= (3, 12):
-        raise HomeAssistantError(
-            "Uonet+ Vulcan is not supported on Python 3.12. Please use Python 3.11."
-        )
     hass.data.setdefault(DOMAIN, {})
     try:
         keystore = Keystore.load(entry.data["keystore"])

--- a/homeassistant/components/vulcan/manifest.json
+++ b/homeassistant/components/vulcan/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/vulcan",
   "iot_class": "cloud_polling",
   "quality_scale": "silver",
-  "requirements": ["vulcan-api==2.3.0"]
+  "requirements": ["vulcan-api==2.3.2"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2769,7 +2769,7 @@ vsure==2.6.6
 vtjp==0.2.1
 
 # homeassistant.components.vulcan
-vulcan-api==2.3.0
+vulcan-api==2.3.2
 
 # homeassistant.components.vultr
 vultr==0.1.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2095,7 +2095,7 @@ volvooncall==0.10.3
 vsure==2.6.6
 
 # homeassistant.components.vulcan
-vulcan-api==2.3.0
+vulcan-api==2.3.2
 
 # homeassistant.components.vultr
 vultr==0.1.2

--- a/tests/components/vulcan/conftest.py
+++ b/tests/components/vulcan/conftest.py
@@ -1,5 +1,0 @@
-"""Skip test collection for Python 3.12."""
-import sys
-
-if sys.version_info >= (3, 12):
-    collect_ignore_glob = ["test_*.py"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump `vulcan-api` to 2.3.2 to make the integration compatible with Python 3.12.

Changelog: https://github.com/kapi2289/vulcan-api/compare/v2.3.0...v2.3.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to pull request: https://github.com/home-assistant/core/pull/101651
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
