### PR TITLE
Allow using either username or password standalone for MJPEG

### DIFF
--- a/homeassistant/components/mjpeg/config_flow.py
+++ b/homeassistant/components/mjpeg/config_flow.py
@@ -75,6 +75,16 @@ def validate_url(
             auth = HTTPDigestAuth(username, password)
         else:
             auth = HTTPBasicAuth(username, password)
+    elif username:
+        if authentication == HTTP_DIGEST_AUTHENTICATION:
+            auth = HTTPDigestAuth(username, None)
+        else:
+            auth = HTTPBasicAuth(username, None)
+    elif password:
+        if authentication == HTTP_DIGEST_AUTHENTICATION:
+            auth = HTTPDigestAuth(None, password)
+        else:
+            auth = HTTPBasicAuth(None, password)
 
     response = requests.get(
         url,


### PR DESCRIPTION
## Proposed change
Some MJPEG cameras only allow using either username or password. Some parts of the code support this but not others. This change intends to add support for either method, in addition to the usual username / password combo.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.