### PR TITLE
Use feed name as entity name in GeoJSON

### DIFF
--- a/homeassistant/components/geo_json_events/geo_location.py
+++ b/homeassistant/components/geo_json_events/geo_location.py
@@ -104,7 +104,10 @@ class GeoJsonLocationEvent(GeolocationEvent):
 
     def _update_from_feed(self, feed_entry: GenericFeedEntry) -> None:
         """Update the internal state from the provided feed entry."""
-        self._attr_name = feed_entry.title
+        if feed_entry.properties and "name" in feed_entry.properties:
+            self._attr_name = feed_entry.properties.get("name")
+        else:
+            self._attr_name = feed_entry.title
         self._attr_distance = feed_entry.distance_to_home
         self._attr_latitude = feed_entry.coordinates[0]
         self._attr_longitude = feed_entry.coordinates[1]

--- a/tests/components/geo_json_events/__init__.py
+++ b/tests/components/geo_json_events/__init__.py
@@ -1,4 +1,5 @@
 """Tests for the geo_json_events component."""
+from typing import Any
 from unittest.mock import MagicMock
 
 
@@ -7,6 +8,7 @@ def _generate_mock_feed_entry(
     title: str,
     distance_to_home: float,
     coordinates: tuple[float, float],
+    properties: dict[str, Any] | None = None,
 ) -> MagicMock:
     """Construct a mock feed entry for testing purposes."""
     feed_entry = MagicMock()
@@ -14,4 +16,5 @@ def _generate_mock_feed_entry(
     feed_entry.title = title
     feed_entry.distance_to_home = distance_to_home
     feed_entry.coordinates = coordinates
+    feed_entry.properties = properties
     return feed_entry

--- a/tests/components/geo_json_events/test_geo_location.py
+++ b/tests/components/geo_json_events/test_geo_location.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
+    ATTR_NAME,
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_RADIUS,
     CONF_SCAN_INTERVAL,
@@ -50,7 +51,13 @@ async def test_entity_lifecycle(
     """Test entity lifecycle.."""
     config_entry.add_to_hass(hass)
     # Set up a mock feed entries for this test.
-    mock_entry_1 = _generate_mock_feed_entry("1234", "Title 1", 15.5, (-31.0, 150.0))
+    mock_entry_1 = _generate_mock_feed_entry(
+        "1234",
+        "Title 1",
+        15.5,
+        (-31.0, 150.0),
+        {ATTR_NAME: "Properties 1"},
+    )
     mock_entry_2 = _generate_mock_feed_entry("2345", "Title 2", 20.5, (-31.1, 150.1))
     mock_entry_3 = _generate_mock_feed_entry("3456", "Title 3", 25.5, (-31.2, 150.2))
     mock_entry_4 = _generate_mock_feed_entry("4567", "Title 4", 12.5, (-31.3, 150.3))
@@ -69,14 +76,14 @@ async def test_entity_lifecycle(
         assert len(hass.states.async_entity_ids(GEO_LOCATION_DOMAIN)) == 3
         assert len(entity_registry.entities) == 3
 
-        state = hass.states.get(f"{GEO_LOCATION_DOMAIN}.title_1")
+        state = hass.states.get(f"{GEO_LOCATION_DOMAIN}.properties_1")
         assert state is not None
-        assert state.name == "Title 1"
+        assert state.name == "Properties 1"
         assert state.attributes == {
             ATTR_EXTERNAL_ID: "1234",
             ATTR_LATITUDE: -31.0,
             ATTR_LONGITUDE: 150.0,
-            ATTR_FRIENDLY_NAME: "Title 1",
+            ATTR_FRIENDLY_NAME: "Properties 1",
             ATTR_UNIT_OF_MEASUREMENT: UnitOfLength.KILOMETERS,
             ATTR_SOURCE: "geo_json_events",
         }


### PR DESCRIPTION
## Breaking change
Previously GeoJSON names were just the config entry ID. This was not very user friendly. Particularly so when there are many config entries and many, many entities from those same many config entries. This is how they look today.

![image](https://github.com/home-assistant/core/assets/50791984/8b64acf0-5a04-43b6-951d-0f9254b3b1a7)

## Proposed change
The proposal is to add support for entity name in GeoJSON. If unavailable in the data source, falls back to the config entry (same as today). This is how they look after.

![image](https://github.com/home-assistant/core/assets/50791984/61839407-b8c0-4c55-a7d6-cbac33436b7b)

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.