### PR TITLE
Add speech-to-text cooldown for local wake word

### DIFF
--- a/homeassistant/components/assist_pipeline/__init__.py
+++ b/homeassistant/components/assist_pipeline/__init__.py
@@ -5,7 +5,7 @@ from collections.abc import AsyncIterable
 
 import voluptuous as vol
 
-from homeassistant.components import stt, wake_word
+from homeassistant.components import stt
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 
@@ -83,7 +83,7 @@ async def async_pipeline_from_audio_stream(
     event_callback: PipelineEventCallback,
     stt_metadata: stt.SpeechMetadata,
     stt_stream: AsyncIterable[bytes],
-    stt_wake_word: wake_word.WakeWord | None = None,
+    stt_wake_up_key: str | None = None,
     pipeline_id: str | None = None,
     conversation_id: str | None = None,
     tts_audio_output: str | None = None,
@@ -102,7 +102,7 @@ async def async_pipeline_from_audio_stream(
         device_id=device_id,
         stt_metadata=stt_metadata,
         stt_stream=stt_stream,
-        stt_wake_word=stt_wake_word,
+        stt_wake_up_key=stt_wake_up_key,
         run=PipelineRun(
             hass,
             context=context,

--- a/homeassistant/components/assist_pipeline/__init__.py
+++ b/homeassistant/components/assist_pipeline/__init__.py
@@ -5,7 +5,7 @@ from collections.abc import AsyncIterable
 
 import voluptuous as vol
 
-from homeassistant.components import stt
+from homeassistant.components import stt, wake_word
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 
@@ -83,6 +83,7 @@ async def async_pipeline_from_audio_stream(
     event_callback: PipelineEventCallback,
     stt_metadata: stt.SpeechMetadata,
     stt_stream: AsyncIterable[bytes],
+    stt_wake_word: wake_word.WakeWord | None = None,
     pipeline_id: str | None = None,
     conversation_id: str | None = None,
     tts_audio_output: str | None = None,
@@ -101,6 +102,7 @@ async def async_pipeline_from_audio_stream(
         device_id=device_id,
         stt_metadata=stt_metadata,
         stt_stream=stt_stream,
+        stt_wake_word=stt_wake_word,
         run=PipelineRun(
             hass,
             context=context,

--- a/homeassistant/components/assist_pipeline/__init__.py
+++ b/homeassistant/components/assist_pipeline/__init__.py
@@ -83,7 +83,7 @@ async def async_pipeline_from_audio_stream(
     event_callback: PipelineEventCallback,
     stt_metadata: stt.SpeechMetadata,
     stt_stream: AsyncIterable[bytes],
-    stt_wake_up_key: str | None = None,
+    wake_word_phrase: str | None = None,
     pipeline_id: str | None = None,
     conversation_id: str | None = None,
     tts_audio_output: str | None = None,
@@ -102,7 +102,7 @@ async def async_pipeline_from_audio_stream(
         device_id=device_id,
         stt_metadata=stt_metadata,
         stt_stream=stt_stream,
-        stt_wake_up_key=stt_wake_up_key,
+        wake_word_phrase=wake_word_phrase,
         run=PipelineRun(
             hass,
             context=context,

--- a/homeassistant/components/assist_pipeline/const.py
+++ b/homeassistant/components/assist_pipeline/const.py
@@ -10,6 +10,6 @@ DEFAULT_WAKE_WORD_TIMEOUT = 3  # seconds
 CONF_DEBUG_RECORDING_DIR = "debug_recording_dir"
 
 DATA_LAST_WAKE_UP = f"{DOMAIN}.last_wake_up"
-DEFAULT_WAKE_WORD_COOLDOWN = 2  # seconds
+WAKE_WORD_COOLDOWN = 2  # seconds
 
 EVENT_RECORDING = f"{DOMAIN}_recording"

--- a/homeassistant/components/assist_pipeline/error.py
+++ b/homeassistant/components/assist_pipeline/error.py
@@ -38,6 +38,14 @@ class SpeechToTextError(PipelineError):
     """Error in speech-to-text portion of pipeline."""
 
 
+class SpeechToTextAborted(WakeWordDetectionError):
+    """Speech-to-text was aborted."""
+
+    def __init__(self) -> None:
+        """Set error message."""
+        super().__init__("speech_to_text_aborted", "")
+
+
 class IntentRecognitionError(PipelineError):
     """Error in intent recognition portion of pipeline."""
 

--- a/homeassistant/components/assist_pipeline/error.py
+++ b/homeassistant/components/assist_pipeline/error.py
@@ -38,12 +38,15 @@ class SpeechToTextError(PipelineError):
     """Error in speech-to-text portion of pipeline."""
 
 
-class SpeechToTextAborted(WakeWordDetectionError):
-    """Speech-to-text was aborted."""
+class DuplicateWakeUpDetectedError(WakeWordDetectionError):
+    """Error when multiple voice assistants wake up at the same time (same wake word)."""
 
-    def __init__(self) -> None:
+    def __init__(self, wake_up_key: str) -> None:
         """Set error message."""
-        super().__init__("speech_to_text_aborted", "")
+        super().__init__(
+            "duplicate_wake_up_detected",
+            f"Duplicate wake-up detected for {wake_up_key}",
+        )
 
 
 class IntentRecognitionError(PipelineError):

--- a/homeassistant/components/assist_pipeline/error.py
+++ b/homeassistant/components/assist_pipeline/error.py
@@ -41,11 +41,11 @@ class SpeechToTextError(PipelineError):
 class DuplicateWakeUpDetectedError(WakeWordDetectionError):
     """Error when multiple voice assistants wake up at the same time (same wake word)."""
 
-    def __init__(self, wake_up_key: str) -> None:
+    def __init__(self, wake_up_phrase: str) -> None:
         """Set error message."""
         super().__init__(
             "duplicate_wake_up_detected",
-            f"Duplicate wake-up detected for {wake_up_key}",
+            f"Duplicate wake-up detected for {wake_up_phrase}",
         )
 
 

--- a/homeassistant/components/assist_pipeline/websocket_api.py
+++ b/homeassistant/components/assist_pipeline/websocket_api.py
@@ -100,7 +100,7 @@ def async_register_websocket_api(hass: HomeAssistant) -> None:
                     {
                         vol.Required("input"): {
                             vol.Required("sample_rate"): int,
-                            vol.Optional("duplicate_wake_up_key"): str,
+                            vol.Optional("wake_word_phrase"): str,
                         }
                     },
                     extra=vol.ALLOW_EXTRA,
@@ -154,7 +154,7 @@ async def websocket_run(
         msg_input = msg["input"]
         audio_queue: asyncio.Queue[bytes] = asyncio.Queue()
         incoming_sample_rate = msg_input["sample_rate"]
-        stt_wake_up_key: str | None = None
+        wake_word_phrase: str | None = None
 
         if start_stage == PipelineStage.WAKE_WORD:
             wake_word_settings = WakeWordSettings(
@@ -162,7 +162,7 @@ async def websocket_run(
                 audio_seconds_to_buffer=msg_input.get("audio_seconds_to_buffer", 0),
             )
         elif start_stage == PipelineStage.STT:
-            stt_wake_up_key = msg["input"].get("duplicate_wake_up_key")
+            wake_word_phrase = msg["input"].get("wake_word_phrase")
 
         async def stt_stream() -> AsyncGenerator[bytes, None]:
             state = None
@@ -197,7 +197,7 @@ async def websocket_run(
             channel=stt.AudioChannels.CHANNEL_MONO,
         )
         input_args["stt_stream"] = stt_stream()
-        input_args["stt_wake_up_key"] = stt_wake_up_key
+        input_args["wake_word_phrase"] = wake_word_phrase
 
         # Audio settings
         audio_settings = AudioSettings(

--- a/homeassistant/components/assist_pipeline/websocket_api.py
+++ b/homeassistant/components/assist_pipeline/websocket_api.py
@@ -12,7 +12,7 @@ from typing import Any, Final
 
 import voluptuous as vol
 
-from homeassistant.components import conversation, stt, tts, websocket_api
+from homeassistant.components import conversation, stt, tts, wake_word, websocket_api
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_SECONDS, MATCH_ALL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, entity_registry as er
@@ -97,7 +97,12 @@ def async_register_websocket_api(hass: HomeAssistant) -> None:
                     extra=vol.ALLOW_EXTRA,
                 ),
                 PipelineStage.STT: vol.Schema(
-                    {vol.Required("input"): {vol.Required("sample_rate"): int}},
+                    {
+                        vol.Required("input"): {
+                            vol.Required("sample_rate"): int,
+                            vol.Optional("wake_word"): str,
+                        }
+                    },
                     extra=vol.ALLOW_EXTRA,
                 ),
                 PipelineStage.INTENT: vol.Schema(
@@ -149,12 +154,19 @@ async def websocket_run(
         msg_input = msg["input"]
         audio_queue: asyncio.Queue[bytes] = asyncio.Queue()
         incoming_sample_rate = msg_input["sample_rate"]
+        stt_wake_word: wake_word.WakeWord | None = None
 
         if start_stage == PipelineStage.WAKE_WORD:
             wake_word_settings = WakeWordSettings(
                 timeout=msg["input"].get("timeout", DEFAULT_WAKE_WORD_TIMEOUT),
                 audio_seconds_to_buffer=msg_input.get("audio_seconds_to_buffer", 0),
             )
+        elif start_stage == PipelineStage.STT:
+            stt_wake_word_id = msg["input"].get("wake_word")
+            if stt_wake_word_id:
+                stt_wake_word = wake_word.WakeWord(
+                    id=stt_wake_word_id, name=stt_wake_word_id
+                )
 
         async def stt_stream() -> AsyncGenerator[bytes, None]:
             state = None
@@ -189,6 +201,7 @@ async def websocket_run(
             channel=stt.AudioChannels.CHANNEL_MONO,
         )
         input_args["stt_stream"] = stt_stream()
+        input_args["stt_wake_word"] = stt_wake_word
 
         # Audio settings
         audio_settings = AudioSettings(

--- a/homeassistant/components/esphome/voice_assistant.py
+++ b/homeassistant/components/esphome/voice_assistant.py
@@ -265,6 +265,7 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
                     channel=stt.AudioChannels.CHANNEL_MONO,
                 ),
                 stt_stream=self._iterate_packets(),
+                # stt_wake_word=wake_word.WakeWord("test", "test"),
                 pipeline_id=pipeline_select.get_chosen_pipeline(
                     self.hass, DOMAIN, self.device_info.mac_address
                 ),

--- a/homeassistant/components/esphome/voice_assistant.py
+++ b/homeassistant/components/esphome/voice_assistant.py
@@ -265,7 +265,6 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
                     channel=stt.AudioChannels.CHANNEL_MONO,
                 ),
                 stt_stream=self._iterate_packets(),
-                # stt_wake_word=wake_word.WakeWord("test", "test"),
                 pipeline_id=pipeline_select.get_chosen_pipeline(
                     self.hass, DOMAIN, self.device_info.mac_address
                 ),

--- a/homeassistant/components/wake_word/models.py
+++ b/homeassistant/components/wake_word/models.py
@@ -17,6 +17,9 @@ class DetectionResult:
     wake_word_id: str
     """Id of detected wake word"""
 
+    wake_word_phrase: str
+    """Normalized phrase for the detected wake word"""
+
     timestamp: int | None
     """Timestamp of audio chunk with detected wake word"""
 

--- a/homeassistant/components/wake_word/models.py
+++ b/homeassistant/components/wake_word/models.py
@@ -7,7 +7,13 @@ class WakeWord:
     """Wake word model."""
 
     id: str
+    """Id of wake word model"""
+
     name: str
+    """Name of wake word model"""
+
+    phrase: str | None = None
+    """Wake word phrase used to trigger model"""
 
 
 @dataclass

--- a/homeassistant/components/wyoming/manifest.json
+++ b/homeassistant/components/wyoming/manifest.json
@@ -6,6 +6,6 @@
   "dependencies": ["assist_pipeline"],
   "documentation": "https://www.home-assistant.io/integrations/wyoming",
   "iot_class": "local_push",
-  "requirements": ["wyoming==1.5.2"],
+  "requirements": ["wyoming==1.5.3"],
   "zeroconf": ["_wyoming._tcp.local."]
 }

--- a/homeassistant/components/wyoming/satellite.py
+++ b/homeassistant/components/wyoming/satellite.py
@@ -88,7 +88,9 @@ class WyomingSatellite:
                     await self._connect_and_loop()
                 except asyncio.CancelledError:
                     raise  # don't restart
-                except Exception:  # pylint: disable=broad-exception-caught
+                except Exception as err:  # pylint: disable=broad-exception-caught
+                    _LOGGER.debug("%s: %s", err.__class__.__name__, str(err))
+
                     # Ensure sensor is off (before restart)
                     self.device.set_is_active(False)
 

--- a/homeassistant/components/wyoming/wake_word.py
+++ b/homeassistant/components/wyoming/wake_word.py
@@ -192,13 +192,13 @@ class WyomingWakeWordProvider(wake_word.WakeWordDetectionEntity):
 
         return None
 
-    def _get_phrase(self, model_name: str) -> str:
-        """Get wake word phrase for model name."""
+    def _get_phrase(self, model_id: str) -> str:
+        """Get wake word phrase for model id."""
         for ww_model in self._supported_wake_words:
             if not ww_model.phrase:
                 continue
 
-            if ww_model.name == model_name:
+            if ww_model.id == model_id:
                 return ww_model.phrase
 
-        return model_name
+        return model_id

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2863,7 +2863,7 @@ wled==0.17.0
 wolf-comm==0.0.4
 
 # homeassistant.components.wyoming
-wyoming==1.5.2
+wyoming==1.5.3
 
 # homeassistant.components.xbox
 xbox-webapi==2.0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2195,7 +2195,7 @@ wled==0.17.0
 wolf-comm==0.0.4
 
 # homeassistant.components.wyoming
-wyoming==1.5.2
+wyoming==1.5.3
 
 # homeassistant.components.xbox
 xbox-webapi==2.0.11

--- a/tests/components/assist_pipeline/conftest.py
+++ b/tests/components/assist_pipeline/conftest.py
@@ -201,16 +201,19 @@ class MockWakeWordEntity(wake_word.WakeWordDetectionEntity):
 
         if self.alternate_detections:
             detected_id = wake_words[self.detected_wake_word_index].id
+            detected_name = wake_words[self.detected_wake_word_index].name
             self.detected_wake_word_index = (self.detected_wake_word_index + 1) % len(
                 wake_words
             )
         else:
             detected_id = wake_words[0].id
+            detected_name = wake_words[0].name
 
         async for chunk, timestamp in stream:
             if chunk.startswith(b"wake word"):
                 return wake_word.DetectionResult(
                     wake_word_id=detected_id,
+                    wake_word_phrase=detected_name,
                     timestamp=timestamp,
                     queued_audio=[(b"queued audio", 0)],
                 )
@@ -240,6 +243,7 @@ class MockWakeWordEntity2(wake_word.WakeWordDetectionEntity):
             if chunk.startswith(b"wake word"):
                 return wake_word.DetectionResult(
                     wake_word_id=wake_words[0].id,
+                    wake_word_phrase=wake_words[0].name,
                     timestamp=timestamp,
                     queued_audio=[(b"queued audio", 0)],
                 )

--- a/tests/components/assist_pipeline/snapshots/test_init.ambr
+++ b/tests/components/assist_pipeline/snapshots/test_init.ambr
@@ -294,6 +294,7 @@
         'wake_word_output': dict({
           'timestamp': 2000,
           'wake_word_id': 'test_ww',
+          'wake_word_phrase': 'Test Wake Word',
         }),
       }),
       'type': <PipelineEventType.WAKE_WORD_END: 'wake_word-end'>,

--- a/tests/components/assist_pipeline/snapshots/test_websocket.ambr
+++ b/tests/components/assist_pipeline/snapshots/test_websocket.ambr
@@ -1085,3 +1085,17 @@
     'timeout': 3,
   })
 # ---
+# name: test_wake_word_cooldown_same_id.4
+  dict({
+    'wake_word_output': dict({
+      'timestamp': 0,
+      'wake_word_id': 'test_ww',
+    }),
+  })
+# ---
+# name: test_wake_word_cooldown_same_id.5
+  dict({
+    'code': 'duplicate_wake_up_detected',
+    'message': 'Duplcate wake-up detected for wake_word.test.test_ww',
+  })
+# ---

--- a/tests/components/assist_pipeline/snapshots/test_websocket.ambr
+++ b/tests/components/assist_pipeline/snapshots/test_websocket.ambr
@@ -695,6 +695,46 @@
 # name: test_pipeline_empty_tts_output.3
   None
 # ---
+# name: test_stt_cooldown_different_ids
+  dict({
+    'language': 'en',
+    'pipeline': <ANY>,
+    'runner_data': dict({
+      'stt_binary_handler_id': 1,
+      'timeout': 300,
+    }),
+  })
+# ---
+# name: test_stt_cooldown_different_ids.1
+  dict({
+    'language': 'en',
+    'pipeline': <ANY>,
+    'runner_data': dict({
+      'stt_binary_handler_id': 1,
+      'timeout': 300,
+    }),
+  })
+# ---
+# name: test_stt_cooldown_same_id
+  dict({
+    'language': 'en',
+    'pipeline': <ANY>,
+    'runner_data': dict({
+      'stt_binary_handler_id': 1,
+      'timeout': 300,
+    }),
+  })
+# ---
+# name: test_stt_cooldown_same_id.1
+  dict({
+    'language': 'en',
+    'pipeline': <ANY>,
+    'runner_data': dict({
+      'stt_binary_handler_id': 1,
+      'timeout': 300,
+    }),
+  })
+# ---
 # name: test_stt_provider_missing
   dict({
     'language': 'en',

--- a/tests/components/assist_pipeline/snapshots/test_websocket.ambr
+++ b/tests/components/assist_pipeline/snapshots/test_websocket.ambr
@@ -971,10 +971,8 @@
 # ---
 # name: test_wake_word_cooldown_different_entities.5
   dict({
-    'wake_word_output': dict({
-      'timestamp': 0,
-      'wake_word_id': 'test_ww',
-    }),
+    'code': 'duplicate_wake_up_detected',
+    'message': 'Duplicate wake-up detected for test ww',
   })
 # ---
 # name: test_wake_word_cooldown_different_ids
@@ -1096,6 +1094,6 @@
 # name: test_wake_word_cooldown_same_id.5
   dict({
     'code': 'duplicate_wake_up_detected',
-    'message': 'Duplicate wake-up detected for wake_word.test.test_ww',
+    'message': 'Duplicate wake-up detected for test ww',
   })
 # ---

--- a/tests/components/assist_pipeline/snapshots/test_websocket.ambr
+++ b/tests/components/assist_pipeline/snapshots/test_websocket.ambr
@@ -1096,6 +1096,6 @@
 # name: test_wake_word_cooldown_same_id.5
   dict({
     'code': 'duplicate_wake_up_detected',
-    'message': 'Duplcate wake-up detected for wake_word.test.test_ww',
+    'message': 'Duplicate wake-up detected for wake_word.test.test_ww',
   })
 # ---

--- a/tests/components/assist_pipeline/snapshots/test_websocket.ambr
+++ b/tests/components/assist_pipeline/snapshots/test_websocket.ambr
@@ -381,6 +381,7 @@
     'wake_word_output': dict({
       'timestamp': 0,
       'wake_word_id': 'test_ww',
+      'wake_word_phrase': 'Test Wake Word',
     }),
   })
 # ---
@@ -966,13 +967,14 @@
     'wake_word_output': dict({
       'timestamp': 0,
       'wake_word_id': 'test_ww',
+      'wake_word_phrase': 'Test Wake Word',
     }),
   })
 # ---
 # name: test_wake_word_cooldown_different_entities.5
   dict({
     'code': 'duplicate_wake_up_detected',
-    'message': 'Duplicate wake-up detected for test ww',
+    'message': 'Duplicate wake-up detected for Test Wake Word',
   })
 # ---
 # name: test_wake_word_cooldown_different_ids
@@ -1026,6 +1028,7 @@
     'wake_word_output': dict({
       'timestamp': 0,
       'wake_word_id': 'test_ww',
+      'wake_word_phrase': 'Test Wake Word',
     }),
   })
 # ---
@@ -1034,6 +1037,7 @@
     'wake_word_output': dict({
       'timestamp': 0,
       'wake_word_id': 'test_ww_2',
+      'wake_word_phrase': 'Test Wake Word 2',
     }),
   })
 # ---
@@ -1088,12 +1092,13 @@
     'wake_word_output': dict({
       'timestamp': 0,
       'wake_word_id': 'test_ww',
+      'wake_word_phrase': 'Test Wake Word',
     }),
   })
 # ---
 # name: test_wake_word_cooldown_same_id.5
   dict({
     'code': 'duplicate_wake_up_detected',
-    'message': 'Duplicate wake-up detected for test ww',
+    'message': 'Duplicate wake-up detected for Test Wake Word',
   })
 # ---

