### PR TITLE
Add additional entities for the Aqara E1 curtain motor to ZHA

### DIFF
--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -74,7 +74,7 @@ class BinarySensor(ZhaEntity, BinarySensorEntity):
 
     _attribute_name: str
 
-    def __init__(self, unique_id, zha_device, cluster_handlers, **kwargs):
+    def __init__(self, unique_id, zha_device, cluster_handlers, **kwargs) -> None:
         """Initialize the ZHA binary sensor."""
         super().__init__(unique_id, zha_device, cluster_handlers, **kwargs)
         self._cluster_handler = cluster_handlers[0]
@@ -336,3 +336,16 @@ class AqaraLinkageAlarmState(BinarySensor):
     _unique_id_suffix = "linkage_alarm_state"
     _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.SMOKE
     _attr_translation_key: str = "linkage_alarm_state"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    cluster_handler_names="opple_cluster", models={"lumi.curtain.agl001"}
+)
+class AqaraE1CurtainMotorOpenedByHandBinarySensor(BinarySensor):
+    """Opened by hand binary sensor."""
+
+    _unique_id_suffix = "hand_open"
+    _attribute_name = "hand_open"
+    _attr_translation_key = "hand_open"
+    _attr_icon = "mdi:hand-wave"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC

--- a/homeassistant/components/zha/button.py
+++ b/homeassistant/components/zha/button.py
@@ -106,8 +106,6 @@ class ZHAIdentifyButton(ZHAButton):
     _attr_device_class = ButtonDeviceClass.IDENTIFY
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _command_name = "identify"
-    _attr_icon = "mdi:eye"
-    _attr_translation_key = "identify"
 
     def get_args(self) -> list[Any]:
         """Return the arguments to use in the command."""

--- a/homeassistant/components/zha/button.py
+++ b/homeassistant/components/zha/button.py
@@ -106,6 +106,8 @@ class ZHAIdentifyButton(ZHAButton):
     _attr_device_class = ButtonDeviceClass.IDENTIFY
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _command_name = "identify"
+    _attr_icon = "mdi:eye"
+    _attr_translation_key = "identify"
 
     def get_args(self) -> list[Any]:
         """Return the arguments to use in the command."""

--- a/homeassistant/components/zha/core/cluster_handlers/general.py
+++ b/homeassistant/components/zha/core/cluster_handlers/general.py
@@ -202,6 +202,9 @@ class BasicClusterHandler(ClusterHandler):
         ):
             self.ZCL_INIT_ATTRS = self.ZCL_INIT_ATTRS.copy()
             self.ZCL_INIT_ATTRS["transmit_power"] = True
+        elif self.cluster.endpoint.model == "lumi.curtain.agl001":
+            self.ZCL_INIT_ATTRS = self.ZCL_INIT_ATTRS.copy()
+            self.ZCL_INIT_ATTRS["power_source"] = True
 
 
 @registries.ZIGBEE_CLUSTER_HANDLER_REGISTRY.register(BinaryInput.cluster_id)

--- a/homeassistant/components/zha/core/cluster_handlers/manufacturerspecific.py
+++ b/homeassistant/components/zha/core/cluster_handlers/manufacturerspecific.py
@@ -160,6 +160,14 @@ class OppleRemoteClusterHandler(ClusterHandler):
                 "startup_on_off": True,
                 "decoupled_mode": True,
             }
+        elif self.cluster.endpoint.model == "lumi.curtain.agl001":
+            self.ZCL_INIT_ATTRS = {
+                "hooks_state": True,
+                "hooks_lock": True,
+                "positions_stored": True,
+                "light_level": True,
+                "hand_open": True,
+            }
 
     async def async_initialize_cluster_handler_specific(self, from_cache: bool) -> None:
         """Initialize cluster handler specific."""

--- a/homeassistant/components/zha/select.py
+++ b/homeassistant/components/zha/select.py
@@ -471,25 +471,6 @@ class AqaraT2RelayDecoupledMode(ZCLEnumSelectEntity):
     _attr_translation_key: str = "decoupled_mode"
 
 
-class AqaraE1ReverseDirection(types.enum8):
-    """Aqara curtain reversal."""
-
-    Normal = 0x00
-    Inverted = 0x01
-
-
-@CONFIG_DIAGNOSTIC_MATCH(
-    cluster_handler_names="window_covering", models={"lumi.curtain.agl001"}
-)
-class AqaraCurtainMode(ZCLEnumSelectEntity):
-    """Representation of a ZHA curtain mode configuration entity."""
-
-    _unique_id_suffix = "window_covering_mode"
-    _attribute_name = "window_covering_mode"
-    _enum = AqaraE1ReverseDirection
-    _attr_translation_key: str = "window_covering_mode"
-
-
 class InovelliOutputMode(types.enum1):
     """Inovelli output mode."""
 

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -10,6 +10,8 @@ import random
 from typing import TYPE_CHECKING, Any, Self
 
 from zigpy import types
