### PR TITLE
Fix duplicate Windy values showing in automations state selector

### DIFF
--- a/homeassistant/components/weather/strings.json
+++ b/homeassistant/components/weather/strings.json
@@ -18,7 +18,7 @@
         "snowy-rainy": "Snowy, rainy",
         "sunny": "Sunny",
         "windy": "Windy",
-        "windy-variant": "Windy"
+        "windy-variant": "Windy, cloudy"
       },
       "state_attributes": {
         "forecast": {


### PR DESCRIPTION
## Proposed change
Fixes duplicate Windy values showing in automations state selector. While both options can be selected uniquely (saving either windy or windy-variant) behind the scenes, unless you broke out the YAML or guessed, you could not distinguish the two.

By breaking out the displayed value, we can make it clearer which option was selected and displayed in line with [the Developers documentation](https://developers.home-assistant.io/docs/core/entity/weather/).

![image](https://github.com/home-assistant/core/assets/50791984/bdfdbfc7-b4a2-4bd0-b25a-d34d28d89d63)

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.