### PR TITLE
Fix turning on the light with a specific color

### DIFF
--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -89,6 +89,10 @@ class MatterLight(MatterEntity, LightEntity):
                 colorY=int(matter_xy[1]),
                 # It's required in TLV. We don't implement transition time yet.
                 transitionTime=0,
+                # allow setting the color while the light is off,
+                # by setting the optionsMask to 1 (=ExecuteIfOff)
+                optionsMask=1,
+                optionsOverride=1,
             )
         )
 
@@ -103,6 +107,10 @@ class MatterLight(MatterEntity, LightEntity):
                 saturation=int(matter_hs[1]),
                 # It's required in TLV. We don't implement transition time yet.
                 transitionTime=0,
+                # allow setting the color while the light is off,
+                # by setting the optionsMask to 1 (=ExecuteIfOff)
+                optionsMask=1,
+                optionsOverride=1,
             )
         )
 
@@ -114,6 +122,10 @@ class MatterLight(MatterEntity, LightEntity):
                 colorTemperatureMireds=color_temp,
                 # It's required in TLV. We don't implement transition time yet.
                 transitionTime=0,
+                # allow setting the color while the light is off,
+                # by setting the optionsMask to 1 (=ExecuteIfOff)
+                optionsMask=1,
+                optionsOverride=1,
             )
         )
 

--- a/tests/components/matter/test_light.py
+++ b/tests/components/matter/test_light.py
@@ -202,6 +202,8 @@ async def test_color_temperature_light(
                 command=clusters.ColorControl.Commands.MoveToColorTemperature(
                     colorTemperatureMireds=300,
                     transitionTime=0,
+                    optionsMask=1,
+                    optionsOverride=1,
                 ),
             ),
             call(
@@ -278,7 +280,11 @@ async def test_extended_color_light(
                 node_id=light_node.node_id,
                 endpoint_id=1,
                 command=clusters.ColorControl.Commands.MoveToColor(
-                    colorX=0.5 * 65536, colorY=0.5 * 65536, transitionTime=0
+                    colorX=0.5 * 65536,
+                    colorY=0.5 * 65536,
+                    transitionTime=0,
+                    optionsMask=1,
+                    optionsOverride=1,
                 ),
             ),
             call(
@@ -311,8 +317,8 @@ async def test_extended_color_light(
                     hue=167,
                     saturation=254,
                     transitionTime=0,
-                    optionsMask=0,
-                    optionsOverride=0,
+                    optionsMask=1,
+                    optionsOverride=1,
                 ),
             ),
             call(


### PR DESCRIPTION
## Proposed change
Fix a small bug where a Matter light ignores the specified color in a turn_on command.
This allows turning on a light and set a new color(temperature) in the same call.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #106190 fixes #105463
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
