### PR TITLE
Reject unifi uptime sensor updates if time delta is small

### DIFF
--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -36,6 +36,7 @@ from homeassistant.const import EntityCategory, UnitOfDataRate, UnitOfPower
 from homeassistant.core import Event as core_Event, HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import StateType
 import homeassistant.util.dt as dt_util
 
 from .const import DEVICE_STATES
@@ -118,7 +119,7 @@ def async_device_uptime_value_fn(
 
 @callback
 def async_device_uptime_value_changed_fn(
-    old: str | int | float | date | Decimal | None, new: datetime | float | str | None
+    old: StateType | date | datetime | Decimal, new: datetime | float | str | None
 ) -> bool:
     """Reject the new uptime value if it's too similar to the old one. Avoids unwanted fluctuation."""
     if isinstance(old, datetime) and isinstance(new, datetime):
@@ -180,7 +181,7 @@ class UnifiSensorEntityDescription(
     is_connected_fn: Callable[[UniFiController, str], bool] | None = None
     # Custom function to determine whether a state change should be recorded
     value_changed_fn: Callable[
-        [str | int | float | date | Decimal | None, datetime | float | str | None],
+        [StateType | date | datetime | Decimal, datetime | float | str | None],
         bool,
     ] = lambda old, new: old != new
 

--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -112,8 +112,11 @@ def async_wlan_client_value_fn(controller: UniFiController, wlan: Wlan) -> int:
 @callback
 def async_device_uptime_value_fn(
     controller: UniFiController, device: Device
-) -> datetime:
+) -> datetime | None:
     """Calculate the approximate time the device started (based on uptime returned from API, in seconds)."""
+    if device.uptime <= 0:
+        # Library defaults to 0 if uptime is not provided, e.g. when offline
+        return None
     return (dt_util.now() - timedelta(seconds=device.uptime)).replace(microsecond=0)
 
 

--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -113,9 +113,7 @@ def async_device_uptime_value_fn(
     controller: UniFiController, device: Device
 ) -> datetime:
     """Calculate the approximate time the device started (based on uptime returned from API, in seconds)."""
-    return (dt_util.now() - timedelta(seconds=device.uptime)).replace(
-        second=0, microsecond=0
-    )
+    return (dt_util.now() - timedelta(seconds=device.uptime)).replace(microsecond=0)
 
 
 @callback
@@ -124,7 +122,7 @@ def async_device_uptime_value_changed_fn(
 ) -> bool:
     """Reject the new uptime value if it's too similar to the old one. Avoids unwanted fluctuation."""
     if isinstance(old, datetime) and isinstance(new, datetime):
-        return new != old and abs((new - old).total_seconds()) > 60
+        return new != old and abs((new - old).total_seconds()) > 120
     return old is None or (new != old)
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change causes device uptime sensors in the `unifi` integration to reject newly-computed values if they are too similar to the previous state.

This is to mitigate a long-standing bug which leads to the sensor value (a timestamp) intermittently shifting forward or backward by a minute (or so) every few seconds, filling the recorder with noise unless the user disables these entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #101690
- This PR is related to issue: n/a
- Link to documentation pull request: n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
