### PR TITLE
Fix lights reporting unsupported colormodes in deCONZ

### DIFF
--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -212,6 +212,10 @@ class DeconzBaseLight(DeconzDevice[_LightDeviceT], LightEntity):
             color_mode = ColorMode.BRIGHTNESS
         else:
             color_mode = ColorMode.ONOFF
+        if color_mode not in self._attr_supported_color_modes:
+            # Some lights controlled by ZigBee scenes can get unsupported color mode
+            return self._attr_color_mode
+        self._attr_color_mode = color_mode
         return color_mode
 
     @property

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -1179,9 +1179,19 @@ async def test_non_color_light_reports_color(
         await setup_deconz_integration(hass, aioclient_mock)
 
     assert len(hass.states.async_all()) == 3
+    assert hass.states.get("light.group").attributes[ATTR_SUPPORTED_COLOR_MODES] == [
+        ColorMode.COLOR_TEMP,
+        ColorMode.HS,
+        ColorMode.XY,
+    ]
+    assert (
+        hass.states.get("light.group").attributes[ATTR_COLOR_MODE]
+        == ColorMode.COLOR_TEMP
+    )
     assert hass.states.get("light.group").attributes[ATTR_COLOR_TEMP] == 250
 
-    # Updating a scene will return a faulty color value for a non-color light causing an exception in hs_color
+    # Updating a scene will return a faulty color value
+    # for a non-color light causing an exception in hs_color
     event_changed_light = {
         "e": "changed",
         "id": "1",
@@ -1200,7 +1210,9 @@ async def test_non_color_light_reports_color(
     await mock_deconz_websocket(data=event_changed_light)
     await hass.async_block_till_done()
 
-    # Bug is fixed if we reach this point, but device won't have neither color temp nor color
+    assert hass.states.get("light.group").attributes[ATTR_COLOR_MODE] == ColorMode.XY
+    # Bug is fixed if we reach this point
+    # device won't have neither color temp nor color
     with pytest.raises(AssertionError):
         assert hass.states.get("light.group").attributes.get(ATTR_COLOR_TEMP) is None
         assert hass.states.get("light.group").attributes.get(ATTR_HS_COLOR) is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix an issue where a light can report a color mode not really supported by the light and thus not reported as supported with the entity. This can happen when a light is grouped with other lights and a zigbee scene gets called.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/108744
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
