### PR TITLE
Get modbus coverage back to 100%

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -133,12 +133,10 @@ from .const import (  # noqa: F401
 )
 from .modbus import ModbusHub, async_modbus_setup
 from .validators import (
-    duplicate_entity_validator,
+    check_config,
     duplicate_fan_mode_validator,
-    duplicate_modbus_validator,
     nan_validator,
     number_validator,
-    scan_interval_validator,
     struct_validator,
 )
 
@@ -417,12 +415,10 @@ CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.All(
             cv.ensure_list,
-            scan_interval_validator,
-            duplicate_entity_validator,
-            duplicate_modbus_validator,
             [
                 vol.Any(SERIAL_SCHEMA, ETHERNET_SCHEMA),
             ],
+            check_config,
         ),
     },
     extra=vol.ALLOW_EXTRA,

--- a/homeassistant/components/modbus/base_platform.py
+++ b/homeassistant/components/modbus/base_platform.py
@@ -97,10 +97,6 @@ class BasePlatform(Entity):
                 },
             )
             _LOGGER.warning(
-                "`close_comm_on_error`: is deprecated and will be removed in version 2024.4"
-            )
-
-            _LOGGER.warning(
                 "`lazy_error_count`: is deprecated and will be removed in version 2024.7"
             )
 

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -209,8 +209,8 @@ def duplicate_fan_mode_validator(config: dict[str, Any]) -> dict:
     errors = []
     for key, value in config[CONF_FAN_MODE_VALUES].items():
         if value in fan_modes:
-            wrn = f"Modbus fan mode {key} has a duplicate value {value}, not loaded, values must be unique!"
-            _LOGGER.warning(wrn)
+            warn = f"Modbus fan mode {key} has a duplicate value {value}, not loaded, values must be unique!"
+            _LOGGER.warning(warn)
             errors.append(key)
         else:
             fan_modes.add(value)

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -203,6 +203,23 @@ def nan_validator(value: Any) -> int:
         raise vol.Invalid(f"invalid number {value}") from err
 
 
+def duplicate_fan_mode_validator(config: dict[str, Any]) -> dict:
+    """Control modbus climate fan mode values for duplicates."""
+    fan_modes: set[int] = set()
+    errors = []
+    for key, value in config[CONF_FAN_MODE_VALUES].items():
+        if value in fan_modes:
+            wrn = f"Modbus fan mode {key} has a duplicate value {value}, not loaded, values must be unique!"
+            _LOGGER.warning(wrn)
+            errors.append(key)
+        else:
+            fan_modes.add(value)
+
+    for key in reversed(errors):
+        del config[CONF_FAN_MODE_VALUES][key]
+    return config
+
+
 def scan_interval_validator(config: dict) -> dict:
     """Control scan_interval."""
     for hub in config:
@@ -306,7 +323,7 @@ def duplicate_entity_validator(config: dict) -> dict:
     return config
 
 
-def duplicate_modbus_validator(config: list) -> list:
+def duplicate_modbus_validator(config: dict) -> dict:
     """Control modbus connection for duplicates."""
     hosts: set[str] = set()
     names: set[str] = set()
@@ -334,18 +351,9 @@ def duplicate_modbus_validator(config: list) -> list:
     return config
 
 
-def duplicate_fan_mode_validator(config: dict[str, Any]) -> dict:
-    """Control modbus climate fan mode values for duplicates."""
-    fan_modes: set[int] = set()
-    errors = []
-    for key, value in config[CONF_FAN_MODE_VALUES].items():
-        if value in fan_modes:
-            wrn = f"Modbus fan mode {key} has a duplicate value {value}, not loaded, values must be unique!"
-            _LOGGER.warning(wrn)
-            errors.append(key)
-        else:
-            fan_modes.add(value)
-
-    for key in reversed(errors):
-        del config[CONF_FAN_MODE_VALUES][key]
-    return config
+def check_config(config: dict) -> dict:
+    """Do final config check."""
+    config2 = duplicate_modbus_validator(config)
+    config3 = scan_interval_validator(config2)
+    config4 = duplicate_entity_validator(config3)
+    return config4

--- a/tests/components/modbus/test_climate.py
+++ b/tests/components/modbus/test_climate.py
@@ -310,6 +310,36 @@ async def test_temperature_climate(
 
 
 @pytest.mark.parametrize(
+    "do_config",
+    [
+        {
+            CONF_CLIMATES: [
+                {
+                    CONF_NAME: TEST_ENTITY_NAME,
+                    CONF_SLAVE: 1,
+                    CONF_TARGET_TEMP: 117,
+                    CONF_ADDRESS: 117,
+                    CONF_DATA_TYPE: DataType.INT32,
+                },
+            ],
+        },
+    ],
+)
+@pytest.mark.parametrize(
+    ("register_words", "expected"),
+    [
+        (
+            None,
+            "unavailable",
+        ),
+    ],
+)
+async def test_temperature_error(hass: HomeAssistant, expected, mock_do_cycle) -> None:
+    """Run test for given config."""
+    assert hass.states.get(ENTITY_ID).state == expected
+
+
+@pytest.mark.parametrize(
     ("do_config", "result", "register_words"),
     [
         (

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -56,6 +56,7 @@ from homeassistant.components.modbus.const import (
     CONF_INPUT_TYPE,
     CONF_MSG_WAIT,
     CONF_PARITY,
+    CONF_RETRIES,
     CONF_RETRY_ON_EMPTY,
     CONF_SLAVE_COUNT,
     CONF_STOPBITS,
@@ -609,6 +610,12 @@ async def test_duplicate_entity_validator_with_climate(do_config) -> None:
             CONF_HOST: TEST_MODBUS_HOST,
             CONF_PORT: TEST_PORT_TCP,
             CONF_CLOSE_COMM_ON_ERROR: True,
+        },
+        {
+            CONF_TYPE: TCP,
+            CONF_HOST: TEST_MODBUS_HOST,
+            CONF_PORT: TEST_PORT_TCP,
+            CONF_RETRIES: 3,
         },
         {
             CONF_TYPE: TCP,

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -9,6 +9,7 @@ from homeassistant.components.modbus.const import (
     CONF_DATA_TYPE,
     CONF_DEVICE_ADDRESS,
     CONF_INPUT_TYPE,
+    CONF_LAZY_ERROR,
     CONF_MAX_VALUE,
     CONF_MIN_VALUE,
     CONF_NAN_VALUE,
@@ -170,6 +171,17 @@ SLAVE_UNIQUE_ID = "ground_floor_sensor"
                     CONF_ADDRESS: 51,
                     CONF_DATA_TYPE: DataType.INT32,
                     CONF_VIRTUAL_COUNT: 5,
+                }
+            ]
+        },
+        {
+            CONF_SENSORS: [
+                {
+                    CONF_NAME: TEST_ENTITY_NAME,
+                    CONF_ADDRESS: 51,
+                    CONF_DATA_TYPE: DataType.INT32,
+                    CONF_VIRTUAL_COUNT: 5,
+                    CONF_LAZY_ERROR: 3,
                 }
             ]
         },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add/Correct missing tests to get coverage back to 100%

Solved a problem in the Voluptuous description (init.py), the global validators was started before the content was tested, moved to be after content is verified by Voluptuous.

Made a combined function for the 3 global validators, to keep the config cleaner.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
This is the first part of moving all configuration into the validators, and have a common log routine, that guarantees that the information the user gets is uniform.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
