### PR TITLE
Reduce overhead for google calendar state updates

### DIFF
--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from datetime import datetime, timedelta
+import itertools
 import logging
 from typing import Any, cast
 
@@ -18,6 +19,7 @@ from gcal_sync.model import AccessRole, DateOrDatetime, Event
 from gcal_sync.store import ScopedCalendarStore
 from gcal_sync.sync import CalendarEventSyncManager
 from gcal_sync.timeline import Timeline
+from ical.iter import SortableItemValue
 
 from homeassistant.components.calendar import (
     CREATE_EVENT_SCHEMA,
@@ -76,6 +78,9 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=15)
+# Maximum number of upcoming events to consider for state changes between
+# coordinator updates.
+MAX_UPCOMING_EVENTS = 50
 
 # Avoid syncing super old data on initial syncs. Note that old but active
 # recurring events are still included.
@@ -244,6 +249,22 @@ async def async_setup_entry(
         )
 
 
+def _truncate_timeline(timeline: Timeline, max_events: int) -> Timeline:
+    """Truncate the timeline to a maximum number of events.
+
+    This is used to avoid repeated expansion of recurring events during
+    state machine updates.
+    """
+    upcoming = timeline.active_after(dt_util.now())
+    truncated = list(itertools.islice(upcoming, max_events))
+    return Timeline(
+        [
+            SortableItemValue(event.timespan_of(dt_util.DEFAULT_TIME_ZONE), event)
+            for event in truncated
+        ]
+    )
+
+
 class CalendarSyncUpdateCoordinator(DataUpdateCoordinator[Timeline]):
     """Coordinator for calendar RPC calls that use an efficient sync."""
 
@@ -263,6 +284,7 @@ class CalendarSyncUpdateCoordinator(DataUpdateCoordinator[Timeline]):
             update_interval=MIN_TIME_BETWEEN_UPDATES,
         )
         self.sync = sync
+        self._upcoming_timeline: Timeline | None = None
 
     async def _async_update_data(self) -> Timeline:
         """Fetch data from API endpoint."""
@@ -271,9 +293,11 @@ class CalendarSyncUpdateCoordinator(DataUpdateCoordinator[Timeline]):
         except ApiException as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
 
-        return await self.sync.store_service.async_get_timeline(
+        timeline = await self.sync.store_service.async_get_timeline(
             dt_util.DEFAULT_TIME_ZONE
         )
+        self._upcoming_timeline = _truncate_timeline(timeline, MAX_UPCOMING_EVENTS)
+        return timeline
 
     async def async_get_events(
         self, start_date: datetime, end_date: datetime
@@ -291,8 +315,8 @@ class CalendarSyncUpdateCoordinator(DataUpdateCoordinator[Timeline]):
     @property
     def upcoming(self) -> Iterable[Event] | None:
         """Return upcoming events if any."""
-        if self.data:
-            return self.data.active_after(dt_util.now())
+        if self._upcoming_timeline:
+            return self._upcoming_timeline.active_after(dt_util.now())
         return None
 
 

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -80,7 +80,7 @@ _LOGGER = logging.getLogger(__name__)
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=15)
 # Maximum number of upcoming events to consider for state changes between
 # coordinator updates.
-MAX_UPCOMING_EVENTS = 50
+MAX_UPCOMING_EVENTS = 20
 
 # Avoid syncing super old data on initial syncs. Note that old but active
 # recurring events are still included.

--- a/homeassistant/components/google/manifest.json
+++ b/homeassistant/components/google/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/calendar.google",
   "iot_class": "cloud_polling",
   "loggers": ["googleapiclient"],
-  "requirements": ["gcal-sync==6.0.3", "oauth2client==4.1.3"]
+  "requirements": ["gcal-sync==6.0.3", "oauth2client==4.1.3", "ical==6.1.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1082,6 +1082,7 @@ ibeacon-ble==1.0.1
 # homeassistant.components.watson_iot
 ibmiotf==0.3.4
 
+# homeassistant.components.google
 # homeassistant.components.local_calendar
 # homeassistant.components.local_todo
 ical==6.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -866,6 +866,7 @@ iaqualink==0.5.0
 # homeassistant.components.ibeacon
 ibeacon-ble==1.0.1
 
+# homeassistant.components.google
 # homeassistant.components.local_calendar
 # homeassistant.components.local_todo
 ical==6.1.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reduce overhead for google calendar state updates. Google calendar syncs down events locally, then performs recurring
event expansion which requires loading all recurring events on to a single iterator. This iterator is expanded just in time however this can have an expensive initial startup cost for users with tons of events. We instead first load the timeline
then flatten and truncate it during the update coordinator so that the state machine update has a smaller bounded set
of events to iterate over. This needs the lower level libraries for timeline building from ical to perform this optimization.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #100645
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
