### PR TITLE
Make remaining WLED entities translatable

### DIFF
--- a/homeassistant/components/wled/binary_sensor.py
+++ b/homeassistant/components/wled/binary_sensor.py
@@ -34,7 +34,7 @@ class WLEDUpdateBinarySensor(WLEDEntity, BinarySensorEntity):
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_device_class = BinarySensorDeviceClass.UPDATE
-    _attr_name = "Firmware"
+    _attr_translation_key = "firmware"
 
     # Disabled by default, as this entity is deprecated.
     _attr_entity_registry_enabled_default = False

--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -121,7 +121,8 @@ class WLEDSegmentLight(WLEDEntity, LightEntity):
         if segment == 0:
             self._attr_name = None
         else:
-            self._attr_name = f"Segment {segment}"
+            self._attr_translation_key = "segment"
+            self._attr_translation_placeholders = {"segment": str(segment)}
 
         self._attr_unique_id = (
             f"{self.coordinator.data.info.mac_address}_{self._segment}"

--- a/homeassistant/components/wled/number.py
+++ b/homeassistant/components/wled/number.py
@@ -49,7 +49,7 @@ class WLEDNumberEntityDescription(NumberEntityDescription):
 NUMBERS = [
     WLEDNumberEntityDescription(
         key=ATTR_SPEED,
-        name="Speed",
+        translation_key="speed",
         icon="mdi:speedometer",
         entity_category=EntityCategory.CONFIG,
         native_step=1,
@@ -59,7 +59,7 @@ NUMBERS = [
     ),
     WLEDNumberEntityDescription(
         key=ATTR_INTENSITY,
-        name="Intensity",
+        translation_key="intensity",
         entity_category=EntityCategory.CONFIG,
         native_step=1,
         native_min_value=0,
@@ -87,7 +87,8 @@ class WLEDNumber(WLEDEntity, NumberEntity):
         # Segment 0 uses a simpler name, which is more natural for when using
         # a single segment / using WLED with one big LED strip.
         if segment != 0:
-            self._attr_name = f"Segment {segment} {description.name}"
+            self._attr_translation_key = f"segment_{description.translation_key}"
+            self._attr_translation_placeholders = {"segment": str(segment)}
 
         self._attr_unique_id = (
             f"{coordinator.data.info.mac_address}_{description.key}_{segment}"

--- a/homeassistant/components/wled/select.py
+++ b/homeassistant/components/wled/select.py
@@ -139,7 +139,7 @@ class WLEDPaletteSelect(WLEDEntity, SelectEntity):
 
     _attr_entity_category = EntityCategory.CONFIG
     _attr_icon = "mdi:palette-outline"
-    _attr_name = "Color palette"
+    _attr_translation_key = "color_palette"
     _segment: int
 
     def __init__(self, coordinator: WLEDDataUpdateCoordinator, segment: int) -> None:
@@ -149,7 +149,8 @@ class WLEDPaletteSelect(WLEDEntity, SelectEntity):
         # Segment 0 uses a simpler name, which is more natural for when using
         # a single segment / using WLED with one big LED strip.
         if segment != 0:
-            self._attr_name = f"Segment {segment} color palette"
+            self._attr_translation_key = "segment_color_palette"
+            self._attr_translation_placeholders = {"segment": str(segment)}
 
         self._attr_unique_id = f"{coordinator.data.info.mac_address}_palette_{segment}"
         self._attr_options = [

--- a/homeassistant/components/wled/strings.json
+++ b/homeassistant/components/wled/strings.json
@@ -38,9 +38,32 @@
     "light": {
       "main": {
         "name": "Main"
+      },
+      "segment": {
+        "name": "Segment {segment}"
+      }
+    },
+    "number": {
+      "intensity": {
+        "name": "Intensity"
+      },
+      "segment_intensity": {
+        "name": "Segment {segment} intensity"
+      },
+      "speed": {
+        "name": "Speed"
+      },
+      "segment_speed": {
+        "name": "Segment {segment} speed"
       }
     },
     "select": {
+      "color_palette": {
+        "name": "Color palette"
+      },
+      "segment_color_palette": {
+        "name": "Segment {segment} color palette"
+      },
       "live_override": {
         "name": "Live override",
         "state": {
@@ -97,6 +120,17 @@
       },
       "sync_receive": {
         "name": "Sync receive"
+      },
+      "reverse": {
+        "name": "Reverse"
+      },
+      "segment_reverse": {
+        "name": "Segment {segment} reverse"
+      }
+    },
+    "update": {
+      "firmware": {
+        "name": "Firmware"
       }
     }
   },

--- a/homeassistant/components/wled/strings.json
+++ b/homeassistant/components/wled/strings.json
@@ -35,6 +35,11 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "firmware": {
+        "name": "Firmware"
+      }
+    },
     "light": {
       "main": {
         "name": "Main"
@@ -126,11 +131,6 @@
       },
       "segment_reverse": {
         "name": "Segment {segment} reverse"
-      }
-    },
-    "update": {
-      "firmware": {
-        "name": "Firmware"
       }
     }
   },

--- a/homeassistant/components/wled/switch.py
+++ b/homeassistant/components/wled/switch.py
@@ -159,7 +159,7 @@ class WLEDReverseSwitch(WLEDEntity, SwitchEntity):
 
     _attr_icon = "mdi:swap-horizontal-bold"
     _attr_entity_category = EntityCategory.CONFIG
-    _attr_name = "Reverse"
+    _attr_translation_key = "reverse"
     _segment: int
 
     def __init__(self, coordinator: WLEDDataUpdateCoordinator, segment: int) -> None:
@@ -169,7 +169,8 @@ class WLEDReverseSwitch(WLEDEntity, SwitchEntity):
         # Segment 0 uses a simpler name, which is more natural for when using
         # a single segment / using WLED with one big LED strip.
         if segment != 0:
-            self._attr_name = f"Segment {segment} reverse"
+            self._attr_translation_key = "segment_reverse"
+            self._attr_translation_placeholders = {"segment": str(segment)}
 
         self._attr_unique_id = f"{coordinator.data.info.mac_address}_reverse_{segment}"
         self._segment = segment

--- a/tests/components/wled/snapshots/test_binary_sensor.ambr
+++ b/tests/components/wled/snapshots/test_binary_sensor.ambr
@@ -38,7 +38,7 @@
     'platform': 'wled',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'firmware',
     'unique_id': 'aabbccddeeff_update',
     'unit_of_measurement': None,
   })

--- a/tests/components/wled/snapshots/test_number.ambr
+++ b/tests/components/wled/snapshots/test_number.ambr
@@ -2,7 +2,7 @@
 # name: test_numbers[number.wled_rgb_light_segment_1_intensity-42-intensity]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'WLED RGB Light Segment 1 Intensity',
+      'friendly_name': 'WLED RGB Light Segment 1 intensity',
       'max': 255,
       'min': 0,
       'mode': <NumberMode.AUTO: 'auto'>,
@@ -42,11 +42,11 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Segment 1 Intensity',
+    'original_name': 'Segment 1 intensity',
     'platform': 'wled',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'segment_intensity',
     'unique_id': 'aabbccddeeff_intensity_1',
     'unit_of_measurement': None,
   })
