### PR TITLE
Fix duplicate config entry additions in tests

### DIFF
--- a/tests/components/anova/test_init.py
+++ b/tests/components/anova/test_init.py
@@ -26,7 +26,6 @@ async def test_wrong_login(
 ) -> None:
     """Test for setup failure if connection to Anova is missing."""
     entry = create_entry(hass)
-    entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     assert entry.state is ConfigEntryState.SETUP_ERROR
 

--- a/tests/components/august/test_sensor.py
+++ b/tests/components/august/test_sensor.py
@@ -351,8 +351,7 @@ async def test_restored_state(
         ],
     )
 
-    august_entry = await _create_august_with_devices(hass, [lock_one])
-    august_entry.add_to_hass(hass)
+    await _create_august_with_devices(hass, [lock_one])
 
     await hass.async_block_till_done()
 

--- a/tests/components/efergy/__init__.py
+++ b/tests/components/efergy/__init__.py
@@ -40,7 +40,6 @@ async def init_integration(
     """Set up the Efergy integration in Home Assistant."""
     entry = create_entry(hass, token=token)
     await mock_responses(hass, aioclient_mock, token=token, error=error)
-    entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -571,7 +571,6 @@ async def test_scan_calendar_error(
     config_entry,
 ) -> None:
     """Test that the calendar update handles a server error."""
-    config_entry.add_to_hass(hass)
     mock_calendars_list({}, exc=ClientError())
     assert await component_setup()
 

--- a/tests/components/kraken/test_sensor.py
+++ b/tests/components/kraken/test_sensor.py
@@ -162,7 +162,6 @@ async def test_sensors_available_after_restart(
             manufacturer="Kraken.com",
             entry_type=dr.DeviceEntryType.SERVICE,
         )
-        entry.add_to_hass(hass)
 
         await hass.config_entries.async_setup(entry.entry_id)
 

--- a/tests/components/ruckus_unleashed/test_device_tracker.py
+++ b/tests/components/ruckus_unleashed/test_device_tracker.py
@@ -98,7 +98,6 @@ async def test_restoring_clients(hass: HomeAssistant) -> None:
     )
 
     with RuckusAjaxApiPatchContext(active_clients={}):
-        entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 

--- a/tests/components/yeelight/test_light.py
+++ b/tests/components/yeelight/test_light.py
@@ -826,6 +826,9 @@ async def test_device_types(
         # nightlight as a setting of the main entity
         if nightlight_mode_properties is not None:
             mocked_bulb.last_properties["active_mode"] = True
+            config_entry = MockConfigEntry(
+                domain=DOMAIN, data={**CONFIG_ENTRY_DATA, CONF_NIGHTLIGHT_SWITCH: False}
+            )
             config_entry.add_to_hass(hass)
             await _async_setup(config_entry)
             state = hass.states.get(entity_id)


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Some tests called `entry.add_to_hass(hass)` multiple times.  This should not happen as the helper could potentially corrupt the state of the config entry items.  https://github.com/home-assistant/core/pull/107590 now logs an error when this happens. In the future we will make this raise an exception once we fix the remaining tests

`zha` and `plex` still add the same config entry multiple times but they are going to need seperate PRs as they have more complex logic


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