+from zigpy.zcl.clusters.closures import WindowCovering
+from zigpy.zcl.clusters.general import Basic
 
 from homeassistant.components.climate import HVACAction
 from homeassistant.components.sensor import (
@@ -277,6 +279,7 @@ class Battery(Sensor):
     _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_translation_key: str = "battery_remaining"
 
     @classmethod
     def create_entity(
@@ -1312,3 +1315,62 @@ class SetpointChangeSource(EnumSensor):
     _attr_icon: str = "mdi:thermostat"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _enum = SetpointChangeSourceEnum
+
+
+@CONFIG_DIAGNOSTIC_MATCH(cluster_handler_names="window_covering")
+# pylint: disable-next=hass-invalid-inheritance # needs fixing
+class WindowCoveringTypeSensor(Sensor):
+    """Sensor that displays the type of a cover device."""
+
+    _attribute_name: str = WindowCovering.AttributeDefs.window_covering_type.name
+    _unique_id_suffix: str = WindowCovering.AttributeDefs.window_covering_type.name
+    _attr_translation_key: str = WindowCovering.AttributeDefs.window_covering_type.name
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:curtains"
+
+    def formatter(self, value: int) -> int | float | None:
+        """Enum formatter."""
+        return WindowCovering.WindowCoveringType(value).name
+
+
+@CONFIG_DIAGNOSTIC_MATCH(cluster_handler_names="basic", models={"lumi.curtain.agl001"})
+# pylint: disable-next=hass-invalid-inheritance # needs fixing
+class AqaraCurtainMotorPowerSourceSensor(Sensor):
+    """Sensor that displays the power source of the Aqara E1 curtain motor device."""
+
+    _attribute_name: str = Basic.AttributeDefs.power_source.name
+    _unique_id_suffix: str = Basic.AttributeDefs.power_source.name
+    _attr_translation_key: str = Basic.AttributeDefs.power_source.name
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:battery-positive"
+
+    def formatter(self, value: int) -> int | float | None:
+        """Enum formatter."""
+        return Basic.PowerSource(value).name
+
+
+class AqaraE1HookState(types.enum8):
+    """Aqara hook state."""
+
+    Unlocked = 0x00
+    Locked = 0x01
+    Locking = 0x02
+    Unlocking = 0x03
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    cluster_handler_names="opple_cluster", models={"lumi.curtain.agl001"}
+)
+# pylint: disable-next=hass-invalid-inheritance # needs fixing
+class AqaraCurtainHookStateSensor(Sensor):
+    """Representation of a ZHA curtain mode configuration entity."""
+
+    _attribute_name = "hooks_state"
+    _unique_id_suffix = "hooks_state"
+    _attr_translation_key: str = "hooks_state"
+    _attr_icon: str = "mdi:hook"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def formatter(self, value: int) -> int | float | None:
+        """Enum formatter."""
+        return AqaraE1HookState(value).name

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -53,6 +53,7 @@ from .core import discovery
 from .core.const import (
     CLUSTER_HANDLER_ANALOG_INPUT,
     CLUSTER_HANDLER_BASIC,
+    CLUSTER_HANDLER_COVER,
     CLUSTER_HANDLER_DEVICE_TEMPERATURE,
     CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT,
     CLUSTER_HANDLER_HUMIDITY,
@@ -279,7 +280,6 @@ class Battery(Sensor):
     _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_native_unit_of_measurement = PERCENTAGE
-    _attr_translation_key: str = "battery_remaining"
 
     @classmethod
     def create_entity(
@@ -1317,7 +1317,7 @@ class SetpointChangeSource(EnumSensor):
     _enum = SetpointChangeSourceEnum
 
 
-@CONFIG_DIAGNOSTIC_MATCH(cluster_handler_names="window_covering")
+@CONFIG_DIAGNOSTIC_MATCH(cluster_handler_names=CLUSTER_HANDLER_COVER)
 # pylint: disable-next=hass-invalid-inheritance # needs fixing
 class WindowCoveringTypeSensor(Sensor):
     """Sensor that displays the type of a cover device."""
@@ -1333,7 +1333,9 @@ class WindowCoveringTypeSensor(Sensor):
         return WindowCovering.WindowCoveringType(value).name
 
 
-@CONFIG_DIAGNOSTIC_MATCH(cluster_handler_names="basic", models={"lumi.curtain.agl001"})
+@CONFIG_DIAGNOSTIC_MATCH(
+    cluster_handler_names=CLUSTER_HANDLER_BASIC, models={"lumi.curtain.agl001"}
+)
 # pylint: disable-next=hass-invalid-inheritance # needs fixing
 class AqaraCurtainMotorPowerSourceSensor(Sensor):
     """Sensor that displays the power source of the Aqara E1 curtain motor device."""

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -1319,36 +1319,30 @@ class SetpointChangeSource(EnumSensor):
 
 @CONFIG_DIAGNOSTIC_MATCH(cluster_handler_names=CLUSTER_HANDLER_COVER)
 # pylint: disable-next=hass-invalid-inheritance # needs fixing
-class WindowCoveringTypeSensor(Sensor):
+class WindowCoveringTypeSensor(EnumSensor):
     """Sensor that displays the type of a cover device."""
 
     _attribute_name: str = WindowCovering.AttributeDefs.window_covering_type.name
+    _enum = WindowCovering.WindowCoveringType
     _unique_id_suffix: str = WindowCovering.AttributeDefs.window_covering_type.name
     _attr_translation_key: str = WindowCovering.AttributeDefs.window_covering_type.name
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_icon = "mdi:curtains"
-
-    def formatter(self, value: int) -> int | float | None:
-        """Enum formatter."""
-        return WindowCovering.WindowCoveringType(value).name
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_BASIC, models={"lumi.curtain.agl001"}
 )
 # pylint: disable-next=hass-invalid-inheritance # needs fixing
-class AqaraCurtainMotorPowerSourceSensor(Sensor):
+class AqaraCurtainMotorPowerSourceSensor(EnumSensor):
     """Sensor that displays the power source of the Aqara E1 curtain motor device."""
 
     _attribute_name: str = Basic.AttributeDefs.power_source.name
+    _enum = Basic.PowerSource
     _unique_id_suffix: str = Basic.AttributeDefs.power_source.name
     _attr_translation_key: str = Basic.AttributeDefs.power_source.name
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_icon = "mdi:battery-positive"
-
-    def formatter(self, value: int) -> int | float | None:
-        """Enum formatter."""
-        return Basic.PowerSource(value).name
 
 
 class AqaraE1HookState(types.enum8):
@@ -1364,15 +1358,12 @@ class AqaraE1HookState(types.enum8):
     cluster_handler_names="opple_cluster", models={"lumi.curtain.agl001"}
 )
 # pylint: disable-next=hass-invalid-inheritance # needs fixing
-class AqaraCurtainHookStateSensor(Sensor):
+class AqaraCurtainHookStateSensor(EnumSensor):
     """Representation of a ZHA curtain mode configuration entity."""
 
     _attribute_name = "hooks_state"
+    _enum = AqaraE1HookState
     _unique_id_suffix = "hooks_state"
     _attr_translation_key: str = "hooks_state"
     _attr_icon: str = "mdi:hook"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    def formatter(self, value: int) -> int | float | None:
-        """Enum formatter."""
-        return AqaraE1HookState(value).name

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -566,6 +566,9 @@
       },
       "ias_zone": {
         "name": "IAS zone"
+      },
+      "hand_open": {
+        "name": "Opened by hand"
       }
     },
     "button": {
@@ -580,6 +583,9 @@
       },
       "self_test": {
         "name": "Self-test"
+      },
+      "identify": {
+        "name": "Identify"
       }
     },
     "climate": {
@@ -896,6 +902,18 @@
       },
       "setpoint_change_source": {
         "name": "Setpoint change source"
+      },
+      "power_source": {
+        "name": "Power source"
+      },
+      "window_covering_type": {
+        "name": "Window covering type"
+      },
+      "battery_remaining": {
+        "name": "Battery remaining"
+      },
+      "hooks_state": {
+        "name": "Hooks state"
       }
     },
     "switch": {
@@ -922,6 +940,9 @@
       },
       "inverted": {
         "name": "Inverted"
+      },
+      "hooks_locked": {
+        "name": "Hooks locked"
       },
       "smart_bulb_mode": {
         "name": "Smart bulb mode"

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -910,7 +910,7 @@
         "name": "Window covering type"
       },
       "battery_remaining": {
-        "name": "Battery remaining"
+        "name": "Battery"
       },
       "hooks_state": {
         "name": "Hooks state"

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -909,9 +909,6 @@
       "window_covering_type": {
         "name": "Window covering type"
       },
-      "battery_remaining": {
-        "name": "Battery"
-      },
       "hooks_state": {
         "name": "Hooks state"
       }

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -583,9 +583,6 @@
       },
       "self_test": {
         "name": "Self-test"
-      },
-      "identify": {
-        "name": "Identify"
       }
     },
     "climate": {

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -685,3 +685,15 @@ class WindowCoveringInversionSwitch(ZHASwitchConfigurationEntity):
         if send_command:
             await self._cluster_handler.write_attributes_safe({name: current_mode})
             await self.async_update()
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    cluster_handler_names="opple_cluster", models={"lumi.curtain.agl001"}
+)
+class AqaraE1CurtainMotorHooksLockedSwitch(ZHASwitchConfigurationEntity):
+    """Representation of a switch that controls whether the curtain motor hooks are locked."""
+
+    _unique_id_suffix = "hooks_lock"
+    _attribute_name = "hooks_lock"
+    _attr_translation_key = "hooks_locked"
+    _attr_icon: str = "mdi:lock"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This PR removes the existing inversion entity specific to the Aqara E1 curtain motor in favor of the standard invert switch added in #108238

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds entities for the Aqara E1 curtain motor.

**depends on** #108238

![image](https://github.com/home-assistant/core/assets/1335687/b050ea7c-b297-4cae-8d31-41e9520a3531)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
