### PR TITLE
Add cloud tts entity

### DIFF
--- a/homeassistant/components/cloud/assist_pipeline.py
+++ b/homeassistant/components/cloud/assist_pipeline.py
@@ -9,16 +9,23 @@ from homeassistant.components.assist_pipeline import (
 )
 from homeassistant.components.conversation import HOME_ASSISTANT_AGENT
 from homeassistant.components.stt import DOMAIN as STT_DOMAIN
+from homeassistant.components.tts import DOMAIN as TTS_DOMAIN
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.entity_registry as er
 
-from .const import DATA_PLATFORMS_SETUP, DOMAIN, STT_ENTITY_UNIQUE_ID
+from .const import (
+    DATA_PLATFORMS_SETUP,
+    DOMAIN,
+    STT_ENTITY_UNIQUE_ID,
+    TTS_ENTITY_UNIQUE_ID,
+)
 
 
 async def async_create_cloud_pipeline(hass: HomeAssistant) -> str | None:
     """Create a cloud assist pipeline."""
-    # Wait for stt and tts platforms to set up before creating the pipeline.
+    # Wait for stt and tts platforms to set up and entities to be added
+    # before creating the pipeline.
     platforms_setup: dict[str, asyncio.Event] = hass.data[DATA_PLATFORMS_SETUP]
     await asyncio.gather(*(event.wait() for event in platforms_setup.values()))
     # Make sure the pipeline store is loaded, needed because assist_pipeline
@@ -29,8 +36,11 @@ async def async_create_cloud_pipeline(hass: HomeAssistant) -> str | None:
     new_stt_engine_id = entity_registry.async_get_entity_id(
         STT_DOMAIN, DOMAIN, STT_ENTITY_UNIQUE_ID
     )
-    if new_stt_engine_id is None:
-        # If there's no cloud stt entity, we can't create a cloud pipeline.
+    new_tts_engine_id = entity_registry.async_get_entity_id(
+        TTS_DOMAIN, DOMAIN, TTS_ENTITY_UNIQUE_ID
+    )
+    if new_stt_engine_id is None or new_tts_engine_id is None:
+        # If there's no cloud stt or tts entity, we can't create a cloud pipeline.
         return None
 
     def cloud_assist_pipeline(hass: HomeAssistant) -> str | None:
@@ -43,7 +53,7 @@ async def async_create_cloud_pipeline(hass: HomeAssistant) -> str | None:
             if (
                 pipeline.conversation_engine == HOME_ASSISTANT_AGENT
                 and pipeline.stt_engine in (DOMAIN, new_stt_engine_id)
-                and pipeline.tts_engine == DOMAIN
+                and pipeline.tts_engine in (DOMAIN, new_tts_engine_id)
             ):
                 return pipeline.id
         return None
@@ -52,7 +62,7 @@ async def async_create_cloud_pipeline(hass: HomeAssistant) -> str | None:
         cloud_pipeline := await async_create_default_pipeline(
             hass,
             stt_engine_id=new_stt_engine_id,
-            tts_engine_id=DOMAIN,
+            tts_engine_id=new_tts_engine_id,
             pipeline_name="Home Assistant Cloud",
         )
     ) is None:
@@ -61,18 +71,28 @@ async def async_create_cloud_pipeline(hass: HomeAssistant) -> str | None:
     return cloud_pipeline.id
 
 
