### PR TITLE
Improve august typing (5)

### DIFF
--- a/homeassistant/components/august/camera.py
+++ b/homeassistant/components/august/camera.py
@@ -58,7 +58,7 @@ class AugustCamera(AugustEntityMixin, Camera):
         return self._device.has_subscription
 
     @property
-    def model(self):
+    def model(self) -> str | None:
         """Return the camera model."""
         return self._detail.model
 

--- a/homeassistant/components/august/entity.py
+++ b/homeassistant/components/august/entity.py
@@ -1,7 +1,7 @@
 """Base class for August entity."""
 from abc import abstractmethod
 
-from yalexs.doorbell import Doorbell
+from yalexs.doorbell import Doorbell, DoorbellDetail
 from yalexs.lock import Lock, LockDetail
 from yalexs.util import get_configuration_url
 
@@ -46,7 +46,7 @@ class AugustEntityMixin(Entity):
         return self._device.device_id
 
     @property
-    def _detail(self):
+    def _detail(self) -> DoorbellDetail | LockDetail:
         return self._data.get_device_detail(self._device.device_id)
 
     @property

--- a/homeassistant/components/august/lock.py
+++ b/homeassistant/components/august/lock.py
@@ -1,9 +1,12 @@
 """Support for August lock."""
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
 import logging
 from typing import Any
 
 from aiohttp import ClientResponseError
-from yalexs.activity import SOURCE_PUBNUB, ActivityType
+from yalexs.activity import SOURCE_PUBNUB, ActivityType, ActivityTypes
 from yalexs.lock import Lock, LockStatus
 from yalexs.util import get_latest_activity, update_lock_detail_from_activity
 
@@ -62,7 +65,9 @@ class AugustLock(AugustEntityMixin, RestoreEntity, LockEntity):
             return
         await self._call_lock_operation(self._data.async_unlock)
 
-    async def _call_lock_operation(self, lock_operation):
+    async def _call_lock_operation(
+        self, lock_operation: Callable[[str], Coroutine[Any, Any, list[ActivityTypes]]]
+    ) -> None:
         try:
             activities = await lock_operation(self._device_id)
         except ClientResponseError as err:

--- a/homeassistant/components/august/sensor.py
+++ b/homeassistant/components/august/sensor.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 import logging
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, TypeVar, cast
 
-from yalexs.activity import ActivityType
+from yalexs.activity import ActivityType, LockOperationActivity
 from yalexs.doorbell import Doorbell
 from yalexs.keypad import KeypadDetail
 from yalexs.lock import Lock, LockDetail
@@ -158,7 +158,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-async def _async_migrate_old_unique_ids(hass, devices):
+async def _async_migrate_old_unique_ids(hass: HomeAssistant, devices) -> None:
     """Keypads now have their own serial number."""
     registry = er.async_get(hass)
     for device in devices:
@@ -184,11 +184,11 @@ class AugustOperatorSensor(AugustEntityMixin, RestoreSensor):
         super().__init__(data, device)
         self._data = data
         self._device = device
-        self._operated_remote = None
-        self._operated_keypad = None
-        self._operated_manual = None
-        self._operated_tag = None
-        self._operated_autorelock = None
+        self._operated_remote: bool | None = None
+        self._operated_keypad: bool | None = None
+        self._operated_manual: bool | None = None
+        self._operated_tag: bool | None = None
+        self._operated_autorelock: bool | None = None
         self._operated_time = None
         self._attr_unique_id = f"{self._device_id}_lock_operator"
         self._update_from_data()
@@ -202,6 +202,7 @@ class AugustOperatorSensor(AugustEntityMixin, RestoreSensor):
 
         self._attr_available = True
         if lock_activity is not None:
+            lock_activity = cast(LockOperationActivity, lock_activity)
             self._attr_native_value = lock_activity.operated_by
             self._operated_remote = lock_activity.operated_remote
             self._operated_keypad = lock_activity.operated_keypad


### PR DESCRIPTION
## Proposed change
Requires #108331

Likely the last one. There are still a few errors left towards strict typing. However as the dependencies are untyped, it doesn't make much sense to add `type: ignore[no-any-return]` for example.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
