### PR TITLE
Add zeroconf to TechnoVE integration

### DIFF
--- a/homeassistant/components/technove/config_flow.py
+++ b/homeassistant/components/technove/config_flow.py
@@ -5,8 +5,9 @@ from typing import Any
 from technove import Station as TechnoVEStation, TechnoVE, TechnoVEConnectionError
 import voluptuous as vol
 
+from homeassistant.components import onboarding, zeroconf
 from homeassistant.config_entries import ConfigFlow
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_MAC
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -15,6 +16,10 @@ from .const import DOMAIN
 
 class TechnoVEConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for TechnoVE."""
+
+    VERSION = 1
+    discovered_host: str
+    discovered_station: TechnoVEStation
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -42,6 +47,50 @@ class TechnoVEConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=vol.Schema({vol.Required(CONF_HOST): str}),
             errors=errors,
+        )
+
+    async def async_step_zeroconf(
+        self, discovery_info: zeroconf.ZeroconfServiceInfo
+    ) -> FlowResult:
+        """Handle zeroconf discovery."""
+        # Abort quick if the mac address is provided by discovery info
+        if mac := discovery_info.properties.get(CONF_MAC):
+            await self.async_set_unique_id(mac)
+            self._abort_if_unique_id_configured(
+                updates={CONF_HOST: discovery_info.host}
+            )
+
+        self.discovered_host = discovery_info.host
+        try:
+            self.discovered_station = await self._async_get_station(discovery_info.host)
+        except TechnoVEConnectionError:
+            return self.async_abort(reason="cannot_connect")
+
+        await self.async_set_unique_id(self.discovered_station.info.mac_address)
+        self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.host})
+
+        self.context.update(
+            {
+                "title_placeholders": {"name": self.discovered_station.info.name},
+            }
+        )
+        return await self.async_step_zeroconf_confirm()
+
+    async def async_step_zeroconf_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle a flow initiated by zeroconf."""
+        if user_input is not None or not onboarding.async_is_onboarded(self.hass):
+            return self.async_create_entry(
+                title=self.discovered_station.info.name,
+                data={
+                    CONF_HOST: self.discovered_host,
+                },
+            )
+
+        return self.async_show_form(
+            step_id="zeroconf_confirm",
+            description_placeholders={"name": self.discovered_station.info.name},
         )
 
     async def _async_get_station(self, host: str) -> TechnoVEStation:

--- a/homeassistant/components/technove/config_flow.py
+++ b/homeassistant/components/technove/config_flow.py
@@ -53,7 +53,7 @@ class TechnoVEConfigFlow(ConfigFlow, domain=DOMAIN):
         self, discovery_info: zeroconf.ZeroconfServiceInfo
     ) -> FlowResult:
         """Handle zeroconf discovery."""
-        # Abort quick if the mac address is provided by discovery info
+        # Abort quick if the device with provided mac is already configured
         if mac := discovery_info.properties.get(CONF_MAC):
             await self.async_set_unique_id(mac)
             self._abort_if_unique_id_configured(

--- a/homeassistant/components/technove/manifest.json
+++ b/homeassistant/components/technove/manifest.json
@@ -6,5 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/technove",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "requirements": ["python-technove==1.1.1"]
+  "requirements": ["python-technove==1.1.1"],
+  "zeroconf": ["_technove-stations._tcp.local."]
 }

--- a/homeassistant/components/technove/strings.json
+++ b/homeassistant/components/technove/strings.json
@@ -10,6 +10,10 @@
         "data_description": {
           "host": "Hostname or IP address of your TechnoVE station."
         }
+      },
+      "zeroconf_confirm": {
+        "description": "Do you want to add the TechnoVE Station named `{name}` to Home Assistant?",
+        "title": "Discovered TechnoVE station"
       }
     },
     "error": {

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -705,6 +705,11 @@ ZEROCONF = {
             "domain": "system_bridge",
         },
     ],
