### PR TITLE
Add media player icon translations

### DIFF
--- a/homeassistant/components/media_player/icons.json
+++ b/homeassistant/components/media_player/icons.json
@@ -1,0 +1,58 @@
+{
+  "entity_component": {
+    "_": {
+      "default": "mdi:cast",
+      "state": {
+        "off": "mdi:cast",
+        "paused": "mdi:cast-connected",
+        "playing": "mdi:cast-connected"
+      }
+    },
+    "receiver": {
+      "default": "mdi:audio-video",
+      "state": {
+        "off": "mdi:audio-video-off"
+      }
+    },
+    "speaker": {
+      "default": "mdi:speaker",
+      "state": {
+        "off": "mdi:speaker-off",
+        "paused": "mdi:speaker-pause",
+        "playing": "mdi:speaker-play"
+      }
+    },
+    "tv": {
+      "default": "mdi:television",
+      "state": {
+        "off": "mdi:television-off",
+        "paused": "mdi:television-pause",
+        "playing": "mdi:television-play"
+      }
+    }
+  },
+  "services": {
+    "clear_playlist": "mdi:playlist-remove",
+    "join": "mdi:group",
+    "media_next_track": "mdi:skip-next",
+    "media_pause": "mdi:pause",
+    "media_play": "mdi:play",
+    "media_play_pause": "mdi:play-pause",
+    "media_previous_track": "mdi:skip-previous",
+    "media_seek": "mdi:fast-forward",
+    "media_stop": "mdi:stop",
+    "play_media": "mdi:play",
+    "repeat_set": "mdi:repeat",
+    "select_sound_mode": "mdi:surround-sound",
+    "select_source": "mdi:import",
+    "shuffle_set": "mdi:shuffle",
+    "toggle": "mdi:play-pause",
+    "turn_off": "mdi:power",
+    "turn_on": "mdi:power",
+    "unjoin": "mdi:ungroup",
+    "volume_down": "mdi:volume-minus",
+    "volume_mute": "mdi:volume-mute",
+    "volume_set": "mdi:volume",
+    "volume_up": "mdi:volume-plus"
+  }
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds icon translations for the media player entity component

Ref: https://github.com/home-assistant/frontend/blob/77dd2a87d962b257e34c79f7c9968bddab9c418c/src/common/entity/domain_icon.ts#L185-L226

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
