### PR TITLE
Fix ESPHome not fully removing entities when entity info changes

### DIFF
--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -203,10 +203,6 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
         self._attr_has_entity_name = True
         self.entity_id = f"{domain}.{device_info.name}_{entity_info.object_id}"
 
-    async def _async_remove_forced(self) -> None:
-        """Fully remove this entity from the state machine."""
-        await self.async_remove(force_remove=True)
-
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
         entry_data = self._entry_data
@@ -217,7 +213,7 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
         self.async_on_remove(
             entry_data.async_register_key_static_info_remove_callback(
                 static_info,
-                self._async_remove_forced,
+                functools.partial(self.async_remove, force_remove=True),
             )
         )
         self.async_on_remove(

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -244,10 +244,11 @@ class RuntimeEntryData:
         self.assist_pipeline_update_callbacks.remove(update_callback)
 
     async def async_remove_entities(
-        self, static_infos: Iterable[EntityInfo], mac: str
+        self, hass: HomeAssistant, static_infos: Iterable[EntityInfo], mac: str
     ) -> None:
         """Schedule the removal of an entity."""
-        ent_reg = er.async_get(self._hass)
+        # Remove from entity registry first so the entity is fully removed
+        ent_reg = er.async_get(hass)
         for info in static_infos:
             if entry := ent_reg.async_get_entity_id(
                 INFO_TYPE_TO_PLATFORM[type(info)], DOMAIN, build_unique_id(mac, info)

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -243,8 +243,17 @@ class RuntimeEntryData:
         """Unsubscribe to assist pipeline updates."""
         self.assist_pipeline_update_callbacks.remove(update_callback)
 
-    async def async_remove_entities(self, static_infos: Iterable[EntityInfo]) -> None:
+    async def async_remove_entities(
+        self, static_infos: Iterable[EntityInfo], mac: str
+    ) -> None:
         """Schedule the removal of an entity."""
+        ent_reg = er.async_get(self._hass)
+        for info in static_infos:
+            if entry := ent_reg.async_get_entity_id(
+                INFO_TYPE_TO_PLATFORM[type(info)], DOMAIN, build_unique_id(mac, info)
+            ):
+                ent_reg.async_remove(entry)
+
         callbacks: list[Coroutine[Any, Any, None]] = []
         for static_info in static_infos:
             callback_key = (type(static_info), static_info.key)

--- a/tests/components/esphome/conftest.py
+++ b/tests/components/esphome/conftest.py
@@ -188,9 +188,6 @@ class MockESPHomeDevice:
         self.home_assistant_state_subscription_callback: Callable[
             [str, str | None], None
         ]
-        self.list_entities_services_callback: Callable[
-            [tuple[list[EntityInfo], list[UserService]]], None
-        ]
 
     def set_state_callback(self, state_callback: Callable[[EntityState], None]) -> None:
         """Set the state callback."""
@@ -201,12 +198,6 @@ class MockESPHomeDevice:
     ) -> None:
         """Set the service call callback."""
         self.service_call_callback = callback
-
-    def set_list_entities_services_callback(
-        self, callback: Callable[[tuple[list[EntityInfo], list[UserService]]], None]
-    ) -> None:
-        """Set the list_entities_services callback."""
-        self.list_entities_services_callback = callback
 
     def mock_service_call(self, service_call: HomeassistantServiceCall) -> None:
         """Mock a service call."""

--- a/tests/components/esphome/conftest.py
+++ b/tests/components/esphome/conftest.py
@@ -177,15 +177,19 @@ async def mock_dashboard(hass):
 class MockESPHomeDevice:
     """Mock an esphome device."""
 
-    def __init__(self, entry: MockConfigEntry) -> None:
+    def __init__(self, entry: MockConfigEntry, client: APIClient) -> None:
         """Init the mock."""
         self.entry = entry
+        self.client = client
         self.state_callback: Callable[[EntityState], None]
         self.service_call_callback: Callable[[HomeassistantServiceCall], None]
         self.on_disconnect: Callable[[bool], None]
         self.on_connect: Callable[[bool], None]
         self.home_assistant_state_subscription_callback: Callable[
             [str, str | None], None
+        ]
+        self.list_entities_services_callback: Callable[
+            [tuple[list[EntityInfo], list[UserService]]], None
         ]
 
     def set_state_callback(self, state_callback: Callable[[EntityState], None]) -> None:
@@ -197,6 +201,12 @@ class MockESPHomeDevice:
     ) -> None:
         """Set the service call callback."""
         self.service_call_callback = callback
+
+    def set_list_entities_services_callback(
+        self, callback: Callable[[tuple[list[EntityInfo], list[UserService]]], None]
+    ) -> None:
+        """Set the list_entities_services callback."""
+        self.list_entities_services_callback = callback
 
     def mock_service_call(self, service_call: HomeassistantServiceCall) -> None:
         """Mock a service call."""
@@ -258,7 +268,7 @@ async def _mock_generic_device_entry(
         )
         entry.add_to_hass(hass)
 
