### PR TITLE
Avoid bytes to string to bytes conversion in websocket api

### DIFF
--- a/homeassistant/components/api/__init__.py
+++ b/homeassistant/components/api/__init__.py
@@ -214,7 +214,7 @@ class APIStatesView(HomeAssistantView):
                 if entity_perm(state.entity_id, "read")
             )
         response = web.Response(
-            body=f'[{",".join(states)}]',
+            body=b"[" + b",".join(states) + b"]",
             content_type=CONTENT_TYPE_JSON,
             zlib_executor_size=32768,
         )

--- a/homeassistant/components/config/device_registry.py
+++ b/homeassistant/components/config/device_registry.py
@@ -45,16 +45,16 @@ def websocket_list_devices(
     msg_json_prefix = (
         f'{{"id":{msg["id"]},"type": "{websocket_api.const.TYPE_RESULT}",'
         f'"success":true,"result": ['
-    )
+    ).encode()
     # Concatenate cached entity registry item JSON serializations
     msg_json = (
         msg_json_prefix
-        + ",".join(
+        + b",".join(
             entry.json_repr
             for entry in registry.devices.values()
             if entry.json_repr is not None
         )
-        + "]}"
+        + b"]}"
     )
     connection.send_message(msg_json)
 

--- a/homeassistant/components/config/entity_registry.py
+++ b/homeassistant/components/config/entity_registry.py
@@ -43,16 +43,16 @@ def websocket_list_entities(
     msg_json_prefix = (
         f'{{"id":{msg["id"]},"type": "{websocket_api.const.TYPE_RESULT}",'
         '"success":true,"result": ['
-    )
+    ).encode()
     # Concatenate cached entity registry item JSON serializations
     msg_json = (
         msg_json_prefix
-        + ",".join(
+        + b",".join(
             entry.partial_json_repr
             for entry in registry.entities.values()
             if entry.partial_json_repr is not None
         )
-        + "]}"
+        + b"]}"
     )
     connection.send_message(msg_json)
 
@@ -73,16 +73,16 @@ def websocket_list_entities_for_display(
     msg_json_prefix = (
         f'{{"id":{msg["id"]},"type":"{websocket_api.const.TYPE_RESULT}","success":true,'
         f'"result":{{"entity_categories":{entity_categories},"entities":['
-    )
+    ).encode()
     # Concatenate cached entity registry item JSON serializations
     msg_json = (
         msg_json_prefix
-        + ",".join(
+        + b",".join(
             entry.display_json_repr
             for entry in registry.entities.values()
             if entry.disabled_by is None and entry.display_json_repr is not None
         )
-        + "]}}"
+        + b"]}}"
     )
     connection.send_message(msg_json)
 

--- a/homeassistant/components/config/entity_registry.py
+++ b/homeassistant/components/config/entity_registry.py
@@ -57,6 +57,9 @@ def websocket_list_entities(
     connection.send_message(msg_json)
 
 
+_ENTITY_CATEGORIES_JSON = json_dumps(er.ENTITY_CATEGORY_INDEX_TO_VALUE)
+
+
 @websocket_api.websocket_command(
     {vol.Required("type"): "config/entity_registry/list_for_display"}
 )
@@ -69,10 +72,9 @@ def websocket_list_entities_for_display(
     """Handle list registry entries command."""
     registry = er.async_get(hass)
     # Build start of response message
-    entity_categories = json_dumps(er.ENTITY_CATEGORY_INDEX_TO_VALUE)
     msg_json_prefix = (
         f'{{"id":{msg["id"]},"type":"{websocket_api.const.TYPE_RESULT}","success":true,'
-        f'"result":{{"entity_categories":{entity_categories},"entities":['
+        f'"result":{{"entity_categories":{_ENTITY_CATEGORIES_JSON},"entities":['
     ).encode()
     # Concatenate cached entity registry item JSON serializations
     msg_json = (

--- a/homeassistant/components/history/websocket_api.py
+++ b/homeassistant/components/history/websocket_api.py
@@ -34,7 +34,7 @@ from homeassistant.helpers.event import (
     async_track_point_in_utc_time,
     async_track_state_change_event,
 )
-from homeassistant.helpers.json import JSON_DUMP
+from homeassistant.helpers.json import json_bytes
 from homeassistant.helpers.typing import EventType
 import homeassistant.util.dt as dt_util
 
@@ -72,9 +72,9 @@ def _ws_get_significant_states(
     significant_changes_only: bool,
     minimal_response: bool,
     no_attributes: bool,
-) -> str:
+) -> bytes:
     """Fetch history significant_states and convert them to json in the executor."""
-    return JSON_DUMP(
+    return json_bytes(
         messages.result_message(
             msg_id,
             history.get_significant_states(
@@ -201,9 +201,9 @@ def _generate_websocket_response(
     start_time: dt,
     end_time: dt,
     states: MutableMapping[str, list[dict[str, Any]]],
-) -> str:
+) -> bytes:
     """Generate a websocket response."""
-    return JSON_DUMP(
+    return json_bytes(
         messages.event_message(
             msg_id, _generate_stream_message(states, start_time, end_time)
         )
@@ -221,7 +221,7 @@ def _generate_historical_response(
     minimal_response: bool,
     no_attributes: bool,
     send_empty: bool,
-) -> tuple[float, dt | None, str | None]:
+) -> tuple[float, dt | None, bytes | None]:
     """Generate a historical response."""
     states = cast(
         MutableMapping[str, list[dict[str, Any]]],
@@ -350,7 +350,7 @@ async def _async_events_consumer(
 
         if history_states := _events_to_compressed_states(events, no_attributes):
             connection.send_message(
-                JSON_DUMP(
+                json_bytes(
                     messages.event_message(
                         msg_id,
                         {"states": history_states},

--- a/homeassistant/components/logbook/websocket_api.py
+++ b/homeassistant/components/logbook/websocket_api.py
@@ -16,7 +16,7 @@ from homeassistant.components.websocket_api import messages
 from homeassistant.components.websocket_api.connection import ActiveConnection
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
 from homeassistant.helpers.event import async_track_point_in_utc_time
-from homeassistant.helpers.json import JSON_DUMP
+from homeassistant.helpers.json import json_bytes
 import homeassistant.util.dt as dt_util
 
 from .const import DOMAIN
@@ -70,7 +70,7 @@ def _async_send_empty_response(
     stream_end_time = end_time or dt_util.utcnow()
     empty_stream_message = _generate_stream_message([], start_time, stream_end_time)
     empty_response = messages.event_message(msg_id, empty_stream_message)
-    connection.send_message(JSON_DUMP(empty_response))
+    connection.send_message(json_bytes(empty_response))
 
 
 async def _async_send_historical_events(
@@ -165,7 +165,7 @@ async def _async_get_ws_stream_events(
     formatter: Callable[[int, Any], dict[str, Any]],
     event_processor: EventProcessor,
     partial: bool,
-) -> tuple[str, dt | None]:
+) -> tuple[bytes, dt | None]:
     """Async wrapper around _ws_formatted_get_events."""
     return await get_instance(hass).async_add_executor_job(
         _ws_stream_get_events,
@@ -196,7 +196,7 @@ def _ws_stream_get_events(
     formatter: Callable[[int, Any], dict[str, Any]],
     event_processor: EventProcessor,
     partial: bool,
-) -> tuple[str, dt | None]:
+) -> tuple[bytes, dt | None]:
     """Fetch events and convert them to json in the executor."""
     events = event_processor.get_events(start_day, end_day)
     last_time = None
@@ -209,7 +209,7 @@ def _ws_stream_get_events(
         # data in case the UI needs to show that historical
         # data is still loading in the future
         message["partial"] = True
-    return JSON_DUMP(formatter(msg_id, message)), last_time
+    return json_bytes(formatter(msg_id, message)), last_time
 
 
 async def _async_events_consumer(
@@ -238,7 +238,7 @@ async def _async_events_consumer(
             async_event_to_row(e) for e in events
         ):
             connection.send_message(
-                JSON_DUMP(
+                json_bytes(
                     messages.event_message(
                         msg_id,
                         {"events": logbook_events},
@@ -435,9 +435,9 @@ def _ws_formatted_get_events(
     start_time: dt,
     end_time: dt,
     event_processor: EventProcessor,
-) -> str:
+) -> bytes:
     """Fetch events and convert them to json in the executor."""
-    return JSON_DUMP(
+    return json_bytes(
         messages.result_message(
             msg_id, event_processor.get_events(start_time, end_time)
         )

--- a/homeassistant/components/recorder/websocket_api.py
+++ b/homeassistant/components/recorder/websocket_api.py
@@ -12,7 +12,7 @@ from homeassistant.components.websocket_api import messages
 from homeassistant.core import HomeAssistant, callback, valid_entity_id
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.json import JSON_DUMP
+from homeassistant.helpers.json import json_bytes
 from homeassistant.util import dt as dt_util
 from homeassistant.util.unit_conversion import (
     DataRateConverter,
@@ -97,9 +97,9 @@ def _ws_get_statistic_during_period(
     statistic_id: str,
     types: set[Literal["max", "mean", "min", "change"]] | None,
     units: dict[str, str],
-) -> str:
+) -> bytes:
     """Fetch statistics and convert them to json in the executor."""
-    return JSON_DUMP(
+    return json_bytes(
         messages.result_message(
             msg_id,
             statistic_during_period(
@@ -155,7 +155,7 @@ def _ws_get_statistics_during_period(
     period: Literal["5minute", "day", "hour", "week", "month"],
     units: dict[str, str],
     types: set[Literal["change", "last_reset", "max", "mean", "min", "state", "sum"]],
-) -> str:
+) -> bytes:
     """Fetch statistics and convert them to json in the executor."""
     result = statistics_during_period(
         hass,
@@ -174,7 +174,7 @@ def _ws_get_statistics_during_period(
                 item["end"] = int(end * 1000)
             if (last_reset := item.get("last_reset")) is not None:
                 item["last_reset"] = int(last_reset * 1000)
-    return JSON_DUMP(messages.result_message(msg_id, result))
+    return json_bytes(messages.result_message(msg_id, result))
 
 
 async def ws_handle_get_statistics_during_period(
@@ -242,12 +242,12 @@ def _ws_get_list_statistic_ids(
     hass: HomeAssistant,
     msg_id: int,
     statistic_type: Literal["mean"] | Literal["sum"] | None = None,
-) -> str:
+) -> bytes:
     """Fetch a list of available statistic_id and convert them to JSON.
 
     Runs in the executor.
     """
-    return JSON_DUMP(
+    return json_bytes(
         messages.result_message(msg_id, list_statistic_ids(hass, None, statistic_type))
     )
 

--- a/homeassistant/components/websocket_api/auth.py
+++ b/homeassistant/components/websocket_api/auth.py
@@ -57,7 +57,7 @@ class AuthPhase:
         self,
         logger: WebSocketAdapter,
         hass: HomeAssistant,
-        send_message: Callable[[str | dict[str, Any]], None],
+        send_message: Callable[[bytes | str | dict[str, Any]], None],
         cancel_ws: CALLBACK_TYPE,
         request: Request,
     ) -> None:

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -104,7 +104,7 @@ def pong_message(iden: int) -> dict[str, Any]:
 
 @callback
 def _forward_events_check_permissions(
-    send_message: Callable[[str | dict[str, Any] | Callable[[], str]], None],
+    send_message: Callable[[bytes | str | dict[str, Any] | Callable[[], str]], None],
     user: User,
     msg_id: int,
     event: Event,
@@ -124,7 +124,7 @@ def _forward_events_check_permissions(
 
 @callback
 def _forward_events_unconditional(
-    send_message: Callable[[str | dict[str, Any] | Callable[[], str]], None],
+    send_message: Callable[[bytes | str | dict[str, Any] | Callable[[], str]], None],
     msg_id: int,
     event: Event,
 ) -> None:
@@ -362,7 +362,7 @@ def _send_handle_get_states_response(
 
 @callback
 def _forward_entity_changes(
-    send_message: Callable[[str | dict[str, Any] | Callable[[], str]], None],
+    send_message: Callable[[str | bytes | dict[str, Any] | Callable[[], str]], None],
     entity_ids: set[str],
     user: User,
     msg_id: int,

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -352,11 +352,11 @@ def handle_get_states(
 
 
 def _send_handle_get_states_response(
-    connection: ActiveConnection, msg_id: int, serialized_states: list[str]
+    connection: ActiveConnection, msg_id: int, serialized_states: list[bytes]
 ) -> None:
     """Send handle get states response."""
     connection.send_message(
-        construct_result_message(msg_id, f'[{",".join(serialized_states)}]')
+        construct_result_message(msg_id, b"[" + b",".join(serialized_states) + b"]")
     )
 
 
@@ -444,11 +444,19 @@ def handle_subscribe_entities(
 
 
 def _send_handle_entities_init_response(
-    connection: ActiveConnection, msg_id: int, serialized_states: list[str]
+    connection: ActiveConnection, msg_id: int, serialized_states: list[bytes]
 ) -> None:
     """Send handle entities init response."""
     connection.send_message(
-        f'{{"id":{msg_id},"type":"event","event":{{"a":{{{",".join(serialized_states)}}}}}}}'
+        b"".join(
+            (
+                b'{"id":',
+                str(msg_id).encode(),
+                b',"type":"event","event":{"a":{',
+                b",".join(serialized_states),
+                b"}}}",
+            )
+        )
     )
 
 
@@ -474,7 +482,9 @@ async def handle_get_services(
 ) -> None:
     """Handle get services command."""
     payload = await _async_get_all_descriptions_json(hass)
-    connection.send_message(construct_result_message(msg["id"], payload))
+    connection.send_message(
+        construct_result_message(msg["id"], payload.encode("utf-8"))
+    )
 
 
 @callback

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -482,9 +482,7 @@ async def handle_get_services(
 ) -> None:
     """Handle get services command."""
     payload = await _async_get_all_descriptions_json(hass)
-    connection.send_message(
-        construct_result_message(msg["id"], payload.encode("utf-8"))
-    )
+    connection.send_message(construct_result_message(msg["id"], payload.encode()))
 
 
 @callback

--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -51,7 +51,7 @@ class ActiveConnection:
         self,
         logger: WebSocketAdapter,
         hass: HomeAssistant,
-        send_message: Callable[[str | dict[str, Any]], None],
+        send_message: Callable[[bytes | str | dict[str, Any]], None],
         user: User,
         refresh_token: RefreshToken,
     ) -> None:
@@ -244,7 +244,7 @@ class ActiveConnection:
 
     @callback
     def _connect_closed_error(
-        self, msg: str | dict[str, Any] | Callable[[], str]
+        self, msg: bytes | str | dict[str, Any] | Callable[[], str]
     ) -> None:
         """Send a message when the connection is closed."""
         self.logger.debug("Tried to send message %s on closed connection", msg)

--- a/homeassistant/components/websocket_api/messages.py
+++ b/homeassistant/components/websocket_api/messages.py
@@ -64,9 +64,17 @@ def result_message(iden: int, result: Any = None) -> dict[str, Any]:
     return {"id": iden, "type": const.TYPE_RESULT, "success": True, "result": result}
 
 
-def construct_result_message(iden: int, payload: str) -> bytes:
+def construct_result_message(iden: int, payload: bytes) -> bytes:
     """Construct a success result message JSON."""
-    return f'{{"id":{iden},"type":"result","success":true,"result":{payload}}}'.encode()
+    return b"".join(
+        (
+            b'{"id":',
+            str(iden).encode("utf-8"),
+            b',"type":"result","success":true,"result":',
+            payload,
+            b"}",
+        )
+    )
 
 
 def error_message(

--- a/homeassistant/components/websocket_api/messages.py
+++ b/homeassistant/components/websocket_api/messages.py
@@ -16,7 +16,11 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, State
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.json import JSON_DUMP, find_paths_unserializable_data
+from homeassistant.helpers.json import (
+    JSON_DUMP,
+    find_paths_unserializable_data,
+    json_bytes,
+)
 from homeassistant.util.json import format_unserializable_data
 
 from . import const
@@ -44,7 +48,7 @@ BASE_ERROR_MESSAGE = {
     "success": False,
 }
 
-INVALID_JSON_PARTIAL_MESSAGE = JSON_DUMP(
+INVALID_JSON_PARTIAL_MESSAGE = json_bytes(
     {
         **BASE_ERROR_MESSAGE,
         "error": {
@@ -60,9 +64,9 @@ def result_message(iden: int, result: Any = None) -> dict[str, Any]:
     return {"id": iden, "type": const.TYPE_RESULT, "success": True, "result": result}
 
 
-def construct_result_message(iden: int, payload: str) -> str:
+def construct_result_message(iden: int, payload: str) -> bytes:
     """Construct a success result message JSON."""
-    return f'{{"id":{iden},"type":"result","success":true,"result":{payload}}}'
+    return f'{{"id":{iden},"type":"result","success":true,"result":{payload}}}'.encode()
 
 
 def error_message(
@@ -96,7 +100,7 @@ def event_message(iden: int, event: Any) -> dict[str, Any]:
     return {"id": iden, "type": "event", "event": event}
 
 
-def cached_event_message(iden: int, event: Event) -> str:
+def cached_event_message(iden: int, event: Event) -> bytes:
     """Return an event message.
 
     Serialize to json once per message.
@@ -105,23 +109,30 @@ def cached_event_message(iden: int, event: Event) -> str:
     all getting many of the same events (mostly state changed)
     we can avoid serializing the same data for each connection.
     """
-    return f'{_partial_cached_event_message(event)[:-1]},"id":{iden}}}'
+    return b"".join(
+        (
+            _partial_cached_event_message(event)[:-1],
+            b',"id":',
+            str(iden).encode("utf-8"),
+            b"}",
+        )
+    )
 
 
 @lru_cache(maxsize=128)
-def _partial_cached_event_message(event: Event) -> str:
+def _partial_cached_event_message(event: Event) -> bytes:
     """Cache and serialize the event to json.
 
     The message is constructed without the id which appended
     in cached_event_message.
     """
     return (
-        _message_to_json_or_none({"type": "event", "event": event.json_fragment})
+        _message_to_json_bytes_or_none({"type": "event", "event": event.json_fragment})
         or INVALID_JSON_PARTIAL_MESSAGE
     )
 
 
-def cached_state_diff_message(iden: int, event: Event) -> str:
+def cached_state_diff_message(iden: int, event: Event) -> bytes:
     """Return an event message.
 
     Serialize to json once per message.
@@ -130,18 +141,27 @@ def cached_state_diff_message(iden: int, event: Event) -> str:
     all getting many of the same events (mostly state changed)
     we can avoid serializing the same data for each connection.
     """
-    return f'{_partial_cached_state_diff_message(event)[:-1]},"id":{iden}}}'
+    return b"".join(
+        (
+            _partial_cached_state_diff_message(event)[:-1],
+            b',"id":',
+            str(iden).encode("utf-8"),
+            b"}",
+        )
+    )
 
 
 @lru_cache(maxsize=128)
-def _partial_cached_state_diff_message(event: Event) -> str:
+def _partial_cached_state_diff_message(event: Event) -> bytes:
     """Cache and serialize the event to json.
 
     The message is constructed without the id which
     will be appended in cached_state_diff_message
     """
     return (
-        _message_to_json_or_none({"type": "event", "event": _state_diff_event(event)})
+        _message_to_json_bytes_or_none(
+            {"type": "event", "event": _state_diff_event(event)}
+        )
         or INVALID_JSON_PARTIAL_MESSAGE
     )
 
@@ -212,10 +232,10 @@ def _state_diff(
     return {ENTITY_EVENT_CHANGE: {new_state.entity_id: diff}}
 
 
-def _message_to_json_or_none(message: dict[str, Any]) -> str | None:
+def _message_to_json_bytes_or_none(message: dict[str, Any]) -> bytes | None:
     """Serialize a websocket message to json or return None."""
     try:
-        return JSON_DUMP(message)
+        return json_bytes(message)
     except (ValueError, TypeError):
         _LOGGER.error(
             "Unable to serialize to JSON. Bad data found at %s",
@@ -226,9 +246,9 @@ def _message_to_json_or_none(message: dict[str, Any]) -> str | None:
     return None
 
 
-def message_to_json(message: dict[str, Any]) -> str:
+def message_to_json_bytes(message: dict[str, Any]) -> bytes:
     """Serialize a websocket message to json or return an error."""
-    return _message_to_json_or_none(message) or JSON_DUMP(
+    return _message_to_json_bytes_or_none(message) or json_bytes(
         error_message(
             message["id"], const.ERR_UNKNOWN_ERROR, "Invalid JSON in response"
         )

--- a/homeassistant/components/websocket_api/messages.py
+++ b/homeassistant/components/websocket_api/messages.py
@@ -69,7 +69,7 @@ def construct_result_message(iden: int, payload: bytes) -> bytes:
     return b"".join(
         (
             b'{"id":',
-            str(iden).encode("utf-8"),
+            str(iden).encode(),
             b',"type":"result","success":true,"result":',
             payload,
             b"}",
@@ -121,7 +121,7 @@ def cached_event_message(iden: int, event: Event) -> bytes:
         (
             _partial_cached_event_message(event)[:-1],
             b',"id":',
-            str(iden).encode("utf-8"),
+            str(iden).encode(),
             b"}",
         )
     )
@@ -153,7 +153,7 @@ def cached_state_diff_message(iden: int, event: Event) -> bytes:
         (
             _partial_cached_state_diff_message(event)[:-1],
             b',"id":',
-            str(iden).encode("utf-8"),
+            str(iden).encode(),
             b"}",
         )
     )

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -86,7 +86,7 @@ from .helpers.deprecation import (
     check_if_deprecated_constant,
     dir_with_deprecated_constants,
 )
-from .helpers.json import json_dumps, json_fragment
+from .helpers.json import json_bytes, json_fragment
 from .util import dt as dt_util, location
 from .util.async_ import (
     cancelling,
@@ -1039,7 +1039,7 @@ class Context:
     @cached_property
     def json_fragment(self) -> json_fragment:
         """Return a JSON fragment of the context."""
-        return json_fragment(json_dumps(self._as_dict))
+        return json_fragment(json_bytes(self._as_dict))
 
 
 class EventOrigin(enum.Enum):
@@ -1121,7 +1121,7 @@ class Event:
     @cached_property
     def json_fragment(self) -> json_fragment:
         """Return an event as a JSON fragment."""
-        return json_fragment(json_dumps(self._as_dict))
+        return json_fragment(json_bytes(self._as_dict))
 
     def __repr__(self) -> str:
         """Return the representation."""
@@ -1497,9 +1497,9 @@ class State:
         return ReadOnlyDict(as_dict)
 
     @cached_property
-    def as_dict_json(self) -> str:
+    def as_dict_json(self) -> bytes:
         """Return a JSON string of the State."""
-        return json_dumps(self._as_dict)
+        return json_bytes(self._as_dict)
 
     @cached_property
     def json_fragment(self) -> json_fragment:
@@ -1535,14 +1535,14 @@ class State:
         return compressed_state
 
     @cached_property
-    def as_compressed_state_json(self) -> str:
+    def as_compressed_state_json(self) -> bytes:
         """Build a compressed JSON key value pair of a state for adds.
 
         The JSON string is a key value pair of the entity_id and the compressed state.
 
         It is used for sending multiple states in a single message.
         """
-        return json_dumps({self.entity_id: self.as_compressed_state})[1:-1]
+        return json_bytes({self.entity_id: self.as_compressed_state})[1:-1]
 
     @classmethod
     def from_dict(cls, json_dict: dict[str, Any]) -> Self | None:

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -29,7 +29,7 @@ from .deprecation import (
     dir_with_deprecated_constants,
 )
 from .frame import report
-from .json import JSON_DUMP, find_paths_unserializable_data
+from .json import JSON_DUMP, find_paths_unserializable_data, json_bytes
 from .typing import UNDEFINED, UndefinedType
 
 if TYPE_CHECKING:
@@ -277,11 +277,11 @@ class DeviceEntry:
         }
 
     @cached_property
-    def json_repr(self) -> str | None:
+    def json_repr(self) -> bytes | None:
         """Return a cached JSON representation of the entry."""
         try:
             dict_repr = self.dict_repr
-            return JSON_DUMP(dict_repr)
+            return json_bytes(dict_repr)
         except (ValueError, TypeError):
             _LOGGER.error(
                 "Unable to serialize entry %s to JSON. Bad data found at %s",

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -51,7 +51,7 @@ from homeassistant.util.read_only_dict import ReadOnlyDict
 
 from . import device_registry as dr, storage
 from .device_registry import EVENT_DEVICE_REGISTRY_UPDATED
-from .json import JSON_DUMP, find_paths_unserializable_data
+from .json import JSON_DUMP, find_paths_unserializable_data, json_bytes
 from .typing import UNDEFINED, UndefinedType
 
 if TYPE_CHECKING:
@@ -227,14 +227,14 @@ class RegistryEntry:
         return display_dict
 
     @cached_property
-    def display_json_repr(self) -> str | None:
+    def display_json_repr(self) -> bytes | None:
         """Return a cached partial JSON representation of the entry.
 
         This version only includes what's needed for display.
         """
         try:
             dict_repr = self._as_display_dict
-            json_repr: str | None = JSON_DUMP(dict_repr) if dict_repr else None
+            json_repr: bytes | None = json_bytes(dict_repr) if dict_repr else None
             return json_repr
         except (ValueError, TypeError):
             _LOGGER.error(
@@ -282,11 +282,11 @@ class RegistryEntry:
         }
 
     @cached_property
-    def partial_json_repr(self) -> str | None:
+    def partial_json_repr(self) -> bytes | None:
         """Return a cached partial JSON representation of the entry."""
         try:
             dict_repr = self.as_partial_dict
-            return JSON_DUMP(dict_repr)
+            return json_bytes(dict_repr)
         except (ValueError, TypeError):
             _LOGGER.error(
                 "Unable to serialize entry %s to JSON. Bad data found at %s",

--- a/tests/components/websocket_api/test_messages.py
+++ b/tests/components/websocket_api/test_messages.py
@@ -5,7 +5,7 @@ from homeassistant.components.websocket_api.messages import (
     _partial_cached_event_message as lru_event_cache,
     _state_diff_event,
     cached_event_message,
-    message_to_json,
+    message_to_json_bytes,
 )
 from homeassistant.const import EVENT_STATE_CHANGED
 from homeassistant.core import Context, Event, HomeAssistant, State, callback
@@ -282,18 +282,18 @@ async def test_state_diff_event(hass: HomeAssistant) -> None:
     }
 
 
-async def test_message_to_json(caplog: pytest.LogCaptureFixture) -> None:
+async def test_message_to_json_bytes(caplog: pytest.LogCaptureFixture) -> None:
     """Test we can serialize websocket messages."""
 
-    json_str = message_to_json({"id": 1, "message": "xyz"})
+    json_str = message_to_json_bytes({"id": 1, "message": "xyz"})
 
-    assert json_str == '{"id":1,"message":"xyz"}'
+    assert json_str == b'{"id":1,"message":"xyz"}'
 
-    json_str2 = message_to_json({"id": 1, "message": _Unserializeable()})
+    json_str2 = message_to_json_bytes({"id": 1, "message": _Unserializeable()})
 
     assert (
         json_str2
-        == '{"id":1,"type":"result","success":false,"error":{"code":"unknown_error","message":"Invalid JSON in response"}}'
+        == b'{"id":1,"type":"result","success":false,"error":{"code":"unknown_error","message":"Invalid JSON in response"}}'
     )
     assert "Unable to serialize to JSON" in caplog.text
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -734,9 +734,9 @@ def test_state_as_dict_json() -> None:
         context=ha.Context(id="01H0D6K3RFJAYAV2093ZW30PCW"),
     )
     expected = (
-        '{"entity_id":"happy.happy","state":"on","attributes":{"pig":"dog"},'
-        '"last_changed":"1984-12-08T12:00:00","last_updated":"1984-12-08T12:00:00",'
-        '"context":{"id":"01H0D6K3RFJAYAV2093ZW30PCW","parent_id":null,"user_id":null}}'
+        b'{"entity_id":"happy.happy","state":"on","attributes":{"pig":"dog"},'
+        b'"last_changed":"1984-12-08T12:00:00","last_updated":"1984-12-08T12:00:00",'
+        b'"context":{"id":"01H0D6K3RFJAYAV2093ZW30PCW","parent_id":null,"user_id":null}}'
     )
     as_dict_json_1 = state.as_dict_json
     assert as_dict_json_1 == expected
@@ -844,7 +844,7 @@ def test_state_as_compressed_state_json() -> None:
         last_changed=last_time,
         context=ha.Context(id="01H0D6H5K3SZJ3XGDHED1TJ79N"),
     )
-    expected = '"happy.happy":{"s":"on","a":{"pig":"dog"},"c":"01H0D6H5K3SZJ3XGDHED1TJ79N","lc":471355200.0}'
+    expected = b'"happy.happy":{"s":"on","a":{"pig":"dog"},"c":"01H0D6H5K3SZJ3XGDHED1TJ79N","lc":471355200.0}'
     as_compressed_state = state.as_compressed_state_json
     # We are not too concerned about these being ReadOnlyDict
     # since we don't expect them to be called by external callers


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Most of the time we send JSON over the websocket and since the json encoder produces bytes, we decode the bytes to str, than push it into the websocket queue, than the websocket code re-encodes it as bytes, compresses and sends it. Skip the conversion from bytes to string back to bytes when possible.

When profiling the calls to `str.encode()` were more expensive than all of the `socket.recv` calls. Which also doesn't include the `str.decode()` step.  This makes a difference in reconnect/app wake up time as we are able to coalesce more websocket messages together in the initial send because of the decreased latancy.

This will also save a tiny bit of ram per string
```
>>> sys.getsizeof("")
41
>>> sys.getsizeof(b"")
33
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
