### PR TITLE
Randomize thread network names

### DIFF
--- a/homeassistant/components/otbr/config_flow.py
+++ b/homeassistant/components/otbr/config_flow.py
@@ -28,7 +28,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DEFAULT_CHANNEL, DOMAIN
-from .util import get_allowed_channel
+from .util import generate_default_network_name, get_allowed_channel
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -88,7 +88,7 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
                 await api.create_active_dataset(
                     python_otbr_api.ActiveDataSet(
                         channel=allowed_channel if allowed_channel else DEFAULT_CHANNEL,
-                        network_name="home-assistant",
+                        network_name=generate_default_network_name(),
                     )
                 )
             await api.set_enabled(True)

--- a/homeassistant/components/otbr/config_flow.py
+++ b/homeassistant/components/otbr/config_flow.py
@@ -28,7 +28,11 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DEFAULT_CHANNEL, DOMAIN
-from .util import generate_default_network_name, get_allowed_channel
+from .util import (
+    compose_default_network_name,
+    generate_random_pan_id,
+    get_allowed_channel,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -85,10 +89,12 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
                 _LOGGER.debug(
                     "not importing TLV with channel %s", thread_dataset_channel
                 )
+                pan_id = generate_random_pan_id()
                 await api.create_active_dataset(
                     python_otbr_api.ActiveDataSet(
                         channel=allowed_channel if allowed_channel else DEFAULT_CHANNEL,
-                        network_name=generate_default_network_name(),
+                        network_name=compose_default_network_name(pan_id),
+                        pan_id=pan_id,
                     )
                 )
             await api.set_enabled(True)

--- a/homeassistant/components/otbr/util.py
+++ b/homeassistant/components/otbr/util.py
@@ -51,7 +51,7 @@ INSECURE_PASSPHRASES = (
 
 def compose_default_network_name(pan_id: int) -> str:
     """Generate a default network name."""
-    return f"homeassistant-{pan_id >> 8:02x}"
+    return f"ha-thread-{pan_id:04x}"
 
 
 def generate_random_pan_id() -> int:

--- a/homeassistant/components/otbr/util.py
+++ b/homeassistant/components/otbr/util.py
@@ -5,6 +5,7 @@ from collections.abc import Callable, Coroutine
 import dataclasses
 from functools import wraps
 import logging
+import random
 from typing import Any, Concatenate, ParamSpec, TypeVar, cast
 
 import python_otbr_api
@@ -46,6 +47,11 @@ INSECURE_PASSPHRASES = (
     # Thread documentation default
     "J01NME",
 )
+
+
+def generate_default_network_name() -> str:
+    """Generate a default network name."""
+    return f"home-assistant-{random.randbytes(2).hex()}"
 
 
 def _handle_otbr_error(

--- a/homeassistant/components/otbr/util.py
+++ b/homeassistant/components/otbr/util.py
@@ -57,7 +57,7 @@ def compose_default_network_name(pan_id: int) -> str:
 def generate_random_pan_id() -> int:
     """Generate a random PAN ID."""
     # PAN ID is 2 bytes, 0xffff is reserved for broadcast
-    return random.randint(0, 0xfffe)
+    return random.randint(0, 0xFFFE)
 
 
 def _handle_otbr_error(

--- a/homeassistant/components/otbr/util.py
+++ b/homeassistant/components/otbr/util.py
@@ -49,9 +49,15 @@ INSECURE_PASSPHRASES = (
 )
 
 
-def generate_default_network_name() -> str:
+def compose_default_network_name(pan_id: int) -> str:
     """Generate a default network name."""
-    return f"home-assistant-{random.randbytes(2).hex()}"
+    return f"home-assistant-{pan_id:04x}"
+
+
+def generate_random_pan_id() -> int:
+    """Generate a random PAN ID."""
+    # PAN ID is 2 bytes, 65535 is reserved for broadcast
+    return random.randint(0, 65534)
 
 
 def _handle_otbr_error(

--- a/homeassistant/components/otbr/util.py
+++ b/homeassistant/components/otbr/util.py
@@ -51,13 +51,13 @@ INSECURE_PASSPHRASES = (
 
 def compose_default_network_name(pan_id: int) -> str:
     """Generate a default network name."""
-    return f"home-assistant-{pan_id:04x}"
+    return f"homeassistant-{pan_id >> 8:02x}"
 
 
 def generate_random_pan_id() -> int:
     """Generate a random PAN ID."""
-    # PAN ID is 2 bytes, 65535 is reserved for broadcast
-    return random.randint(0, 65534)
+    # PAN ID is 2 bytes, 0xffff is reserved for broadcast
+    return random.randint(0, 0xfffe)
 
 
 def _handle_otbr_error(

--- a/homeassistant/components/otbr/websocket_api.py
+++ b/homeassistant/components/otbr/websocket_api.py
@@ -16,7 +16,12 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import DEFAULT_CHANNEL, DOMAIN
-from .util import OTBRData, get_allowed_channel, update_issues
+from .util import (
+    OTBRData,
+    generate_default_network_name,
+    get_allowed_channel,
+    update_issues,
+)
 
 
 @callback
@@ -102,7 +107,7 @@ async def websocket_create_network(
     try:
         await data.create_active_dataset(
             python_otbr_api.ActiveDataSet(
-                channel=channel, network_name="home-assistant"
+                channel=channel, network_name=generate_default_network_name()
             )
         )
     except HomeAssistantError as exc:

--- a/homeassistant/components/otbr/websocket_api.py
+++ b/homeassistant/components/otbr/websocket_api.py
@@ -18,7 +18,8 @@ from homeassistant.exceptions import HomeAssistantError
 from .const import DEFAULT_CHANNEL, DOMAIN
 from .util import (
     OTBRData,
-    generate_default_network_name,
+    compose_default_network_name,
+    generate_random_pan_id,
     get_allowed_channel,
     update_issues,
 )
@@ -104,10 +105,13 @@ async def websocket_create_network(
         connection.send_error(msg["id"], "factory_reset_failed", str(exc))
         return
 
+    pan_id = generate_random_pan_id()
     try:
         await data.create_active_dataset(
             python_otbr_api.ActiveDataSet(
-                channel=channel, network_name=generate_default_network_name()
+                channel=channel,
+                network_name=compose_default_network_name(pan_id),
+                pan_id=pan_id,
             )
         )
     except HomeAssistantError as exc:

--- a/tests/components/otbr/test_config_flow.py
+++ b/tests/components/otbr/test_config_flow.py
@@ -121,8 +121,12 @@ async def test_user_flow_router_not_setup(
     # Check we create a dataset and enable the router
     assert aioclient_mock.mock_calls[-2][0] == "PUT"
     assert aioclient_mock.mock_calls[-2][1].path == "/node/dataset/active"
-    assert aioclient_mock.mock_calls[-2][2]["Channel"] == 15
-    assert aioclient_mock.mock_calls[-2][2]["NetworkName"].startswith("home-assistant-")
+    pan_id = aioclient_mock.mock_calls[-2][2]["PanId"]
+    assert aioclient_mock.mock_calls[-2][2] == {
+        "Channel": 15,
+        "NetworkName": f"home-assistant-{pan_id:04x}",
+        "PanId": pan_id,
+    }
 
     assert aioclient_mock.mock_calls[-1][0] == "PUT"
     assert aioclient_mock.mock_calls[-1][1].path == "/node/state"
@@ -423,8 +427,12 @@ async def test_hassio_discovery_flow_router_not_setup(
     # Check we create a dataset and enable the router
     assert aioclient_mock.mock_calls[-2][0] == "PUT"
     assert aioclient_mock.mock_calls[-2][1].path == "/node/dataset/active"
-    assert aioclient_mock.mock_calls[-2][2]["Channel"] == 15
-    assert aioclient_mock.mock_calls[-2][2]["NetworkName"].startswith("home-assistant-")
+    pan_id = aioclient_mock.mock_calls[-2][2]["PanId"]
+    assert aioclient_mock.mock_calls[-2][2] == {
+        "Channel": 15,
+        "NetworkName": f"home-assistant-{pan_id:04x}",
+        "PanId": pan_id,
+    }
 
     assert aioclient_mock.mock_calls[-1][0] == "PUT"
     assert aioclient_mock.mock_calls[-1][1].path == "/node/state"
@@ -528,8 +536,12 @@ async def test_hassio_discovery_flow_router_not_setup_has_preferred_2(
     # Check we create a dataset and enable the router
     assert aioclient_mock.mock_calls[-2][0] == "PUT"
     assert aioclient_mock.mock_calls[-2][1].path == "/node/dataset/active"
-    assert aioclient_mock.mock_calls[-2][2]["Channel"] == 15
-    assert aioclient_mock.mock_calls[-2][2]["NetworkName"].startswith("home-assistant-")
+    pan_id = aioclient_mock.mock_calls[-2][2]["PanId"]
+    assert aioclient_mock.mock_calls[-2][2] == {
+        "Channel": 15,
+        "NetworkName": f"home-assistant-{pan_id:04x}",
+        "PanId": pan_id,
+    }
 
     assert aioclient_mock.mock_calls[-1][0] == "PUT"
     assert aioclient_mock.mock_calls[-1][1].path == "/node/state"

--- a/tests/components/otbr/test_config_flow.py
+++ b/tests/components/otbr/test_config_flow.py
@@ -121,10 +121,8 @@ async def test_user_flow_router_not_setup(
     # Check we create a dataset and enable the router
     assert aioclient_mock.mock_calls[-2][0] == "PUT"
     assert aioclient_mock.mock_calls[-2][1].path == "/node/dataset/active"
-    assert aioclient_mock.mock_calls[-2][2] == {
-        "Channel": 15,
-        "NetworkName": "home-assistant",
-    }
+    assert aioclient_mock.mock_calls[-2][2]["Channel"] == 15
+    assert aioclient_mock.mock_calls[-2][2]["NetworkName"].startswith("home-assistant-")
 
     assert aioclient_mock.mock_calls[-1][0] == "PUT"
     assert aioclient_mock.mock_calls[-1][1].path == "/node/state"
@@ -425,10 +423,8 @@ async def test_hassio_discovery_flow_router_not_setup(
     # Check we create a dataset and enable the router
     assert aioclient_mock.mock_calls[-2][0] == "PUT"
     assert aioclient_mock.mock_calls[-2][1].path == "/node/dataset/active"
-    assert aioclient_mock.mock_calls[-2][2] == {
-        "Channel": 15,
-        "NetworkName": "home-assistant",
-    }
+    assert aioclient_mock.mock_calls[-2][2]["Channel"] == 15
+    assert aioclient_mock.mock_calls[-2][2]["NetworkName"].startswith("home-assistant-")
 
     assert aioclient_mock.mock_calls[-1][0] == "PUT"
     assert aioclient_mock.mock_calls[-1][1].path == "/node/state"
@@ -532,10 +528,8 @@ async def test_hassio_discovery_flow_router_not_setup_has_preferred_2(
     # Check we create a dataset and enable the router
     assert aioclient_mock.mock_calls[-2][0] == "PUT"
     assert aioclient_mock.mock_calls[-2][1].path == "/node/dataset/active"
-    assert aioclient_mock.mock_calls[-2][2] == {
-        "Channel": 15,
-        "NetworkName": "home-assistant",
-    }
+    assert aioclient_mock.mock_calls[-2][2]["Channel"] == 15
+    assert aioclient_mock.mock_calls[-2][2]["NetworkName"].startswith("home-assistant-")
 
     assert aioclient_mock.mock_calls[-1][0] == "PUT"
     assert aioclient_mock.mock_calls[-1][1].path == "/node/state"

--- a/tests/components/otbr/test_config_flow.py
+++ b/tests/components/otbr/test_config_flow.py
@@ -124,7 +124,7 @@ async def test_user_flow_router_not_setup(
     pan_id = aioclient_mock.mock_calls[-2][2]["PanId"]
     assert aioclient_mock.mock_calls[-2][2] == {
         "Channel": 15,
-        "NetworkName": f"home-assistant-{pan_id:04x}",
+        "NetworkName": f"homeassistant-{pan_id>>8:02x}",
         "PanId": pan_id,
     }
 
@@ -430,7 +430,7 @@ async def test_hassio_discovery_flow_router_not_setup(
     pan_id = aioclient_mock.mock_calls[-2][2]["PanId"]
     assert aioclient_mock.mock_calls[-2][2] == {
         "Channel": 15,
-        "NetworkName": f"home-assistant-{pan_id:04x}",
+        "NetworkName": f"homeassistant-{pan_id>>8:02x}",
         "PanId": pan_id,
     }
 
@@ -539,7 +539,7 @@ async def test_hassio_discovery_flow_router_not_setup_has_preferred_2(
     pan_id = aioclient_mock.mock_calls[-2][2]["PanId"]
     assert aioclient_mock.mock_calls[-2][2] == {
         "Channel": 15,
-        "NetworkName": f"home-assistant-{pan_id:04x}",
+        "NetworkName": f"homeassistant-{pan_id>>8:02x}",
         "PanId": pan_id,
     }
 

--- a/tests/components/otbr/test_config_flow.py
+++ b/tests/components/otbr/test_config_flow.py
@@ -124,7 +124,7 @@ async def test_user_flow_router_not_setup(
     pan_id = aioclient_mock.mock_calls[-2][2]["PanId"]
     assert aioclient_mock.mock_calls[-2][2] == {
         "Channel": 15,
-        "NetworkName": f"homeassistant-{pan_id>>8:02x}",
+        "NetworkName": f"ha-thread-{pan_id:04x}",
         "PanId": pan_id,
     }
 
@@ -430,7 +430,7 @@ async def test_hassio_discovery_flow_router_not_setup(
     pan_id = aioclient_mock.mock_calls[-2][2]["PanId"]
     assert aioclient_mock.mock_calls[-2][2] == {
         "Channel": 15,
-        "NetworkName": f"homeassistant-{pan_id>>8:02x}",
+        "NetworkName": f"ha-thread-{pan_id:04x}",
         "PanId": pan_id,
     }
 
@@ -539,7 +539,7 @@ async def test_hassio_discovery_flow_router_not_setup_has_preferred_2(
     pan_id = aioclient_mock.mock_calls[-2][2]["PanId"]
     assert aioclient_mock.mock_calls[-2][2] == {
         "Channel": 15,
-        "NetworkName": f"homeassistant-{pan_id>>8:02x}",
+        "NetworkName": f"ha-thread-{pan_id:04x}",
         "PanId": pan_id,
     }
 

--- a/tests/components/otbr/test_websocket_api.py
+++ b/tests/components/otbr/test_websocket_api.py
@@ -105,7 +105,10 @@ async def test_create_network(
         "python_otbr_api.OTBR.get_active_dataset_tlvs", return_value=DATASET_CH16
     ) as get_active_dataset_tlvs_mock, patch(
         "homeassistant.components.thread.dataset_store.DatasetStore.async_add"
-    ) as mock_add:
+    ) as mock_add, patch(
+        "homeassistant.components.otbr.util.random.randbytes",
+        return_value=bytes.fromhex("1234"),
+    ):
         await websocket_client.send_json_auto_id({"type": "otbr/create_network"})
 
         msg = await websocket_client.receive_json()
@@ -113,7 +116,9 @@ async def test_create_network(
         assert msg["result"] is None
 
     create_dataset_mock.assert_called_once_with(
-        python_otbr_api.models.ActiveDataSet(channel=15, network_name="home-assistant")
+        python_otbr_api.models.ActiveDataSet(
+            channel=15, network_name="home-assistant-1234"
+        )
     )
     factory_reset_mock.assert_called_once_with()
     assert len(set_enabled_mock.mock_calls) == 2

--- a/tests/components/otbr/test_websocket_api.py
+++ b/tests/components/otbr/test_websocket_api.py
@@ -117,7 +117,7 @@ async def test_create_network(
 
     create_dataset_mock.assert_called_once_with(
         python_otbr_api.models.ActiveDataSet(
-            channel=15, network_name="home-assistant-1234", pan_id=0x1234
+            channel=15, network_name="homeassistant-12", pan_id=0x1234
         )
     )
     factory_reset_mock.assert_called_once_with()

--- a/tests/components/otbr/test_websocket_api.py
+++ b/tests/components/otbr/test_websocket_api.py
@@ -117,7 +117,7 @@ async def test_create_network(
 
     create_dataset_mock.assert_called_once_with(
         python_otbr_api.models.ActiveDataSet(
-            channel=15, network_name="homeassistant-12", pan_id=0x1234
+            channel=15, network_name="ha-thread-1234", pan_id=0x1234
         )
     )
     factory_reset_mock.assert_called_once_with()

--- a/tests/components/otbr/test_websocket_api.py
+++ b/tests/components/otbr/test_websocket_api.py
@@ -106,8 +106,8 @@ async def test_create_network(
     ) as get_active_dataset_tlvs_mock, patch(
         "homeassistant.components.thread.dataset_store.DatasetStore.async_add"
     ) as mock_add, patch(
-        "homeassistant.components.otbr.util.random.randbytes",
-        return_value=bytes.fromhex("1234"),
+        "homeassistant.components.otbr.util.random.randint",
+        return_value=0x1234,
     ):
         await websocket_client.send_json_auto_id({"type": "otbr/create_network"})
 
@@ -117,7 +117,7 @@ async def test_create_network(
 
     create_dataset_mock.assert_called_once_with(
         python_otbr_api.models.ActiveDataSet(
-            channel=15, network_name="home-assistant-1234"
+            channel=15, network_name="home-assistant-1234", pan_id=0x1234
         )
     )
     factory_reset_mock.assert_called_once_with()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Randomize thread network names, the network name is now `ha-thread-{pan_id:04x}"` instead of just `"home-assistant"`

Note:
`home-assistant-1234` would have been preferred, but it exceeds the maximum network name of 16 characters.

### Rationale

It's confusing when every thread network created by us is just called "home-assistant"

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
