### PR TITLE
Dlink add current consumption

### DIFF
--- a/homeassistant/components/dlink/const.py
+++ b/homeassistant/components/dlink/const.py
@@ -2,6 +2,7 @@
 
 ATTRIBUTION = "Data provided by D-Link"
 ATTR_TOTAL_CONSUMPTION = "total_consumption"
+ATTR_CURRENT_CONSUMPTION = "current_consumption"
 
 CONF_USE_LEGACY_PROTOCOL = "use_legacy_protocol"
 

--- a/homeassistant/components/dlink/switch.py
+++ b/homeassistant/components/dlink/switch.py
@@ -10,7 +10,7 @@ from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import ATTR_TOTAL_CONSUMPTION, DOMAIN
+from .const import ATTR_CURRENT_CONSUMPTION, ATTR_TOTAL_CONSUMPTION, DOMAIN
 from .entity import DLinkEntity
 
 SCAN_INTERVAL = timedelta(minutes=2)
@@ -46,12 +46,19 @@ class SmartPlugSwitch(DLinkEntity, SwitchEntity):
             temperature = None
 
         try:
+            current_consumption = float(self.data.current_consumption)
+        except ValueError:
+            current_consumption = None
+
+        try:
             total_consumption = float(self.data.total_consumption)
         except ValueError:
             total_consumption = None
 
+
         attrs = {
             ATTR_TOTAL_CONSUMPTION: total_consumption,
+            ATTR_CURRENT_CONSUMPTION: current_consumption,
             ATTR_TEMPERATURE: temperature,
         }
 

--- a/homeassistant/components/dlink/switch.py
+++ b/homeassistant/components/dlink/switch.py
@@ -55,7 +55,6 @@ class SmartPlugSwitch(DLinkEntity, SwitchEntity):
         except ValueError:
             total_consumption = None
 
-
         attrs = {
             ATTR_TOTAL_CONSUMPTION: total_consumption,
             ATTR_CURRENT_CONSUMPTION: current_consumption,

--- a/tests/components/dlink/test_switch.py
+++ b/tests/components/dlink/test_switch.py
@@ -31,6 +31,7 @@ async def test_switch_state(hass: HomeAssistant, mocked_plug: AsyncMock) -> None
     entity_id = "switch.mock_title"
     state = hass.states.get(entity_id)
     assert state.state == STATE_OFF
+    assert state.attributes["current_consumption"] == 50.0
     assert state.attributes["total_consumption"] == 1040.0
     assert state.attributes["temperature"] == 33
     await hass.services.async_call(
@@ -65,4 +66,5 @@ async def test_switch_no_value(
     state = hass.states.get("switch.mock_title")
     assert state.state == STATE_OFF
     assert state.attributes["total_consumption"] is None
+    assert state.attributes["current_consumption"] is None
     assert state.attributes["temperature"] is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The underlying library, pyW215, supports reading the current consumption from DLink smart plugs as well as the total consumption. This proposed change exposes the current consumption as an attribute.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
