### PR TITLE
Add icon translations to Plugwise

### DIFF
--- a/homeassistant/components/plugwise/binary_sensor.py
+++ b/homeassistant/components/plugwise/binary_sensor.py
@@ -28,64 +28,48 @@ class PlugwiseBinarySensorEntityDescription(BinarySensorEntityDescription):
     """Describes a Plugwise binary sensor entity."""
 
     key: BinarySensorType
-    icon_off: str | None = None
 
 
 BINARY_SENSORS: tuple[PlugwiseBinarySensorEntityDescription, ...] = (
     PlugwiseBinarySensorEntityDescription(
         key="compressor_state",
         translation_key="compressor_state",
-        icon="mdi:hvac",
-        icon_off="mdi:hvac-off",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     PlugwiseBinarySensorEntityDescription(
         key="cooling_enabled",
         translation_key="cooling_enabled",
-        icon="mdi:snowflake-thermometer",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     PlugwiseBinarySensorEntityDescription(
         key="dhw_state",
         translation_key="dhw_state",
-        icon="mdi:water-pump",
-        icon_off="mdi:water-pump-off",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     PlugwiseBinarySensorEntityDescription(
         key="flame_state",
         translation_key="flame_state",
         name="Flame state",
-        icon="mdi:fire",
-        icon_off="mdi:fire-off",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     PlugwiseBinarySensorEntityDescription(
         key="heating_state",
         translation_key="heating_state",
-        icon="mdi:radiator",
-        icon_off="mdi:radiator-off",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     PlugwiseBinarySensorEntityDescription(
         key="cooling_state",
         translation_key="cooling_state",
-        icon="mdi:snowflake",
-        icon_off="mdi:snowflake-off",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     PlugwiseBinarySensorEntityDescription(
         key="slave_boiler_state",
         translation_key="slave_boiler_state",
-        icon="mdi:fire",
-        icon_off="mdi:circle-off-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     PlugwiseBinarySensorEntityDescription(
         key="plugwise_notification",
         translation_key="plugwise_notification",
-        icon="mdi:mailbox-up-outline",
-        icon_off="mdi:mailbox-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )
@@ -139,13 +123,6 @@ class PlugwiseBinarySensorEntity(PlugwiseEntity, BinarySensorEntity):
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
         return self.device["binary_sensors"][self.entity_description.key]
-
-    @property
-    def icon(self) -> str | None:
-        """Return the icon to use in the frontend, if any."""
-        if (icon_off := self.entity_description.icon_off) and self.is_on is False:
-            return icon_off
-        return self.entity_description.icon
 
     @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:

--- a/homeassistant/components/plugwise/icons.json
+++ b/homeassistant/components/plugwise/icons.json
@@ -1,0 +1,102 @@
+{
+  "entity": {
+    "binary_sensor": {
+      "compressor_state": {
+        "default": "mdi:hvac",
+        "state": {
+          "off": "mdi:hvac-off"
+        }
+      },
+      "cooling_enabled": {
+        "default": "mdi:snowflake-thermometer"
+      },
+      "cooling_state": {
+        "default": "mdi:snowflake",
+        "state": {
+          "off": "mdi:snowflake-off"
+        }
+      },
+      "dhw_state": {
+        "default": "mdi:water-pump",
+        "state": {
+          "off": "mdi:water-pump-off"
+        }
+      },
+      "flame_state": {
+        "default": "mdi:fire",
+        "state": {
+          "off": "mdi:fire-off"
+        }
+      },
+      "heating_state": {
+        "default": "mdi:radiator",
+        "state": {
+          "off": "mdi:radiator-off"
+        }
+      },
+      "plugwise_notification": {
+        "default": "mdi:mailbox-up-outline",
+        "state": {
+          "off": "mdi:mailbox-outline"
+        }
+      },
+      "slave_boiler_state": {
+        "default": "mdi:fire",
+        "state": {
+          "off": "mdi:circle-off-outline"
+        }
+      }
+    },
+    "climate": {
+      "plugwise": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "asleep": "mdi:weather-night",
+              "away": "mdi:account-arrow-right",
+              "home": "mdi:home",
+              "no_frost": "mdi:snowflake-melt",
+              "vacation": "mdi:beach"
+            }
+          }
+        }
+      }
+    },
+    "select": {
+      "dhw_mode": {
+        "default": "mdi:shower"
+      },
+      "gateway_mode": {
+        "default": "mdi:cog-outline"
+      },
+      "regulation_mode": {
+        "default": "mdi:hvac"
+      },
+      "select_schedule": {
+        "default": "mdi:calendar-clock"
+      }
+    },
+    "sensor": {
+      "gas_consumed_interval": {
+        "default": "mdi:meter-gas"
+      },
+      "modulation_level": {
+        "default": "mdi:percent"
+      },
+      "valve_position": {
+        "default": "mdi:valve"
+      }
+    },
+    "switch": {
+      "cooling_ena_switch": {
+        "default": "mdi:snowflake-thermometer"
+      },
+      "dhw_cm_switch": {
+        "default": "mdi:water-plus"
+      },
+      "lock": {
+        "default": "mdi:lock"
+      }
+    }
+  }
+}

--- a/homeassistant/components/plugwise/select.py
+++ b/homeassistant/components/plugwise/select.py
@@ -30,14 +30,12 @@ SELECT_TYPES = (
     PlugwiseSelectEntityDescription(
         key="select_schedule",
         translation_key="select_schedule",
-        icon="mdi:calendar-clock",
         command=lambda api, loc, opt: api.set_schedule_state(loc, STATE_ON, opt),
         options_key="available_schedules",
     ),
     PlugwiseSelectEntityDescription(
         key="select_regulation_mode",
         translation_key="regulation_mode",
-        icon="mdi:hvac",
         entity_category=EntityCategory.CONFIG,
         command=lambda api, loc, opt: api.set_regulation_mode(opt),
         options_key="regulation_modes",
@@ -45,7 +43,6 @@ SELECT_TYPES = (
     PlugwiseSelectEntityDescription(
         key="select_dhw_mode",
         translation_key="dhw_mode",
-        icon="mdi:shower",
         entity_category=EntityCategory.CONFIG,
         command=lambda api, loc, opt: api.set_dhw_mode(opt),
         options_key="dhw_modes",
@@ -53,7 +50,6 @@ SELECT_TYPES = (
     PlugwiseSelectEntityDescription(
         key="select_gateway_mode",
         translation_key="gateway_mode",
-        icon="mdi:cog-outline",
         entity_category=EntityCategory.CONFIG,
         command=lambda api, loc, opt: api.set_gateway_mode(opt),
         options_key="gateway_modes",

--- a/homeassistant/components/plugwise/sensor.py
+++ b/homeassistant/components/plugwise/sensor.py
@@ -315,7 +315,6 @@ SENSORS: tuple[PlugwiseSensorEntityDescription, ...] = (
     PlugwiseSensorEntityDescription(
         key="gas_consumed_interval",
         translation_key="gas_consumed_interval",
-        icon="mdi:meter-gas",
         native_unit_of_measurement=UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         state_class=SensorStateClass.MEASUREMENT,
     ),
@@ -357,7 +356,6 @@ SENSORS: tuple[PlugwiseSensorEntityDescription, ...] = (
     PlugwiseSensorEntityDescription(
         key="modulation_level",
         translation_key="modulation_level",
-        icon="mdi:percent",
         native_unit_of_measurement=PERCENTAGE,
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
@@ -365,7 +363,6 @@ SENSORS: tuple[PlugwiseSensorEntityDescription, ...] = (
     PlugwiseSensorEntityDescription(
         key="valve_position",
         translation_key="valve_position",
-        icon="mdi:valve",
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,

--- a/homeassistant/components/plugwise/switch.py
+++ b/homeassistant/components/plugwise/switch.py
@@ -33,13 +33,11 @@ SWITCHES: tuple[PlugwiseSwitchEntityDescription, ...] = (
     PlugwiseSwitchEntityDescription(
         key="dhw_cm_switch",
         translation_key="dhw_cm_switch",
-        icon="mdi:water-plus",
         entity_category=EntityCategory.CONFIG,
     ),
     PlugwiseSwitchEntityDescription(
         key="lock",
         translation_key="lock",
-        icon="mdi:lock",
         entity_category=EntityCategory.CONFIG,
     ),
     PlugwiseSwitchEntityDescription(
@@ -51,7 +49,6 @@ SWITCHES: tuple[PlugwiseSwitchEntityDescription, ...] = (
         key="cooling_ena_switch",
         translation_key="cooling_ena_switch",
         name="Cooling",
-        icon="mdi:snowflake-thermometer",
         entity_category=EntityCategory.CONFIG,
     ),
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds icon translations to the Plugwise integrations. Moving out icons from the code/state machine and removing on/off icon logic.

![CleanShot 2024-01-20 at 15 09 37@2x](https://github.com/home-assistant/core/assets/195327/cc5c8b35-55e0-4dd4-a755-2914fc86ddf3)

Everything remains the same. What is new is that we are now able to provide icons for attributes, in this case: Presets.

![image](https://github.com/home-assistant/core/assets/195327/b569eb56-66e8-4687-96ba-859770dc62cb)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
