### PR TITLE
Refactor event time trackers to avoid using nonlocal

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1443,10 +1443,11 @@ def async_track_point_in_utc_time(
     # Ensure point_in_time is UTC
     utc_point_in_time = dt_util.as_utc(point_in_time)
     expected_fire_timestamp = dt_util.utc_to_timestamp(utc_point_in_time)
-    if isinstance(action, HassJob):
-        job = action
-    else:
-        job = HassJob(action, f"track point in utc time {utc_point_in_time}")
+    job = (
+        action
+        if isinstance(action, HassJob)
+        else HassJob(action, f"track point in utc time {utc_point_in_time}")
+    )
     return _TrackPointUTCTime(
         hass, job, utc_point_in_time, expected_fire_timestamp
     ).cancel

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1555,8 +1555,11 @@ class _TrackTimeInterval:
         """Schedule the call_at."""
         if TYPE_CHECKING:
             assert self._track_job is not None
-        self._cancel_callback = async_call_later(
-            self.hass, self.seconds, self._track_job
+        hass = self.hass
+        self._cancel_callback = async_call_at(
+            hass,
+            self._track_job,
+            hass.loop.time() + self.seconds,
         )
 
     @callback

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1443,13 +1443,9 @@ def async_track_point_in_utc_time(
     # Ensure point_in_time is UTC
     utc_point_in_time = dt_util.as_utc(point_in_time)
     expected_fire_timestamp = dt_util.utc_to_timestamp(utc_point_in_time)
-    if type(action) is HassJob:
-        if TYPE_CHECKING:
-            assert isinstance(action, HassJob)
+    if isinstance(action, HassJob):
         job = action
     else:
-        if TYPE_CHECKING:
-            assert not isinstance(action, HassJob)
         job = HassJob(action, f"track point in utc time {utc_point_in_time}")
     return _TrackPointUTCTime(
         hass, job, utc_point_in_time, expected_fire_timestamp

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1397,7 +1397,7 @@ class _TrackPointUTCTime:
     expected_fire_timestamp: float
     _cancel_callback: asyncio.TimerHandle | None = None
 
-    def __post_init__(self) -> None:
+    def start(self) -> None:
         """Initialize track job."""
         loop = self.hass.loop
         self._cancel_callback = loop.call_at(
@@ -1448,9 +1448,9 @@ def async_track_point_in_utc_time(
         if isinstance(action, HassJob)
         else HassJob(action, f"track point in utc time {utc_point_in_time}")
     )
-    return _TrackPointUTCTime(
-        hass, job, utc_point_in_time, expected_fire_timestamp
-    ).cancel
+    track = _TrackPointUTCTime(hass, job, utc_point_in_time, expected_fire_timestamp)
+    track.start()
+    return track.cancel
 
 
 track_point_in_utc_time = threaded_listener_factory(async_track_point_in_utc_time)
@@ -1522,7 +1522,7 @@ class _TrackTimeInterval:
     _run_job: HassJob[[datetime], Coroutine[Any, Any, None] | None] | None = None
     _cancel_callback: CALLBACK_TYPE | None = None
 
-    def __post_init__(self) -> None:
+    def start(self) -> None:
         """Initialize track job."""
         hass = self.hass
         self._track_job = HassJob(
@@ -1582,9 +1582,9 @@ def async_track_time_interval(
     job_name = f"track time interval {seconds} {action}"
     if name:
         job_name = f"{name}: {job_name}"
-    return _TrackTimeInterval(
-        hass, seconds, job_name, action, cancel_on_shutdown
-    ).cancel
+    track = _TrackTimeInterval(hass, seconds, job_name, action, cancel_on_shutdown)
+    track.start()
+    return track.cancel
 
 
 track_time_interval = threaded_listener_factory(async_track_time_interval)

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1397,7 +1397,7 @@ class _TrackPointUTCTime:
     expected_fire_timestamp: float
     _cancel_callback: asyncio.TimerHandle | None = None
 
-    def start(self) -> None:
+    def async_attach(self) -> None:
         """Initialize track job."""
         loop = self.hass.loop
         self._cancel_callback = loop.call_at(
@@ -1421,7 +1421,7 @@ class _TrackPointUTCTime:
         self.hass.async_run_hass_job(self.job, self.utc_point_in_time)
 
     @callback
-    def cancel(self) -> None:
+    def async_cancel(self) -> None:
         """Cancel the call_at."""
         if TYPE_CHECKING:
             assert self._cancel_callback is not None
@@ -1449,8 +1449,8 @@ def async_track_point_in_utc_time(
         else HassJob(action, f"track point in utc time {utc_point_in_time}")
     )
     track = _TrackPointUTCTime(hass, job, utc_point_in_time, expected_fire_timestamp)
-    track.start()
-    return track.cancel
+    track.async_attach()
+    return track.async_cancel
 
 
 track_point_in_utc_time = threaded_listener_factory(async_track_point_in_utc_time)
@@ -1522,7 +1522,7 @@ class _TrackTimeInterval:
     _run_job: HassJob[[datetime], Coroutine[Any, Any, None] | None] | None = None
     _cancel_callback: CALLBACK_TYPE | None = None
 
-    def start(self) -> None:
+    def async_attach(self) -> None:
         """Initialize track job."""
         hass = self.hass
         self._track_job = HassJob(
@@ -1557,7 +1557,7 @@ class _TrackTimeInterval:
         hass.async_run_hass_job(self._run_job, now)
 
     @callback
-    def cancel(self) -> None:
+    def async_cancel(self) -> None:
         """Cancel the call_at."""
         if TYPE_CHECKING:
             assert self._cancel_callback is not None
@@ -1583,8 +1583,8 @@ def async_track_time_interval(
     if name:
         job_name = f"{name}: {job_name}"
     track = _TrackTimeInterval(hass, seconds, job_name, action, cancel_on_shutdown)
-    track.start()
-    return track.cancel
+    track.async_attach()
+    return track.async_cancel
 
 
 track_time_interval = threaded_listener_factory(async_track_time_interval)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor event time trackers to avoid using `nonlocal`.  The pattern is now similar to `SunListener`. `async_track_utc_time_change` could be done the same way as well but not for this PR.

This also makes debugging a lot easier since the `profiler.dump_log_objects` service can dump `_TrackPointUTCTime` or `_TrackTimeInterval` to the log which makes it much easier to look for leaks

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
