### PR TITLE
Reduce log level for creating ZHA cluster handler

### DIFF
--- a/homeassistant/components/zha/core/endpoint.py
+++ b/homeassistant/components/zha/core/endpoint.py
@@ -132,7 +132,7 @@ class Endpoint:
             if not cluster_handler_class.matches(cluster, self):
                 cluster_handler_class = ClusterHandler
 
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Creating cluster handler for cluster id: %s class: %s",
                 cluster_id,
                 cluster_handler_class,


### PR DESCRIPTION
## Proposed change
This lowers the log level for creating a ZHA cluster handler from `info` to `debug`.

IMO, there's little to no value in seeing many lines of ZHA creating cluster handlers during startup, even when you choose to see the more verbose `info` log level (instead of the default `warning` level).

As an example, starting my production HA instance with ~150 ZHA devices causes this: https://dpaste.org/ah7Mu
So, a total of 1160 lines of logging just for ZHA cluster handlers. Generally, the `info` logging isn't spammy otherwise.

The logs were added with the ZHA refactor PR: https://github.com/home-assistant/core/pull/91476
I've left this in draft for now. Maybe there's a good reason this was added to `info` instead of `debug` in the first place?

### "Warning" log

Note: If a cluster handler can't be created, a (more important) `warning` will still be logged:
https://github.com/home-assistant/core/blob/df9faeae6fe1f4e4a0249093b9c575af70492973/homeassistant/components/zha/core/endpoint.py#L141-L145

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
