### PR TITLE
Pause Wyoming satellite on mute

### DIFF
--- a/homeassistant/components/wyoming/manifest.json
+++ b/homeassistant/components/wyoming/manifest.json
@@ -6,6 +6,6 @@
   "dependencies": ["assist_pipeline"],
   "documentation": "https://www.home-assistant.io/integrations/wyoming",
   "iot_class": "local_push",
-  "requirements": ["wyoming==1.5.0"],
+  "requirements": ["wyoming==1.5.2"],
   "zeroconf": ["_wyoming._tcp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2821,7 +2821,7 @@ wled==0.17.0
 wolf-smartset==0.1.11
 
 # homeassistant.components.wyoming
-wyoming==1.5.0
+wyoming==1.5.2
 
 # homeassistant.components.xbox
 xbox-webapi==2.0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2144,7 +2144,7 @@ wled==0.17.0
 wolf-smartset==0.1.11
 
 # homeassistant.components.wyoming
-wyoming==1.5.0
+wyoming==1.5.2
 
 # homeassistant.components.xbox
 xbox-webapi==2.0.11

--- a/tests/components/wyoming/__init__.py
+++ b/tests/components/wyoming/__init__.py
@@ -35,8 +35,10 @@ STT_INFO = Info(
                     installed=True,
                     attribution=TEST_ATTR,
                     languages=["en-US"],
+                    version=None,
                 )
             ],
+            version=None,
         )
     ]
 )
@@ -55,8 +57,10 @@ TTS_INFO = Info(
                     attribution=TEST_ATTR,
                     languages=["en-US"],
                     speakers=[TtsVoiceSpeaker(name="Test Speaker")],
+                    version=None,
                 )
             ],
+            version=None,
         )
     ]
 )
@@ -74,8 +78,10 @@ WAKE_WORD_INFO = Info(
                     installed=True,
                     attribution=TEST_ATTR,
                     languages=["en-US"],
+                    version=None,
                 )
             ],
+            version=None,
         )
     ]
 )
@@ -86,6 +92,7 @@ SATELLITE_INFO = Info(
         installed=True,
         attribution=TEST_ATTR,
         area="Office",
+        version=None,
     )
 )
 EMPTY_INFO = Info()

--- a/tests/components/wyoming/test_wake_word.py
+++ b/tests/components/wyoming/test_wake_word.py
@@ -188,6 +188,7 @@ async def test_dynamic_wake_word_info(
                         installed=True,
                         attribution=TEST_ATTR,
                         languages=[],
+                        version=None,
                     ),
                     WakeModel(
                         name="ww2",
@@ -195,8 +196,10 @@ async def test_dynamic_wake_word_info(
                         installed=True,
                         attribution=TEST_ATTR,
                         languages=[],
+                        version=None,
                     ),
                 ],
+                version=None,
             )
         ]
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Bump wyoming to 1.5.2: https://github.com/rhasspy/wyoming/compare/1.5.0...1.5.2
- Send a `pause-satellite` message when muted or stopping so satellites can stop listening immediately

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
