### PR TITLE
Add ecobee indefinite away preset, remove unusable/broken presets

### DIFF
--- a/homeassistant/components/ecobee/strings.json
+++ b/homeassistant/components/ecobee/strings.json
@@ -20,6 +20,17 @@
     }
   },
   "entity": {
+    "climate": {
+      "ecobee": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "away_indefinitely": "Away Indefinitely"
+            }
+          }
+        }
+      }
+    },
     "number": {
       "ventilator_min_type_home": {
         "name": "Ventilator min time home"

--- a/homeassistant/components/ecobee/util.py
+++ b/homeassistant/components/ecobee/util.py
@@ -1,6 +1,6 @@
 """Validation utility functions for ecobee services."""
 
-from datetime import datetime
+from datetime import date, datetime, timedelta
 
 import voluptuous as vol
 
@@ -23,3 +23,13 @@ def ecobee_time(time_string):
             "Time does not match ecobee 24-hour time format HH:MM:SS"
         ) from err
     return time_string
+
+
+def is_indefinite_hold(start_date_string: str, end_date_string: str) -> bool:
+    """Determine if the given start and end dates from the ecobee API represent an indefinite hold.
+
+    This is not documented in the API, so a rough heuristic is used where a hold over 1 year is considered indefinite.
+    """
+    return date.fromisoformat(end_date_string) - date.fromisoformat(
+        start_date_string
+    ) > timedelta(days=365)

--- a/tests/components/ecobee/__init__.py
+++ b/tests/components/ecobee/__init__.py
@@ -39,8 +39,10 @@ GENERIC_THERMOSTAT_INFO = {
             "running": True,
             "type": "hold",
             "holdClimateRef": "away",
-            "endDate": "2022-01-01 10:00:00",
-            "startDate": "2022-02-02 11:00:00",
+            "startDate": "2022-02-02",
+            "startTime": "11:00:00",
+            "endDate": "2022-01-01",
+            "endTime": "10:00:00",
         }
     ],
     "remoteSensors": [
@@ -99,8 +101,10 @@ GENERIC_THERMOSTAT_INFO_WITH_HEATPUMP = {
             "running": True,
             "type": "hold",
             "holdClimateRef": "away",
-            "endDate": "2022-01-01 10:00:00",
-            "startDate": "2022-02-02 11:00:00",
+            "startDate": "2022-02-02",
+            "startTime": "11:00:00",
+            "endDate": "2022-01-01",
+            "endTime": "10:00:00",
         }
     ],
     "remoteSensors": [

--- a/tests/components/ecobee/fixtures/ecobee-data.json
+++ b/tests/components/ecobee/fixtures/ecobee-data.json
@@ -42,8 +42,10 @@
           "running": true,
           "type": "hold",
           "holdClimateRef": "away",
-          "endDate": "2022-01-01 10:00:00",
-          "startDate": "2022-02-02 11:00:00"
+          "startDate": "2022-02-02",
+          "startTime": "11:00:00",
+          "endDate": "2022-01-01",
+          "endTime": "10:00:00"
         }
       ],
       "remoteSensors": [
@@ -110,8 +112,10 @@
           "running": true,
           "type": "hold",
           "holdClimateRef": "away",
-          "endDate": "2022-01-01 10:00:00",
-          "startDate": "2022-02-02 11:00:00"
+          "startDate": "2022-02-02",
+          "startTime": "11:00:00",
+          "endDate": "2022-01-01",
+          "endTime": "10:00:00"
         }
       ],
       "remoteSensors": [

--- a/tests/components/ecobee/test_climate.py
+++ b/tests/components/ecobee/test_climate.py
@@ -9,7 +9,11 @@ import pytest
 
 from homeassistant.components import climate
 from homeassistant.components.climate import ClimateEntityFeature
-from homeassistant.components.ecobee.climate import ECOBEE_AUX_HEAT_ONLY, Thermostat
+from homeassistant.components.ecobee.climate import (
+    ECOBEE_AUX_HEAT_ONLY,
+    PRESET_AWAY_INDEFINITELY,
+    Thermostat,
+)
 import homeassistant.const as const
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_SUPPORTED_FEATURES, STATE_OFF
 from homeassistant.core import HomeAssistant
@@ -31,6 +35,7 @@ def ecobee_fixture():
             "climates": [
                 {"name": "Climate1", "climateRef": "c1"},
                 {"name": "Climate2", "climateRef": "c2"},
+                {"name": "Away", "climateRef": "away"},
             ],
             "currentClimateRef": "c1",
         },
@@ -56,9 +61,11 @@ def ecobee_fixture():
                 "name": "Event1",
                 "running": True,
                 "type": "hold",
-                "holdClimateRef": "away",
-                "endDate": "2017-01-01 10:00:00",
-                "startDate": "2017-02-02 11:00:00",
+                "holdClimateRef": "c1",
+                "startDate": "2017-02-02",
+                "startTime": "11:00:00",
+                "endDate": "2017-01-01",
+                "endTime": "10:00:00",
             }
         ],
     }
@@ -428,3 +435,30 @@ async def test_turn_aux_heat_off(hass: HomeAssistant, mock_ecobee: MagicMock) ->
     )
     assert mock_ecobee.set_hvac_mode.call_count == 1
     assert mock_ecobee.set_hvac_mode.call_args == mock.call(0, "auto")
+
+
+async def test_preset_indefinite_away(ecobee_fixture, thermostat) -> None:
+    """Test indefinite away showing correctly, and not as temporary away."""
+    ecobee_fixture["program"]["currentClimateRef"] = "away"
+    ecobee_fixture["events"][0]["holdClimateRef"] = "away"
+    assert thermostat.preset_mode == "Away"
+
+    ecobee_fixture["events"][0]["endDate"] = "2999-01-01"
+    assert thermostat.preset_mode == PRESET_AWAY_INDEFINITELY
+
+
+async def test_set_preset_mode(ecobee_fixture, thermostat, data) -> None:
+    """Test set preset mode."""
+    # Set a preset provided by ecobee.
+    data.reset_mock()
+    thermostat.set_preset_mode("Climate2")
+    data.ecobee.set_climate_hold.assert_has_calls(
+        [mock.call(1, "c2", thermostat.hold_preference(), thermostat.hold_hours())]
+    )
+
+    # Set the indefinite away preset provided by this integration.
+    data.reset_mock()
+    thermostat.set_preset_mode(PRESET_AWAY_INDEFINITELY)
+    data.ecobee.set_climate_hold.assert_has_calls(
+        [mock.call(1, "away", "indefinite", thermostat.hold_hours())]
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Replaces the non-functional `away` preset mode with the correct `away_indefinitely` preset mode.
If any service or automation was depending on the `away` preset mode it needs to be updated.


## Proposed change
Add an explicit "away_indefinitely" preset mode to the ecobee component, replacing an undocumented "away" [lowercase] preset (different from the "Away" [title case] preset provided by the ecobee API) which users had relied on to set indefinite holds. The "away" [lowercase] preset broke with the validation introduced in #105745, as it (and some other undocumented presets provided by this component) was not present in the list of available presets exposed by the component.

Fixes #107322

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #107322
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