+    "_technove-stations._tcp.local.": [
+        {
+            "domain": "technove",
+        },
+    ],
     "_touch-able._tcp.local.": [
         {
             "domain": "apple_tv",

--- a/tests/components/technove/conftest.py
+++ b/tests/components/technove/conftest.py
@@ -32,6 +32,16 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
+def mock_onboarding() -> Generator[MagicMock, None, None]:
+    """Mock that Home Assistant is currently onboarding."""
+    with patch(
+        "homeassistant.components.onboarding.async_is_onboarded",
+        return_value=False,
+    ) as mock_onboarding:
+        yield mock_onboarding
+
+
+@pytest.fixture
 def device_fixture() -> TechnoVEStation:
     """Return the device fixture for a specific device."""
     return TechnoVEStation(load_json_object_fixture("station_charging.json", DOMAIN))

--- a/tests/components/technove/test_config_flow.py
+++ b/tests/components/technove/test_config_flow.py
@@ -240,11 +240,13 @@ async def test_zeroconf_without_mac_station_exists_abort(
     assert result.get("reason") == "already_configured"
 
 
+@pytest.mark.usefixtures("mock_technove")
 async def test_zeroconf_with_mac_station_exists_abort(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_technove: MagicMock
 ) -> None:
     """Test we abort zeroconf flow if TechnoVE station already configured."""
     mock_config_entry.add_to_hass(hass)
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
@@ -259,5 +261,6 @@ async def test_zeroconf_with_mac_station_exists_abort(
         ),
     )
 
+    mock_technove.update.assert_not_called()
     assert result.get("type") == FlowResultType.ABORT
     assert result.get("reason") == "already_configured"

--- a/tests/components/technove/test_config_flow.py
+++ b/tests/components/technove/test_config_flow.py
@@ -1,13 +1,15 @@
 """Tests for the TechnoVE config flow."""
 
-from unittest.mock import MagicMock
+from ipaddress import ip_address
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from technove import TechnoVEConnectionError
 
+from homeassistant.components import zeroconf
 from homeassistant.components.technove.const import DOMAIN
-from homeassistant.config_entries import SOURCE_USER
-from homeassistant.const import CONF_HOST
+from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
+from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -102,3 +104,160 @@ async def test_full_user_flow_with_error(
     assert result["data"][CONF_HOST] == "192.168.1.123"
     assert "result" in result
     assert result["result"].unique_id == "AA:AA:AA:AA:AA:BB"
+
+
+@pytest.mark.usefixtures("mock_setup_entry", "mock_technove")
+async def test_full_zeroconf_flow_implementation(hass: HomeAssistant) -> None:
+    """Test the full manual user flow from start to finish."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=zeroconf.ZeroconfServiceInfo(
+            ip_address=ip_address("192.168.1.123"),
+            ip_addresses=[ip_address("192.168.1.123")],
+            hostname="example.local.",
+            name="mock_name",
+            port=None,
+            properties={CONF_MAC: "AA:AA:AA:AA:AA:BB"},
+            type="mock_type",
+        ),
+    )
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+
+    assert result.get("description_placeholders") == {CONF_NAME: "TechnoVE Station"}
+    assert result.get("step_id") == "zeroconf_confirm"
+    assert result.get("type") == FlowResultType.FORM
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    assert result2.get("title") == "TechnoVE Station"
+    assert result2.get("type") == FlowResultType.CREATE_ENTRY
+
+    assert "data" in result2
+    assert result2["data"][CONF_HOST] == "192.168.1.123"
+    assert "result" in result2
+    assert result2["result"].unique_id == "AA:AA:AA:AA:AA:BB"
+
+
+@pytest.mark.usefixtures("mock_technove")
+async def test_zeroconf_during_onboarding(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_onboarding: MagicMock,
+) -> None:
+    """Test we create a config entry when discovered during onboarding."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=zeroconf.ZeroconfServiceInfo(
+            ip_address=ip_address("192.168.1.123"),
+            ip_addresses=[ip_address("192.168.1.123")],
+            hostname="example.local.",
+            name="mock_name",
+            port=None,
+            properties={CONF_MAC: "AA:AA:AA:AA:AA:BB"},
+            type="mock_type",
+        ),
+    )
+
+    assert result.get("title") == "TechnoVE Station"
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+
+    assert result.get("data") == {CONF_HOST: "192.168.1.123"}
+    assert "result" in result
+    assert result["result"].unique_id == "AA:AA:AA:AA:AA:BB"
+
+    assert len(mock_setup_entry.mock_calls) == 1
+    assert len(mock_onboarding.mock_calls) == 1
+
+
+async def test_zeroconf_connection_error(
+    hass: HomeAssistant, mock_technove: MagicMock
+) -> None:
+    """Test we abort zeroconf flow on TechnoVE connection error."""
+    mock_technove.update.side_effect = TechnoVEConnectionError
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=zeroconf.ZeroconfServiceInfo(
+            ip_address=ip_address("192.168.1.123"),
+            ip_addresses=[ip_address("192.168.1.123")],
+            hostname="example.local.",
+            name="mock_name",
+            port=None,
+            properties={CONF_MAC: "AA:AA:AA:AA:AA:BB"},
+            type="mock_type",
+        ),
+    )
+
+    assert result.get("type") == FlowResultType.ABORT
+    assert result.get("reason") == "cannot_connect"
+
+
+@pytest.mark.usefixtures("mock_technove")
+async def test_user_station_exists_abort(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test we abort zeroconf flow if TechnoVE station already configured."""
+    mock_config_entry.add_to_hass(hass)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={CONF_HOST: "192.168.1.123"},
+    )
+
+    assert result.get("type") == FlowResultType.ABORT
+    assert result.get("reason") == "already_configured"
+
+
+@pytest.mark.usefixtures("mock_technove")
+async def test_zeroconf_without_mac_station_exists_abort(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test we abort zeroconf flow if TechnoVE station already configured."""
+    mock_config_entry.add_to_hass(hass)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=zeroconf.ZeroconfServiceInfo(
+            ip_address=ip_address("192.168.1.123"),
+            ip_addresses=[ip_address("192.168.1.123")],
+            hostname="example.local.",
+            name="mock_name",
+            port=None,
+            properties={},
+            type="mock_type",
+        ),
+    )
+
+    assert result.get("type") == FlowResultType.ABORT
+    assert result.get("reason") == "already_configured"
+
+
+async def test_zeroconf_with_mac_station_exists_abort(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test we abort zeroconf flow if TechnoVE station already configured."""
+    mock_config_entry.add_to_hass(hass)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=zeroconf.ZeroconfServiceInfo(
+            ip_address=ip_address("192.168.1.123"),
+            ip_addresses=[ip_address("192.168.1.123")],
+            hostname="example.local.",
+            name="mock_name",
+            port=None,
+            properties={CONF_MAC: "AA:AA:AA:AA:AA:BB"},
+            type="mock_type",
+        ),
+    )
+
+    assert result.get("type") == FlowResultType.ABORT
+    assert result.get("reason") == "already_configured"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds zeroconf feature to the TechnoVE integration. The smart charging station usually has mDNS enabled that allows it to be discovered on the network.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30924

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
