### PR TITLE
Attempt to use Digest authorisation before Basic for MJPEG

### DIFF
--- a/homeassistant/components/mjpeg/config_flow.py
+++ b/homeassistant/components/mjpeg/config_flow.py
@@ -66,7 +66,7 @@ def validate_url(
     username: str | None,
     password: str,
     verify_ssl: bool,
-    authentication: str = HTTP_BASIC_AUTHENTICATION,
+    authentication: str = HTTP_DIGEST_AUTHENTICATION,
 ) -> str:
     """Test if the given setting works as expected."""
     auth: HTTPDigestAuth | HTTPBasicAuth | None = None
@@ -85,10 +85,10 @@ def validate_url(
     )
 
     if response.status_code == HTTPStatus.UNAUTHORIZED:
-        # If unauthorized, try again using digest auth
-        if authentication == HTTP_BASIC_AUTHENTICATION:
+        # If unauthorized with digest, try again using basic auth
+        if authentication == HTTP_DIGEST_AUTHENTICATION:
             return validate_url(
-                url, username, password, verify_ssl, HTTP_DIGEST_AUTHENTICATION
+                url, username, password, verify_ssl, HTTP_BASIC_AUTHENTICATION
             )
         raise InvalidAuth
 
@@ -104,7 +104,7 @@ async def async_validate_input(
     """Manage MJPEG IP Camera options."""
     errors = {}
     field = "base"
-    authentication = HTTP_BASIC_AUTHENTICATION
+    authentication = HTTP_DIGEST_AUTHENTICATION
     try:
         for field in (CONF_MJPEG_URL, CONF_STILL_IMAGE_URL):
             if not (url := user_input.get(field)):


### PR DESCRIPTION
## Proposed change
Increases security of MJPEG Cameras by attempting to use Digest authorisation (where available) before Basic, retries with Basic if Digest failed.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.