### PR TITLE
Ensure icon translations aren't the same as the default

### DIFF
--- a/homeassistant/components/cover/icons.json
+++ b/homeassistant/components/cover/icons.json
@@ -27,17 +27,13 @@
     "damper": {
       "default": "mdi:circle",
       "state": {
-        "closed": "mdi:circle-slice-8",
-        "closing": "mdi:circle",
-        "opening": "mdi:circle"
+        "closed": "mdi:circle-slice-8"
       }
     },
     "door": {
       "default": "mdi:door-open",
       "state": {
-        "closed": "mdi:door-closed",
-        "closing": "mdi:door-open",
-        "opening": "mdi:door-open"
+        "closed": "mdi:door-closed"
       }
     },
     "garage": {

--- a/homeassistant/components/media_player/icons.json
+++ b/homeassistant/components/media_player/icons.json
@@ -3,7 +3,7 @@
     "_": {
       "default": "mdi:cast",
       "state": {
-        "off": "mdi:cast",
+        "off": "mdi:cast-off",
         "paused": "mdi:cast-connected",
         "playing": "mdi:cast-connected"
       }

--- a/homeassistant/components/weather/icons.json
+++ b/homeassistant/components/weather/icons.json
@@ -10,7 +10,6 @@
         "hail": "mdi:weather-hail",
         "lightning": "mdi:weather-lightning",
         "lightning-rainy": "mdi:weather-lightning-rainy",
-        "partlycloudy": "mdi:weather-partly-cloudy",
         "pouring": "mdi:weather-pouring",
         "rainy": "mdi:weather-rainy",
         "snowy": "mdi:weather-snowy",

--- a/script/hassfest/icons.py
+++ b/script/hassfest/icons.py
@@ -32,6 +32,20 @@ def require_default_icon_validator(value: dict) -> dict:
     return value
 
 
+def ensure_not_same_as_default(value: dict) -> dict:
+    """Validate an icon isn't the same as its default icon."""
+    for translation_key, section in value.items():
+        if (default := section.get("default")) and (states := section.get("state")):
+            for state, icon in states.items():
+                if icon == default:
+                    raise vol.Invalid(
+                        f"The icon for state `{translation_key}.{state}` is the"
+                        " same as the default icon and thus can be removed"
+                    )
+
+    return value
+
+
 def icon_schema(integration_type: str) -> vol.Schema:
     """Create a icon schema."""
 
@@ -44,12 +58,15 @@ def icon_schema(integration_type: str) -> vol.Schema:
         return {
             marker("default"): icon_value_validator,
             vol.Optional("state"): state_validator,
-            vol.Optional("state_attributes"): cv.schema_with_slug_keys(
-                {
-                    marker("default"): icon_value_validator,
-                    marker("state"): state_validator,
-                },
-                slug_validator=translation_key_validator,
+            vol.Optional("state_attributes"): vol.All(
+                cv.schema_with_slug_keys(
+                    {
+                        marker("default"): icon_value_validator,
+                        marker("state"): state_validator,
+                    },
+                    slug_validator=translation_key_validator,
+                ),
+                ensure_not_same_as_default,
             ),
         }
 
@@ -68,18 +85,22 @@ def icon_schema(integration_type: str) -> vol.Schema:
                         slug_validator=vol.Any("_", cv.slug),
                     ),
                     require_default_icon_validator,
+                    ensure_not_same_as_default,
                 )
             }
         )
     return base_schema.extend(
         {
-            vol.Optional("entity"): cv.schema_with_slug_keys(
+            vol.Optional("entity"): vol.All(
                 cv.schema_with_slug_keys(
-                    icon_schema_slug(vol.Optional),
-                    slug_validator=translation_key_validator,
+                    cv.schema_with_slug_keys(
+                        icon_schema_slug(vol.Optional),
+                        slug_validator=translation_key_validator,
+                    ),
+                    slug_validator=cv.slug,
                 ),
-                slug_validator=cv.slug,
-            ),
+                ensure_not_same_as_default,
+            )
         }
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Extends the hassfest icon translations validation with check that ensure the states translated aren't the same as the default.

It found some occurrences already, which have been cleaned up as well.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