@@ -86,7 +86,7 @@
 # name: test_numbers[number.wled_rgb_light_segment_1_speed-42-speed]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'WLED RGB Light Segment 1 Speed',
+      'friendly_name': 'WLED RGB Light Segment 1 speed',
       'icon': 'mdi:speedometer',
       'max': 255,
       'min': 0,
@@ -127,11 +127,11 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:speedometer',
-    'original_name': 'Segment 1 Speed',
+    'original_name': 'Segment 1 speed',
     'platform': 'wled',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'segment_speed',
     'unique_id': 'aabbccddeeff_speed_1',
     'unit_of_measurement': None,
   })

--- a/tests/components/wled/snapshots/test_select.ambr
+++ b/tests/components/wled/snapshots/test_select.ambr
@@ -230,7 +230,7 @@
     'platform': 'wled',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'segment_color_palette',
     'unique_id': 'aabbccddeeff_palette_1',
     'unit_of_measurement': None,
   })

--- a/tests/components/wled/snapshots/test_switch.ambr
+++ b/tests/components/wled/snapshots/test_switch.ambr
@@ -117,7 +117,7 @@
     'platform': 'wled',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'reverse',
     'unique_id': 'aabbccddeeff_reverse_0',
     'unit_of_measurement': None,
   })


### PR DESCRIPTION
## Proposed change
Since we now have the option of adding placeholders to the translations, we can make the remaining entities translatable.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
