### PR TITLE
Extend config entry update/abort helper to also update unique id

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1941,11 +1941,12 @@ class ConfigFlow(data_entry_flow.FlowHandler):
     def async_update_reload_and_abort(
         self,
         entry: ConfigEntry,
+        *,
+        unique_id: str | None | UndefinedType = UNDEFINED,
         title: str | UndefinedType = UNDEFINED,
         data: Mapping[str, Any] | UndefinedType = UNDEFINED,
         options: Mapping[str, Any] | UndefinedType = UNDEFINED,
         reason: str = "reauth_successful",
-        unique_id: str | None | UndefinedType = UNDEFINED,
     ) -> data_entry_flow.FlowResult:
         """Update config entry, reload config entry and finish config flow."""
         result = self.hass.config_entries.async_update_entry(

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1941,6 +1941,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
     def async_update_reload_and_abort(
         self,
         entry: ConfigEntry,
+        unique_id: str | None | UndefinedType = UNDEFINED,
         title: str | UndefinedType = UNDEFINED,
         data: Mapping[str, Any] | UndefinedType = UNDEFINED,
         options: Mapping[str, Any] | UndefinedType = UNDEFINED,
@@ -1949,6 +1950,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         """Update config entry, reload config entry and finish config flow."""
         result = self.hass.config_entries.async_update_entry(
             entry=entry,
+            unique_id=unique_id,
             title=title,
             data=data,
             options=options,

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1941,11 +1941,11 @@ class ConfigFlow(data_entry_flow.FlowHandler):
     def async_update_reload_and_abort(
         self,
         entry: ConfigEntry,
-        unique_id: str | None | UndefinedType = UNDEFINED,
         title: str | UndefinedType = UNDEFINED,
         data: Mapping[str, Any] | UndefinedType = UNDEFINED,
         options: Mapping[str, Any] | UndefinedType = UNDEFINED,
         reason: str = "reauth_successful",
+        unique_id: str | None | UndefinedType = UNDEFINED,
     ) -> data_entry_flow.FlowResult:
         """Update config entry, reload config entry and finish config flow."""
         result = self.hass.config_entries.async_update_entry(

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -4152,6 +4152,7 @@ async def test_update_entry_and_reload(
     """Test updating an entry and reloading."""
     entry = MockConfigEntry(
         domain="comp",
+        unique_id="1234",
         title="Test",
         data={"vendor": "data"},
         options={"vendor": "options"},
@@ -4172,6 +4173,7 @@ async def test_update_entry_and_reload(
             """Mock Reauth."""
             return self.async_update_reload_and_abort(
                 entry=entry,
+                unique_id="5678",
                 title="Updated Title",
                 data={"vendor": "data2"},
                 options={"vendor": "options2"},
@@ -4182,6 +4184,7 @@ async def test_update_entry_and_reload(
         await hass.async_block_till_done()
 
         assert entry.title == "Updated Title"
+        assert entry.unique_id == "5678"
         assert entry.data == {"vendor": "data2"}
         assert entry.options == {"vendor": "options2"}
         assert entry.state == config_entries.ConfigEntryState.LOADED


### PR DESCRIPTION
## Proposed change
Extend the new config entry update/abort helper to also be able to update the unique id as this seems to be common case.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
