### PR TITLE
Pin pandas to 2.1.4

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -185,3 +185,6 @@ charset-normalizer==3.2.0
 # dacite: Ensure we have a version that is able to handle type unions for
 # Roborock, NAM, Brother, and GIOS.
 dacite>=1.7.0
+
+# Musle wheels for pandas 2.2.0 cannot be build for any architecture.
+pandas==2.1.4

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -178,6 +178,9 @@ charset-normalizer==3.2.0
 # dacite: Ensure we have a version that is able to handle type unions for
 # Roborock, NAM, Brother, and GIOS.
 dacite>=1.7.0
+
+# Musle wheels for pandas 2.2.0 cannot be build for any architecture.
+pandas==2.1.4
 """
 
 GENERATED_MESSAGE = (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

12 hours ago, pandas 2.2.0 was released, see: <https://github.com/pandas-dev/pandas/releases/tag/v2.2.0>

The wheels for this release, are not buildable for musl against any architecture.

```
      FAILED: pandas/_libs/json.cpython-311-x86_64-linux-musl.so.p/src_vendored_ujson_python_JSONtoObj.c.o
      cc -Ipandas/_libs/json.cpython-311-x86_64-linux-musl.so.p -Ipandas/_libs -I../../pandas/_libs -I../../../../pip-build-env-72d_eq63/overlay/lib/python3.11/site-packages/numpy/core/include -I../../pandas/_libs/include -I/usr/local/include/python3.11 -fvisibility=hidden -fdiagnostics-color=always -DNDEBUG -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=c11 -O3 -DNPY_NO_DEPRECATED_API=0 -DNPY_TARGET_VERSION=NPY_1_21_API_VERSION -fPIC -MD -MQ pandas/_libs/json.cpython-311-x86_64-linux-musl.so.p/src_vendored_ujson_python_JSONtoObj.c.o -MF pandas/_libs/json.cpython-311-x86_64-linux-musl.so.p/src_vendored_ujson_python_JSONtoObj.c.o.d -o pandas/_libs/json.cpython-311-x86_64-linux-musl.so.p/src_vendored_ujson_python_JSONtoObj.c.o -c ../../pandas/_libs/src/vendored/ujson/python/JSONtoObj.c
      In file included from /usr/include/fortify/string.h:26,
                       from ../../pandas/_libs/include/pandas/portable.h:12,
                       from ../../pandas/_libs/include/pandas/vendored/ujson/lib/ultrajson.h:55,
                       from ../../pandas/_libs/src/vendored/ujson/python/JSONtoObj.c:41:
      /usr/include/fortify/stdlib.h:42:1: error: 'realpath' undeclared here (not in a function)
         42 | _FORTIFY_FN(realpath) char *realpath(const char *__p, char *__r)
            | ^~~~~~~~~~~
      In file included from /usr/local/include/python3.11/Python.h:23,
                       from ../../pandas/_libs/src/vendored/ujson/python/JSONtoObj.c:43:
      /usr/include/fortify/stdlib.h: In function 'realpath':
      /usr/include/fortify/stdlib.h:45:2: error: #error PATH_MAX unset. A fortified realpath will not work.
         45 | #error PATH_MAX unset. A fortified realpath will not work.
            |  ^~~~~
      ninja: build stopped: subcommand failed.
      [end of output]
```

![CleanShot 2024-01-20 at 16 47 27@2x](https://github.com/home-assistant/core/assets/195327/ef978945-c73e-4953-b9a4-83863e803dbc)


This PR pins pandas to the last known working version, this is to unblock #108502

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
