### PR TITLE
Add helper function to update and reload config entry to config flow

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1938,7 +1938,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         return result
 
     @callback
-    def async_update_and_reload_entry(
+    def async_update_reload_and_abort(
         self,
         entry: ConfigEntry,
         title: str | UndefinedType = UNDEFINED,

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1937,6 +1937,24 @@ class ConfigFlow(data_entry_flow.FlowHandler):
 
         return result
 
+    async def async_update_and_reload_entry(
+        self,
+        entry: ConfigEntry,
+        title: str | UndefinedType = UNDEFINED,
+        data: Mapping[str, Any] | UndefinedType = UNDEFINED,
+        options: Mapping[str, Any] | UndefinedType = UNDEFINED,
+        reason: str = "reauth_successful",
+    ) -> data_entry_flow.FlowResult:
+        """Update config entry, reload config entry and finish config flow."""
+        self.hass.config_entries.async_update_entry(
+            entry=entry,
+            title=title,
+            data=data,
+            options=options,
+        )
+        await self.hass.config_entries.async_reload(entry.entry_id)
+        return self.async_abort(reason=reason)
+
 
 class OptionsFlowManager(data_entry_flow.FlowManager):
     """Flow to set options for a configuration entry."""

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1947,15 +1947,17 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         reason: str = "reauth_successful",
     ) -> data_entry_flow.FlowResult:
         """Update config entry, reload config entry and finish config flow."""
-        self.hass.config_entries.async_update_entry(
+        result = self.hass.config_entries.async_update_entry(
             entry=entry,
             title=title,
             data=data,
             options=options,
         )
-        self.hass.async_create_task(
-            self.hass.config_entries.async_reload(entry.entry_id)
-        )
+        if result:
+            self.hass.async_create_task(
+                self.hass.config_entries.async_reload(entry.entry_id),
+                f"config entry reload {entry.title} {entry.domain} {entry.entry_id}",
+            )
         return self.async_abort(reason=reason)
 
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1937,7 +1937,8 @@ class ConfigFlow(data_entry_flow.FlowHandler):
 
         return result
 
-    async def async_update_and_reload_entry(
+    @callback
+    def async_update_and_reload_entry(
         self,
         entry: ConfigEntry,
         title: str | UndefinedType = UNDEFINED,
@@ -1952,7 +1953,9 @@ class ConfigFlow(data_entry_flow.FlowHandler):
             data=data,
             options=options,
         )
-        await self.hass.config_entries.async_reload(entry.entry_id)
+        self.hass.async_create_task(
+            self.hass.config_entries.async_reload(entry.entry_id)
+        )
         return self.async_abort(reason=reason)
 
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -4170,7 +4170,7 @@ async def test_update_entry_and_reload(
 
         async def async_step_reauth(self, data):
             """Mock Reauth."""
-            return self.async_update_and_reload_entry(
+            return self.async_update_reload_and_abort(
                 entry=entry,
                 title="Updated Title",
                 data={"vendor": "data2"},

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -4170,7 +4170,7 @@ async def test_update_entry_and_reload(
 
         async def async_step_reauth(self, data):
             """Mock Reauth."""
-            return await self.async_update_and_reload_entry(
+            return self.async_update_and_reload_entry(
                 entry=entry,
                 title="Updated Title",
                 data={"vendor": "data2"},

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -4144,3 +4144,46 @@ def test_raise_trying_to_add_same_config_entry_twice(
     entry.add_to_hass(hass)
     entry.add_to_hass(hass)
     assert f"An entry with the id {entry.entry_id} already exists" in caplog.text
+
+
+async def test_update_entry_and_reload(
+    hass: HomeAssistant, manager: config_entries.ConfigEntries
+) -> None:
+    """Test updating an entry and reloading."""
+    entry = MockConfigEntry(
+        domain="comp",
+        title="Test",
+        data={"vendor": "data"},
+        options={"vendor": "options"},
+    )
+    entry.add_to_hass(hass)
+
+    mock_integration(
+        hass, MockModule("comp", async_setup_entry=AsyncMock(return_value=True))
+    )
+    mock_platform(hass, "comp.config_flow", None)
+
+    class MockFlowHandler(config_entries.ConfigFlow):
+        """Define a mock flow handler."""
+
+        VERSION = 1
+
+        async def async_step_reauth(self, data):
+            """Mock Reauth."""
+            return await self.async_update_and_reload_entry(
+                entry=entry,
+                title="Updated Title",
+                data={"vendor": "data2"},
+                options={"vendor": "options2"},
+            )
+
+    with patch.dict(config_entries.HANDLERS, {"comp": MockFlowHandler}):
+        task = await manager.flow.async_init("comp", context={"source": "reauth"})
+        await hass.async_block_till_done()
+
+        assert entry.title == "Updated Title"
+        assert entry.data == {"vendor": "data2"}
+        assert entry.options == {"vendor": "options2"}
+        assert entry.state == config_entries.ConfigEntryState.LOADED
+        assert task["type"] == FlowResultType.ABORT
+        assert task["reason"] == "reauth_successful"


### PR DESCRIPTION
## Proposed change
We currently use something like the following in a lot of our config flows:

```python
self.hass.config_entries.async_update_entry(
    self.existing_entry,
    data={
        CONF_EMAIL: user_input[CONF_EMAIL],
        CONF_PASSWORD: user_input[CONF_PASSWORD],
    },
)
await self.hass.config_entries.async_reload(
    self.existing_entry.entry_id
)
return self.async_abort(reason="reauth_successful")
```

So I thought it would be nice to have an helper function for this.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
