### PR TITLE
Reorganize ZHA device availability code

### DIFF
--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -127,7 +127,6 @@ class ZHADevice(LogMixin):
         self.hass = hass
         self._zigpy_device = zigpy_device
         self._zha_gateway = zha_gateway
-        self._available = False
         self._available_signal = f"{self.name}_{self.ieee}_{SIGNAL_AVAILABLE}"
         self._checkins_missed_count = 0
         self.unsubs: list[Callable[[], None]] = []
@@ -152,7 +151,10 @@ class ZHADevice(LogMixin):
                 CONF_CONSIDER_UNAVAILABLE_BATTERY,
                 CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY,
             )
-
+        self._available = self.is_coordinator or (
+            self.last_seen is not None
+            and time.time() - self.last_seen < self.consider_unavailable_time
+        )
         self._zdo_handler: ZDOClusterHandler = ZDOClusterHandler(self)
         self._power_config_ch: ClusterHandler | None = None
         self._identify_ch: ClusterHandler | None = None

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -11,7 +11,7 @@ import time
 from typing import TYPE_CHECKING, Any, Self
 
 from zigpy import types
-import zigpy.device
+from zigpy.device import Device as ZigpyDevice
 import zigpy.exceptions
 from zigpy.profiles import PROFILES
 import zigpy.quirks
@@ -124,21 +124,23 @@ class ZHADevice(LogMixin):
         zha_gateway: ZHAGateway,
     ) -> None:
         """Initialize the gateway."""
-        self.hass = hass
-        self._zigpy_device = zigpy_device
-        self._zha_gateway = zha_gateway
-        self._available_signal = f"{self.name}_{self.ieee}_{SIGNAL_AVAILABLE}"
-        self._checkins_missed_count = 0
+        self.hass: HomeAssistant = hass
+        self._zigpy_device: ZigpyDevice = zigpy_device
+        self._zha_gateway: ZHAGateway = zha_gateway
+        self._available_signal: str = f"{self.name}_{self.ieee}_{SIGNAL_AVAILABLE}"
+        self._checkins_missed_count: int = 0
         self.unsubs: list[Callable[[], None]] = []
-        self.quirk_applied = isinstance(self._zigpy_device, zigpy.quirks.CustomDevice)
-        self.quirk_class = (
+        self.quirk_applied: bool = isinstance(
+            self._zigpy_device, zigpy.quirks.CustomDevice
+        )
+        self.quirk_class: str = (
             f"{self._zigpy_device.__class__.__module__}."
             f"{self._zigpy_device.__class__.__name__}"
         )
-        self.quirk_id = getattr(self._zigpy_device, ATTR_QUIRK_ID, None)
+        self.quirk_id: str | None = getattr(self._zigpy_device, ATTR_QUIRK_ID, None)
 
         if self.is_mains_powered:
-            self.consider_unavailable_time = async_get_zha_config_value(
+            self.consider_unavailable_time: int = async_get_zha_config_value(
                 self._zha_gateway.config_entry,
                 ZHA_OPTIONS,
                 CONF_CONSIDER_UNAVAILABLE_MAINS,
@@ -151,7 +153,7 @@ class ZHADevice(LogMixin):
                 CONF_CONSIDER_UNAVAILABLE_BATTERY,
                 CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY,
             )
-        self._available = self.is_coordinator or (
+        self._available: bool = self.is_coordinator or (
             self.last_seen is not None
             and time.time() - self.last_seen < self.consider_unavailable_time
         )
@@ -410,7 +412,6 @@ class ZHADevice(LogMixin):
         hass: HomeAssistant,
         zigpy_dev: zigpy.device.Device,
         gateway: ZHAGateway,
-        restored: bool = False,
     ) -> Self:
         """Create new device."""
         zha_dev = cls(hass, zigpy_dev, gateway)

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -268,7 +268,6 @@ class ZHAGateway:
             delta_msg = "not known"
             if zha_device.last_seen is not None:
                 delta = round(time.time() - zha_device.last_seen)
-                zha_device.available = delta < zha_device.consider_unavailable_time
                 delta_msg = f"{str(timedelta(seconds=delta))} ago"
             _LOGGER.debug(
                 (

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -223,7 +223,7 @@ class ZHAGateway:
         zha_data.gateway = self
 
         self.coordinator_zha_device = self._async_get_or_create_device(
-            self._find_coordinator_device(), restored=True
+            self._find_coordinator_device()
         )
 
         self.async_load_devices()
@@ -264,7 +264,7 @@ class ZHAGateway:
         """Restore ZHA devices from zigpy application state."""
 
         for zigpy_device in self.application_controller.devices.values():
-            zha_device = self._async_get_or_create_device(zigpy_device, restored=True)
+            zha_device = self._async_get_or_create_device(zigpy_device)
             delta_msg = "not known"
             if zha_device.last_seen is not None:
                 delta = round(time.time() - zha_device.last_seen)
@@ -621,11 +621,11 @@ class ZHAGateway:
 
     @callback
     def _async_get_or_create_device(
-        self, zigpy_device: zigpy.device.Device, restored: bool = False
+        self, zigpy_device: zigpy.device.Device
     ) -> ZHADevice:
         """Get or create a ZHA device."""
         if (zha_device := self._devices.get(zigpy_device.ieee)) is None:
-            zha_device = ZHADevice.new(self.hass, zigpy_device, self, restored)
+            zha_device = ZHADevice.new(self.hass, zigpy_device, self)
             self._devices[zigpy_device.ieee] = zha_device
 
             device_registry = dr.async_get(self.hass)

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -25,6 +25,7 @@ import zigpy.zdo.types as zdo_t
 
 import homeassistant.components.zha.core.const as zha_const
 import homeassistant.components.zha.core.device as zha_core_device
+from homeassistant.components.zha.core.gateway import ZHAGateway
 from homeassistant.components.zha.core.helpers import get_zha_gateway
 from homeassistant.helpers import restore_state
 from homeassistant.setup import async_setup_component
@@ -381,7 +382,7 @@ def zha_device_joined_restored(request):
 
 @pytest.fixture
 def zha_device_mock(
-    hass, zigpy_device_mock
+    hass, config_entry, zigpy_device_mock
 ) -> Callable[..., zha_core_device.ZHADevice]:
     """Return a ZHA Device factory."""
 
@@ -409,7 +410,11 @@ def zha_device_mock(
         zigpy_device = zigpy_device_mock(
             endpoints, ieee, manufacturer, model, node_desc, patch_cluster=patch_cluster
         )
-        zha_device = zha_core_device.ZHADevice(hass, zigpy_device, MagicMock())
+        zha_device = zha_core_device.ZHADevice(
+            hass,
+            zigpy_device,
+            ZHAGateway(hass, {}, config_entry),
+        )
         return zha_device
 
     return _zha_device

--- a/tests/components/zha/test_gateway.py
+++ b/tests/components/zha/test_gateway.py
@@ -365,7 +365,7 @@ async def test_startup_concurrency_limit(
             zigpy.zdo.types.NodeDescriptor.MACCapabilityFlags.MainsPowered
         )
 
-        zha_gateway._async_get_or_create_device(zigpy_dev, restored=True)
+        zha_gateway._async_get_or_create_device(zigpy_dev)
 
     # Keep track of request concurrency during initialization
     current_concurrency = 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR refactors how the available property is initially set on `ZHADevice` instances and it cleans up an unused restored flag.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
