### PR TITLE
Disable Python 3.12 incompatible integrations

### DIFF
--- a/homeassistant/components/apache_kafka/manifest.json
+++ b/homeassistant/components/apache_kafka/manifest.json
@@ -2,6 +2,7 @@
   "domain": "apache_kafka",
   "name": "Apache Kafka",
   "codeowners": ["@bachya"],
+  "disabled": "Integration library not compatible with Python 3.12",
   "documentation": "https://www.home-assistant.io/integrations/apache_kafka",
   "iot_class": "local_push",
   "loggers": ["aiokafka", "kafka_python"],

--- a/homeassistant/components/apache_kafka/manifest.json
+++ b/homeassistant/components/apache_kafka/manifest.json
@@ -2,7 +2,6 @@
   "domain": "apache_kafka",
   "name": "Apache Kafka",
   "codeowners": ["@bachya"],
-  "disabled": "Integration library not compatible with Python 3.12",
   "documentation": "https://www.home-assistant.io/integrations/apache_kafka",
   "iot_class": "local_push",
   "loggers": ["aiokafka", "kafka_python"],

--- a/homeassistant/components/cisco_webex_teams/manifest.json
+++ b/homeassistant/components/cisco_webex_teams/manifest.json
@@ -2,6 +2,7 @@
   "domain": "cisco_webex_teams",
   "name": "Cisco Webex Teams",
   "codeowners": ["@fbradyirl"],
+  "disabled": "Integration library not compatible with Python 3.12",
   "documentation": "https://www.home-assistant.io/integrations/cisco_webex_teams",
   "iot_class": "cloud_push",
   "loggers": ["webexteamssdk"],

--- a/homeassistant/components/metoffice/manifest.json
+++ b/homeassistant/components/metoffice/manifest.json
@@ -3,6 +3,7 @@
   "name": "Met Office",
   "codeowners": ["@MrHarcombe", "@avee87"],
   "config_flow": true,
+  "disabled": "Integration library not compatible with Python 3.12",
   "documentation": "https://www.home-assistant.io/integrations/metoffice",
   "iot_class": "cloud_polling",
   "loggers": ["datapoint"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -275,9 +275,6 @@ aiohue==4.7.0
 # homeassistant.components.imap
 aioimaplib==1.0.1
 
-# homeassistant.components.apache_kafka
-aiokafka==0.10.0
-
 # homeassistant.components.kef
 aiokef==0.2.16
 
@@ -664,9 +661,6 @@ crownstone-uart==2.1.0
 
 # homeassistant.components.datadog
 datadog==0.15.0
-
-# homeassistant.components.metoffice
-datapoint==0.9.8;python_version<'3.12'
 
 # homeassistant.components.bluetooth
 dbus-fast==2.21.1
@@ -2795,9 +2789,6 @@ watchdog==2.3.1
 
 # homeassistant.components.waterfurnace
 waterfurnace==1.1.0
-
-# homeassistant.components.cisco_webex_teams
-webexteamssdk==1.1.1;python_version<'3.12'
 
 # homeassistant.components.assist_pipeline
 webrtc-noise-gain==1.2.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -275,6 +275,9 @@ aiohue==4.7.0
 # homeassistant.components.imap
 aioimaplib==1.0.1
 
+# homeassistant.components.apache_kafka
+aiokafka==0.10.0
+
 # homeassistant.components.kef
 aiokef==0.2.16
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -251,6 +251,9 @@ aiohue==4.7.0
 # homeassistant.components.imap
 aioimaplib==1.0.1
 
+# homeassistant.components.apache_kafka
+aiokafka==0.10.0
+
 # homeassistant.components.lifx
 aiolifx-effects==0.3.2
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -251,9 +251,6 @@ aiohue==4.7.0
 # homeassistant.components.imap
 aioimaplib==1.0.1
 
-# homeassistant.components.apache_kafka
-aiokafka==0.10.0
-
 # homeassistant.components.lifx
 aiolifx-effects==0.3.2
 
@@ -545,9 +542,6 @@ crownstone-uart==2.1.0
 
 # homeassistant.components.datadog
 datadog==0.15.0
-
-# homeassistant.components.metoffice
-datapoint==0.9.8;python_version<'3.12'
 
 # homeassistant.components.bluetooth
 dbus-fast==2.21.1

--- a/tests/components/metoffice/conftest.py
+++ b/tests/components/metoffice/conftest.py
@@ -1,13 +1,14 @@
 """Fixtures for Met Office weather integration tests."""
-import sys
 from unittest.mock import patch
 
 import pytest
 
-if sys.version_info < (3, 12):
-    from datapoint.exceptions import APIException
-else:
-    collect_ignore_glob = ["test_*.py"]
+# All tests are marked as disabled, as the integration is disabled in the
+# integration manifest. `datapoint` isn't compatible with Python 3.12
+#
+# from datapoint.exceptions import APIException
+APIException = Exception
+collect_ignore_glob = ["test_*.py"]
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The following integrations have been disabled. The upstream libraries used by Home Assistant are not compatible with Python 3.12.

- Cisco Webex Teams
- Met Office

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

See above


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
