### PR TITLE
Improve coordinator logic in Tessie to allow sleep

### DIFF
--- a/homeassistant/components/tessie/binary_sensor.py
+++ b/homeassistant/components/tessie/binary_sensor.py
@@ -14,7 +14,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, TessieStatus
+from .const import DOMAIN, TessieState
 from .coordinator import TessieStateUpdateCoordinator
 from .entity import TessieEntity
 
@@ -30,7 +30,7 @@ DESCRIPTIONS: tuple[TessieBinarySensorEntityDescription, ...] = (
     TessieBinarySensorEntityDescription(
         key="state",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
-        is_on=lambda x: x == TessieStatus.ONLINE,
+        is_on=lambda x: x == TessieState.ONLINE,
     ),
     TessieBinarySensorEntityDescription(
         key="charge_state_battery_heater_on",

--- a/homeassistant/components/tessie/const.py
+++ b/homeassistant/components/tessie/const.py
@@ -13,11 +13,19 @@ MODELS = {
 }
 
 
-class TessieStatus(StrEnum):
+class TessieState(StrEnum):
     """Tessie status."""
 
     ASLEEP = "asleep"
     ONLINE = "online"
+
+
+class TessieStatus(StrEnum):
+    """Tessie status."""
+
+    ASLEEP = "asleep"
+    AWAKE = "awake"
+    WAITING = "waiting_for_sleep"
 
 
 class TessieSeatHeaterOptions(StrEnum):

--- a/homeassistant/components/tessie/coordinator.py
+++ b/homeassistant/components/tessie/coordinator.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any
 
 from aiohttp import ClientResponseError
-from tessie_api import get_state, status as get_status
+from tessie_api import get_state, get_status
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed

--- a/homeassistant/components/tessie/coordinator.py
+++ b/homeassistant/components/tessie/coordinator.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any
 
 from aiohttp import ClientResponseError
-from tessie_api import get_state
+from tessie_api import get_state, status as get_status
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -45,11 +45,21 @@ class TessieStateUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def _async_update_data(self) -> dict[str, Any]:
         """Update vehicle data using Tessie API."""
         try:
+            status = await get_status(
+                session=self.session,
+                api_key=self.api_key,
+                vin=self.vin,
+            )
+            if status["status"] == TessieStatus.ASLEEP:
+                # Vehicle is asleep, no need to poll for data
+                self.data["state"] = status["status"]
+                return self.data
+
             vehicle = await get_state(
                 session=self.session,
                 api_key=self.api_key,
                 vin=self.vin,
-                use_cache=False,
+                use_cache=True,
             )
         except ClientResponseError as e:
             if e.status == HTTPStatus.UNAUTHORIZED:
@@ -57,13 +67,7 @@ class TessieStateUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 raise ConfigEntryAuthFailed from e
             raise e
 
-        if vehicle["state"] == TessieStatus.ONLINE:
-            # Vehicle is online, all data is fresh
-            return self._flatten(vehicle)
-
-        # Vehicle is asleep, only update state
-        self.data["state"] = vehicle["state"]
-        return self.data
+        return self._flatten(vehicle)
 
     def _flatten(
         self, data: dict[str, Any], parent: str | None = None

--- a/tests/components/tessie/common.py
+++ b/tests/components/tessie/common.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from aiohttp import ClientConnectionError, ClientResponseError
 from aiohttp.client import RequestInfo
 
-from homeassistant.components.tessie.const import DOMAIN
+from homeassistant.components.tessie.const import DOMAIN, TessieStatus
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
 
@@ -14,7 +14,9 @@ from tests.common import MockConfigEntry, load_json_object_fixture
 
 TEST_STATE_OF_ALL_VEHICLES = load_json_object_fixture("vehicles.json", DOMAIN)
 TEST_VEHICLE_STATE_ONLINE = load_json_object_fixture("online.json", DOMAIN)
-TEST_VEHICLE_STATE_ASLEEP = load_json_object_fixture("asleep.json", DOMAIN)
+TEST_VEHICLE_STATUS_AWAKE = {"status": TessieStatus.AWAKE}
+TEST_VEHICLE_STATUS_ASLEEP = {"status": TessieStatus.ASLEEP}
+
 TEST_RESPONSE = {"result": True}
 TEST_RESPONSE_ERROR = {"result": False, "reason": "reason why"}
 

--- a/tests/components/tessie/conftest.py
+++ b/tests/components/tessie/conftest.py
@@ -5,7 +5,11 @@ from unittest.mock import patch
 
 import pytest
 
-from .common import TEST_STATE_OF_ALL_VEHICLES, TEST_VEHICLE_STATE_ONLINE
+from .common import (
+    TEST_STATE_OF_ALL_VEHICLES,
+    TEST_VEHICLE_STATE_ONLINE,
+    TEST_VEHICLE_STATUS_AWAKE,
+)
 
 
 @pytest.fixture
@@ -16,6 +20,16 @@ def mock_get_state():
         return_value=TEST_VEHICLE_STATE_ONLINE,
     ) as mock_get_state:
         yield mock_get_state
+
+
+@pytest.fixture
+def mock_get_status():
+    """Mock get_status function."""
+    with patch(
+        "homeassistant.components.tessie.coordinator.get_status",
+        return_value=TEST_VEHICLE_STATUS_AWAKE,
+    ) as mock_get_status:
+        yield mock_get_status
 
 
 @pytest.fixture

--- a/tests/components/tessie/test_coordinator.py
+++ b/tests/components/tessie/test_coordinator.py
@@ -10,8 +10,7 @@ from .common import (
     ERROR_AUTH,
     ERROR_CONNECTION,
     ERROR_UNKNOWN,
-    TEST_VEHICLE_STATE_ASLEEP,
-    TEST_VEHICLE_STATE_ONLINE,
+    TEST_VEHICLE_STATUS_ASLEEP,
     setup_platform,
 )
 
@@ -20,59 +19,61 @@ from tests.common import async_fire_time_changed
 WAIT = timedelta(seconds=TESSIE_SYNC_INTERVAL)
 
 
-async def test_coordinator_online(hass: HomeAssistant, mock_get_state) -> None:
+async def test_coordinator_online(
+    hass: HomeAssistant, mock_get_state, mock_get_status
+) -> None:
     """Tests that the coordinator handles online vehicles."""
 
-    mock_get_state.return_value = TEST_VEHICLE_STATE_ONLINE
     await setup_platform(hass)
 
     async_fire_time_changed(hass, utcnow() + WAIT)
     await hass.async_block_till_done()
+    mock_get_status.assert_called_once()
     mock_get_state.assert_called_once()
     assert hass.states.get("binary_sensor.test_status").state == STATE_ON
 
 
-async def test_coordinator_asleep(hass: HomeAssistant, mock_get_state) -> None:
+async def test_coordinator_asleep(hass: HomeAssistant, mock_get_status) -> None:
     """Tests that the coordinator handles asleep vehicles."""
 
-    mock_get_state.return_value = TEST_VEHICLE_STATE_ASLEEP
     await setup_platform(hass)
+    mock_get_status.return_value = TEST_VEHICLE_STATUS_ASLEEP
 
     async_fire_time_changed(hass, utcnow() + WAIT)
     await hass.async_block_till_done()
-    mock_get_state.assert_called_once()
+    mock_get_status.assert_called_once()
     assert hass.states.get("binary_sensor.test_status").state == STATE_OFF
 
 
-async def test_coordinator_clienterror(hass: HomeAssistant, mock_get_state) -> None:
+async def test_coordinator_clienterror(hass: HomeAssistant, mock_get_status) -> None:
     """Tests that the coordinator handles client errors."""
 
-    mock_get_state.side_effect = ERROR_UNKNOWN
+    mock_get_status.side_effect = ERROR_UNKNOWN
     await setup_platform(hass)
 
     async_fire_time_changed(hass, utcnow() + WAIT)
     await hass.async_block_till_done()
-    mock_get_state.assert_called_once()
+    mock_get_status.assert_called_once()
     assert hass.states.get("binary_sensor.test_status").state == STATE_UNAVAILABLE
 
 
-async def test_coordinator_auth(hass: HomeAssistant, mock_get_state) -> None:
+async def test_coordinator_auth(hass: HomeAssistant, mock_get_status) -> None:
     """Tests that the coordinator handles timeout errors."""
 
-    mock_get_state.side_effect = ERROR_AUTH
+    mock_get_status.side_effect = ERROR_AUTH
     await setup_platform(hass)
 
     async_fire_time_changed(hass, utcnow() + WAIT)
     await hass.async_block_till_done()
-    mock_get_state.assert_called_once()
+    mock_get_status.assert_called_once()
 
 
-async def test_coordinator_connection(hass: HomeAssistant, mock_get_state) -> None:
+async def test_coordinator_connection(hass: HomeAssistant, mock_get_status) -> None:
     """Tests that the coordinator handles connection errors."""
 
-    mock_get_state.side_effect = ERROR_CONNECTION
+    mock_get_status.side_effect = ERROR_CONNECTION
     await setup_platform(hass)
     async_fire_time_changed(hass, utcnow() + WAIT)
     await hass.async_block_till_done()
-    mock_get_state.assert_called_once()
+    mock_get_status.assert_called_once()
     assert hass.states.get("binary_sensor.test_status").state == STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Older Model S and X vehicles cannot sleep if they are polled frequently. This change adds use_cache=true back to the state API call, but adds a status API call before hand to check if the vehicle is asleep or waiting for sleep.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #107982 #107515
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
