### PR TITLE
Improve tests of mqtt device triggers

### DIFF
--- a/tests/components/mqtt/test_device_trigger.py
+++ b/tests/components/mqtt/test_device_trigger.py
@@ -312,7 +312,7 @@ async def test_if_fires_on_mqtt_message(
         '{ "automation_type":"trigger",'
         '  "device":{"identifiers":["0AFFD2"]},'
         '  "payload": "long_press",'
-        '  "topic": "foobar/triggers/button1",'
+        '  "topic": "foobar/triggers/button2",'
         '  "type": "button_long_press",'
         '  "subtype": "button_2" }'
     )
@@ -346,8 +346,8 @@ async def test_if_fires_on_mqtt_message(
                         "domain": DOMAIN,
                         "device_id": device_entry.id,
                         "discovery_id": "bla2",
-                        "type": "button_1",
-                        "subtype": "button_long_press",
+                        "type": "button_long_press",
+                        "subtype": "button_2",
                     },
                     "action": {
                         "service": "test.automation",
@@ -365,7 +365,7 @@ async def test_if_fires_on_mqtt_message(
     assert calls[0].data["some"] == "short_press"
 
     # Fake long press.
-    async_fire_mqtt_message(hass, "foobar/triggers/button1", "long_press")
+    async_fire_mqtt_message(hass, "foobar/triggers/button2", "long_press")
     await hass.async_block_till_done()
     assert len(calls) == 2
     assert calls[1].data["some"] == "long_press"
@@ -569,7 +569,7 @@ async def test_if_fires_on_mqtt_message_template(
     calls: list[ServiceCall],
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
-    """Test triggers firing."""
+    """Test triggers firing with a message template and a shared topic."""
     await mqtt_mock_entry()
     data1 = (
         '{ "automation_type":"trigger",'
@@ -619,8 +619,8 @@ async def test_if_fires_on_mqtt_message_template(
                         "domain": DOMAIN,
                         "device_id": device_entry.id,
                         "discovery_id": "bla2",
-                        "type": "button_1",
-                        "subtype": "button_long_press",
+                        "type": "button_long_press",
+                        "subtype": "button_2",
                     },
                     "action": {
                         "service": "test.automation",
@@ -669,7 +669,7 @@ async def test_if_fires_on_mqtt_message_late_discover(
         '{ "automation_type":"trigger",'
         '  "device":{"identifiers":["0AFFD2"]},'
         '  "payload": "long_press",'
-        '  "topic": "foobar/triggers/button1",'
+        '  "topic": "foobar/triggers/button2",'
         '  "type": "button_long_press",'
         '  "subtype": "button_2" }'
     )
@@ -702,8 +702,8 @@ async def test_if_fires_on_mqtt_message_late_discover(
                         "domain": DOMAIN,
                         "device_id": device_entry.id,
                         "discovery_id": "bla2",
-                        "type": "button_1",
-                        "subtype": "button_long_press",
+                        "type": "button_long_press",
+                        "subtype": "button_2",
                     },
                     "action": {
                         "service": "test.automation",
@@ -725,7 +725,7 @@ async def test_if_fires_on_mqtt_message_late_discover(
     assert calls[0].data["some"] == "short_press"
 
     # Fake long press.
-    async_fire_mqtt_message(hass, "foobar/triggers/button1", "long_press")
+    async_fire_mqtt_message(hass, "foobar/triggers/button2", "long_press")
     await hass.async_block_till_done()
     assert len(calls) == 2
     assert calls[1].data["some"] == "long_press"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve the quality of the tests of MQTT device triggers. Correct test where the type or subtype of the attached trigger differs from the type and subtype in the device automation and only is linked to the discovery_id.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
