### PR TITLE
Remove deprecated redundant dry and fan modes from `zwave_js` climates

### DIFF
--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -37,10 +37,9 @@ from homeassistant.const import ATTR_TEMPERATURE, PRECISION_TENTHS, UnitOfTemper
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.util.unit_conversion import TemperatureConverter
 
-from .const import DATA_CLIENT, DOMAIN, LOGGER
+from .const import DATA_CLIENT, DOMAIN
 from .discovery import ZwaveDiscoveryInfo
 from .discovery_data_template import DynamicCurrentTempClimateDataTemplate
 from .entity import ZWaveBaseEntity
@@ -243,11 +242,6 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
                 # treat value as hvac mode
                 if hass_mode := ZW_HVAC_MODE_MAP.get(mode_id):
                     all_modes[hass_mode] = mode_id
-                # Dry and Fan modes are in the process of being migrated from
-                # presets to hvac modes. In the meantime, we will set them as
-                # both, presets and hvac modes, to maintain backwards compatibility
-                if mode_id in (ThermostatMode.DRY, ThermostatMode.FAN):
-                    all_presets[mode_name] = mode_id
             else:
                 # treat value as hvac preset
                 all_presets[mode_name] = mode_id
@@ -503,27 +497,6 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
         preset_mode_value = self._hvac_presets.get(preset_mode)
         if preset_mode_value is None:
             raise ValueError(f"Received an invalid preset mode: {preset_mode}")
-        # Dry and Fan preset modes are deprecated as of Home Assistant 2023.8.
-        # Please use Dry and Fan HVAC modes instead.
-        if preset_mode_value in (ThermostatMode.DRY, ThermostatMode.FAN):
-            LOGGER.warning(
-                "Dry and Fan preset modes are deprecated and will be removed in Home "
-                "Assistant 2024.2. Please use the corresponding Dry and Fan HVAC "
-                "modes instead"
-            )
-            async_create_issue(
-                self.hass,
-                DOMAIN,
-                f"dry_fan_presets_deprecation_{self.entity_id}",
-                breaks_in_ha_version="2024.2.0",
-                is_fixable=True,
-                is_persistent=True,
-                severity=IssueSeverity.WARNING,
-                translation_key="dry_fan_presets_deprecation",
-                translation_placeholders={
-                    "entity_id": self.entity_id,
-                },
-            )
 
         await self._async_set_value(self._current_mode, preset_mode_value)
 

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -151,17 +151,6 @@
       "title": "Newer version of Z-Wave JS Server needed",
       "description": "The version of Z-Wave JS Server you are currently running is too old for this version of Home Assistant. Please update the Z-Wave JS Server to the latest version to fix this issue."
     },
