### PR TITLE
Workaround for Met Eireann current weather conditions

### DIFF
--- a/homeassistant/components/met_eireann/__init__.py
+++ b/homeassistant/components/met_eireann/__init__.py
@@ -84,8 +84,12 @@ class MetEireannWeatherData:
     async def fetch_data(self) -> Self:
         """Fetch data from API - (current weather and forecast)."""
         await self._weather_data.fetching_data()
-        self.current_weather_data = self._weather_data.get_current_weather()
         time_zone = dt_util.DEFAULT_TIME_ZONE
+
+        # Workaround for https://github.com/home-assistant/core/issues/101653:
+        # Use get_forecast()[0] instead of get_current_weather()
+        self.current_weather_data = self._weather_data.get_forecast(time_zone, True)[0]
+
         self.daily_forecast = self._weather_data.get_forecast(time_zone, False)
         self.hourly_forecast = self._weather_data.get_forecast(time_zone, True)
         return self

--- a/tests/components/met_eireann/test_weather.py
+++ b/tests/components/met_eireann/test_weather.py
@@ -64,13 +64,13 @@ async def test_weather(hass: HomeAssistant, mock_weather) -> None:
     """Test weather entity."""
     await setup_config_entry(hass)
     assert len(hass.states.async_entity_ids("weather")) == 1
-    assert len(mock_weather.mock_calls) == 4
+    assert len(mock_weather.mock_calls) == 2
 
     # Test we do not track config
     await hass.config.async_update(latitude=10, longitude=20)
     await hass.async_block_till_done()
 
-    assert len(mock_weather.mock_calls) == 4
+    assert len(mock_weather.mock_calls) == 2
 
     entry = hass.config_entries.async_entries()[0]
     await hass.config_entries.async_remove(entry.entry_id)


### PR DESCRIPTION
## Proposed change

Workaround for https://github.com/home-assistant/core/issues/101653. Use the first hour's worth of forecast to get a reasonably-accurate "current conditions" value. Without this change, instead of "current conditions", the values returned are "aggregate for rest of the day", e.g. maximal hourly temperature (rather than current).


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #101653

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works. - *should not be necessary*

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
