### PR TITLE
Add cover icon translations

### DIFF
--- a/homeassistant/components/cover/icons.json
+++ b/homeassistant/components/cover/icons.json
@@ -1,0 +1,96 @@
+{
+  "entity_component": {
+    "_": {
+      "default": "mdi:window-open",
+      "states": {
+        "closed": "mdi:window-closed",
+        "closing": "mdi:arrow-down-box",
+        "opening": "mdi:arrow-up-box"
+      }
+    },
+    "blind": {
+      "default": "mdi:blinds-horizontal",
+      "states": {
+        "closed": "mdi:blinds-horizontal-closed",
+        "closing": "mdi:arrow-down-box",
+        "opening": "mdi:arrow-up-box"
+      }
+    },
+    "curtain": {
+      "default": "mdi:curtains",
+      "states": {
+        "closed": "mdi:curtains-closed",
+        "closing": "mdi:arrow-collapse-horizontal",
+        "opening": "mdi:arrow-split-vertical"
+      }
+    },
+    "damper": {
+      "default": "mdi:circle",
+      "states": {
+        "closed": "mdi:circle-slice-8",
+        "closing": "mdi:circle",
+        "opening": "mdi:circle"
+      }
+    },
+    "door": {
+      "default": "mdi:door-open",
+      "states": {
+        "closed": "mdi:door-closed",
+        "closing": "mdi:door-open",
+        "opening": "mdi:door-open"
+      }
+    },
+    "garage": {
+      "default": "mdi:garage-open",
+      "states": {
+        "closed": "mdi:garage",
+        "closing": "mdi:arrow-down-box",
+        "opening": "mdi:arrow-up-box"
+      }
+    },
+    "gate": {
+      "default": "mdi:gate-open",
+      "states": {
+        "closed": "mdi:gate",
+        "closing": "mdi:arrow-right",
+        "opening": "mdi:arrow-right"
+      }
+    },
+    "shade": {
+      "default": "mdi:roller-shade",
+      "states": {
+        "closed": "mdi:roller-shade-closed",
+        "closing": "mdi:arrow-down-box",
+        "opening": "mdi:arrow-up-box"
+      }
+    },
+    "shutter": {
+      "default": "mdi:window-shutter-open",
+      "states": {
+        "closed": "mdi:window-shutter",
+        "closing": "mdi:arrow-down-box",
+        "opening": "mdi:arrow-up-box"
+      }
+    },
+    "window": {
+      "default": "mdi:window-open",
+      "states": {
+        "closed": "mdi:window-closed",
+        "closing": "mdi:arrow-down-box",
+        "opening": "mdi:arrow-up-box"
+      }
+    }
+  },
+  "services": {
+    "close_cover": "mdi:arrow-down-box",
+    "close_cover_tilt": "mdi:arrow-bottom-left",
+    "open_cover": "mdi:arrow-up-box",
+    "open_cover_tilt": "mdi:arrow-top-right",
+    "set_cover_position": "mdi:arrow-down-box",
+    "set_cover_tilt_position": "mdi:arrow-top-right",
+    "stop_cover": "mdi:stop",
+    "stop_cover_tilt": "mdi:stop",
+    "toggle": "mdi:arrow-up-down",
+    "toggle_cover_tilt": "mdi:arrow-top-right-bottom-left"
+  }
+}

--- a/homeassistant/components/cover/icons.json
+++ b/homeassistant/components/cover/icons.json
@@ -2,7 +2,7 @@
   "entity_component": {
     "_": {
       "default": "mdi:window-open",
-      "states": {
+      "state": {
         "closed": "mdi:window-closed",
         "closing": "mdi:arrow-down-box",
         "opening": "mdi:arrow-up-box"
@@ -10,7 +10,7 @@
     },
     "blind": {
       "default": "mdi:blinds-horizontal",
-      "states": {
+      "state": {
         "closed": "mdi:blinds-horizontal-closed",
         "closing": "mdi:arrow-down-box",
         "opening": "mdi:arrow-up-box"
@@ -18,7 +18,7 @@
     },
     "curtain": {
       "default": "mdi:curtains",
-      "states": {
+      "state": {
         "closed": "mdi:curtains-closed",
         "closing": "mdi:arrow-collapse-horizontal",
         "opening": "mdi:arrow-split-vertical"
@@ -26,7 +26,7 @@
     },
     "damper": {
       "default": "mdi:circle",
-      "states": {
+      "state": {
         "closed": "mdi:circle-slice-8",
         "closing": "mdi:circle",
         "opening": "mdi:circle"
@@ -34,7 +34,7 @@
     },
     "door": {
       "default": "mdi:door-open",
-      "states": {
+      "state": {
         "closed": "mdi:door-closed",
         "closing": "mdi:door-open",
         "opening": "mdi:door-open"
@@ -42,7 +42,7 @@
     },
     "garage": {
       "default": "mdi:garage-open",
-      "states": {
+      "state": {
         "closed": "mdi:garage",
         "closing": "mdi:arrow-down-box",
         "opening": "mdi:arrow-up-box"
@@ -50,7 +50,7 @@
     },
     "gate": {
       "default": "mdi:gate-open",
-      "states": {
+      "state": {
         "closed": "mdi:gate",
         "closing": "mdi:arrow-right",
         "opening": "mdi:arrow-right"
@@ -58,7 +58,7 @@
     },
     "shade": {
       "default": "mdi:roller-shade",
-      "states": {
+      "state": {
         "closed": "mdi:roller-shade-closed",
         "closing": "mdi:arrow-down-box",
         "opening": "mdi:arrow-up-box"
@@ -66,7 +66,7 @@
     },
     "shutter": {
       "default": "mdi:window-shutter-open",
-      "states": {
+      "state": {
         "closed": "mdi:window-shutter",
         "closing": "mdi:arrow-down-box",
         "opening": "mdi:arrow-up-box"
@@ -74,7 +74,7 @@
     },
     "window": {
       "default": "mdi:window-open",
-      "states": {
+      "state": {
         "closed": "mdi:window-closed",
         "closing": "mdi:arrow-down-box",
         "opening": "mdi:arrow-up-box"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds icon translations for the cover entity component.

Sourced from:
- https://github.com/home-assistant/frontend/blob/dcb3accdb86f534277c16fd6d1c063f0a79c52dd/src/common/entity/cover_icon.ts#L32-L128
- https://github.com/home-assistant/frontend/blob/dcb3accdb86f534277c16fd6d1c063f0a79c52dd/src/components/ha-cover-tilt-controls.ts#L34-L35
- https://github.com/home-assistant/frontend/blob/dcb3accdb86f534277c16fd6d1c063f0a79c52dd/src/components/ha-cover-tilt-controls.ts#L46-L47
- https://github.com/home-assistant/frontend/blob/dcb3accdb86f534277c16fd6d1c063f0a79c52dd/src/components/ha-cover-tilt-controls.ts#L58-L59

Most notable is the missing `awing` device class in these definitions. I've left it the same as the frontend at this point, as the goals of these PRs is aimed at migrating.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
