### PR TITLE
Small cleanups to async_get_all_descriptions

### DIFF
--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -581,25 +581,30 @@ async def async_get_all_descriptions(
     descriptions_cache: dict[
         tuple[str, str], dict[str, Any] | None
     ] = hass.data.setdefault(SERVICE_DESCRIPTION_CACHE, {})
-    services = hass.services.async_services()
+
+    # We don't mutate services here so we avoid calling
+    # async_services which makes a copy of every services
+    # dict.
+    services = hass.services._services  # pylint: disable=protected-access
 
     # See if there are new services not seen before.
     # Any service that we saw before already has an entry in description_cache.
-    missing = set()
-    all_services = []
-    for domain in services:
-        for service_name in services[domain]:
+    missing: set[str] = set()
+    all_services: set[tuple[str, str]] = set()
+    for domain, services_by_domain in services.items():
+        for service_name in services_by_domain:
             cache_key = (domain, service_name)
-            all_services.append(cache_key)
+            all_services.add(cache_key)
             if cache_key not in descriptions_cache:
                 missing.add(domain)
 
     # If we have a complete cache, check if it is still valid
+    all_cache: tuple[set[tuple[str, str]], dict[str, dict[str, Any]]] | None
     if all_cache := hass.data.get(ALL_SERVICE_DESCRIPTIONS_CACHE):
         previous_all_services, previous_descriptions_cache = all_cache
         # If the services are the same, we can return the cache
         if previous_all_services == all_services:
-            return cast(dict[str, dict[str, Any]], previous_descriptions_cache)
+            return previous_descriptions_cache  # type: ignore[no-any-return]
 
     # Files we loaded for missing descriptions
     loaded: dict[str, JSON_TYPE] = {}
@@ -621,7 +626,7 @@ async def async_get_all_descriptions(
 
     # Load translations for all service domains
     translations = await translation.async_get_translations(
-        hass, "en", "services", list(services)
+        hass, "en", "services", services
     )
 
     # Build response

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -589,14 +589,14 @@ async def async_get_all_descriptions(
 
     # See if there are new services not seen before.
     # Any service that we saw before already has an entry in description_cache.
-    missing: set[str] = set()
+    domains_with_missing_services: set[str] = set()
     all_services: set[tuple[str, str]] = set()
     for domain, services_by_domain in services.items():
         for service_name in services_by_domain:
             cache_key = (domain, service_name)
             all_services.add(cache_key)
             if cache_key not in descriptions_cache:
-                missing.add(domain)
+                domains_with_missing_services.add(domain)
 
     # If we have a complete cache, check if it is still valid
     all_cache: tuple[set[tuple[str, str]], dict[str, dict[str, Any]]] | None
@@ -609,8 +609,8 @@ async def async_get_all_descriptions(
     # Files we loaded for missing descriptions
     loaded: dict[str, JSON_TYPE] = {}
 
-    if missing:
-        ints_or_excs = await async_get_integrations(hass, missing)
+    if domains_with_missing_services:
+        ints_or_excs = await async_get_integrations(hass, domains_with_missing_services)
         integrations: list[Integration] = []
         for domain, int_or_exc in ints_or_excs.items():
             if type(int_or_exc) is Integration:  # noqa: E721
@@ -622,7 +622,7 @@ async def async_get_all_descriptions(
         contents = await hass.async_add_executor_job(
             _load_services_files, hass, integrations
         )
-        loaded = dict(zip(missing, contents))
+        loaded = dict(zip(domains_with_missing_services, contents))
 
     # Load translations for all service domains
     translations = await translation.async_get_translations(


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Small cleanups to async_get_all_descriptions

- Add missing typing
- Use a set instead of a list for comparing all services
- Avoid many copy calls

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
