### PR TITLE
Add matrix message format 'notice' (m.notice)

### DIFF
--- a/homeassistant/components/matrix/__init__.py
+++ b/homeassistant/components/matrix/__init__.py
@@ -43,7 +43,7 @@ from homeassistant.helpers.json import save_json
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.json import JsonObjectType, load_json_object
 
-from .const import DOMAIN, FORMAT_HTML, FORMAT_TEXT, SERVICE_SEND_MESSAGE
+from .const import DOMAIN, FORMAT_HTML, FORMAT_TEXT, FORMAT_NOTICE, SERVICE_SEND_MESSAGE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,7 +62,7 @@ EVENT_MATRIX_COMMAND = "matrix_command"
 
 DEFAULT_CONTENT_TYPE = "application/octet-stream"
 
-MESSAGE_FORMATS = [FORMAT_HTML, FORMAT_TEXT]
+MESSAGE_FORMATS = [FORMAT_HTML, FORMAT_TEXT, FORMAT_NOTICE]
 DEFAULT_MESSAGE_FORMAT = FORMAT_TEXT
 
 ATTR_FORMAT = "format"  # optional message format
@@ -501,7 +501,11 @@ class MatrixBot:
         self, message: str, target_rooms: list[RoomAnyID], data: dict | None
     ) -> None:
         """Send a message to the Matrix server."""
-        content = {"msgtype": "m.text", "body": message}
+        msgtype = "m.text"
+        if data is not None and data.get(ATTR_FORMAT) == FORMAT_NOTICE:
+            msgtype = "m.notice"
+
+        content = {"msgtype": msgtype, "body": message}
         if data is not None and data.get(ATTR_FORMAT) == FORMAT_HTML:
             content |= {"format": "org.matrix.custom.html", "formatted_body": message}
 

--- a/homeassistant/components/matrix/const.py
+++ b/homeassistant/components/matrix/const.py
@@ -5,3 +5,4 @@ SERVICE_SEND_MESSAGE = "send_message"
 
 FORMAT_HTML = "html"
 FORMAT_TEXT = "text"
+FORMAT_NOTICE = "notice"

--- a/tests/components/matrix/conftest.py
+++ b/tests/components/matrix/conftest.py
@@ -289,7 +289,7 @@ async def matrix_bot(
 
     with patch.object(
         matrix_bot, "_handle_multi_room_send", wraps=matrix_bot._handle_multi_room_send
-    ) as mock:
+    ):
         await hass.async_start()
         yield matrix_bot
 

