### PR TITLE
Wrap client exceptions in xbox component

### DIFF
--- a/homeassistant/components/xbox/media_player.py
+++ b/homeassistant/components/xbox/media_player.py
@@ -22,6 +22,7 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -157,42 +158,71 @@ class XboxMediaPlayer(CoordinatorEntity[XboxUpdateCoordinator], MediaPlayerEntit
 
     async def async_turn_on(self) -> None:
         """Turn the media player on."""
-        await self.client.smartglass.wake_up(self._console.id)
+        try:
+            await self.client.smartglass.wake_up(self._console.id)
+        except Exception as e:
+            raise HomeAssistantError("Error turning Xbox on") from e
 
     async def async_turn_off(self) -> None:
         """Turn the media player off."""
-        await self.client.smartglass.turn_off(self._console.id)
+        try:
+            await self.client.smartglass.turn_off(self._console.id)
+        except Exception as e:
+            raise HomeAssistantError("Error turning Xbox off") from e
 
     async def async_mute_volume(self, mute: bool) -> None:
         """Mute the volume."""
-        if mute:
-            await self.client.smartglass.mute(self._console.id)
-        else:
-            await self.client.smartglass.unmute(self._console.id)
+        try:
+            if mute:
+                await self.client.smartglass.mute(self._console.id)
+            else:
+                await self.client.smartglass.unmute(self._console.id)
+        except Exception as e:
+            raise HomeAssistantError(f"Error setting Xbox mute to {mute}") from e
 
     async def async_volume_up(self) -> None:
         """Turn volume up for media player."""
-        await self.client.smartglass.volume(self._console.id, VolumeDirection.Up)
+        try:
+            await self.client.smartglass.volume(self._console.id, VolumeDirection.Up)
+        except Exception as e:
+            raise HomeAssistantError("Error turning Xbox volume up") from e
 
     async def async_volume_down(self) -> None:
         """Turn volume down for media player."""
-        await self.client.smartglass.volume(self._console.id, VolumeDirection.Down)
+        try:
+            await self.client.smartglass.volume(self._console.id, VolumeDirection.Down)
+        except Exception as e:
+            raise HomeAssistantError("Error turning Xbox volume down") from e
 
     async def async_media_play(self) -> None:
         """Send play command."""
-        await self.client.smartglass.play(self._console.id)
+        try:
+            await self.client.smartglass.play(self._console.id)
+        except Exception as e:
+            raise HomeAssistantError("Error sending play command to Xbox") from e
 
     async def async_media_pause(self) -> None:
         """Send pause command."""
-        await self.client.smartglass.pause(self._console.id)
+        try:
+            await self.client.smartglass.pause(self._console.id)
+        except Exception as e:
+            raise HomeAssistantError("Error sending pause command to Xbox") from e
 
     async def async_media_previous_track(self) -> None:
         """Send previous track command."""
-        await self.client.smartglass.previous(self._console.id)
+        try:
+            await self.client.smartglass.previous(self._console.id)
+        except Exception as e:
+            raise HomeAssistantError(
+                "Error sending previous track command to Xbox"
+            ) from e
 
     async def async_media_next_track(self) -> None:
         """Send next track command."""
-        await self.client.smartglass.next(self._console.id)
+        try:
+            await self.client.smartglass.next(self._console.id)
+        except Exception as e:
+            raise HomeAssistantError("Error sending next track command to Xbox") from e
 
     async def async_browse_media(self, media_content_type=None, media_content_id=None):
         """Implement the websocket media browsing helper."""
@@ -208,12 +238,15 @@ class XboxMediaPlayer(CoordinatorEntity[XboxUpdateCoordinator], MediaPlayerEntit
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:
         """Launch an app on the Xbox."""
-        if media_id == "Home":
-            await self.client.smartglass.go_home(self._console.id)
-        elif media_id == "TV":
-            await self.client.smartglass.show_tv_guide(self._console.id)
-        else:
-            await self.client.smartglass.launch_app(self._console.id, media_id)
+        try:
+            if media_id == "Home":
+                await self.client.smartglass.go_home(self._console.id)
+            elif media_id == "TV":
+                await self.client.smartglass.show_tv_guide(self._console.id)
+            else:
+                await self.client.smartglass.launch_app(self._console.id, media_id)
+        except Exception as e:
+            raise HomeAssistantError("Error launching app on Xbox") from e
 
     @property
     def device_info(self) -> DeviceInfo:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This patch wraps downstream api client exceptions within the xbox component into HomeAssistantErrors so that continue_on_error works as expected for scripts, automations, etc.  Currently, continue_on_error ignores any errors that occur in this component. 

My patch catches any exceptions and wraps them in a HomeAssistantError so that continue_on_error correctly recognizes them. I considered catching something more specific than Exception here, but the specific error that I'm getting is bubbling up from a library two layers down from the xbox component. It seemed like a better tradeoff to catch them all rather than coupling to that implementation detail.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: 101663

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
