### PR TITLE
Show WebRTC cameras that also support HLS in the media browser

### DIFF
--- a/homeassistant/components/camera/media_source.py
+++ b/homeassistant/components/camera/media_source.py
@@ -1,6 +1,8 @@
 """Expose cameras as media sources."""
 from __future__ import annotations
 
+from typing import cast
+
 from homeassistant.components.media_player import BrowseError, MediaClass
 from homeassistant.components.media_source.error import Unresolvable
 from homeassistant.components.media_source.models import (
@@ -10,7 +12,8 @@ from homeassistant.components.media_source.models import (
     PlayMedia,
 )
 from homeassistant.components.stream import FORMAT_CONTENT_TYPE, HLS_PROVIDER
-from homeassistant.core import HomeAssistant
+from homeassistant.const import ATTR_FRIENDLY_NAME
+from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_component import EntityComponent
 
@@ -81,7 +84,7 @@ class CameraMediaSource(MediaSource):
             if stream_type is None:
                 content_type = camera.content_type
 
-            elif can_stream_hls and stream_type == StreamType.HLS:
+            elif can_stream_hls and stream_type is not None:
                 content_type = FORMAT_CONTENT_TYPE[HLS_PROVIDER]
 
             else:
@@ -94,7 +97,9 @@ class CameraMediaSource(MediaSource):
                     identifier=camera.entity_id,
                     media_class=MediaClass.VIDEO,
                     media_content_type=content_type,
-                    title=camera.name,
+                    title=cast(
+                        State, self.hass.states.get(camera.entity_id)
+                    ).attributes.get(ATTR_FRIENDLY_NAME, camera.name),
                     thumbnail=f"/api/camera_proxy/{camera.entity_id}",
                     can_play=True,
                     can_expand=False,

--- a/homeassistant/components/camera/media_source.py
+++ b/homeassistant/components/camera/media_source.py
@@ -94,14 +94,11 @@ class CameraMediaSource(MediaSource):
                 return None
 
             content_type = FORMAT_CONTENT_TYPE[HLS_PROVIDER]
-            if stream_type != StreamType.HLS:
-                source = await camera.stream_source()
-                if not source:
-                    return None
+            if stream_type != StreamType.HLS and not (await camera.stream_source()):
+                return None
 
             return _media_source_for_camera(camera, content_type)
 
-        # Root. List cameras.
         component: EntityComponent[Camera] = self.hass.data[DOMAIN]
         results = await asyncio.gather(
             *(_filter_browsable_camera(camera) for camera in component.entities),

--- a/homeassistant/components/camera/media_source.py
+++ b/homeassistant/components/camera/media_source.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-from typing import cast
 
 from homeassistant.components.media_player import BrowseError, MediaClass
 from homeassistant.components.media_source.error import Unresolvable
@@ -13,8 +12,7 @@ from homeassistant.components.media_source.models import (
     PlayMedia,
 )
 from homeassistant.components.stream import FORMAT_CONTENT_TYPE, HLS_PROVIDER
-from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_component import EntityComponent
 
@@ -95,9 +93,7 @@ class CameraMediaSource(MediaSource):
                 identifier=camera.entity_id,
                 media_class=MediaClass.VIDEO,
                 media_content_type=content_type,
-                title=cast(
-                    State, self.hass.states.get(camera.entity_id)
-                ).attributes.get(ATTR_FRIENDLY_NAME, camera.name),
+                title=camera.name,
                 thumbnail=f"/api/camera_proxy/{camera.entity_id}",
                 can_play=True,
                 can_expand=False,

--- a/homeassistant/components/camera/media_source.py
+++ b/homeassistant/components/camera/media_source.py
@@ -88,18 +88,16 @@ class CameraMediaSource(MediaSource):
 
         async def _filter_browsable_camera(camera: Camera) -> BrowseMediaSource | None:
             stream_type = camera.frontend_stream_type
-
             if stream_type is None:
-                content_type = camera.content_type
-
-            elif can_stream_hls:
-                content_type = FORMAT_CONTENT_TYPE[HLS_PROVIDER]
-                if stream_type != StreamType.HLS:
-                    source = await camera.stream_source()
-                    if not source:
-                        return None
-            else:
+                return _media_source_for_camera(camera, camera.content_type)
+            if not can_stream_hls:
                 return None
+
+            content_type = FORMAT_CONTENT_TYPE[HLS_PROVIDER]
+            if stream_type != StreamType.HLS:
+                source = await camera.stream_source()
+                if not source:
+                    return None
 
             return _media_source_for_camera(camera, content_type)
 

--- a/tests/components/camera/test_media_source.py
+++ b/tests/components/camera/test_media_source.py
@@ -43,15 +43,21 @@ async def test_browsing_mjpeg(hass: HomeAssistant, mock_camera) -> None:
     assert item.children[0].media_content_type == "image/jpg"
 
 
-async def test_browsing_filter_web_rtc(
-    hass: HomeAssistant, mock_camera_web_rtc
-) -> None:
-    """Test browsing camera media source hides non-HLS cameras."""
+async def test_browsing_web_rtc(hass: HomeAssistant, mock_camera_web_rtc) -> None:
+    """Test browsing camera media source."""
     item = await media_source.async_browse_media(hass, "media-source://camera")
     assert item is not None
     assert item.title == "Camera"
     assert len(item.children) == 0
     assert item.not_shown == 3
+
+    # Adding stream enables HLS camera
+    hass.config.components.add("stream")
+
+    item = await media_source.async_browse_media(hass, "media-source://camera")
+    assert item.not_shown == 0
+    assert len(item.children) == 3
+    assert item.children[0].media_content_type == FORMAT_CONTENT_TYPE["hls"]
 
 
 async def test_resolving(hass: HomeAssistant, mock_camera_hls) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As discussed in https://github.com/home-assistant/architecture/discussions/1030, support for resolving WebRTC cameras as media sources was added in https://github.com/home-assistant/core/pull/80646. Those cameras, however, were still excluded from the media browser. This PR makes them available in the browser instead of being filtered out.
While it's possible some of these cameras will fail to play, most should succeed. Specifically:
* RTSPtoWebRTC was the impetus for the aforementioned PR.
* Nest cameras [can support both WebRTC and HLS](https://github.com/home-assistant/core/blob/ef5d46c79c00f92425c51b84d8f1b093be27f3c4/tests/components/nest/test_camera.py#L693)(at least for some cameras, I'm not sure if there are exceptions).
* While not a native integration, Frigate is a popular custom integration, and it [recently added support for serving both WebRTC and HLS](https://github.com/blakeblackshear/frigate-hass-integration/pull/602).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