--- a/tests/components/assist_pipeline/test_websocket.py
+++ b/tests/components/assist_pipeline/test_websocket.py
@@ -2568,8 +2568,7 @@ async def test_stt_cooldown_same_id(
             "end_stage": "tts",
             "input": {
                 "sample_rate": 16000,
-                # Normalization will make this match "ok_nabu"
-                "wake_word_phrase": "OK, Nabu!",
+                "wake_word_phrase": "ok_nabu",
             },
         }
     )

--- a/tests/components/assist_pipeline/test_websocket.py
+++ b/tests/components/assist_pipeline/test_websocket.py
@@ -1888,14 +1888,23 @@ async def test_wake_word_cooldown_same_id(
     await client_2.send_bytes(bytes([handler_id_2]) + b"wake word")
 
     # Get response events
+    error_data: dict[str, Any] | None = None
     msg = await client_1.receive_json()
     event_type_1 = msg["event"]["type"]
+    assert msg["event"]["data"] == snapshot
+    if event_type_1 == "error":
+        error_data = msg["event"]["data"]
 
     msg = await client_2.receive_json()
     event_type_2 = msg["event"]["type"]
+    assert msg["event"]["data"] == snapshot
+    if event_type_2 == "error":
+        error_data = msg["event"]["data"]
 
     # One should be a wake up, one should be an error
     assert {event_type_1, event_type_2} == {"wake_word-end", "error"}
+    assert error_data is not None
+    assert error_data["code"] == "duplicate_wake_up_detected"
 
 
 async def test_wake_word_cooldown_different_ids(
@@ -2542,7 +2551,7 @@ async def test_stt_cooldown_same_id(
             "end_stage": "tts",
             "input": {
                 "sample_rate": 16000,
-                "wake_word": "ok_nabu",
+                "duplicate_wake_up_key": "ok_nabu",
             },
         }
     )
@@ -2554,7 +2563,7 @@ async def test_stt_cooldown_same_id(
             "end_stage": "tts",
             "input": {
                 "sample_rate": 16000,
-                "wake_word": "ok_nabu",
+                "duplicate_wake_up_key": "ok_nabu",
             },
         }
     )
