### PR TITLE
Add icon translations to HomeWizard Energy

### DIFF
--- a/homeassistant/components/homewizard/icons.json
+++ b/homeassistant/components/homewizard/icons.json
@@ -1,0 +1,76 @@
+{
+  "entity": {
+    "number": {
+      "status_light_brightness": {
+        "default": "mdi:lightbulb-on"
+      }
+    },
+    "sensor": {
+      "active_liter_lpm": {
+        "default": "mdi:water"
+      },
+      "active_tariff": {
+        "default": "mdi:calendar-clock"
+      },
+      "any_power_fail_count": {
+        "default": "mdi:transmission-tower-off"
+      },
+      "dsmr_version": {
+        "default": "mdi:counter"
+      },
+      "gas_unique_id": {
+        "default": "mdi:alphabetical-variant"
+      },
+      "long_power_fail_count": {
+        "default": "mdi:transmission-tower-off"
+      },
+      "meter_model": {
+        "default": "mdi:gauge"
+      },
+      "total_liter_m3": {
+        "default": "mdi:gauge"
+      },
+      "unique_meter_id": {
+        "default": "mdi:alphabetical-variant"
+      },
+      "voltage_sag_l1_count": {
+        "default": "mdi:alert"
+      },
+      "voltage_sag_l2_count": {
+        "default": "mdi:alert"
+      },
+      "voltage_sag_l3_count": {
+        "default": "mdi:alert"
+      },
+      "voltage_swell_l1_count": {
+        "default": "mdi:alert"
+      },
+      "voltage_swell_l2_count": {
+        "default": "mdi:alert"
+      },
+      "voltage_swell_l3_count": {
+        "default": "mdi:alert"
+      },
+      "wifi_ssid": {
+        "default": "mdi:wifi"
+      },
+      "wifi_strength": {
+        "default": "mdi:wifi"
+      }
+    },
+    "switch": {
+      "cloud_connection": {
+        "default": "mdi:cloud",
+        "state": {
+          "off": "mdi:cloud-off-outline"
+        }
+      },
+      "switch_lock": {
+        "default": "mdi:lock",
+        "state": {
+          "off": "mdi:lock-open"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/homewizard/number.py
+++ b/homeassistant/components/homewizard/number.py
@@ -29,7 +29,6 @@ class HWEnergyNumberEntity(HomeWizardEntity, NumberEntity):
     """Representation of status light number."""
 
     _attr_entity_category = EntityCategory.CONFIG
-    _attr_icon = "mdi:lightbulb-on"
     _attr_translation_key = "status_light_brightness"
     _attr_native_unit_of_measurement = PERCENTAGE
 

--- a/homeassistant/components/homewizard/sensor.py
+++ b/homeassistant/components/homewizard/sensor.py
@@ -48,7 +48,6 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
     HomeWizardSensorEntityDescription(
         key="smr_version",
         translation_key="dsmr_version",
-        icon="mdi:counter",
         entity_category=EntityCategory.DIAGNOSTIC,
         has_fn=lambda data: data.smr_version is not None,
         value_fn=lambda data: data.smr_version,
@@ -56,7 +55,6 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
     HomeWizardSensorEntityDescription(
         key="meter_model",
         translation_key="meter_model",
-        icon="mdi:gauge",
         entity_category=EntityCategory.DIAGNOSTIC,
         has_fn=lambda data: data.meter_model is not None,
         value_fn=lambda data: data.meter_model,
@@ -64,7 +62,6 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
     HomeWizardSensorEntityDescription(
         key="unique_meter_id",
         translation_key="unique_meter_id",
-        icon="mdi:alphabetical-variant",
         entity_category=EntityCategory.DIAGNOSTIC,
         has_fn=lambda data: data.unique_meter_id is not None,
         value_fn=lambda data: data.unique_meter_id,
@@ -72,7 +69,6 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
     HomeWizardSensorEntityDescription(
         key="wifi_ssid",
         translation_key="wifi_ssid",
-        icon="mdi:wifi",
         entity_category=EntityCategory.DIAGNOSTIC,
         has_fn=lambda data: data.wifi_ssid is not None,
         value_fn=lambda data: data.wifi_ssid,
@@ -80,7 +76,6 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
     HomeWizardSensorEntityDescription(
         key="active_tariff",
         translation_key="active_tariff",
-        icon="mdi:calendar-clock",
         has_fn=lambda data: data.active_tariff is not None,
         value_fn=lambda data: (
             None if data.active_tariff is None else str(data.active_tariff)
@@ -91,7 +86,6 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
     HomeWizardSensorEntityDescription(
         key="wifi_strength",
         translation_key="wifi_strength",
-        icon="mdi:wifi",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -315,7 +309,6 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
     HomeWizardSensorEntityDescription(
         key="voltage_sag_l1_count",
         translation_key="voltage_sag_l1_count",
-        icon="mdi:alert",
         entity_category=EntityCategory.DIAGNOSTIC,
         has_fn=lambda data: data.voltage_sag_l1_count is not None,
         value_fn=lambda data: data.voltage_sag_l1_count,
@@ -323,7 +316,6 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
     HomeWizardSensorEntityDescription(
         key="voltage_sag_l2_count",
         translation_key="voltage_sag_l2_count",
-        icon="mdi:alert",
         entity_category=EntityCategory.DIAGNOSTIC,
         has_fn=lambda data: data.voltage_sag_l2_count is not None,
         value_fn=lambda data: data.voltage_sag_l2_count,
@@ -331,7 +323,6 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
     HomeWizardSensorEntityDescription(
         key="voltage_sag_l3_count",
         translation_key="voltage_sag_l3_count",
-        icon="mdi:alert",
         entity_category=EntityCategory.DIAGNOSTIC,
         has_fn=lambda data: data.voltage_sag_l3_count is not None,
         value_fn=lambda data: data.voltage_sag_l3_count,
@@ -339,7 +330,6 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
     HomeWizardSensorEntityDescription(
         key="voltage_swell_l1_count",
         translation_key="voltage_swell_l1_count",
-        icon="mdi:alert",
         entity_category=EntityCategory.DIAGNOSTIC,
         has_fn=lambda data: data.voltage_swell_l1_count is not None,
         value_fn=lambda data: data.voltage_swell_l1_count,
@@ -347,7 +337,6 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
     HomeWizardSensorEntityDescription(
         key="voltage_swell_l2_count",
         translation_key="voltage_swell_l2_count",
-        icon="mdi:alert",
         entity_category=EntityCategory.DIAGNOSTIC,
         has_fn=lambda data: data.voltage_swell_l2_count is not None,
         value_fn=lambda data: data.voltage_swell_l2_count,
@@ -355,7 +344,6 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
     HomeWizardSensorEntityDescription(
         key="voltage_swell_l3_count",
         translation_key="voltage_swell_l3_count",
-        icon="mdi:alert",
         entity_category=EntityCategory.DIAGNOSTIC,
         has_fn=lambda data: data.voltage_swell_l3_count is not None,
         value_fn=lambda data: data.voltage_swell_l3_count,
@@ -363,7 +351,6 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
     HomeWizardSensorEntityDescription(
         key="any_power_fail_count",
         translation_key="any_power_fail_count",
-        icon="mdi:transmission-tower-off",
         entity_category=EntityCategory.DIAGNOSTIC,
         has_fn=lambda data: data.any_power_fail_count is not None,
         value_fn=lambda data: data.any_power_fail_count,
@@ -371,7 +358,6 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
     HomeWizardSensorEntityDescription(
         key="long_power_fail_count",
         translation_key="long_power_fail_count",
-        icon="mdi:transmission-tower-off",
         entity_category=EntityCategory.DIAGNOSTIC,
         has_fn=lambda data: data.long_power_fail_count is not None,
         value_fn=lambda data: data.long_power_fail_count,
@@ -404,7 +390,6 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
     HomeWizardSensorEntityDescription(
         key="gas_unique_id",
         translation_key="gas_unique_id",
-        icon="mdi:alphabetical-variant",
         entity_category=EntityCategory.DIAGNOSTIC,
         has_fn=lambda data: data.gas_unique_id is not None,
         value_fn=lambda data: data.gas_unique_id,
@@ -413,7 +398,6 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         key="active_liter_lpm",
         translation_key="active_liter_lpm",
         native_unit_of_measurement="l/min",
-        icon="mdi:water",
         state_class=SensorStateClass.MEASUREMENT,
         has_fn=lambda data: data.active_liter_lpm is not None,
         value_fn=lambda data: data.active_liter_lpm,
@@ -422,7 +406,6 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         key="total_liter_m3",
         translation_key="total_liter_m3",
         native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
-        icon="mdi:gauge",
         device_class=SensorDeviceClass.WATER,
         state_class=SensorStateClass.TOTAL_INCREASING,
         has_fn=lambda data: data.total_liter_m3 is not None,

--- a/homeassistant/components/homewizard/switch.py
+++ b/homeassistant/components/homewizard/switch.py
@@ -29,7 +29,6 @@ class HomeWizardSwitchEntityDescription(SwitchEntityDescription):
 
     available_fn: Callable[[DeviceResponseEntry], bool]
     create_fn: Callable[[HWEnergyDeviceUpdateCoordinator], bool]
-    icon_off: str | None = None
     is_on_fn: Callable[[DeviceResponseEntry], bool | None]
     set_fn: Callable[[HomeWizardEnergy, bool], Awaitable[Any]]
 
@@ -48,8 +47,6 @@ SWITCHES = [
         key="switch_lock",
         translation_key="switch_lock",
         entity_category=EntityCategory.CONFIG,
-        icon="mdi:lock",
-        icon_off="mdi:lock-open",
         create_fn=lambda coordinator: coordinator.supports_state(),
         available_fn=lambda data: data.state is not None,
         is_on_fn=lambda data: data.state.switch_lock if data.state else None,
@@ -59,8 +56,6 @@ SWITCHES = [
         key="cloud_connection",
         translation_key="cloud_connection",
         entity_category=EntityCategory.CONFIG,
-        icon="mdi:cloud",
-        icon_off="mdi:cloud-off-outline",
         create_fn=lambda coordinator: coordinator.supports_system(),
         available_fn=lambda data: data.system is not None,
         is_on_fn=lambda data: data.system.cloud_enabled if data.system else None,
@@ -98,13 +93,6 @@ class HomeWizardSwitchEntity(HomeWizardEntity, SwitchEntity):
         super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{description.key}"
-
-    @property
-    def icon(self) -> str | None:
-        """Return the icon."""
-        if self.entity_description.icon_off and self.is_on is False:
-            return self.entity_description.icon_off
-        return super().icon
 
     @property
     def available(self) -> bool:

--- a/tests/components/homewizard/snapshots/test_number.ambr
+++ b/tests/components/homewizard/snapshots/test_number.ambr
@@ -3,7 +3,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Status light brightness',
-      'icon': 'mdi:lightbulb-on',
       'max': 100.0,
       'min': 0.0,
       'mode': <NumberMode.AUTO: 'auto'>,
@@ -43,7 +42,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:lightbulb-on',
+    'original_icon': None,
     'original_name': 'Status light brightness',
     'platform': 'homewizard',
     'previous_unique_id': None,

--- a/tests/components/homewizard/snapshots/test_sensor.ambr
+++ b/tests/components/homewizard/snapshots/test_sensor.ambr
@@ -788,7 +788,7 @@
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
-    'original_icon': 'mdi:calendar-clock',
+    'original_icon': None,
     'original_name': 'Active tariff',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -803,7 +803,6 @@
     'attributes': ReadOnlyDict({
       'device_class': 'enum',
       'friendly_name': 'Device Active tariff',
-      'icon': 'mdi:calendar-clock',
       'options': list([
         '1',
         '2',
@@ -1113,7 +1112,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:water',
+    'original_icon': None,
     'original_name': 'Active water usage',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -1127,7 +1126,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Active water usage',
-      'icon': 'mdi:water',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'l/min',
     }),
@@ -1191,7 +1189,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:counter',
+    'original_icon': None,
     'original_name': 'DSMR version',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -1205,7 +1203,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device DSMR version',
-      'icon': 'mdi:counter',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_dsmr_version',
@@ -1267,7 +1264,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:alphabetical-variant',
+    'original_icon': None,
     'original_name': 'Gas meter identifier',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -1281,7 +1278,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Gas meter identifier',
-      'icon': 'mdi:alphabetical-variant',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_gas_meter_identifier',
@@ -1343,7 +1339,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:transmission-tower-off',
+    'original_icon': None,
     'original_name': 'Long power failures detected',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -1357,7 +1353,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Long power failures detected',
-      'icon': 'mdi:transmission-tower-off',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_long_power_failures_detected',
@@ -1496,7 +1491,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:transmission-tower-off',
+    'original_icon': None,
     'original_name': 'Power failures detected',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -1510,7 +1505,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Power failures detected',
-      'icon': 'mdi:transmission-tower-off',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_power_failures_detected',
@@ -1572,7 +1566,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:alphabetical-variant',
+    'original_icon': None,
     'original_name': 'Smart meter identifier',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -1586,7 +1580,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Smart meter identifier',
-      'icon': 'mdi:alphabetical-variant',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_smart_meter_identifier',
@@ -1648,7 +1641,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:gauge',
+    'original_icon': None,
     'original_name': 'Smart meter model',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -1662,7 +1655,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Smart meter model',
-      'icon': 'mdi:gauge',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_smart_meter_model',
@@ -2606,7 +2598,7 @@
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.WATER: 'water'>,
-    'original_icon': 'mdi:gauge',
+    'original_icon': None,
     'original_name': 'Total water usage',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -2621,7 +2613,6 @@
     'attributes': ReadOnlyDict({
       'device_class': 'water',
       'friendly_name': 'Device Total water usage',
-      'icon': 'mdi:gauge',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfVolume.CUBIC_METERS: 'm³'>,
     }),
@@ -2685,7 +2676,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:alert',
+    'original_icon': None,
     'original_name': 'Voltage sags detected phase 1',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -2699,7 +2690,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Voltage sags detected phase 1',
-      'icon': 'mdi:alert',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_voltage_sags_detected_phase_1',
@@ -2761,7 +2751,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:alert',
+    'original_icon': None,
     'original_name': 'Voltage sags detected phase 2',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -2775,7 +2765,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Voltage sags detected phase 2',
-      'icon': 'mdi:alert',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_voltage_sags_detected_phase_2',
@@ -2837,7 +2826,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:alert',
+    'original_icon': None,
     'original_name': 'Voltage sags detected phase 3',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -2851,7 +2840,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Voltage sags detected phase 3',
-      'icon': 'mdi:alert',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_voltage_sags_detected_phase_3',
@@ -2913,7 +2901,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:alert',
+    'original_icon': None,
     'original_name': 'Voltage swells detected phase 1',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -2927,7 +2915,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Voltage swells detected phase 1',
-      'icon': 'mdi:alert',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_voltage_swells_detected_phase_1',
@@ -2989,7 +2976,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:alert',
+    'original_icon': None,
     'original_name': 'Voltage swells detected phase 2',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -3003,7 +2990,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Voltage swells detected phase 2',
-      'icon': 'mdi:alert',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_voltage_swells_detected_phase_2',
@@ -3065,7 +3051,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:alert',
+    'original_icon': None,
     'original_name': 'Voltage swells detected phase 3',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -3079,7 +3065,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Voltage swells detected phase 3',
-      'icon': 'mdi:alert',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_voltage_swells_detected_phase_3',
@@ -3141,7 +3126,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:wifi',
+    'original_icon': None,
     'original_name': 'Wi-Fi SSID',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -3155,7 +3140,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Wi-Fi SSID',
-      'icon': 'mdi:wifi',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_wi_fi_ssid',
@@ -3219,7 +3203,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:wifi',
+    'original_icon': None,
     'original_name': 'Wi-Fi strength',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -3233,7 +3217,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Wi-Fi strength',
-      'icon': 'mdi:wifi',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
@@ -4268,7 +4251,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:water',
+    'original_icon': None,
     'original_name': 'Active water usage',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -4282,7 +4265,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Active water usage',
-      'icon': 'mdi:water',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'l/min',
     }),
@@ -4346,7 +4328,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:transmission-tower-off',
+    'original_icon': None,
     'original_name': 'Long power failures detected',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -4360,7 +4342,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Long power failures detected',
-      'icon': 'mdi:transmission-tower-off',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_long_power_failures_detected',
@@ -4499,7 +4480,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:transmission-tower-off',
+    'original_icon': None,
     'original_name': 'Power failures detected',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -4513,7 +4494,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Power failures detected',
-      'icon': 'mdi:transmission-tower-off',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_power_failures_detected',
@@ -5457,7 +5437,7 @@
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.WATER: 'water'>,
-    'original_icon': 'mdi:gauge',
+    'original_icon': None,
     'original_name': 'Total water usage',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -5472,7 +5452,6 @@
     'attributes': ReadOnlyDict({
       'device_class': 'water',
       'friendly_name': 'Device Total water usage',
-      'icon': 'mdi:gauge',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfVolume.CUBIC_METERS: 'm³'>,
     }),
@@ -5536,7 +5515,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:alert',
+    'original_icon': None,
     'original_name': 'Voltage sags detected phase 1',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -5550,7 +5529,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Voltage sags detected phase 1',
-      'icon': 'mdi:alert',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_voltage_sags_detected_phase_1',
@@ -5612,7 +5590,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:alert',
+    'original_icon': None,
     'original_name': 'Voltage sags detected phase 2',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -5626,7 +5604,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Voltage sags detected phase 2',
-      'icon': 'mdi:alert',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_voltage_sags_detected_phase_2',
@@ -5688,7 +5665,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:alert',
+    'original_icon': None,
     'original_name': 'Voltage sags detected phase 3',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -5702,7 +5679,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Voltage sags detected phase 3',
-      'icon': 'mdi:alert',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_voltage_sags_detected_phase_3',
@@ -5764,7 +5740,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:alert',
+    'original_icon': None,
     'original_name': 'Voltage swells detected phase 1',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -5778,7 +5754,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Voltage swells detected phase 1',
-      'icon': 'mdi:alert',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_voltage_swells_detected_phase_1',
@@ -5840,7 +5815,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:alert',
+    'original_icon': None,
     'original_name': 'Voltage swells detected phase 2',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -5854,7 +5829,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Voltage swells detected phase 2',
-      'icon': 'mdi:alert',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_voltage_swells_detected_phase_2',
@@ -5916,7 +5890,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:alert',
+    'original_icon': None,
     'original_name': 'Voltage swells detected phase 3',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -5930,7 +5904,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Voltage swells detected phase 3',
-      'icon': 'mdi:alert',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_voltage_swells_detected_phase_3',
@@ -6318,7 +6291,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:wifi',
+    'original_icon': None,
     'original_name': 'Wi-Fi SSID',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -6332,7 +6305,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Wi-Fi SSID',
-      'icon': 'mdi:wifi',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_wi_fi_ssid',
@@ -6396,7 +6368,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:wifi',
+    'original_icon': None,
     'original_name': 'Wi-Fi strength',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -6410,7 +6382,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Wi-Fi strength',
-      'icon': 'mdi:wifi',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
@@ -6476,7 +6447,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:water',
+    'original_icon': None,
     'original_name': 'Active water usage',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -6490,7 +6461,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Active water usage',
-      'icon': 'mdi:water',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'l/min',
     }),
@@ -6556,7 +6526,7 @@
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.WATER: 'water'>,
-    'original_icon': 'mdi:gauge',
+    'original_icon': None,
     'original_name': 'Total water usage',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -6571,7 +6541,6 @@
     'attributes': ReadOnlyDict({
       'device_class': 'water',
       'friendly_name': 'Device Total water usage',
-      'icon': 'mdi:gauge',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfVolume.CUBIC_METERS: 'm³'>,
     }),
@@ -6635,7 +6604,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:wifi',
+    'original_icon': None,
     'original_name': 'Wi-Fi SSID',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -6649,7 +6618,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Wi-Fi SSID',
-      'icon': 'mdi:wifi',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_wi_fi_ssid',
@@ -6713,7 +6681,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:wifi',
+    'original_icon': None,
     'original_name': 'Wi-Fi strength',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -6727,7 +6695,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Wi-Fi strength',
-      'icon': 'mdi:wifi',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
@@ -7117,7 +7084,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:wifi',
+    'original_icon': None,
     'original_name': 'Wi-Fi SSID',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -7131,7 +7098,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Wi-Fi SSID',
-      'icon': 'mdi:wifi',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_wi_fi_ssid',
@@ -7195,7 +7161,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:wifi',
+    'original_icon': None,
     'original_name': 'Wi-Fi strength',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -7209,7 +7175,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Wi-Fi strength',
-      'icon': 'mdi:wifi',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
@@ -7765,7 +7730,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:wifi',
+    'original_icon': None,
     'original_name': 'Wi-Fi SSID',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -7779,7 +7744,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Wi-Fi SSID',
-      'icon': 'mdi:wifi',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.device_wi_fi_ssid',
@@ -7843,7 +7807,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:wifi',
+    'original_icon': None,
     'original_name': 'Wi-Fi strength',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -7857,7 +7821,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Wi-Fi strength',
-      'icon': 'mdi:wifi',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),

--- a/tests/components/homewizard/snapshots/test_switch.ambr
+++ b/tests/components/homewizard/snapshots/test_switch.ambr
@@ -79,7 +79,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Cloud connection',
-      'icon': 'mdi:cloud',
     }),
     'context': <ANY>,
     'entity_id': 'switch.device_cloud_connection',
@@ -109,7 +108,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:cloud',
+    'original_icon': None,
     'original_name': 'Cloud connection',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -155,7 +154,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Switch lock',
-      'icon': 'mdi:lock-open',
     }),
     'context': <ANY>,
     'entity_id': 'switch.device_switch_lock',
@@ -185,7 +183,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:lock-open',
+    'original_icon': None,
     'original_name': 'Switch lock',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -231,7 +229,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Cloud connection',
-      'icon': 'mdi:cloud',
     }),
     'context': <ANY>,
     'entity_id': 'switch.device_cloud_connection',
@@ -261,7 +258,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:cloud',
+    'original_icon': None,
     'original_name': 'Cloud connection',
     'platform': 'homewizard',
     'previous_unique_id': None,
@@ -307,7 +304,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Cloud connection',
-      'icon': 'mdi:cloud',
     }),
     'context': <ANY>,
     'entity_id': 'switch.device_cloud_connection',
@@ -337,7 +333,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:cloud',
+    'original_icon': None,
     'original_name': 'Cloud connection',
     'platform': 'homewizard',
     'previous_unique_id': None,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds icon translations to the HomeWizard Energy integration.

This removes the icons from the state machine, and cleans up logic for on/off icons that is now native functionality.

![CleanShot 2024-01-20 at 16 24 39@2x](https://github.com/home-assistant/core/assets/195327/48071dfe-d30a-4bbc-871a-910e60a11d5a)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
