### PR TITLE
Fix malformed user input error on MJPEG config flow

### DIFF
--- a/homeassistant/components/mjpeg/config_flow.py
+++ b/homeassistant/components/mjpeg/config_flow.py
@@ -54,7 +54,7 @@ def async_get_schema(
 
     if show_name:
         schema = {
-            vol.Optional(CONF_NAME, default=defaults.get(CONF_NAME)): str,
+            vol.Required(CONF_NAME, default=defaults.get(CONF_NAME)): str,
             **schema,
         }
 


### PR DESCRIPTION
## Proposed change
Name is required for the config flow but doesn't make it mandatory - this change does - which fixes error "User input malformed: expected str for dictionary value @ data['name']".

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.