-    "dry_fan_presets_deprecation": {
-      "title": "Dry and Fan preset modes will be removed: {entity_id}",
-      "fix_flow": {
-        "step": {
-          "confirm": {
-            "title": "Dry and Fan preset modes will be removed: {entity_id}",
-            "description": "You are using the Dry or Fan preset modes in your entity `{entity_id}`.\n\nDry and Fan preset modes are deprecated and will be removed. Please update your automations to use the corresponding Dry and Fan **HVAC modes** instead.\n\nClick on SUBMIT below once you have manually fixed this issue."
-          }
-        }
-      }
-    },
     "device_config_file_changed": {
       "title": "Device configuration file changed: {device_name}",
       "fix_flow": {

--- a/tests/components/zwave_js/test_climate.py
+++ b/tests/components/zwave_js/test_climate.py
@@ -18,7 +18,6 @@ from homeassistant.components.climate import (
     ATTR_MAX_TEMP,
     ATTR_MIN_TEMP,
     ATTR_PRESET_MODE,
-    ATTR_PRESET_MODES,
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
     DOMAIN as CLIMATE_DOMAIN,
@@ -41,10 +40,8 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers import issue_registry as ir
 
 from .common import (
-    CLIMATE_AIDOO_HVAC_UNIT_ENTITY,
     CLIMATE_DANFOSS_LC13_ENTITY,
     CLIMATE_EUROTRONICS_SPIRIT_Z_ENTITY,
     CLIMATE_FLOOR_THERMOSTAT_ENTITY,
@@ -769,98 +766,3 @@ async def test_thermostat_unknown_values(
     state = hass.states.get(CLIMATE_RADIO_THERMOSTAT_ENTITY)
 
     assert ATTR_HVAC_ACTION not in state.attributes
-
-
-async def test_thermostat_dry_and_fan_both_hvac_mode_and_preset(
-    hass: HomeAssistant,
-    client,
-    climate_airzone_aidoo_control_hvac_unit,
-    integration,
-) -> None:
-    """Test that dry and fan modes are both available as hvac mode and preset."""
-    state = hass.states.get(CLIMATE_AIDOO_HVAC_UNIT_ENTITY)
-    assert state
-    assert state.attributes[ATTR_HVAC_MODES] == [
-        HVACMode.OFF,
-        HVACMode.HEAT,
-        HVACMode.COOL,
-        HVACMode.FAN_ONLY,
-        HVACMode.DRY,
-        HVACMode.HEAT_COOL,
-    ]
-    assert state.attributes[ATTR_PRESET_MODES] == [
-        PRESET_NONE,
-        "Fan",
-        "Dry",
-    ]
-
-
-async def test_thermostat_raise_repair_issue_and_warning_when_setting_dry_preset(
-    hass: HomeAssistant,
-    client,
-    climate_airzone_aidoo_control_hvac_unit,
-    integration,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test raise of repair issue and warning when setting Dry preset."""
-    client.async_send_command.return_value = {"result": {"status": 1}}
-
-    state = hass.states.get(CLIMATE_AIDOO_HVAC_UNIT_ENTITY)
-    assert state
-
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_PRESET_MODE,
-        {
-            ATTR_ENTITY_ID: CLIMATE_AIDOO_HVAC_UNIT_ENTITY,
-            ATTR_PRESET_MODE: "Dry",
-        },
-        blocking=True,
-    )
-
-    issue_id = f"dry_fan_presets_deprecation_{CLIMATE_AIDOO_HVAC_UNIT_ENTITY}"
-    issue_registry = ir.async_get(hass)
-
-    assert issue_registry.async_get_issue(
-        domain=DOMAIN,
-        issue_id=issue_id,
-    )
-    assert (
-        "Dry and Fan preset modes are deprecated and will be removed in Home Assistant 2024.2. Please use the corresponding Dry and Fan HVAC modes instead"
-        in caplog.text
-    )
-
-
-async def test_thermostat_raise_repair_issue_and_warning_when_setting_fan_preset(
-    hass: HomeAssistant,
-    client,
-    climate_airzone_aidoo_control_hvac_unit,
-    integration,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test raise of repair issue and warning when setting Fan preset."""
-    client.async_send_command.return_value = {"result": {"status": 1}}
-    state = hass.states.get(CLIMATE_AIDOO_HVAC_UNIT_ENTITY)
-    assert state
-
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_PRESET_MODE,
-        {
-            ATTR_ENTITY_ID: CLIMATE_AIDOO_HVAC_UNIT_ENTITY,
-            ATTR_PRESET_MODE: "Fan",
-        },
-        blocking=True,
-    )
-
-    issue_id = f"dry_fan_presets_deprecation_{CLIMATE_AIDOO_HVAC_UNIT_ENTITY}"
-    issue_registry = ir.async_get(hass)
-
-    assert issue_registry.async_get_issue(
-        domain=DOMAIN,
-        issue_id=issue_id,
-    )
-    assert (
-        "Dry and Fan preset modes are deprecated and will be removed in Home Assistant 2024.2. Please use the corresponding Dry and Fan HVAC modes instead"
-        in caplog.text
-    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The Fan and Dry climate Preset modes have been removed after a period of deprecation. You should update your automations or scripts to use the corresponding Dry and Fan **HVAC modes** instead, if you haven't done so already.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature reque/st, be sure to link to that issue in the
  additional information section.
-->
Remove deprecated redundant dry and fan modes from zwave_js climates.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
