### PR TITLE
Add missing dependencies

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -36,6 +36,7 @@ janus==1.0.0
 Jinja2==3.1.2
 lru-dict==1.3.0
 mutagen==1.47.0
+numpy==1.26.0
 orjson==3.9.10
 packaging>=23.1
 paho-mqtt==1.6.1
@@ -46,6 +47,7 @@ PyJWT==2.8.0
 PyNaCl==1.5.0
 pyOpenSSL==23.2.0
 pyserial==3.5
+python-dateutil==2.8.2
 python-slugify==4.0.1
 PyTurboJPEG==1.7.1
 pyudev==0.23.2
@@ -112,9 +114,6 @@ httpcore==1.0.2
 # Ensure we have a hyperframe version that works in Python 3.10
 # 5.2.0 fixed a collections abc deprecation
 hyperframe>=5.2.0
-
-# Ensure we run compatible with musllinux build env
-numpy==1.26.0
 
 # Prevent dependency conflicts between sisyphus-control and aioambient
 # until upper bounds for sisyphus-control have been updated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ dependencies    = [
     "ifaddr==0.2.0",
     "Jinja2==3.1.2",
     "lru-dict==1.3.0",
+    "mutagen==1.47.0",
+    # Ensure we run compatible with musllinux build env
+    "numpy==1.26.0",
     "PyJWT==2.8.0",
     # PyJWT has loose dependency. We want the latest one.
     "cryptography==41.0.7",
@@ -49,6 +52,7 @@ dependencies    = [
     "orjson==3.9.10",
     "packaging>=23.1",
     "pip>=21.3.1",
+    "python-dateutil==2.8.2",
     "python-slugify==4.0.1",
     "PyYAML==6.0.1",
     "requests==2.31.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,12 +19,15 @@ home-assistant-bluetooth==1.12.0
 ifaddr==0.2.0
 Jinja2==3.1.2
 lru-dict==1.3.0
+mutagen==1.47.0
+numpy==1.26.0
 PyJWT==2.8.0
 cryptography==41.0.7
 pyOpenSSL==23.2.0
 orjson==3.9.10
 packaging>=23.1
 pip>=21.3.1
+python-dateutil==2.8.2
 python-slugify==4.0.1
 PyYAML==6.0.1
 requests==2.31.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -106,9 +106,6 @@ httpcore==1.0.2
 # 5.2.0 fixed a collections abc deprecation
 hyperframe>=5.2.0
 
-# Ensure we run compatible with musllinux build env
-numpy==1.26.0
-
 # Prevent dependency conflicts between sisyphus-control and aioambient
 # until upper bounds for sisyphus-control have been updated
 # https://github.com/jkeljo/sisyphus-control/issues/6


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When I follow [Installation for linux](https://www.home-assistant.io/installation/linux/#install-home-assistant-core) and after I run `hass`, the output print python module was missing. And after try 3 times (rm -rf /home/homeassistant/.homeassistant), I finally installed all the dependences which are `numpy`, `mutagen` and `python-dateutil`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
