### PR TITLE
Fix Local Calendar changing user-specified capitalisation of calendar names

### DIFF
--- a/homeassistant/components/local_calendar/calendar.py
+++ b/homeassistant/components/local_calendar/calendar.py
@@ -73,7 +73,7 @@ class LocalCalendarEntity(CalendarEntity):
         self._store = store
         self._calendar = calendar
         self._event: CalendarEvent | None = None
-        self._attr_name = name.capitalize()
+        self._attr_name = name
         self._attr_unique_id = unique_id
 
     @property

--- a/tests/components/local_calendar/conftest.py
+++ b/tests/components/local_calendar/conftest.py
@@ -19,7 +19,7 @@ from tests.common import MockConfigEntry
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 CALENDAR_NAME = "Light Schedule"
-FRIENDLY_NAME = "Light schedule"
+FRIENDLY_NAME = "Light Schedule"
 STORAGE_KEY = "light_schedule"
 TEST_ENTITY = "calendar.light_schedule"
 


### PR DESCRIPTION
## Proposed change
When you create a Local Calendar, say, "Home Maintenance", the integration overrides this on the Calendar entity to instead be "Home maintenance" but leaves the config entry as "Home Maintenance". This change makes the two consistently named.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.