### PR TITLE
Add entity name translations to Tibber

### DIFF
--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -64,129 +64,129 @@ PARALLEL_UPDATES = 0
 RT_SENSORS: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="averagePower",
-        name="average power",
+        translation_key="average_power",
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.WATT,
     ),
     SensorEntityDescription(
         key="power",
-        name="power",
+        translation_key="power",
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfPower.WATT,
     ),
     SensorEntityDescription(
         key="powerProduction",
-        name="power production",
+        translation_key="power_production",
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfPower.WATT,
     ),
     SensorEntityDescription(
         key="minPower",
-        name="min power",
+        translation_key="min_power",
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.WATT,
     ),
     SensorEntityDescription(
         key="maxPower",
-        name="max power",
+        translation_key="max_power",
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.WATT,
     ),
     SensorEntityDescription(
         key="accumulatedConsumption",
-        name="accumulated consumption",
+        translation_key="accumulated_consumption",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL,
     ),
     SensorEntityDescription(
         key="accumulatedConsumptionLastHour",
-        name="accumulated consumption current hour",
+        translation_key="accumulated_consumption_last_hour",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
     SensorEntityDescription(
         key="estimatedHourConsumption",
-        name="Estimated consumption current hour",
+        translation_key="estimated_hour_consumption",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
     ),
     SensorEntityDescription(
         key="accumulatedProduction",
-        name="accumulated production",
+        translation_key="accumulated_production",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL,
     ),
     SensorEntityDescription(
         key="accumulatedProductionLastHour",
-        name="accumulated production current hour",
+        translation_key="accumulated_production_last_hour",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
     SensorEntityDescription(
         key="lastMeterConsumption",
-        name="last meter consumption",
+        translation_key="last_meter_consumption",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
     SensorEntityDescription(
         key="lastMeterProduction",
-        name="last meter production",
+        translation_key="last_meter_production",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
     SensorEntityDescription(
         key="voltagePhase1",
-        name="voltage phase1",
+        translation_key="voltage_phase1",
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key="voltagePhase2",
-        name="voltage phase2",
+        translation_key="voltage_phase2",
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key="voltagePhase3",
-        name="voltage phase3",
+        translation_key="voltage_phase3",
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key="currentL1",
-        name="current L1",
+        translation_key="current_l1",
         device_class=SensorDeviceClass.CURRENT,
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key="currentL2",
-        name="current L2",
+        translation_key="current_l2",
         device_class=SensorDeviceClass.CURRENT,
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key="currentL3",
-        name="current L3",
+        translation_key="current_l3",
         device_class=SensorDeviceClass.CURRENT,
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key="signalStrength",
-        name="signal strength",
+        translation_key="signal_strength",
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS,
         state_class=SensorStateClass.MEASUREMENT,
@@ -194,19 +194,19 @@ RT_SENSORS: tuple[SensorEntityDescription, ...] = (
     ),
     SensorEntityDescription(
         key="accumulatedReward",
-        name="accumulated reward",
+        translation_key="accumulated_reward",
         device_class=SensorDeviceClass.MONETARY,
         state_class=SensorStateClass.TOTAL,
     ),
     SensorEntityDescription(
         key="accumulatedCost",
-        name="accumulated cost",
+        translation_key="accumulated_cost",
         device_class=SensorDeviceClass.MONETARY,
         state_class=SensorStateClass.TOTAL,
     ),
     SensorEntityDescription(
         key="powerFactor",
-        name="power factor",
+        translation_key="power_factor",
         device_class=SensorDeviceClass.POWER_FACTOR,
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -216,23 +216,23 @@ RT_SENSORS: tuple[SensorEntityDescription, ...] = (
 SENSORS: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="month_cost",
-        name="Monthly cost",
+        translation_key="month_cost",
         device_class=SensorDeviceClass.MONETARY,
     ),
     SensorEntityDescription(
         key="peak_hour",
-        name="Monthly peak hour consumption",
+        translation_key="peak_hour",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
     ),
     SensorEntityDescription(
         key="peak_hour_time",
-        name="Time of max hour consumption",
+        translation_key="peak_hour_time",
         device_class=SensorDeviceClass.TIMESTAMP,
     ),
     SensorEntityDescription(
         key="month_cons",
-        name="Monthly net consumption",
+        translation_key="month_cons",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -305,6 +305,8 @@ async def async_setup_entry(
 class TibberSensor(SensorEntity):
     """Representation of a generic Tibber sensor."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self, *args: Any, tibber_home: tibber.TibberHome, **kwargs: Any
     ) -> None:
@@ -335,6 +337,9 @@ class TibberSensor(SensorEntity):
 class TibberSensorElPrice(TibberSensor):
     """Representation of a Tibber sensor for el price."""
 
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_translation_key = "electricity_price"
+
     def __init__(self, tibber_home: tibber.TibberHome) -> None:
         """Initialize the sensor."""
         super().__init__(tibber_home=tibber_home)
@@ -355,8 +360,6 @@ class TibberSensorElPrice(TibberSensor):
             "off_peak_2": None,
         }
         self._attr_icon = ICON
-        self._attr_name = f"Electricity price {self._home_name}"
-        self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_unique_id = self._tibber_home.home_id
         self._model = "Price Sensor"
 
@@ -424,7 +427,6 @@ class TibberDataSensor(TibberSensor, CoordinatorEntity["TibberDataCoordinator"])
         self._attr_unique_id = (
             f"{self._tibber_home.home_id}_{self.entity_description.key}"
         )
-        self._attr_name = f"{entity_description.name} {self._home_name}"
         if entity_description.key == "month_cost":
             self._attr_native_unit_of_measurement = self._tibber_home.currency
 
@@ -452,7 +454,6 @@ class TibberSensorRT(TibberSensor, CoordinatorEntity["TibberRtDataCoordinator"])
         self._model = "Tibber Pulse"
         self._device_name = f"{self._model} {self._home_name}"
 
-        self._attr_name = f"{description.name} {self._home_name}"
         self._attr_native_value = initial_state
         self._attr_unique_id = f"{self._tibber_home.home_id}_rt_{description.name}"
 

--- a/homeassistant/components/tibber/strings.json
+++ b/homeassistant/components/tibber/strings.json
@@ -17,70 +17,70 @@
         "name": "Monthly net consumption"
       },
       "average_power": {
-        "name": "average power"
+        "name": "Average power"
       },
       "power": {
-        "name": "power"
+        "name": "Power"
       },
       "power_production": {
-        "name": "power production"
+        "name": "Power production"
       },
       "min_power": {
-        "name": "min power"
+        "name": "Min power"
       },
       "max_power": {
-        "name": "max power"
+        "name": "Max power"
       },
       "accumulated_consumption": {
-        "name": "accumulated consumption"
+        "name": "Accumulated consumption"
       },
       "accumulated_consumption_last_hour": {
-        "name": "accumulated consumption current hour"
+        "name": "Accumulated consumption current hour"
       },
       "estimated_hour_consumption": {
         "name": "Estimated consumption current hour"
       },
       "accumulated_production": {
-        "name": "accumulated production"
+        "name": "Accumulated production"
       },
       "accumulated_production_last_hour": {
-        "name": "accumulated production current hour"
+        "name": "Accumulated production current hour"
       },
       "last_meter_consumption": {
-        "name": "last meter consumption"
+        "name": "Last meter consumption"
       },
       "last_meter_production": {
-        "name": "last meter production"
+        "name": "Last meter production"
       },
       "voltage_phase1": {
-        "name": "voltage phase1"
+        "name": "Voltage phase1"
       },
       "voltage_phase2": {
-        "name": "voltage phase2"
+        "name": "Voltage phase2"
       },
       "voltage_phase3": {
-        "name": "voltage phase3"
+        "name": "Voltage phase3"
       },
       "current_l1": {
-        "name": "current L1"
+        "name": "Current L1"
       },
       "current_l2": {
-        "name": "current L2"
+        "name": "Current L2"
       },
       "current_l3": {
-        "name": "current L3"
+        "name": "Current L3"
       },
       "signal_strength": {
-        "name": "signal strength"
+        "name": "Signal strength"
       },
       "accumulated_reward": {
-        "name": "accumulated reward"
+        "name": "Accumulated reward"
       },
       "accumulated_cost": {
-        "name": "accumulated cost"
+        "name": "Accumulated cost"
       },
       "power_factor": {
-        "name": "power factor"
+        "name": "Power factor"
       }
     }
   },

--- a/homeassistant/components/tibber/strings.json
+++ b/homeassistant/components/tibber/strings.json
@@ -1,4 +1,89 @@
 {
+  "entity": {
+    "sensor": {
+      "electricity_price": {
+        "name": "Electricity price"
+      },
+      "month_cost": {
+        "name": "Monthly cost"
+      },
+      "peak_hour": {
+        "name": "Monthly peak hour consumption"
+      },
+      "peak_hour_time": {
+        "name": "Time of max hour consumption"
+      },
+      "month_cons": {
+        "name": "Monthly net consumption"
+      },
+      "average_power": {
+        "name": "average power"
+      },
+      "power": {
+        "name": "power"
+      },
+      "power_production": {
+        "name": "power production"
+      },
+      "min_power": {
+        "name": "min power"
+      },
+      "max_power": {
+        "name": "max power"
+      },
+      "accumulated_consumption": {
+        "name": "accumulated consumption"
+      },
+      "accumulated_consumption_last_hour": {
+        "name": "accumulated consumption current hour"
+      },
+      "estimated_hour_consumption": {
+        "name": "Estimated consumption current hour"
+      },
+      "accumulated_production": {
+        "name": "accumulated production"
+      },
+      "accumulated_production_last_hour": {
+        "name": "accumulated production current hour"
+      },
+      "last_meter_consumption": {
+        "name": "last meter consumption"
+      },
+      "last_meter_production": {
+        "name": "last meter production"
+      },
+      "voltage_phase1": {
+        "name": "voltage phase1"
+      },
+      "voltage_phase2": {
+        "name": "voltage phase2"
+      },
+      "voltage_phase3": {
+        "name": "voltage phase3"
+      },
+      "current_l1": {
+        "name": "current L1"
+      },
+      "current_l2": {
+        "name": "current L2"
+      },
+      "current_l3": {
+        "name": "current L3"
+      },
+      "signal_strength": {
+        "name": "signal strength"
+      },
+      "accumulated_reward": {
+        "name": "accumulated reward"
+      },
+      "accumulated_cost": {
+        "name": "accumulated cost"
+      },
+      "power_factor": {
+        "name": "power factor"
+      }
+    }
+  },
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"


### PR DESCRIPTION
## Proposed change
Add entity name translations to Tibber. This would change the entity names from `sensor.electricity_price_streichenstrasse_12` to `sensor.streichenstrasse_12_electricity_price` for new config entries/entities.

Will do the migration to the icon translations in a followup PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