-async def async_migrate_cloud_pipeline_stt_engine(
-    hass: HomeAssistant, stt_engine_id: str
+async def async_migrate_cloud_pipeline_engine(
+    hass: HomeAssistant, platform: Platform, engine_id: str
 ) -> None:
-    """Migrate the speech-to-text engine in the cloud assist pipeline."""
-    # Migrate existing pipelines with cloud stt to use new cloud stt engine id.
-    # Added in 2024.01.0. Can be removed in 2025.01.0.
+    """Migrate the pipeline engines in the cloud assist pipeline."""
+    # Migrate existing pipelines with cloud stt or tts to use new cloud engine id.
+    # Added in 2024.02.0. Can be removed in 2025.02.0.
 
-    # We need to make sure that tts is loaded before this migration.
-    # Assist pipeline will call default engine of tts when setting up the store.
-    # Wait for the tts platform loaded event here.
+    # We need to make sure that that both stt and tts are loaded before this migration.
+    # Assist pipeline will call default engine when setting up the store.
+    # Wait for the stt or tts platform loaded event here.
+    kwargs: dict[str, str] = {}
+    if platform == Platform.STT:
+        wait_for_platform = Platform.TTS
+        kwargs["stt_engine"] = engine_id
+    elif platform == Platform.TTS:
+        wait_for_platform = Platform.STT
+        kwargs["tts_engine"] = engine_id
+    else:
+        raise ValueError(f"Invalid platform {platform}")
+
     platforms_setup: dict[str, asyncio.Event] = hass.data[DATA_PLATFORMS_SETUP]
-    await platforms_setup[Platform.TTS].wait()
+    await platforms_setup[wait_for_platform].wait()
 
     # Make sure the pipeline store is loaded, needed because assist_pipeline
     # is an after dependency of cloud
@@ -80,6 +100,6 @@ async def async_migrate_cloud_pipeline_stt_engine(
 
     pipelines = async_get_pipelines(hass)
     for pipeline in pipelines:
-        if pipeline.stt_engine != DOMAIN:
+        if pipeline.stt_engine != DOMAIN or pipeline.tts_engine != DOMAIN:
             continue
-        await async_update_pipeline(hass, pipeline, stt_engine=stt_engine_id)
+        await async_update_pipeline(hass, pipeline, **kwargs)

--- a/homeassistant/components/cloud/assist_pipeline.py
+++ b/homeassistant/components/cloud/assist_pipeline.py
@@ -78,7 +78,7 @@ async def async_migrate_cloud_pipeline_engine(
     # Migrate existing pipelines with cloud stt or tts to use new cloud engine id.
     # Added in 2024.02.0. Can be removed in 2025.02.0.
 
-    # We need to make sure that that both stt and tts are loaded before this migration.
+    # We need to make sure that both stt and tts are loaded before this migration.
     # Assist pipeline will call default engine when setting up the store.
     # Wait for the stt or tts platform loaded event here.
     if platform == Platform.STT:

--- a/homeassistant/components/cloud/assist_pipeline.py
+++ b/homeassistant/components/cloud/assist_pipeline.py
@@ -100,6 +100,5 @@ async def async_migrate_cloud_pipeline_engine(
 
     pipelines = async_get_pipelines(hass)
     for pipeline in pipelines:
-        if pipeline.stt_engine != DOMAIN or pipeline.tts_engine != DOMAIN:
-            continue
-        await async_update_pipeline(hass, pipeline, **kwargs)
+        if DOMAIN in (pipeline.stt_engine, pipeline.tts_engine):
+            await async_update_pipeline(hass, pipeline, **kwargs)

--- a/homeassistant/components/cloud/const.py
+++ b/homeassistant/components/cloud/const.py
@@ -73,3 +73,4 @@ MODE_PROD = "production"
 DISPATCHER_REMOTE_UPDATE: SignalType[Any] = SignalType("cloud_remote_update")
 
 STT_ENTITY_UNIQUE_ID = "cloud-speech-to-text"
+TTS_ENTITY_UNIQUE_ID = "cloud-text-to-speech"

--- a/homeassistant/components/cloud/prefs.py
+++ b/homeassistant/components/cloud/prefs.py
@@ -104,9 +104,17 @@ class CloudPreferences:
     @callback
     def async_listen_updates(
         self, listener: Callable[[CloudPreferences], Coroutine[Any, Any, None]]
-    ) -> None:
+    ) -> Callable[[], None]:
         """Listen for updates to the preferences."""
+
+        @callback
+        def unsubscribe() -> None:
+            """Remove the listener."""
+            self._listeners.remove(listener)
+
         self._listeners.append(listener)
+
+        return unsubscribe
 
     async def async_update(
         self,

--- a/homeassistant/components/cloud/stt.py
+++ b/homeassistant/components/cloud/stt.py
@@ -1,6 +1,7 @@
 """Support for the cloud for speech to text service."""
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncIterable
 import logging
 
@@ -19,12 +20,13 @@ from homeassistant.components.stt import (
     SpeechToTextEntity,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .assist_pipeline import async_migrate_cloud_pipeline_stt_engine
+from .assist_pipeline import async_migrate_cloud_pipeline_engine
 from .client import CloudClient
-from .const import DOMAIN, STT_ENTITY_UNIQUE_ID
+from .const import DATA_PLATFORMS_SETUP, DOMAIN, STT_ENTITY_UNIQUE_ID
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,18 +37,20 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Home Assistant Cloud speech platform via config entry."""
+    stt_platform_loaded: asyncio.Event = hass.data[DATA_PLATFORMS_SETUP][Platform.STT]
+    stt_platform_loaded.set()
     cloud: Cloud[CloudClient] = hass.data[DOMAIN]
     async_add_entities([CloudProviderEntity(cloud)])
 
 
 class CloudProviderEntity(SpeechToTextEntity):
-    """NabuCasa speech API provider."""
+    """Home Assistant Cloud speech API provider."""
 
     _attr_name = "Home Assistant Cloud"
     _attr_unique_id = STT_ENTITY_UNIQUE_ID
 
     def __init__(self, cloud: Cloud[CloudClient]) -> None:
-        """Home Assistant NabuCasa Speech to text."""
+        """Initialize cloud Speech to text entity."""
         self.cloud = cloud
 
     @property
@@ -81,7 +85,9 @@ class CloudProviderEntity(SpeechToTextEntity):
 
     async def async_added_to_hass(self) -> None:
         """Run when entity is about to be added to hass."""
-        await async_migrate_cloud_pipeline_stt_engine(self.hass, self.entity_id)
+        await async_migrate_cloud_pipeline_engine(
+            self.hass, platform=Platform.STT, engine_id=self.entity_id
+        )
 
     async def async_process_audio_stream(
         self, metadata: SpeechMetadata, stream: AsyncIterable[bytes]

--- a/homeassistant/components/cloud/tts.py
+++ b/homeassistant/components/cloud/tts.py
@@ -1,6 +1,7 @@
 """Support for the cloud for text-to-speech service."""
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
@@ -12,16 +13,21 @@ from homeassistant.components.tts import (
     ATTR_AUDIO_OUTPUT,
     ATTR_VOICE,
     CONF_LANG,
-    PLATFORM_SCHEMA,
+    PLATFORM_SCHEMA as TTS_PLATFORM_SCHEMA,
     Provider,
+    TextToSpeechEntity,
     TtsAudioType,
     Voice,
 )
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
+from .assist_pipeline import async_migrate_cloud_pipeline_engine
 from .client import CloudClient
-from .const import DOMAIN
+from .const import DATA_PLATFORMS_SETUP, DOMAIN, TTS_ENTITY_UNIQUE_ID
 from .prefs import CloudPreferences
 
 ATTR_GENDER = "gender"
@@ -48,7 +54,7 @@ def validate_lang(value: dict[str, Any]) -> dict[str, Any]:
 
 
 PLATFORM_SCHEMA = vol.All(
-    PLATFORM_SCHEMA.extend(
+    TTS_PLATFORM_SCHEMA.extend(
         {
             vol.Optional(CONF_LANG): str,
             vol.Optional(ATTR_GENDER): str,
@@ -81,8 +87,95 @@ async def async_get_engine(
     return cloud_provider
 
 
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Home Assistant Cloud text-to-speech platform."""
+    tts_platform_loaded: asyncio.Event = hass.data[DATA_PLATFORMS_SETUP][Platform.TTS]
+    tts_platform_loaded.set()
+    cloud: Cloud[CloudClient] = hass.data[DOMAIN]
+    async_add_entities([CloudTTSEntity(cloud)])
+
+
+class CloudTTSEntity(TextToSpeechEntity):
+    """Home Assistant Cloud text-to-speech entity."""
+
+    _attr_name = "Home Assistant Cloud"
+    _attr_unique_id = TTS_ENTITY_UNIQUE_ID
+
+    def __init__(self, cloud: Cloud[CloudClient]) -> None:
+        """Initialize cloud text-to-speech entity."""
+        self.cloud = cloud
+        self._language, self._gender = cloud.client.prefs.tts_default_voice
+
+    async def _sync_prefs(self, prefs: CloudPreferences) -> None:
+        """Sync preferences."""
+        self._language, self._gender = prefs.tts_default_voice
+
+    @property
+    def default_language(self) -> str:
+        """Return the default language."""
+        return self._language
+
+    @property
+    def default_options(self) -> dict[str, Any]:
+        """Return a dict include default options."""
+        return {
+            ATTR_GENDER: self._gender,
+            ATTR_AUDIO_OUTPUT: AudioOutput.MP3,
+        }
+
+    @property
+    def supported_languages(self) -> list[str]:
+        """Return list of supported languages."""
+        return SUPPORT_LANGUAGES
+
+    @property
+    def supported_options(self) -> list[str]:
+        """Return list of supported options like voice, emotion."""
+        return [ATTR_GENDER, ATTR_VOICE, ATTR_AUDIO_OUTPUT]
+
+    async def async_added_to_hass(self) -> None:
+        """Handle entity which will be added."""
+        await super().async_added_to_hass()
+        await async_migrate_cloud_pipeline_engine(
+            self.hass, platform=Platform.TTS, engine_id=self.entity_id
+        )
+        self.async_on_remove(
+            self.cloud.client.prefs.async_listen_updates(self._sync_prefs)
+        )
+
+    @callback
+    def async_get_supported_voices(self, language: str) -> list[Voice] | None:
+        """Return a list of supported voices for a language."""
+        if not (voices := TTS_VOICES.get(language)):
+            return None
+        return [Voice(voice, voice) for voice in voices]
+
+    async def async_get_tts_audio(
+        self, message: str, language: str, options: dict[str, Any]
+    ) -> TtsAudioType:
+        """Load TTS from Home Assistant Cloud."""
+        # Process TTS
+        try:
+            data = await self.cloud.voice.process_tts(
+                text=message,
+                language=language,
+                gender=options.get(ATTR_GENDER),
+                voice=options.get(ATTR_VOICE),
+                output=options[ATTR_AUDIO_OUTPUT],
+            )
+        except VoiceError as err:
+            _LOGGER.error("Voice error: %s", err)
+            return (None, None)
+
+        return (str(options[ATTR_AUDIO_OUTPUT].value), data)
+
+
 class CloudProvider(Provider):
-    """NabuCasa Cloud speech API provider."""
+    """Home Assistant Cloud speech API provider."""
 
     def __init__(
         self, cloud: Cloud[CloudClient], language: str | None, gender: str | None
@@ -136,7 +229,7 @@ class CloudProvider(Provider):
     async def async_get_tts_audio(
         self, message: str, language: str, options: dict[str, Any]
     ) -> TtsAudioType:
-        """Load TTS from NabuCasa Cloud."""
+        """Load TTS from Home Assistant Cloud."""
         # Process TTS
         try:
             data = await self.cloud.voice.process_tts(

--- a/tests/components/cloud/__init__.py
+++ b/tests/components/cloud/__init__.py
@@ -7,6 +7,54 @@ from homeassistant.components import cloud
 from homeassistant.components.cloud import const, prefs as cloud_prefs
 from homeassistant.setup import async_setup_component
 
+PIPELINE_DATA = {
+    "items": [
+        {
+            "conversation_engine": "conversation_engine_1",
+            "conversation_language": "language_1",
+            "id": "01GX8ZWBAQYWNB1XV3EXEZ75DY",
+            "language": "language_1",
+            "name": "Home Assistant Cloud",
+            "stt_engine": "cloud",
+            "stt_language": "language_1",
+            "tts_engine": "cloud",
+            "tts_language": "language_1",
+            "tts_voice": "Arnold Schwarzenegger",
+            "wake_word_entity": None,
+            "wake_word_id": None,
+        },
+        {
+            "conversation_engine": "conversation_engine_2",
+            "conversation_language": "language_2",
+            "id": "01GX8ZWBAQTKFQNK4W7Q4CTRCX",
+            "language": "language_2",
+            "name": "name_2",
+            "stt_engine": "stt_engine_2",
+            "stt_language": "language_2",
+            "tts_engine": "tts_engine_2",
+            "tts_language": "language_2",
+            "tts_voice": "The Voice",
+            "wake_word_entity": None,
+            "wake_word_id": None,
+        },
+        {
+            "conversation_engine": "conversation_engine_3",
+            "conversation_language": "language_3",
+            "id": "01GX8ZWBAQSV1HP3WGJPFWEJ8J",
+            "language": "language_3",
+            "name": "name_3",
+            "stt_engine": None,
+            "stt_language": None,
+            "tts_engine": None,
+            "tts_language": None,
+            "tts_voice": None,
+            "wake_word_entity": None,
+            "wake_word_id": None,
+        },
+    ],
+    "preferred_item": "01GX8ZWBAQYWNB1XV3EXEZ75DY",
+}
+
 
 async def mock_cloud(hass, config=None):
     """Mock cloud."""

--- a/tests/components/cloud/conftest.py
+++ b/tests/components/cloud/conftest.py
@@ -15,9 +15,20 @@ import jwt
 import pytest
 
 from homeassistant.components.cloud import CloudClient, const, prefs
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
 from . import mock_cloud, mock_cloud_prefs
+
+
+@pytest.fixture(autouse=True)
+async def load_homeassistant(hass: HomeAssistant) -> None:
+    """Load the homeassistant integration.
+
+    This is needed for the cloud integration to work.
+    """
+    assert await async_setup_component(hass, "homeassistant", {})
 
 
 @pytest.fixture(name="cloud")

--- a/tests/components/cloud/test_assist_pipeline.py
+++ b/tests/components/cloud/test_assist_pipeline.py
@@ -1,0 +1,16 @@
+"""Test the cloud assist pipeline."""
+import pytest
+
+from homeassistant.components.cloud.assist_pipeline import (
+    async_migrate_cloud_pipeline_engine,
+)
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+
+async def test_migrate_pipeline_invalid_platform(hass: HomeAssistant) -> None:
+    """Test migrate pipeline with invalid platform."""
+    with pytest.raises(ValueError):
+        await async_migrate_cloud_pipeline_engine(
+            hass, Platform.BINARY_SENSOR, "test-engine-id"
+        )

--- a/tests/components/cloud/test_http_api.py
+++ b/tests/components/cloud/test_http_api.py
@@ -243,7 +243,7 @@ async def test_login_view_create_pipeline(
     create_pipeline_mock.assert_awaited_once_with(
         hass,
         stt_engine_id="stt.home_assistant_cloud",
-        tts_engine_id="cloud",
+        tts_engine_id="tts.home_assistant_cloud",
         pipeline_name="Home Assistant Cloud",
     )
 
@@ -282,7 +282,7 @@ async def test_login_view_create_pipeline_fail(
     create_pipeline_mock.assert_awaited_once_with(
         hass,
         stt_engine_id="stt.home_assistant_cloud",
-        tts_engine_id="cloud",
+        tts_engine_id="tts.home_assistant_cloud",
         pipeline_name="Home Assistant Cloud",
     )
 

--- a/tests/components/cloud/test_http_api.py
+++ b/tests/components/cloud/test_http_api.py
@@ -147,15 +147,19 @@ async def test_google_actions_sync_fails(
         assert mock_request_sync.call_count == 1
 
 
-async def test_login_view_missing_stt_entity(
+@pytest.mark.parametrize(
+    "entity_id", ["stt.home_assistant_cloud", "tts.home_assistant_cloud"]
+)
+async def test_login_view_missing_entity(
     hass: HomeAssistant,
     setup_cloud: None,
     entity_registry: er.EntityRegistry,
     hass_client: ClientSessionGenerator,
+    entity_id: str,
 ) -> None:
-    """Test logging in when the cloud stt entity is missing."""
-    # Make sure that the cloud stt entity does not exist.
-    entity_registry.async_remove("stt.home_assistant_cloud")
+    """Test logging in when a cloud assist pipeline needed entity is missing."""
+    # Make sure that the cloud entity does not exist.
+    entity_registry.async_remove(entity_id)
     await hass.async_block_till_done()
 
     cloud_client = await hass_client()

--- a/tests/components/cloud/test_stt.py
+++ b/tests/components/cloud/test_stt.py
@@ -14,55 +14,9 @@ from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from tests.typing import ClientSessionGenerator
+from . import PIPELINE_DATA
 
-PIPELINE_DATA = {
-    "items": [
-        {
-            "conversation_engine": "conversation_engine_1",
-            "conversation_language": "language_1",
-            "id": "01GX8ZWBAQYWNB1XV3EXEZ75DY",
-            "language": "language_1",
-            "name": "Home Assistant Cloud",
-            "stt_engine": "cloud",
-            "stt_language": "language_1",
-            "tts_engine": "cloud",
-            "tts_language": "language_1",
-            "tts_voice": "Arnold Schwarzenegger",
-            "wake_word_entity": None,
-            "wake_word_id": None,
-        },
-        {
-            "conversation_engine": "conversation_engine_2",
-            "conversation_language": "language_2",
-            "id": "01GX8ZWBAQTKFQNK4W7Q4CTRCX",
-            "language": "language_2",
-            "name": "name_2",
-            "stt_engine": "stt_engine_2",
-            "stt_language": "language_2",
-            "tts_engine": "tts_engine_2",
-            "tts_language": "language_2",
-            "tts_voice": "The Voice",
-            "wake_word_entity": None,
-            "wake_word_id": None,
-        },
-        {
-            "conversation_engine": "conversation_engine_3",
-            "conversation_language": "language_3",
-            "id": "01GX8ZWBAQSV1HP3WGJPFWEJ8J",
-            "language": "language_3",
-            "name": "name_3",
-            "stt_engine": None,
-            "stt_language": None,
-            "tts_engine": None,
-            "tts_language": None,
-            "tts_voice": None,
-            "wake_word_entity": None,
-            "wake_word_id": None,
-        },
-    ],
-    "preferred_item": "01GX8ZWBAQYWNB1XV3EXEZ75DY",
-}
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture(autouse=True)
@@ -137,6 +91,7 @@ async def test_migrating_pipelines(
     hass_storage: dict[str, Any],
 ) -> None:
     """Test migrating pipelines when cloud stt entity is added."""
+    entity_id = "stt.home_assistant_cloud"
     cloud.voice.process_stt = AsyncMock(
         return_value=STTResponse(True, "Turn the Kitchen Lights on")
     )
@@ -151,18 +106,18 @@ async def test_migrating_pipelines(
     assert await async_setup_component(hass, DOMAIN, {"cloud": {}})
     await hass.async_block_till_done()
 
-    on_start_callback = cloud.register_on_start.call_args[0][0]
-    await on_start_callback()
+    await cloud.login("test-user", "test-pass")
     await hass.async_block_till_done()
 
-    state = hass.states.get("stt.home_assistant_cloud")
+    state = hass.states.get(entity_id)
     assert state
     assert state.state == STATE_UNKNOWN
 
-    # The stt engine should be updated to the new cloud stt engine id.
+    # The stt/tts engines should have been updated to the new cloud engine ids.
+    assert hass_storage[STORAGE_KEY]["data"]["items"][0]["stt_engine"] == entity_id
     assert (
-        hass_storage[STORAGE_KEY]["data"]["items"][0]["stt_engine"]
-        == "stt.home_assistant_cloud"
+        hass_storage[STORAGE_KEY]["data"]["items"][0]["tts_engine"]
+        == "tts.home_assistant_cloud"
     )
 
     # The other items should stay the same.
@@ -183,7 +138,6 @@ async def test_migrating_pipelines(
         hass_storage[STORAGE_KEY]["data"]["items"][0]["name"] == "Home Assistant Cloud"
     )
     assert hass_storage[STORAGE_KEY]["data"]["items"][0]["stt_language"] == "language_1"
-    assert hass_storage[STORAGE_KEY]["data"]["items"][0]["tts_engine"] == "cloud"
     assert hass_storage[STORAGE_KEY]["data"]["items"][0]["tts_language"] == "language_1"
     assert (
         hass_storage[STORAGE_KEY]["data"]["items"][0]["tts_voice"]

--- a/tests/components/cloud/test_stt.py
+++ b/tests/components/cloud/test_stt.py
@@ -66,12 +66,6 @@ PIPELINE_DATA = {
 
 
 @pytest.fixture(autouse=True)
-async def load_homeassistant(hass: HomeAssistant) -> None:
-    """Load the homeassistant integration."""
-    assert await async_setup_component(hass, "homeassistant", {})
-
-
-@pytest.fixture(autouse=True)
 async def delay_save_fixture() -> AsyncGenerator[None, None]:
     """Load the homeassistant integration."""
     with patch("homeassistant.helpers.collection.SAVE_DELAY", new=0):

--- a/tests/components/cloud/test_tts.py
+++ b/tests/components/cloud/test_tts.py
@@ -1,13 +1,15 @@
 """Tests for cloud tts."""
-from collections.abc import Callable, Coroutine
+from collections.abc import AsyncGenerator, Callable, Coroutine
+from copy import deepcopy
 from http import HTTPStatus
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from hass_nabucasa.voice import MAP_VOICE, VoiceError, VoiceTokenError
 import pytest
 import voluptuous as vol
 
+from homeassistant.components.assist_pipeline.pipeline import STORAGE_KEY
 from homeassistant.components.cloud import DOMAIN, const, tts
 from homeassistant.components.tts import DOMAIN as TTS_DOMAIN
 from homeassistant.components.tts.helper import get_engine_instance
@@ -17,7 +19,16 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.setup import async_setup_component
 
+from . import PIPELINE_DATA
+
 from tests.typing import ClientSessionGenerator
+
+
+@pytest.fixture(autouse=True)
+async def delay_save_fixture() -> AsyncGenerator[None, None]:
+    """Load the homeassistant integration."""
+    with patch("homeassistant.helpers.collection.SAVE_DELAY", new=0):
+        yield
 
 
 @pytest.fixture(autouse=True)
@@ -331,3 +342,69 @@ async def test_tts_entity(
 
     state = hass.states.get(entity_id)
     assert state is None
+
+
+async def test_migrating_pipelines(
+    hass: HomeAssistant,
+    cloud: MagicMock,
+    hass_client: ClientSessionGenerator,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test migrating pipelines when cloud tts entity is added."""
+    entity_id = "tts.home_assistant_cloud"
+    mock_process_tts = AsyncMock(
+        return_value=b"",
+    )
+    cloud.voice.process_tts = mock_process_tts
+    hass_storage[STORAGE_KEY] = {
+        "version": 1,
+        "minor_version": 1,
+        "key": "assist_pipeline.pipelines",
+        "data": deepcopy(PIPELINE_DATA),
+    }
+
+    assert await async_setup_component(hass, "assist_pipeline", {})
+    assert await async_setup_component(hass, DOMAIN, {"cloud": {}})
+    await hass.async_block_till_done()
+
+    await cloud.login("test-user", "test-pass")
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_UNKNOWN
+
+    # The stt/tts engines should have been updated to the new cloud engine ids.
+    assert (
+        hass_storage[STORAGE_KEY]["data"]["items"][0]["stt_engine"]
+        == "stt.home_assistant_cloud"
+    )
+    assert hass_storage[STORAGE_KEY]["data"]["items"][0]["tts_engine"] == entity_id
+
+    # The other items should stay the same.
+    assert (
+        hass_storage[STORAGE_KEY]["data"]["items"][0]["conversation_engine"]
+        == "conversation_engine_1"
+    )
+    assert (
+        hass_storage[STORAGE_KEY]["data"]["items"][0]["conversation_language"]
+        == "language_1"
+    )
+    assert (
+        hass_storage[STORAGE_KEY]["data"]["items"][0]["id"]
+        == "01GX8ZWBAQYWNB1XV3EXEZ75DY"
+    )
+    assert hass_storage[STORAGE_KEY]["data"]["items"][0]["language"] == "language_1"
+    assert (
+        hass_storage[STORAGE_KEY]["data"]["items"][0]["name"] == "Home Assistant Cloud"
+    )
+    assert hass_storage[STORAGE_KEY]["data"]["items"][0]["stt_language"] == "language_1"
+    assert hass_storage[STORAGE_KEY]["data"]["items"][0]["tts_language"] == "language_1"
+    assert (
+        hass_storage[STORAGE_KEY]["data"]["items"][0]["tts_voice"]
+        == "Arnold Schwarzenegger"
+    )
+    assert hass_storage[STORAGE_KEY]["data"]["items"][0]["wake_word_entity"] is None
+    assert hass_storage[STORAGE_KEY]["data"]["items"][0]["wake_word_id"] is None
+    assert hass_storage[STORAGE_KEY]["data"]["items"][1] == PIPELINE_DATA["items"][1]
+    assert hass_storage[STORAGE_KEY]["data"]["items"][2] == PIPELINE_DATA["items"][2]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Add cloud tts entity.
- Migrate assist pipelines that use the old cloud tts engine to the new cloud tts entity engine.
- Update synchronization to avoid deadlock, while still making sure that required resources are available.
- For now, we'll keep the legacy cloud tts provider and set it up to allow users that use the corresponding service to still use that. We haven't decided if and when we want to deprecate that.

TODO:
- [x] Complete tests
- [x] Check that no more migration is required.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