@@ -2592,7 +2601,7 @@ async def test_stt_cooldown_same_id(
     # One should be a stt start, one should be an error
     assert {event_type_1, event_type_2} == {"stt-start", "error"}
     assert error_data is not None
-    assert error_data["code"] == "speech_to_text_aborted"
+    assert error_data["code"] == "duplicate_wake_up_detected"
 
 
 async def test_stt_cooldown_different_ids(
@@ -2613,7 +2622,7 @@ async def test_stt_cooldown_different_ids(
             "end_stage": "tts",
             "input": {
                 "sample_rate": 16000,
-                "wake_word": "ok_nabu",
+                "duplicate_wake_up_key": "ok_nabu",
             },
         }
     )
@@ -2625,7 +2634,7 @@ async def test_stt_cooldown_different_ids(
             "end_stage": "tts",
             "input": {
                 "sample_rate": 16000,
-                "wake_word": "hey_jarvis",
+                "duplicate_wake_up_key": "hey_jarvis",
             },
         }
     )

--- a/tests/components/assist_pipeline/test_websocket.py
+++ b/tests/components/assist_pipeline/test_websocket.py
@@ -1,6 +1,7 @@
 """Websocket tests for Voice Assistant integration."""
 import asyncio
 import base64
+from typing import Any
 from unittest.mock import ANY, patch
 
 from syrupy.assertion import SnapshotAssertion