-    mock_device = MockESPHomeDevice(entry)
+    mock_device = MockESPHomeDevice(entry, mock_client)
 
     default_device_info = {
         "name": "test",

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -1,6 +1,7 @@
 """Test ESPHome binary sensors."""
 from collections.abc import Awaitable, Callable
 from typing import Any
+from unittest.mock import AsyncMock
 
 from aioesphomeapi import (
     APIClient,
@@ -21,6 +22,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from .conftest import MockESPHomeDevice
 
@@ -34,7 +36,8 @@ async def test_entities_removed(
         Awaitable[MockESPHomeDevice],
     ],
 ) -> None:
-    """Test a generic binary_sensor where has_state is false."""
+    """Test entities are removed when static info changes."""
+    ent_reg = er.async_get(hass)
     entity_info = [
         BinarySensorInfo(
             object_id="mybinary_sensor",
@@ -80,6 +83,8 @@ async def test_entities_removed(
     assert state.attributes[ATTR_RESTORED] is True
     state = hass.states.get("binary_sensor.test_mybinary_sensor_to_be_removed")
     assert state is not None
+    reg_entry = ent_reg.async_get("binary_sensor.test_mybinary_sensor_to_be_removed")
+    assert reg_entry is not None
     assert state.attributes[ATTR_RESTORED] is True
 
     entity_info = [
@@ -106,7 +111,124 @@ async def test_entities_removed(
     assert state.state == STATE_ON
     state = hass.states.get("binary_sensor.test_mybinary_sensor_to_be_removed")
     assert state is None
+    reg_entry = ent_reg.async_get("binary_sensor.test_mybinary_sensor_to_be_removed")
+    assert reg_entry is None
     await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert len(hass_storage[storage_key]["data"]["binary_sensor"]) == 1
+
+
+async def test_entities_removed_after_reload(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    hass_storage: dict[str, Any],
+    mock_esphome_device: Callable[
+        [APIClient, list[EntityInfo], list[UserService], list[EntityState]],
+        Awaitable[MockESPHomeDevice],
+    ],
+) -> None:
+    """Test entities and their registry entry are removed when static info changes after a reload."""
+    ent_reg = er.async_get(hass)
+    entity_info = [
+        BinarySensorInfo(
+            object_id="mybinary_sensor",
+            key=1,
+            name="my binary_sensor",
+            unique_id="my_binary_sensor",
+        ),
+        BinarySensorInfo(
+            object_id="mybinary_sensor_to_be_removed",
+            key=2,
+            name="my binary_sensor to be removed",
+            unique_id="mybinary_sensor_to_be_removed",
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False),
+        BinarySensorState(key=2, state=True, missing_state=False),
+    ]
+    user_service = []
+    mock_device: MockESPHomeDevice = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    entry = mock_device.entry
+    entry_id = entry.entry_id
+    storage_key = f"esphome.{entry_id}"
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
+    assert state is not None
+    assert state.state == STATE_ON
+    state = hass.states.get("binary_sensor.test_mybinary_sensor_to_be_removed")
+    assert state is not None
+    assert state.state == STATE_ON
+
+    reg_entry = ent_reg.async_get("binary_sensor.test_mybinary_sensor_to_be_removed")
+    assert reg_entry is not None
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass_storage[storage_key]["data"]["binary_sensor"]) == 2
+
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
+    assert state is not None
+    assert state.attributes[ATTR_RESTORED] is True
+    state = hass.states.get("binary_sensor.test_mybinary_sensor_to_be_removed")
+    assert state is not None
+    assert state.attributes[ATTR_RESTORED] is True
+
+    reg_entry = ent_reg.async_get("binary_sensor.test_mybinary_sensor_to_be_removed")
+    assert reg_entry is not None
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass_storage[storage_key]["data"]["binary_sensor"]) == 2
+
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
+    assert state is not None
+    assert ATTR_RESTORED not in state.attributes
+    state = hass.states.get("binary_sensor.test_mybinary_sensor_to_be_removed")
+    assert state is not None
+    assert ATTR_RESTORED not in state.attributes
+    reg_entry = ent_reg.async_get("binary_sensor.test_mybinary_sensor_to_be_removed")
+    assert reg_entry is not None
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_info = [
+        BinarySensorInfo(
+            object_id="mybinary_sensor",
+            key=1,
+            name="my binary_sensor",
+            unique_id="my_binary_sensor",
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False),
+    ]
+    mock_device.client.list_entities_services = AsyncMock(
+        return_value=(entity_info, user_service)
+    )
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_device.entry.entry_id == entry_id
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
+    assert state is not None
+    assert state.state == STATE_ON
+    state = hass.states.get("binary_sensor.test_mybinary_sensor_to_be_removed")
+    assert state is None
+
+    await hass.async_block_till_done()
+
+    reg_entry = ent_reg.async_get("binary_sensor.test_mybinary_sensor_to_be_removed")
+    assert reg_entry is None
+    assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
     assert len(hass_storage[storage_key]["data"]["binary_sensor"]) == 1
 


### PR DESCRIPTION
Please do not tag for backport. I'd prefer this to go through beta


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The entity was removed from the state machine but never from the registry so it would never disappear in the UI and they were impossible to delete in the UI as well.

reported at
https://github.com/ratgdo/esphome-ratgdo/issues/204 https://github.com/ratgdo/esphome-ratgdo/issues/163

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
