### PR TITLE
Add translation placeholders for TPLink power strip

### DIFF
--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -40,7 +40,7 @@ class CoordinatedTPLinkEntity(CoordinatorEntity[TPLinkDataUpdateCoordinator]):
         """Initialize the switch."""
         super().__init__(coordinator)
         self.device: SmartDevice = device
-        self._attr_unique_id = self.device.device_id
+        self._attr_unique_id = device.device_id
         self._attr_device_info = DeviceInfo(
             connections={(dr.CONNECTION_NETWORK_MAC, device.mac)},
             identifiers={(DOMAIN, str(device.device_id))},

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -108,11 +108,13 @@ def async_emeter_from_device(
 
 
 def _async_sensors_for_device(
-    device: SmartDevice, coordinator: TPLinkDataUpdateCoordinator
+    device: SmartDevice,
+    coordinator: TPLinkDataUpdateCoordinator,
+    has_parent: bool = False,
 ) -> list[SmartPlugSensor]:
     """Generate the sensors for the device."""
     return [
-        SmartPlugSensor(device, coordinator, description)
+        SmartPlugSensor(device, coordinator, description, has_parent)
         for description in ENERGY_SENSORS
         if async_emeter_from_device(device, description) is not None
     ]
@@ -136,7 +138,7 @@ async def async_setup_entry(
         # Historically we only add the children if the device is a strip
         for idx, child in enumerate(parent.children):
             entities.extend(
-                _async_sensors_for_device(child, children_coordinators[idx])
+                _async_sensors_for_device(child, children_coordinators[idx], True)
             )
     else:
         entities.extend(_async_sensors_for_device(parent, parent_coordinator))
@@ -154,13 +156,20 @@ class SmartPlugSensor(CoordinatedTPLinkEntity, SensorEntity):
         device: SmartDevice,
         coordinator: TPLinkDataUpdateCoordinator,
         description: TPLinkSensorEntityDescription,
+        has_parent: bool = False,
     ) -> None:
         """Initialize the switch."""
         super().__init__(device, coordinator)
         self.entity_description = description
-        self._attr_unique_id = (
-            f"{legacy_device_id(self.device)}_{self.entity_description.key}"
-        )
+        self._attr_unique_id = f"{legacy_device_id(device)}_{description.key}"
+        if has_parent:
+            assert device.alias
+            self._attr_translation_placeholders = {"device_name": device.alias}
+            if description.translation_key:
+                self._attr_translation_key = f"{description.translation_key}_child"
+            else:
+                assert description.device_class
+                self._attr_translation_key = f"{description.device_class.value}_child"
 
     @property
     def native_value(self) -> float | None:

--- a/homeassistant/components/tplink/strings.json
+++ b/homeassistant/components/tplink/strings.json
@@ -67,6 +67,21 @@
       },
       "today_consumption": {
         "name": "Today's consumption"
+      },
+      "current_consumption_child": {
+        "name": "{device_name} current consumption"
+      },
+      "total_consumption_child": {
+        "name": "{device_name} total consumption"
+      },
+      "today_consumption_child": {
+        "name": "{device_name} today's consumption"
+      },
+      "current_child": {
+        "name": "{device_name} current"
+      },
+      "voltage_child": {
+        "name": "{device_name} voltage"
       }
     },
     "switch": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add translation placeholders for TPLink power strip

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #98245
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
