### PR TITLE
Fix statuses for ZHA attribute reporting configuration event

### DIFF
--- a/homeassistant/components/zha/core/cluster_handlers/__init__.py
+++ b/homeassistant/components/zha/core/cluster_handlers/__init__.py
@@ -7,7 +7,7 @@ import contextlib
 from enum import Enum
 import functools
 import logging
-from typing import TYPE_CHECKING, Any, ParamSpec, TypedDict
+from typing import TYPE_CHECKING, Any, ParamSpec, TypedDict, cast
 
 import zigpy.exceptions
 import zigpy.util
@@ -275,9 +275,33 @@ class ClusterHandler(LogMixin):
             try:
                 res = await self.cluster.configure_reporting_multiple(reports, **kwargs)
                 self._configure_reporting_status(reports, res[0])
-                # if we get a response, then it's a success
-                for attr_stat in event_data.values():
-                    attr_stat["success"] = True
+                # 2.5.8.1.3 Status Field
+                # The status field specifies the status of the Configure Reporting operation attempted on this attribute, as de- tailed in 2.5.7.3.
+                # Note that attribute status records are not included for successfully configured attributes, in order to save bandwidth.
+                # In the case of successful configuration of all attributes, only a single attribute status record SHALL be included in the command,
+                # with the status field set to SUCCESS and the direction and attribute identifier fields omitted.
+                if len(res) == 1 and res[0].status == Status.SUCCESS:
+                    for attr_id in reports:
+                        attr_name = (
+                            self._get_attribute_name(cast(int, attr_id))
+                            if isinstance(attr_id, int)
+                            else attr_id
+                        )
+                        event_data[attr_name]["success"] = True
+                else:
+                    for response in res:
+                        # we check 3 statuses because we don't want the pairing screen
+                        # or the reconfigure dialog to show failure when attributes aren't
+                        # supported or reportable. We only want to show failure for attributes
+                        # that are supported and reportable but failed to configure.
+                        event_data[self._get_attribute_name(response.attrid)][
+                            "success"
+                        ] = response.status in (
+                            Status.SUCCESS,
+                            Status.UNSUPPORTED_ATTRIBUTE,
+                            Status.UNREPORTABLE_ATTRIBUTE,
+                        )
+
             except (zigpy.exceptions.ZigbeeException, asyncio.TimeoutError) as ex:
                 self.debug(
                     "failed to set reporting on '%s' cluster for: %s",

--- a/homeassistant/components/zha/core/cluster_handlers/__init__.py
+++ b/homeassistant/components/zha/core/cluster_handlers/__init__.py
@@ -326,7 +326,7 @@ class ClusterHandler(LogMixin):
                 res,
             )
             # 2.5.8.1.3 Status Field
-            # The status field specifies the status of the Configure Reporting operation attempted on this attribute, as de- tailed in 2.5.7.3.
+            # The status field specifies the status of the Configure Reporting operation attempted on this attribute, as detailed in 2.5.7.3.
             # Note that attribute status records are not included for successfully configured attributes, in order to save bandwidth.
             # In the case of successful configuration of all attributes, only a single attribute status record SHALL be included in the command,
             # with the status field set to SUCCESS and the direction and attribute identifier fields omitted.

--- a/homeassistant/components/zha/core/cluster_handlers/__init__.py
+++ b/homeassistant/components/zha/core/cluster_handlers/__init__.py
@@ -276,7 +276,7 @@ class ClusterHandler(LogMixin):
                 res = await self.cluster.configure_reporting_multiple(reports, **kwargs)
                 self._configure_reporting_status(reports, res[0])
                 # 2.5.8.1.3 Status Field
-                # The status field specifies the status of the Configure Reporting operation attempted on this attribute, as de- tailed in 2.5.7.3.
+                # The status field specifies the status of the Configure Reporting operation attempted on this attribute, as detailed in 2.5.7.3.
                 # Note that attribute status records are not included for successfully configured attributes, in order to save bandwidth.
                 # In the case of successful configuration of all attributes, only a single attribute status record SHALL be included in the command,
                 # with the status field set to SUCCESS and the direction and attribute identifier fields omitted.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR corrects hard coded success statuses on the events sent to the front end during attribute reporting configuration.

Frontend PR:
https://github.com/home-assistant/frontend/pull/19527

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #104810
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
