### PR TITLE
Significantly reduce websocket api connection auth phase latency

### DIFF
--- a/homeassistant/components/websocket_api/auth.py
+++ b/homeassistant/components/websocket_api/auth.py
@@ -1,14 +1,13 @@
 """Handle the auth of a connection."""
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Any, Final
 
 from aiohttp.web import Request
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
 
-from homeassistant.auth.models import RefreshToken, User
 from homeassistant.components.http.ban import process_success_login, process_wrong_login
 from homeassistant.const import __version__
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
@@ -41,9 +40,9 @@ AUTH_REQUIRED_MESSAGE = json_bytes(
 )
 
 
-def auth_invalid_message(message: str) -> dict[str, str]:
+def auth_invalid_message(message: str) -> bytes:
     """Return an auth_invalid message."""
-    return {"type": TYPE_AUTH_INVALID, "message": message}
+    return json_bytes({"type": TYPE_AUTH_INVALID, "message": message})
 
 
 class AuthPhase:
@@ -56,13 +55,17 @@ class AuthPhase:
         send_message: Callable[[bytes | str | dict[str, Any]], None],
         cancel_ws: CALLBACK_TYPE,
         request: Request,
+        send_bytes_text: Callable[[bytes], Coroutine[Any, Any, None]],
     ) -> None:
-        """Initialize the authentiated connection."""
+        """Initialize the authenticated connection."""
         self._hass = hass
+        # send_message will send a message to the client via the queue.
         self._send_message = send_message
         self._cancel_ws = cancel_ws
         self._logger = logger
         self._request = request
+        # send_bytes_text will directly send a message to the client.
+        self._send_bytes_text = send_bytes_text
 
     async def async_handle(self, msg: JsonValueType) -> ActiveConnection:
         """Handle authentication."""
@@ -73,7 +76,7 @@ class AuthPhase:
                 f"Auth message incorrectly formatted: {humanize_error(msg, err)}"
             )
             self._logger.warning(error_msg)
-            self._send_message(auth_invalid_message(error_msg))
+            await self._send_bytes_text(auth_invalid_message(error_msg))
             raise Disconnect from err
 
         if (access_token := valid_msg.get("access_token")) and (
@@ -81,26 +84,25 @@ class AuthPhase:
                 access_token
             )
         ):
-            conn = await self._async_finish_auth(refresh_token.user, refresh_token)
+            conn = ActiveConnection(
+                self._logger,
+                self._hass,
+                self._send_message,
+                refresh_token.user,
+                refresh_token,
+            )
             conn.subscriptions[
                 "auth"
             ] = self._hass.auth.async_register_revoke_token_callback(
                 refresh_token.id, self._cancel_ws
             )
-
+            await self._send_bytes_text(AUTH_OK_MESSAGE)
+            self._logger.debug("Auth OK")
+            process_success_login(self._request)
             return conn
 
-        self._send_message(auth_invalid_message("Invalid access token or password"))
+        await self._send_bytes_text(
+            auth_invalid_message("Invalid access token or password")
+        )
         await process_wrong_login(self._request)
         raise Disconnect
-
-    async def _async_finish_auth(
-        self, user: User, refresh_token: RefreshToken
-    ) -> ActiveConnection:
-        """Create an active connection."""
-        self._logger.debug("Auth OK")
-        process_success_login(self._request)
-        self._send_message(AUTH_OK_MESSAGE)
-        return ActiveConnection(
-            self._logger, self._hass, self._send_message, user, refresh_token
-        )

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import deque
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 import datetime as dt
 from functools import partial
 import logging
@@ -116,16 +116,14 @@ class WebSocketHandler:
             return describe_request(request)
         return "finished connection"
 
-    async def _writer(self) -> None:
+    async def _writer(
+        self, send_bytes_text: Callable[[bytes], Coroutine[Any, Any, None]]
+    ) -> None:
         """Write outgoing messages."""
         # Variables are set locally to avoid lookups in the loop
         message_queue = self._message_queue
         logger = self._logger
         wsock = self._wsock
-        writer = wsock._writer  # pylint: disable=protected-access
-        if TYPE_CHECKING:
-            assert writer is not None
-        send_str = partial(writer.send, binary=False)
         loop = self._hass.loop
         debug = logger.debug
         is_enabled_for = logger.isEnabledFor