@@ -2521,3 +2522,138 @@ async def test_pipeline_list_devices(
             "pipeline_entity": "select.test_assist_device_test_prefix_pipeline",
         }
     ]
+
+
+async def test_stt_cooldown_same_id(
+    hass: HomeAssistant,
+    init_components,
+    mock_stt_provider,
+    hass_ws_client: WebSocketGenerator,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test that two speech-to-text pipelines cannot run within the cooldown period if they have the same wake word."""
+    client_1 = await hass_ws_client(hass)
+    client_2 = await hass_ws_client(hass)
+
+    await client_1.send_json_auto_id(
+        {
+            "type": "assist_pipeline/run",
+            "start_stage": "stt",
+            "end_stage": "tts",
+            "input": {
+                "sample_rate": 16000,
+                "wake_word": "ok_nabu",
+            },
+        }
+    )
+
+    await client_2.send_json_auto_id(
+        {
+            "type": "assist_pipeline/run",
+            "start_stage": "stt",
+            "end_stage": "tts",
+            "input": {
+                "sample_rate": 16000,
+                "wake_word": "ok_nabu",
+            },
+        }
+    )
+
+    # result
+    msg = await client_1.receive_json()
+    assert msg["success"], msg
+
+    msg = await client_2.receive_json()
+    assert msg["success"], msg
+
+    # run start
+    msg = await client_1.receive_json()
+    assert msg["event"]["type"] == "run-start"
+    msg["event"]["data"]["pipeline"] = ANY
+    assert msg["event"]["data"] == snapshot
+
+    msg = await client_2.receive_json()
+    assert msg["event"]["type"] == "run-start"
+    msg["event"]["data"]["pipeline"] = ANY
+    assert msg["event"]["data"] == snapshot
+
+    # Get response events
+    error_data: dict[str, Any] | None = None
+    msg = await client_1.receive_json()
+    event_type_1 = msg["event"]["type"]
+    if event_type_1 == "error":
+        error_data = msg["event"]["data"]
+
+    msg = await client_2.receive_json()
+    event_type_2 = msg["event"]["type"]
+    if event_type_2 == "error":
+        error_data = msg["event"]["data"]
+
+    # One should be a stt start, one should be an error
+    assert {event_type_1, event_type_2} == {"stt-start", "error"}
+    assert error_data is not None
+    assert error_data["code"] == "speech_to_text_aborted"
+
+
+async def test_stt_cooldown_different_ids(
+    hass: HomeAssistant,
+    init_components,
+    mock_stt_provider,
+    hass_ws_client: WebSocketGenerator,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test that two speech-to-text pipelines can run within the cooldown period if they have the different wake words."""
+    client_1 = await hass_ws_client(hass)
+    client_2 = await hass_ws_client(hass)
+
+    await client_1.send_json_auto_id(
+        {
+            "type": "assist_pipeline/run",
+            "start_stage": "stt",
+            "end_stage": "tts",
+            "input": {
+                "sample_rate": 16000,
+                "wake_word": "ok_nabu",
+            },
+        }
+    )
+
+    await client_2.send_json_auto_id(
+        {
+            "type": "assist_pipeline/run",
+            "start_stage": "stt",
+            "end_stage": "tts",
+            "input": {
+                "sample_rate": 16000,
+                "wake_word": "hey_jarvis",
+            },
+        }
+    )
+
+    # result
+    msg = await client_1.receive_json()
+    assert msg["success"], msg
+
+    msg = await client_2.receive_json()
+    assert msg["success"], msg
+
+    # run start
+    msg = await client_1.receive_json()
+    assert msg["event"]["type"] == "run-start"
+    msg["event"]["data"]["pipeline"] = ANY
+    assert msg["event"]["data"] == snapshot
+
+    msg = await client_2.receive_json()
+    assert msg["event"]["type"] == "run-start"
+    msg["event"]["data"]["pipeline"] = ANY
+    assert msg["event"]["data"] == snapshot
+
+    # Get response events
+    msg = await client_1.receive_json()
+    event_type_1 = msg["event"]["type"]
+
+    msg = await client_2.receive_json()
+    event_type_2 = msg["event"]["type"]
+
+    # Both should start stt
+    assert {event_type_1, event_type_2} == {"stt-start"}

--- a/tests/components/wake_word/test_init.py
+++ b/tests/components/wake_word/test_init.py
@@ -1,4 +1,5 @@
 """Test wake_word component setup."""
+
 import asyncio
 from collections.abc import AsyncIterable, Generator
 from functools import partial
@@ -43,8 +44,12 @@ class MockProviderEntity(wake_word.WakeWordDetectionEntity):
     async def get_supported_wake_words(self) -> list[wake_word.WakeWord]:
         """Return a list of supported wake words."""
         return [
-            wake_word.WakeWord(id="test_ww", name="Test Wake Word"),
-            wake_word.WakeWord(id="test_ww_2", name="Test Wake Word 2"),
+            wake_word.WakeWord(
+                id="test_ww", name="Test Wake Word", phrase="Test Phrase"
+            ),
+            wake_word.WakeWord(
+                id="test_ww_2", name="Test Wake Word 2", phrase="Test Phrase 2"
+            ),
         ]
 
     async def _async_process_audio_stream(
@@ -54,10 +59,18 @@ class MockProviderEntity(wake_word.WakeWordDetectionEntity):
         if wake_word_id is None:
             wake_word_id = (await self.get_supported_wake_words())[0].id
 
+        wake_word_phrase = wake_word_id
+        for ww in await self.get_supported_wake_words():
+            if ww.id == wake_word_id:
+                wake_word_phrase = ww.phrase or ww.name
+                break
+
         async for _chunk, timestamp in stream:
             if timestamp >= 2000:
                 return wake_word.DetectionResult(
-                    wake_word_id=wake_word_id, timestamp=timestamp
+                    wake_word_id=wake_word_id,
+                    wake_word_phrase=wake_word_phrase,
+                    timestamp=timestamp,
                 )
 
         # Not detected
@@ -159,10 +172,10 @@ async def test_config_entry_unload(
 
 @freeze_time("2023-06-22 10:30:00+00:00")
 @pytest.mark.parametrize(
-    ("wake_word_id", "expected_ww"),
+    ("wake_word_id", "expected_ww", "expected_phrase"),
     [
-        (None, "test_ww"),
-        ("test_ww_2", "test_ww_2"),
+        (None, "test_ww", "Test Phrase"),
+        ("test_ww_2", "test_ww_2", "Test Phrase 2"),
     ],
 )
 async def test_detected_entity(
@@ -171,6 +184,7 @@ async def test_detected_entity(
     setup: MockProviderEntity,
     wake_word_id: str | None,
     expected_ww: str,
+    expected_phrase: str,
 ) -> None:
     """Test successful detection through entity."""
 
@@ -184,7 +198,9 @@ async def test_detected_entity(
     state = setup.state
     assert state is None
     result = await setup.async_process_audio_stream(three_second_stream(), wake_word_id)
-    assert result == wake_word.DetectionResult(expected_ww, 2048)
+    assert result == wake_word.DetectionResult(
+        wake_word_id=expected_ww, wake_word_phrase=expected_phrase, timestamp=2048
+    )
 
     assert state != setup.state
     assert setup.state == "2023-06-22T10:30:00+00:00"
@@ -285,8 +301,8 @@ async def test_list_wake_words(
     assert msg["success"]
     assert msg["result"] == {
         "wake_words": [
-            {"id": "test_ww", "name": "Test Wake Word"},
-            {"id": "test_ww_2", "name": "Test Wake Word 2"},
+            {"id": "test_ww", "name": "Test Wake Word", "phrase": "Test Phrase"},
+            {"id": "test_ww_2", "name": "Test Wake Word 2", "phrase": "Test Phrase 2"},
         ]
     }
 
@@ -320,9 +336,10 @@ async def test_list_wake_words_timeout(
     """Test that the list_wake_words websocket command handles unknown entity."""
     client = await hass_ws_client(hass)
 
-    with patch.object(
-        setup, "get_supported_wake_words", partial(asyncio.sleep, 1)
-    ), patch("homeassistant.components.wake_word.TIMEOUT_FETCH_WAKE_WORDS", 0):
+    with (
+        patch.object(setup, "get_supported_wake_words", partial(asyncio.sleep, 1)),
+        patch("homeassistant.components.wake_word.TIMEOUT_FETCH_WAKE_WORDS", 0),
+    ):
         await client.send_json(
             {
                 "id": 5,

--- a/tests/components/wyoming/__init__.py
+++ b/tests/components/wyoming/__init__.py
@@ -75,6 +75,7 @@ WAKE_WORD_INFO = Info(
                 WakeModel(
                     name="Test Model",
                     description="Test Model",
+                    phrase="Test Phrase",
                     installed=True,
                     attribution=TEST_ATTR,
                     languages=["en-US"],

--- a/tests/components/wyoming/snapshots/test_wake_word.ambr
+++ b/tests/components/wyoming/snapshots/test_wake_word.ambr
@@ -8,6 +8,7 @@
       ),
     ]),
     'timestamp': 0,
-    'wake_word_id': 'Test Model',
+    'wake_word_id': 'TEST_MODEL_v1.0',
+    'wake_word_phrase': 'test model',
   })
 # ---

--- a/tests/components/wyoming/snapshots/test_wake_word.ambr
+++ b/tests/components/wyoming/snapshots/test_wake_word.ambr
@@ -8,7 +8,7 @@
       ),
     ]),
     'timestamp': 0,
-    'wake_word_id': 'TEST_MODEL_v1.0',
-    'wake_word_phrase': 'test model',
+    'wake_word_id': 'Test Model',
+    'wake_word_phrase': 'Test Phrase',
   })
 # ---

--- a/tests/components/wyoming/test_satellite.py
+++ b/tests/components/wyoming/test_satellite.py
@@ -1,4 +1,5 @@
 """Test Wyoming satellite."""
+
 from __future__ import annotations
 
 import asyncio
@@ -12,6 +13,7 @@ from wyoming.asr import Transcribe, Transcript
 from wyoming.audio import AudioChunk, AudioStart, AudioStop
 from wyoming.error import Error
 from wyoming.event import Event
+from wyoming.info import Info
 from wyoming.ping import Ping, Pong
 from wyoming.pipeline import PipelineStage, RunPipeline
 from wyoming.satellite import RunSatellite
@@ -26,7 +28,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from . import SATELLITE_INFO, MockAsyncTcpClient
+from . import SATELLITE_INFO, WAKE_WORD_INFO, MockAsyncTcpClient
 
 from tests.common import MockConfigEntry
 
@@ -207,19 +209,25 @@ async def test_satellite_pipeline(hass: HomeAssistant) -> None:
                 audio_chunk_received.set()
                 break
 
-    with patch(
-        "homeassistant.components.wyoming.data.load_wyoming_info",
-        return_value=SATELLITE_INFO,
-    ), patch(
-        "homeassistant.components.wyoming.satellite.AsyncTcpClient",
-        SatelliteAsyncTcpClient(events),
-    ) as mock_client, patch(
-        "homeassistant.components.wyoming.satellite.assist_pipeline.async_pipeline_from_audio_stream",
-        async_pipeline_from_audio_stream,
-    ), patch(
-        "homeassistant.components.wyoming.satellite.tts.async_get_media_source_audio",
-        return_value=("wav", get_test_wav()),
-    ), patch("homeassistant.components.wyoming.satellite._PING_SEND_DELAY", 0):
+    with (
+        patch(
+            "homeassistant.components.wyoming.data.load_wyoming_info",
+            return_value=SATELLITE_INFO,
+        ),
+        patch(
+            "homeassistant.components.wyoming.satellite.AsyncTcpClient",
+            SatelliteAsyncTcpClient(events),
+        ) as mock_client,
+        patch(
+            "homeassistant.components.wyoming.satellite.assist_pipeline.async_pipeline_from_audio_stream",
+            async_pipeline_from_audio_stream,
+        ),
+        patch(
+            "homeassistant.components.wyoming.satellite.tts.async_get_media_source_audio",
+            return_value=("wav", get_test_wav()),
+        ),
+        patch("homeassistant.components.wyoming.satellite._PING_SEND_DELAY", 0),
+    ):
         entry = await setup_config_entry(hass)
         device: SatelliteDevice = hass.data[wyoming.DOMAIN][
             entry.entry_id
@@ -433,14 +441,16 @@ async def test_satellite_muted(hass: HomeAssistant) -> None:
         self.device.set_is_muted(False)
         on_muted_event.set()
 
-    with patch(
-        "homeassistant.components.wyoming.data.load_wyoming_info",
-        return_value=SATELLITE_INFO,
-    ), patch(
-        "homeassistant.components.wyoming._make_satellite", make_muted_satellite
-    ), patch(
-        "homeassistant.components.wyoming.satellite.WyomingSatellite.on_muted",
-        on_muted,
+    with (
+        patch(
+            "homeassistant.components.wyoming.data.load_wyoming_info",
+            return_value=SATELLITE_INFO,
+        ),
+        patch("homeassistant.components.wyoming._make_satellite", make_muted_satellite),
+        patch(
+            "homeassistant.components.wyoming.satellite.WyomingSatellite.on_muted",
+            on_muted,
+        ),
     ):
         entry = await setup_config_entry(hass)
         async with asyncio.timeout(1):
@@ -462,16 +472,21 @@ async def test_satellite_restart(hass: HomeAssistant) -> None:
         self.stop()
         on_restart_event.set()
 
-    with patch(
-        "homeassistant.components.wyoming.data.load_wyoming_info",
-        return_value=SATELLITE_INFO,
-    ), patch(
-        "homeassistant.components.wyoming.satellite.WyomingSatellite._connect_and_loop",
-        side_effect=RuntimeError(),
-    ), patch(
-        "homeassistant.components.wyoming.satellite.WyomingSatellite.on_restart",
-        on_restart,
-    ), patch("homeassistant.components.wyoming.satellite._RESTART_SECONDS", 0):
+    with (
+        patch(
+            "homeassistant.components.wyoming.data.load_wyoming_info",
+            return_value=SATELLITE_INFO,
+        ),
+        patch(
+            "homeassistant.components.wyoming.satellite.WyomingSatellite._connect_and_loop",
+            side_effect=RuntimeError(),
+        ),
+        patch(
+            "homeassistant.components.wyoming.satellite.WyomingSatellite.on_restart",
+            on_restart,
+        ),
+        patch("homeassistant.components.wyoming.satellite._RESTART_SECONDS", 0),
+    ):
         await setup_config_entry(hass)
         async with asyncio.timeout(1):
             await on_restart_event.wait()
@@ -497,19 +512,25 @@ async def test_satellite_reconnect(hass: HomeAssistant) -> None:
     async def on_stopped(self):
         stopped_event.set()
 
-    with patch(
-        "homeassistant.components.wyoming.data.load_wyoming_info",
-        return_value=SATELLITE_INFO,
-    ), patch(
-        "homeassistant.components.wyoming.satellite.AsyncTcpClient.connect",
-        side_effect=ConnectionRefusedError(),
-    ), patch(
-        "homeassistant.components.wyoming.satellite.WyomingSatellite.on_reconnect",
-        on_reconnect,
-    ), patch(
-        "homeassistant.components.wyoming.satellite.WyomingSatellite.on_stopped",
-        on_stopped,
-    ), patch("homeassistant.components.wyoming.satellite._RECONNECT_SECONDS", 0):
+    with (
+        patch(
+            "homeassistant.components.wyoming.data.load_wyoming_info",
+            return_value=SATELLITE_INFO,
+        ),
+        patch(
+            "homeassistant.components.wyoming.satellite.AsyncTcpClient.connect",
+            side_effect=ConnectionRefusedError(),
+        ),
+        patch(
+            "homeassistant.components.wyoming.satellite.WyomingSatellite.on_reconnect",
+            on_reconnect,
+        ),
+        patch(
+            "homeassistant.components.wyoming.satellite.WyomingSatellite.on_stopped",
+            on_stopped,
+        ),
+        patch("homeassistant.components.wyoming.satellite._RECONNECT_SECONDS", 0),
+    ):
         await setup_config_entry(hass)
         async with asyncio.timeout(1):
             await reconnect_event.wait()
@@ -524,17 +545,22 @@ async def test_satellite_disconnect_before_pipeline(hass: HomeAssistant) -> None
         self.stop()
         on_restart_event.set()
 
-    with patch(
-        "homeassistant.components.wyoming.data.load_wyoming_info",
-        return_value=SATELLITE_INFO,
-    ), patch(
-        "homeassistant.components.wyoming.satellite.AsyncTcpClient",
-        MockAsyncTcpClient([]),  # no RunPipeline event
-    ), patch(
-        "homeassistant.components.wyoming.satellite.assist_pipeline.async_pipeline_from_audio_stream",
-    ) as mock_run_pipeline, patch(
-        "homeassistant.components.wyoming.satellite.WyomingSatellite.on_restart",
-        on_restart,
+    with (
+        patch(
+            "homeassistant.components.wyoming.data.load_wyoming_info",
+            return_value=SATELLITE_INFO,
+        ),
+        patch(
+            "homeassistant.components.wyoming.satellite.AsyncTcpClient",
+            MockAsyncTcpClient([]),  # no RunPipeline event
+        ),
+        patch(
+            "homeassistant.components.wyoming.satellite.assist_pipeline.async_pipeline_from_audio_stream",
+        ) as mock_run_pipeline,
+        patch(
+            "homeassistant.components.wyoming.satellite.WyomingSatellite.on_restart",
+            on_restart,
+        ),
     ):
         await setup_config_entry(hass)
         async with asyncio.timeout(1):
@@ -564,20 +590,26 @@ async def test_satellite_disconnect_during_pipeline(hass: HomeAssistant) -> None
     async def on_stopped(self):
         on_stopped_event.set()
 
-    with patch(
-        "homeassistant.components.wyoming.data.load_wyoming_info",
-        return_value=SATELLITE_INFO,
-    ), patch(
-        "homeassistant.components.wyoming.satellite.AsyncTcpClient",
-        MockAsyncTcpClient(events),
-    ), patch(
-        "homeassistant.components.wyoming.satellite.assist_pipeline.async_pipeline_from_audio_stream",
-    ) as mock_run_pipeline, patch(
-        "homeassistant.components.wyoming.satellite.WyomingSatellite.on_restart",
-        on_restart,
-    ), patch(
-        "homeassistant.components.wyoming.satellite.WyomingSatellite.on_stopped",
-        on_stopped,
+    with (
+        patch(
+            "homeassistant.components.wyoming.data.load_wyoming_info",
+            return_value=SATELLITE_INFO,
+        ),
+        patch(
+            "homeassistant.components.wyoming.satellite.AsyncTcpClient",
+            MockAsyncTcpClient(events),
+        ),
+        patch(
+            "homeassistant.components.wyoming.satellite.assist_pipeline.async_pipeline_from_audio_stream",
+        ) as mock_run_pipeline,
+        patch(
+            "homeassistant.components.wyoming.satellite.WyomingSatellite.on_restart",
+            on_restart,
+        ),
+        patch(
+            "homeassistant.components.wyoming.satellite.WyomingSatellite.on_stopped",
+            on_stopped,
+        ),
     ):
         entry = await setup_config_entry(hass)
         device: SatelliteDevice = hass.data[wyoming.DOMAIN][
@@ -608,16 +640,20 @@ async def test_satellite_error_during_pipeline(hass: HomeAssistant) -> None:
     def _async_pipeline_from_audio_stream(*args: Any, **kwargs: Any) -> None:
         pipeline_event.set()
 
-    with patch(
-        "homeassistant.components.wyoming.data.load_wyoming_info",
-        return_value=SATELLITE_INFO,
-    ), patch(
-        "homeassistant.components.wyoming.satellite.AsyncTcpClient",
-        SatelliteAsyncTcpClient(events),
-    ) as mock_client, patch(
-        "homeassistant.components.wyoming.satellite.assist_pipeline.async_pipeline_from_audio_stream",
-        wraps=_async_pipeline_from_audio_stream,
-    ) as mock_run_pipeline:
+    with (
+        patch(
+            "homeassistant.components.wyoming.data.load_wyoming_info",
+            return_value=SATELLITE_INFO,
+        ),
+        patch(
+            "homeassistant.components.wyoming.satellite.AsyncTcpClient",
+            SatelliteAsyncTcpClient(events),
+        ) as mock_client,
+        patch(
+            "homeassistant.components.wyoming.satellite.assist_pipeline.async_pipeline_from_audio_stream",
+            wraps=_async_pipeline_from_audio_stream,
+        ) as mock_run_pipeline,
+    ):
         await setup_config_entry(hass)
 
         async with asyncio.timeout(1):
@@ -663,21 +699,27 @@ async def test_tts_not_wav(hass: HomeAssistant) -> None:
     def _async_pipeline_from_audio_stream(*args: Any, **kwargs: Any) -> None:
         pipeline_event.set()
 
-    with patch(
-        "homeassistant.components.wyoming.data.load_wyoming_info",
-        return_value=SATELLITE_INFO,
-    ), patch(
-        "homeassistant.components.wyoming.satellite.AsyncTcpClient",
-        SatelliteAsyncTcpClient(events),
-    ) as mock_client, patch(
-        "homeassistant.components.wyoming.satellite.assist_pipeline.async_pipeline_from_audio_stream",
-        wraps=_async_pipeline_from_audio_stream,
-    ) as mock_run_pipeline, patch(
-        "homeassistant.components.wyoming.satellite.tts.async_get_media_source_audio",
-        return_value=("mp3", bytes(1)),
-    ), patch(
-        "homeassistant.components.wyoming.satellite.WyomingSatellite._stream_tts",
-        _stream_tts,
+    with (
+        patch(
+            "homeassistant.components.wyoming.data.load_wyoming_info",
+            return_value=SATELLITE_INFO,
+        ),
+        patch(
+            "homeassistant.components.wyoming.satellite.AsyncTcpClient",
+            SatelliteAsyncTcpClient(events),
+        ) as mock_client,
+        patch(
+            "homeassistant.components.wyoming.satellite.assist_pipeline.async_pipeline_from_audio_stream",
+            wraps=_async_pipeline_from_audio_stream,
+        ) as mock_run_pipeline,
+        patch(
+            "homeassistant.components.wyoming.satellite.tts.async_get_media_source_audio",
+            return_value=("mp3", bytes(1)),
+        ),
+        patch(
+            "homeassistant.components.wyoming.satellite.WyomingSatellite._stream_tts",
+            _stream_tts,
+        ),
     ):
         entry = await setup_config_entry(hass)
 
@@ -752,15 +794,19 @@ async def test_pipeline_changed(hass: HomeAssistant) -> None:
 
         pipeline_stopped.set()
 
-    with patch(
-        "homeassistant.components.wyoming.data.load_wyoming_info",
-        return_value=SATELLITE_INFO,
-    ), patch(
-        "homeassistant.components.wyoming.satellite.AsyncTcpClient",
-        SatelliteAsyncTcpClient(events),
-    ) as mock_client, patch(
-        "homeassistant.components.wyoming.satellite.assist_pipeline.async_pipeline_from_audio_stream",
-        async_pipeline_from_audio_stream,
+    with (
+        patch(
+            "homeassistant.components.wyoming.data.load_wyoming_info",
+            return_value=SATELLITE_INFO,
+        ),
+        patch(
+            "homeassistant.components.wyoming.satellite.AsyncTcpClient",
+            SatelliteAsyncTcpClient(events),
+        ) as mock_client,
+        patch(
+            "homeassistant.components.wyoming.satellite.assist_pipeline.async_pipeline_from_audio_stream",
+            async_pipeline_from_audio_stream,
+        ),
     ):
         entry = await setup_config_entry(hass)
         device: SatelliteDevice = hass.data[wyoming.DOMAIN][
@@ -822,15 +868,19 @@ async def test_audio_settings_changed(hass: HomeAssistant) -> None:
 
         pipeline_stopped.set()
 
-    with patch(
-        "homeassistant.components.wyoming.data.load_wyoming_info",
-        return_value=SATELLITE_INFO,
-    ), patch(
-        "homeassistant.components.wyoming.satellite.AsyncTcpClient",
-        SatelliteAsyncTcpClient(events),
-    ) as mock_client, patch(
-        "homeassistant.components.wyoming.satellite.assist_pipeline.async_pipeline_from_audio_stream",
-        async_pipeline_from_audio_stream,
+    with (
+        patch(
+            "homeassistant.components.wyoming.data.load_wyoming_info",
+            return_value=SATELLITE_INFO,
+        ),
+        patch(
+            "homeassistant.components.wyoming.satellite.AsyncTcpClient",
+            SatelliteAsyncTcpClient(events),
+        ) as mock_client,
+        patch(
+            "homeassistant.components.wyoming.satellite.assist_pipeline.async_pipeline_from_audio_stream",
+            async_pipeline_from_audio_stream,
+        ),
     ):
         entry = await setup_config_entry(hass)
         device: SatelliteDevice = hass.data[wyoming.DOMAIN][
@@ -873,7 +923,7 @@ async def test_invalid_stages(hass: HomeAssistant) -> None:
     start_stage_event = asyncio.Event()
     end_stage_event = asyncio.Event()
 
-    def _run_pipeline_once(self, run_pipeline):
+    def _run_pipeline_once(self, run_pipeline, wake_word_phrase):
         # Set bad start stage
         run_pipeline.start_stage = PipelineStage.INTENT
         run_pipeline.end_stage = PipelineStage.TTS
@@ -892,15 +942,19 @@ async def test_invalid_stages(hass: HomeAssistant) -> None:
         except ValueError:
             end_stage_event.set()
 
-    with patch(
-        "homeassistant.components.wyoming.data.load_wyoming_info",
-        return_value=SATELLITE_INFO,
-    ), patch(
-        "homeassistant.components.wyoming.satellite.AsyncTcpClient",
-        SatelliteAsyncTcpClient(events),
-    ) as mock_client, patch(
-        "homeassistant.components.wyoming.satellite.WyomingSatellite._run_pipeline_once",
-        _run_pipeline_once,
+    with (
+        patch(
+            "homeassistant.components.wyoming.data.load_wyoming_info",
+            return_value=SATELLITE_INFO,
+        ),
+        patch(
+            "homeassistant.components.wyoming.satellite.AsyncTcpClient",
+            SatelliteAsyncTcpClient(events),
+        ) as mock_client,
+        patch(
+            "homeassistant.components.wyoming.satellite.WyomingSatellite._run_pipeline_once",
+            _run_pipeline_once,
+        ),
     ):
         entry = await setup_config_entry(hass)
 
@@ -950,15 +1004,19 @@ async def test_client_stops_pipeline(hass: HomeAssistant) -> None:
 
         pipeline_stopped.set()
 
-    with patch(
-        "homeassistant.components.wyoming.data.load_wyoming_info",
-        return_value=SATELLITE_INFO,
-    ), patch(
-        "homeassistant.components.wyoming.satellite.AsyncTcpClient",
-        SatelliteAsyncTcpClient(events),
-    ) as mock_client, patch(
-        "homeassistant.components.wyoming.satellite.assist_pipeline.async_pipeline_from_audio_stream",
-        async_pipeline_from_audio_stream,
+    with (
+        patch(
+            "homeassistant.components.wyoming.data.load_wyoming_info",
+            return_value=SATELLITE_INFO,
+        ),
+        patch(
+            "homeassistant.components.wyoming.satellite.AsyncTcpClient",
+            SatelliteAsyncTcpClient(events),
+        ) as mock_client,
+        patch(
+            "homeassistant.components.wyoming.satellite.assist_pipeline.async_pipeline_from_audio_stream",
+            async_pipeline_from_audio_stream,
+        ),
     ):
         entry = await setup_config_entry(hass)
 
@@ -982,3 +1040,46 @@ async def test_client_stops_pipeline(hass: HomeAssistant) -> None:
         # Stop the satellite
         await hass.config_entries.async_unload(entry.entry_id)
         await hass.async_block_till_done()
+
+
+async def test_wake_word_phrase(hass: HomeAssistant) -> None:
+    """Test that wake word phrase from info is given to pipeline."""
+    events = [
+        # Fake local wake word detection
+        Info(satellite=SATELLITE_INFO.satellite, wake=WAKE_WORD_INFO.wake).event(),
+        Detection(name="Test Model").event(),
+        RunPipeline(
+            start_stage=PipelineStage.WAKE, end_stage=PipelineStage.TTS
+        ).event(),
+    ]
+
+    pipeline_event = asyncio.Event()
+
+    def _async_pipeline_from_audio_stream(*args: Any, **kwargs: Any) -> None:
+        pipeline_event.set()
+
+    with (
+        patch(
+            "homeassistant.components.wyoming.data.load_wyoming_info",
+            return_value=SATELLITE_INFO,
+        ),
+        patch(
+            "homeassistant.components.wyoming.satellite.AsyncTcpClient",
+            SatelliteAsyncTcpClient(events),
+        ),
+        patch(
+            "homeassistant.components.wyoming.satellite.assist_pipeline.async_pipeline_from_audio_stream",
+            wraps=_async_pipeline_from_audio_stream,
+        ) as mock_run_pipeline,
+    ):
+        await setup_config_entry(hass)
+
+        async with asyncio.timeout(1):
+            await pipeline_event.wait()
+
+        # async_pipeline_from_audio_stream will receive the wake word phrase for
+        # deconfliction.
+        mock_run_pipeline.assert_called_once()
+        assert (
+            mock_run_pipeline.call_args.kwargs.get("wake_word_phrase") == "Test Phrase"
+        )

--- a/tests/components/wyoming/test_wake_word.py
+++ b/tests/components/wyoming/test_wake_word.py
@@ -48,7 +48,7 @@ async def test_streaming_audio(
 
     client_events = [
         Transcript("not a wake word event").event(),
-        Detection(name="Test Model", timestamp=0).event(),
+        Detection(name="TEST_MODEL_v1.0", timestamp=0).event(),
     ]
 
     with patch(
@@ -59,6 +59,8 @@ async def test_streaming_audio(
 
     assert result is not None
     assert result == snapshot
+    assert result.wake_word_id == "TEST_MODEL_v1.0"
+    assert result.wake_word_phrase == "test model"
 
 
 async def test_streaming_audio_connection_lost(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With streaming wake word detection, HA stops multiple satellites waking up at the same time by enforcing a "cooldown" period (default: 5 seconds). During this period, any pipeline with the same wake word (and wake word system) cannot run.

When satellites use local wake word detection, they begin their pipeline runs at the speech-to-text (STT) stage instead. This PR adds a "cooldown" to STT, and includes a new parameter for identifying the wake word phrase that was detected by the satellite (e.g., "ok nabu"). Now, if two satellites report the same wake word and attempt to begin their STT stages within the cooldown period (5 seconds), one will succeed and the other will receive a `duplicate_wake_up_detected` error.

Additionally, both local and streaming wake word detection now share cooldown periods for the same "wake word phrase". For example, if one satellite uses streaming wake word detection with an `ok nabu` phrase and a different satellite uses local wake word detection with an `ok nabu` phrase, they cannot both be woken up at the same time.

The wake word phrase must be supplied by the wake word provider or satellite. For Wyoming-based services, this is now included in the `info` message.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
