### PR TITLE
Remove YAML import support for plum_lightpad

### DIFF
--- a/homeassistant/components/plum_lightpad/__init__.py
+++ b/homeassistant/components/plum_lightpad/__init__.py
@@ -3,73 +3,23 @@ import logging
 
 from aiohttp import ContentTypeError
 from requests.exceptions import ConnectTimeout, HTTPError
-import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_PASSWORD,
     CONF_USERNAME,
     EVENT_HOMEASSISTANT_STOP,
     Platform,
 )
-from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
-from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
 from .utils import load_plum
 
 _LOGGER = logging.getLogger(__name__)
 
-CONFIG_SCHEMA = vol.Schema(
-    vol.All(
-        cv.deprecated(DOMAIN),
-        {
-            DOMAIN: vol.Schema(
-                {
-                    vol.Required(CONF_USERNAME): cv.string,
-                    vol.Required(CONF_PASSWORD): cv.string,
-                }
-            )
-        },
-    ),
-    extra=vol.ALLOW_EXTRA,
-)
-
 PLATFORMS = [Platform.LIGHT]
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Plum Lightpad Platform initialization."""
-    if DOMAIN not in config:
-        return True
-
-    conf = config[DOMAIN]
-
-    _LOGGER.debug("Found Plum Lightpad configuration in config, importing")
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
-        )
-    )
-    async_create_issue(
-        hass,
-        HOMEASSISTANT_DOMAIN,
-        f"deprecated_yaml_{DOMAIN}",
-        breaks_in_ha_version="2024.2.0",
-        is_fixable=False,
-        issue_domain=DOMAIN,
-        severity=IssueSeverity.WARNING,
-        translation_key="deprecated_yaml",
-        translation_placeholders={
-            "domain": DOMAIN,
-            "integration_title": "Plum Lightpad",
-        },
-    )
-
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/plum_lightpad/config_flow.py
+++ b/homeassistant/components/plum_lightpad/config_flow.py
@@ -58,9 +58,3 @@ class PlumLightpadConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_create_entry(
             title=username, data={CONF_USERNAME: username, CONF_PASSWORD: password}
         )
-
-    async def async_step_import(
-        self, import_config: dict[str, Any] | None
-    ) -> FlowResult:
-        """Import a config entry from configuration.yaml."""
-        return await self.async_step_user(import_config)

--- a/tests/components/plum_lightpad/test_config_flow.py
+++ b/tests/components/plum_lightpad/test_config_flow.py
@@ -22,8 +22,6 @@ async def test_form(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.components.plum_lightpad.utils.Plum.loadCloudData"
     ), patch(
-        "homeassistant.components.plum_lightpad.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.plum_lightpad.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -39,7 +37,6 @@ async def test_form(hass: HomeAssistant) -> None:
         "username": "test-plum-username",
         "password": "test-plum-password",
     }
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -76,7 +73,7 @@ async def test_form_one_entry_per_email_allowed(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.plum_lightpad.utils.Plum.loadCloudData"
-    ), patch("homeassistant.components.plum_lightpad.async_setup") as mock_setup, patch(
+    ), patch(
         "homeassistant.components.plum_lightpad.async_setup_entry"
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
@@ -86,32 +83,4 @@ async def test_form_one_entry_per_email_allowed(hass: HomeAssistant) -> None:
 
     assert result2["type"] == "abort"
     await hass.async_block_till_done()
-    assert len(mock_setup.mock_calls) == 0
     assert len(mock_setup_entry.mock_calls) == 0
-
-
-async def test_import(hass: HomeAssistant) -> None:
-    """Test configuring the flow using configuration.yaml."""
-
-    with patch(
-        "homeassistant.components.plum_lightpad.utils.Plum.loadCloudData"
-    ), patch(
-        "homeassistant.components.plum_lightpad.async_setup", return_value=True
-    ) as mock_setup, patch(
-        "homeassistant.components.plum_lightpad.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={"username": "test-plum-username", "password": "test-plum-password"},
-        )
-        assert result["type"] == "create_entry"
-        assert result["title"] == "test-plum-username"
-        assert result["data"] == {
-            "username": "test-plum-username",
-            "password": "test-plum-password",
-        }
-        await hass.async_block_till_done()
-        assert len(mock_setup.mock_calls) == 1
-        assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/plum_lightpad/test_init.py
+++ b/tests/components/plum_lightpad/test_init.py
@@ -19,31 +19,6 @@ async def test_async_setup_no_domain_config(hass: HomeAssistant) -> None:
     assert DOMAIN not in hass.data
 
 
-async def test_async_setup_imports_from_config(hass: HomeAssistant) -> None:
-    """Test that specifying config will setup an entry."""
-    with patch(
-        "homeassistant.components.plum_lightpad.utils.Plum.loadCloudData"
-    ) as mock_loadCloudData, patch(
-        "homeassistant.components.plum_lightpad.async_setup_entry",
-        return_value=True,
-    ) as mock_async_setup_entry:
-        result = await async_setup_component(
-            hass,
-            DOMAIN,
-            {
-                DOMAIN: {
-                    "username": "test-plum-username",
-                    "password": "test-plum-password",
-                }
-            },
-        )
-        await hass.async_block_till_done()
-
-    assert result is True
-    assert len(mock_loadCloudData.mock_calls) == 1
-    assert len(mock_async_setup_entry.mock_calls) == 1
-
-
 async def test_async_setup_entry_sets_up_light(hass: HomeAssistant) -> None:
     """Test that configuring entry sets up light domain."""
     config_entry = MockConfigEntry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
YAML import support was removed from `plum_lightpad` after a period of deprecation. The configuration was migrated automatically and users were instructed to remove the deprecated YAML config from their `configuration.yaml`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove YAML import support for plum_lightpad

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