--- a/tests/components/matrix/conftest.py
+++ b/tests/components/matrix/conftest.py
@@ -287,9 +287,11 @@ async def matrix_bot(
     await hass.async_block_till_done()
     assert isinstance(matrix_bot := hass.data[MATRIX_DOMAIN], MatrixBot)
 
-    await hass.async_start()
-
-    return matrix_bot
+    with patch.object(
+        matrix_bot, "_handle_multi_room_send", wraps=matrix_bot._handle_multi_room_send
+    ) as mock:
+        await hass.async_start()
+        yield matrix_bot
 
 
 @pytest.fixture

--- a/tests/components/matrix/test_send_message.py
+++ b/tests/components/matrix/test_send_message.py
@@ -6,7 +6,7 @@ from homeassistant.components.matrix import (
     DOMAIN as MATRIX_DOMAIN,
     MatrixBot,
 )
-from homeassistant.components.matrix.const import FORMAT_HTML, SERVICE_SEND_MESSAGE
+from homeassistant.components.matrix.const import FORMAT_HTML, FORMAT_NOTICE, SERVICE_SEND_MESSAGE
 from homeassistant.components.notify import ATTR_DATA, ATTR_MESSAGE, ATTR_TARGET
 from homeassistant.core import HomeAssistant
 
@@ -46,6 +46,19 @@ async def test_send_message(
 
     # Send a message with an attached image.
     data[ATTR_DATA] = {ATTR_IMAGES: [image_path.name]}
+    await hass.services.async_call(
+        MATRIX_DOMAIN, SERVICE_SEND_MESSAGE, data, blocking=True
+    )
+
+    for room_alias_or_id in TEST_JOINABLE_ROOMS:
+        assert f"Message delivered to room '{room_alias_or_id}'" in caplog.messages
+
+    # Send bot notice (m.notice) message.
+    data = {
+        ATTR_MESSAGE: "Test bot (notice) message",
+        ATTR_TARGET: list(TEST_JOINABLE_ROOMS),
+        ATTR_DATA: {ATTR_FORMAT: FORMAT_NOTICE},
+    }
     await hass.services.async_call(
         MATRIX_DOMAIN, SERVICE_SEND_MESSAGE, data, blocking=True
     )

--- a/tests/components/matrix/test_send_message.py
+++ b/tests/components/matrix/test_send_message.py
@@ -6,7 +6,11 @@ from homeassistant.components.matrix import (
     DOMAIN as MATRIX_DOMAIN,
     MatrixBot,
 )
-from homeassistant.components.matrix.const import FORMAT_HTML, FORMAT_NOTICE, SERVICE_SEND_MESSAGE
+from homeassistant.components.matrix.const import (
+    FORMAT_HTML,
+    FORMAT_NOTICE,
+    SERVICE_SEND_MESSAGE,
+)
 from homeassistant.components.notify import ATTR_DATA, ATTR_MESSAGE, ATTR_TARGET
 from homeassistant.core import HomeAssistant
 

--- a/tests/components/matrix/test_send_message.py
+++ b/tests/components/matrix/test_send_message.py
@@ -1,5 +1,9 @@
 """Test the send_message service."""
 
+import io
+
+import pytest
+
 from homeassistant.components.matrix import (
     ATTR_FORMAT,
     ATTR_IMAGES,
@@ -7,21 +11,19 @@ from homeassistant.components.matrix import (
     MatrixBot,
 )
 from homeassistant.components.matrix.const import (
-    FORMAT_TEXT,
     FORMAT_HTML,
     FORMAT_NOTICE,
+    FORMAT_TEXT,
     SERVICE_SEND_MESSAGE,
 )
 from homeassistant.components.notify import ATTR_DATA, ATTR_MESSAGE, ATTR_TARGET
 from homeassistant.core import HomeAssistant
 
 from tests.components.matrix.conftest import TEST_BAD_ROOM, TEST_JOINABLE_ROOMS
-import pytest
-import io
 
 
 @pytest.mark.parametrize(
-    "ids, data, expected_attributes",
+    ("ids", "data", "expected_attributes"),
     [
         (
             "Text message",
@@ -104,7 +106,7 @@ async def test_send_image(
     matrix_events: list,
     caplog: pytest.LogCaptureFixture,
 ):
-    """Test send a message with an attached image"""
+    """Test send a message with an attached image."""
 
     await hass.async_start()
     assert len(matrix_events) == 0

--- a/tests/components/matrix/test_send_message.py
+++ b/tests/components/matrix/test_send_message.py
@@ -20,58 +20,52 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "ids, expected_attributes",
+    "ids, data, expected_attributes",
     [
         (
             "Text message",
             {
-                "data": {
-                    ATTR_MESSAGE: "Test text message",
-                    ATTR_DATA: {ATTR_FORMAT: FORMAT_TEXT},
-                    ATTR_TARGET: list(TEST_JOINABLE_ROOMS.keys()),
-                },
-                "expected_result": {
-                    "target_rooms": list(TEST_JOINABLE_ROOMS.keys()),
-                    "message_type": "m.room.message",
-                    "content": {"msgtype": "m.text", "body": "Test text message"},
-                },
+                ATTR_MESSAGE: "Test text message",
+                ATTR_DATA: {ATTR_FORMAT: FORMAT_TEXT},
+                ATTR_TARGET: list(TEST_JOINABLE_ROOMS.keys()),
+            },
+            {
+                "target_rooms": list(TEST_JOINABLE_ROOMS.keys()),
+                "message_type": "m.room.message",
+                "content": {"msgtype": "m.text", "body": "Test text message"},
             },
         ),
         (
             "HTML message",
             {
-                "data": {
-                    ATTR_MESSAGE: "Test <b>html</b> message",
-                    ATTR_DATA: {ATTR_FORMAT: FORMAT_HTML},
-                    ATTR_TARGET: list(TEST_JOINABLE_ROOMS.keys()),
-                },
-                "expected_result": {
-                    "target_rooms": list(TEST_JOINABLE_ROOMS.keys()),
-                    "message_type": "m.room.message",
-                    "content": {
-                        "msgtype": "m.text",
-                        "body": "Test <b>html</b> message",
-                        "format": "org.matrix.custom.html",
-                        "formatted_body": "Test <b>html</b> message",
-                    },
+                ATTR_MESSAGE: "Test <b>html</b> message",
+                ATTR_DATA: {ATTR_FORMAT: FORMAT_HTML},
+                ATTR_TARGET: list(TEST_JOINABLE_ROOMS.keys()),
+            },
+            {
+                "target_rooms": list(TEST_JOINABLE_ROOMS.keys()),
+                "message_type": "m.room.message",
+                "content": {
+                    "msgtype": "m.text",
+                    "body": "Test <b>html</b> message",
+                    "format": "org.matrix.custom.html",
+                    "formatted_body": "Test <b>html</b> message",
                 },
             },
         ),
         (
             "Bot (notice) message",
             {
-                "data": {
-                    ATTR_MESSAGE: "Test bot (notice) message",
-                    ATTR_DATA: {ATTR_FORMAT: FORMAT_NOTICE},
-                    ATTR_TARGET: list(TEST_JOINABLE_ROOMS.keys()),
-                },
-                "expected_result": {
-                    "target_rooms": list(TEST_JOINABLE_ROOMS.keys()),
-                    "message_type": "m.room.message",
-                    "content": {
-                        "msgtype": "m.notice",
-                        "body": "Test bot (notice) message",
-                    },
+                ATTR_MESSAGE: "Test bot (notice) message",
+                ATTR_DATA: {ATTR_FORMAT: FORMAT_NOTICE},
+                ATTR_TARGET: list(TEST_JOINABLE_ROOMS.keys()),
+            },
+            {
+                "target_rooms": list(TEST_JOINABLE_ROOMS.keys()),
+                "message_type": "m.room.message",
+                "content": {
+                    "msgtype": "m.notice",
+                    "body": "Test bot (notice) message",
                 },
             },
         ),
@@ -84,6 +78,7 @@ async def test_send_message(
     matrix_events,
     caplog,
     ids,
+    data,
     expected_attributes,
 ):
     """Test the send_message service."""
@@ -93,12 +88,10 @@ async def test_send_message(
     await matrix_bot._login()
 
     await hass.services.async_call(
-        MATRIX_DOMAIN, SERVICE_SEND_MESSAGE, expected_attributes["data"], blocking=True
+        MATRIX_DOMAIN, SERVICE_SEND_MESSAGE, data, blocking=True
     )
 
-    matrix_bot._handle_multi_room_send.assert_called_once_with(
-        **expected_attributes["expected_result"]
-    )
+    matrix_bot._handle_multi_room_send.assert_called_once_with(**expected_attributes)
 
     for room_alias_or_id in TEST_JOINABLE_ROOMS:
         assert f"Message delivered to room '{room_alias_or_id}'" in caplog.messages

--- a/tests/components/matrix/test_send_message.py
+++ b/tests/components/matrix/test_send_message.py
@@ -64,11 +64,7 @@ async def test_send_message(
             "formatted_body": data[ATTR_MESSAGE],
         },
     }
-    matrix_bot._handle_multi_room_send.assert_called_once_with(
-        target_rooms=expected_data["target_rooms"],
-        message_type=expected_data["message_type"],
-        content=expected_data["content"],
-    )
+    matrix_bot._handle_multi_room_send.assert_called_once_with(**expected_data)
 
     for room_alias_or_id in TEST_JOINABLE_ROOMS:
         assert f"Message delivered to room '{room_alias_or_id}'" in caplog.messages

--- a/tests/components/matrix/test_send_message.py
+++ b/tests/components/matrix/test_send_message.py
@@ -20,7 +20,7 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "test_name, test_params",
+    "ids, expected_attributes",
     [
         (
             "Text message",
@@ -83,8 +83,8 @@ async def test_send_message(
     image_path,
     matrix_events,
     caplog,
-    test_name,
-    test_params,
+    ids,
+    expected_attributes,
 ):
     """Test the send_message service."""
 
@@ -93,11 +93,11 @@ async def test_send_message(
     await matrix_bot._login()
 
     await hass.services.async_call(
-        MATRIX_DOMAIN, SERVICE_SEND_MESSAGE, test_params["data"], blocking=True
+        MATRIX_DOMAIN, SERVICE_SEND_MESSAGE, expected_attributes["data"], blocking=True
     )
 
     matrix_bot._handle_multi_room_send.assert_called_once_with(
-        **test_params["expected_result"]
+        **expected_attributes["expected_result"]
     )
 
     for room_alias_or_id in TEST_JOINABLE_ROOMS:

--- a/tests/components/matrix/test_send_message.py
+++ b/tests/components/matrix/test_send_message.py
@@ -95,11 +95,7 @@ async def test_send_message(
         "message_type": "m.room.message",
         "content": {"msgtype": "m.notice", "body": data[ATTR_MESSAGE]},
     }
-    matrix_bot._handle_multi_room_send.assert_called_once_with(
-        target_rooms=expected_data["target_rooms"],
-        message_type=expected_data["message_type"],
-        content=expected_data["content"],
-    )
+    matrix_bot._handle_multi_room_send.assert_called_once_with(**expected_data)
 
     for room_alias_or_id in TEST_JOINABLE_ROOMS:
         assert f"Message delivered to room '{room_alias_or_id}'" in caplog.messages

--- a/tests/components/matrix/test_send_message.py
+++ b/tests/components/matrix/test_send_message.py
@@ -17,6 +17,7 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.matrix.conftest import TEST_BAD_ROOM, TEST_JOINABLE_ROOMS
 import pytest
+import io
 
 
 @pytest.mark.parametrize(
@@ -74,12 +75,11 @@ import pytest
 async def test_send_message(
     hass: HomeAssistant,
     matrix_bot: MatrixBot,
-    image_path,
-    matrix_events,
-    caplog,
-    ids,
-    data,
-    expected_attributes,
+    matrix_events: list,
+    caplog: pytest.LogCaptureFixture,
+    ids: str,
+    data: dict,
+    expected_attributes: dict,
 ):
     """Test the send_message service."""
 
@@ -98,7 +98,11 @@ async def test_send_message(
 
 
 async def test_send_image(
-    hass: HomeAssistant, matrix_bot: MatrixBot, image_path, matrix_events, caplog
+    hass: HomeAssistant,
+    matrix_bot: MatrixBot,
+    image_path: io.BytesIO,
+    matrix_events: list,
+    caplog: pytest.LogCaptureFixture,
 ):
     """Test send a message with an attached image"""
 
@@ -120,7 +124,10 @@ async def test_send_image(
 
 
 async def test_unsendable_message(
-    hass: HomeAssistant, matrix_bot: MatrixBot, matrix_events, caplog
+    hass: HomeAssistant,
+    matrix_bot: MatrixBot,
+    matrix_events: list,
+    caplog: pytest.LogCaptureFixture,
 ):
     """Test the send_message service with an invalid room."""
     assert len(matrix_events) == 0

--- a/tests/components/matrix/test_send_message.py
+++ b/tests/components/matrix/test_send_message.py
@@ -38,11 +38,7 @@ async def test_send_message(
         "message_type": "m.room.message",
         "content": {"msgtype": "m.text", "body": data[ATTR_MESSAGE]},
     }
-    matrix_bot._handle_multi_room_send.assert_called_once_with(
-        target_rooms=expected_data["target_rooms"],
-        message_type=expected_data["message_type"],
-        content=expected_data["content"],
-    )
+    matrix_bot._handle_multi_room_send.assert_called_once_with(**expected_data)
 
     for room_alias_or_id in TEST_JOINABLE_ROOMS:
         assert f"Message delivered to room '{room_alias_or_id}'" in caplog.messages

--- a/tests/components/matrix/test_send_message.py
+++ b/tests/components/matrix/test_send_message.py
@@ -92,7 +92,6 @@ async def test_send_message(
     assert len(matrix_events) == 0
     await matrix_bot._login()
 
-    print(test_params)
     await hass.services.async_call(
         MATRIX_DOMAIN, SERVICE_SEND_MESSAGE, test_params["data"], blocking=True
     )

--- a/tests/components/matrix/test_send_message.py
+++ b/tests/components/matrix/test_send_message.py
@@ -7,6 +7,7 @@ from homeassistant.components.matrix import (
     MatrixBot,
 )
 from homeassistant.components.matrix.const import (
+    FORMAT_TEXT,
     FORMAT_HTML,
     FORMAT_NOTICE,
     SERVICE_SEND_MESSAGE,
@@ -15,10 +16,75 @@ from homeassistant.components.notify import ATTR_DATA, ATTR_MESSAGE, ATTR_TARGET
 from homeassistant.core import HomeAssistant
 
 from tests.components.matrix.conftest import TEST_BAD_ROOM, TEST_JOINABLE_ROOMS
+import pytest
 
 
+@pytest.mark.parametrize(
+    "test_name, test_params",
+    [
+        (
+            "Text message",
+            {
+                "data": {
+                    ATTR_MESSAGE: "Test text message",
+                    ATTR_DATA: {ATTR_FORMAT: FORMAT_TEXT},
+                    ATTR_TARGET: list(TEST_JOINABLE_ROOMS.keys()),
+                },
+                "expected_result": {
+                    "target_rooms": list(TEST_JOINABLE_ROOMS.keys()),
+                    "message_type": "m.room.message",
+                    "content": {"msgtype": "m.text", "body": "Test text message"},
+                },
+            },
+        ),
+        (
+            "HTML message",
+            {
+                "data": {
+                    ATTR_MESSAGE: "Test <b>html</b> message",
+                    ATTR_DATA: {ATTR_FORMAT: FORMAT_HTML},
+                    ATTR_TARGET: list(TEST_JOINABLE_ROOMS.keys()),
+                },
+                "expected_result": {
+                    "target_rooms": list(TEST_JOINABLE_ROOMS.keys()),
+                    "message_type": "m.room.message",
+                    "content": {
+                        "msgtype": "m.text",
+                        "body": "Test <b>html</b> message",
+                        "format": "org.matrix.custom.html",
+                        "formatted_body": "Test <b>html</b> message",
+                    },
+                },
+            },
+        ),
+        (
+            "Bot (notice) message",
+            {
+                "data": {
+                    ATTR_MESSAGE: "Test bot (notice) message",
+                    ATTR_DATA: {ATTR_FORMAT: FORMAT_NOTICE},
+                    ATTR_TARGET: list(TEST_JOINABLE_ROOMS.keys()),
+                },
+                "expected_result": {
+                    "target_rooms": list(TEST_JOINABLE_ROOMS.keys()),
+                    "message_type": "m.room.message",
+                    "content": {
+                        "msgtype": "m.notice",
+                        "body": "Test bot (notice) message",
+                    },
+                },
+            },
+        ),
+    ],
+)
 async def test_send_message(
-    hass: HomeAssistant, matrix_bot: MatrixBot, image_path, matrix_events, caplog
+    hass: HomeAssistant,
+    matrix_bot: MatrixBot,
+    image_path,
+    matrix_events,
+    caplog,
+    test_name,
+    test_params,
 ):
     """Test the send_message service."""
 
@@ -26,76 +92,36 @@ async def test_send_message(
     assert len(matrix_events) == 0
     await matrix_bot._login()
 
-    # Send a message without an attached image.
-    matrix_bot._handle_multi_room_send.reset_mock()
-    data = {ATTR_MESSAGE: "Test message", ATTR_TARGET: list(TEST_JOINABLE_ROOMS)}
+    print(test_params)
     await hass.services.async_call(
-        MATRIX_DOMAIN, SERVICE_SEND_MESSAGE, data, blocking=True
+        MATRIX_DOMAIN, SERVICE_SEND_MESSAGE, test_params["data"], blocking=True
     )
 
-    expected_data = {
-        "target_rooms": list(TEST_JOINABLE_ROOMS.keys()),
-        "message_type": "m.room.message",
-        "content": {"msgtype": "m.text", "body": data[ATTR_MESSAGE]},
-    }
-    matrix_bot._handle_multi_room_send.assert_called_once_with(**expected_data)
+    matrix_bot._handle_multi_room_send.assert_called_once_with(
+        **test_params["expected_result"]
+    )
 
     for room_alias_or_id in TEST_JOINABLE_ROOMS:
         assert f"Message delivered to room '{room_alias_or_id}'" in caplog.messages
 
-    # Send an HTML message without an attached image.
-    matrix_bot._handle_multi_room_send.reset_mock()
+
+async def test_send_image(
+    hass: HomeAssistant, matrix_bot: MatrixBot, image_path, matrix_events, caplog
+):
+    """Test send a message with an attached image"""
+
+    await hass.async_start()
+    assert len(matrix_events) == 0
+    await matrix_bot._login()
+
     data = {
         ATTR_MESSAGE: "Test <b>html</b> message",
         ATTR_TARGET: list(TEST_JOINABLE_ROOMS),
-        ATTR_DATA: {ATTR_FORMAT: FORMAT_HTML},
+        ATTR_DATA: {ATTR_IMAGES: [image_path.name]},
     }
     await hass.services.async_call(
         MATRIX_DOMAIN, SERVICE_SEND_MESSAGE, data, blocking=True
     )
-
-    expected_data = {
-        "target_rooms": list(TEST_JOINABLE_ROOMS.keys()),
-        "message_type": "m.room.message",
-        "content": {
-            "msgtype": "m.text",
-            "body": data[ATTR_MESSAGE],
-            "format": "org.matrix.custom.html",
-            "formatted_body": data[ATTR_MESSAGE],
-        },
-    }
-    matrix_bot._handle_multi_room_send.assert_called_once_with(**expected_data)
-
-    for room_alias_or_id in TEST_JOINABLE_ROOMS:
-        assert f"Message delivered to room '{room_alias_or_id}'" in caplog.messages
-
-    # Send a message with an attached image.
-    data[ATTR_DATA] = {ATTR_IMAGES: [image_path.name]}
-    await hass.services.async_call(
-        MATRIX_DOMAIN, SERVICE_SEND_MESSAGE, data, blocking=True
-    )
-
-    for room_alias_or_id in TEST_JOINABLE_ROOMS:
-        assert f"Message delivered to room '{room_alias_or_id}'" in caplog.messages
-
-    # Send bot notice (m.notice) message.
-    matrix_bot._handle_multi_room_send.reset_mock()
-    data = {
-        ATTR_MESSAGE: "Test bot (notice) message",
-        ATTR_TARGET: list(TEST_JOINABLE_ROOMS),
-        ATTR_DATA: {ATTR_FORMAT: FORMAT_NOTICE},
-    }
-
-    await hass.services.async_call(
-        MATRIX_DOMAIN, SERVICE_SEND_MESSAGE, data, blocking=True
-    )
-
-    expected_data = {
-        "target_rooms": list(TEST_JOINABLE_ROOMS.keys()),
-        "message_type": "m.room.message",
-        "content": {"msgtype": "m.notice", "body": data[ATTR_MESSAGE]},
-    }
-    matrix_bot._handle_multi_room_send.assert_called_once_with(**expected_data)
 
     for room_alias_or_id in TEST_JOINABLE_ROOMS:
         assert f"Message delivered to room '{room_alias_or_id}'" in caplog.messages


### PR DESCRIPTION
This format is a so called "bot notice" is used for bot to post information into a room. This message will not cause notification on the members of the room.

This is very usefull for home-assistant tasks, which don't need user attention but just FYI messages.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Add new format `m.notice` for posting messages via Matrix Connector. `m.notice` or "bot notice" is commonly used in Matrix for posting information into chat rooms by bot. This will not trigger a notification in the room.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] New feature (which adds functionality to an existing integration)

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30878

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