@@ -152,7 +150,7 @@ class WebSocketHandler:
                 ):
                     if debug_enabled:
                         debug("%s: Sending %s", self.description, message)
-                    await send_str(message)
+                    await send_bytes_text(message)
                     continue
 
                 messages: list[bytes] = [message]
@@ -166,7 +164,7 @@ class WebSocketHandler:
                 coalesced_messages = b"".join((b"[", b",".join(messages), b"]"))
                 if debug_enabled:
                     debug("%s: Sending %s", self.description, coalesced_messages)
-                await send_str(coalesced_messages)
+                await send_bytes_text(coalesced_messages)
         except asyncio.CancelledError:
             debug("%s: Writer cancelled", self.description)
             raise
@@ -186,7 +184,7 @@ class WebSocketHandler:
 
     @callback
     def _send_message(self, message: str | bytes | dict[str, Any]) -> None:
-        """Send a message to the client.
+        """Queue sending a message to the client.
 
         Closes connection if the client is not reading the messages.
 
@@ -295,21 +293,27 @@ class WebSocketHandler:
             EVENT_HOMEASSISTANT_STOP, self._async_handle_hass_stop
         )
 
+        writer = wsock._writer  # pylint: disable=protected-access
+        if TYPE_CHECKING:
+            assert writer is not None
+
+        send_bytes_text = partial(writer.send, binary=False)
         # As the webserver is now started before the start
         # event we do not want to block for websocket responses
-        self._writer_task = asyncio.create_task(self._writer())
+        self._writer_task = asyncio.create_task(self._writer(send_bytes_text))
 
-        auth = AuthPhase(logger, hass, self._send_message, self._cancel, request)
+        auth = AuthPhase(
+            logger, hass, self._send_message, self._cancel, request, send_bytes_text
+        )
         connection = None
         disconnect_warn = None
 
         try:
-            self._send_message(AUTH_REQUIRED_MESSAGE)
+            await send_bytes_text(AUTH_REQUIRED_MESSAGE)
 
             # Auth Phase
             try:
-                async with asyncio.timeout(10):
-                    msg = await wsock.receive()
+                msg = await wsock.receive(10)
             except asyncio.TimeoutError as err:
                 disconnect_warn = "Did not receive auth message within 10 seconds"
                 raise Disconnect from err
@@ -370,7 +374,7 @@ class WebSocketHandler:
             # added a way to set the limit, but there is no way to actually
             # reach the code to set the limit, so we have to set it directly.
             #
-            wsock._writer._limit = 2**20  # type: ignore[union-attr] # pylint: disable=protected-access
+            writer._limit = 2**20  # pylint: disable=protected-access
             async_handle_str = connection.async_handle
             async_handle_binary = connection.async_handle_binary
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I started looking at the auth phase timings as a result of testing https://github.com/home-assistant/core/pull/108428 and noticed initial auth on the websocket connection took about 35-60ms locally.

Since the auth phase has exclusive control over the websocket until `ActiveConnection` is created, we can bypass the queue and send messages right away. This reduces the latency and reconnect time since we do not have to wait for the background processing of the queue to send the auth required/ok messages.

Additionally we now only start the queue consumer aka `_writer` if auth is successful since we no longer need it for auth failure cases. This saves some cpu cycles if there are a lot of failed auth attempts (ie brute force attacks).

locally its much faster
<img width="982" alt="Screenshot 2024-01-20 at 11 27 19 PM" src="https://github.com/home-assistant/core/assets/663432/28b2cc7c-32c6-4f52-bea7-a5a888846d5b">

remote on local network is almost as good
<img width="587" alt="Screenshot 2024-01-20 at 11 26 04 PM" src="https://github.com/home-assistant/core/assets/663432/ab15d91c-a90f-41c9-aa47-f8ef45341f13">

and remote ~4000 miles away with >100ms ping time
<img width="982" alt="Screenshot 2024-01-20 at 11 27 19 PM" src="https://github.com/home-assistant/core/assets/663432/5aabe311-e773-469a-937e-8b6a634b3934">

On average this saves ~30ms of latency on reconnect/wake

My test install also has aiohttp 3.10.x and https://github.com/jpadilla/pyjwt/pull/940 which also helps improve the performance

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
