### PR TITLE
Improved Assist debug

### DIFF
--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -321,8 +321,7 @@ async def websocket_hass_agent_debug(
                 conversation_id=None,
                 device_id=msg.get("device_id"),
                 language=msg.get("language", hass.config.language),
-            ),
-            run_triggers=False,
+            )
         )
         for sentence in msg["sentences"]
     ]

--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -32,6 +32,7 @@ from homeassistant.util import language as language_util
 from .agent import AbstractConversationAgent, ConversationInput, ConversationResult
 from .const import HOME_ASSISTANT_AGENT
 from .default_agent import (
+    METADATA_CUSTOM_FILE,
     METADATA_CUSTOM_SENTENCE,
     DefaultAgent,
     SentenceTriggerResult,
@@ -384,6 +385,7 @@ async def websocket_hass_agent_debug(
                 METADATA_CUSTOM_SENTENCE
             ):
                 result_dict["source"] = "custom"
+                result_dict["file"] = result.intent_metadata.get(METADATA_CUSTOM_FILE)
             else:
                 result_dict["source"] = "builtin"
 

--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -31,7 +31,12 @@ from homeassistant.util import language as language_util
 
 from .agent import AbstractConversationAgent, ConversationInput, ConversationResult
 from .const import HOME_ASSISTANT_AGENT
-from .default_agent import DefaultAgent, async_setup as async_setup_default_agent
+from .default_agent import (
+    METADATA_CUSTOM_SENTENCE,
+    DefaultAgent,
+    SentenceTriggerResult,
+    async_setup as async_setup_default_agent,
+)
 
 __all__ = [
     "DOMAIN",
@@ -316,7 +321,8 @@ async def websocket_hass_agent_debug(
                 conversation_id=None,
                 device_id=msg.get("device_id"),
                 language=msg.get("language", hass.config.language),
-            )
+            ),
+            run_triggers=False,
         )
         for sentence in msg["sentences"]
     ]
@@ -324,49 +330,63 @@ async def websocket_hass_agent_debug(
     # Return results for each sentence in the same order as the input.
     result_dicts: list[dict[str, Any] | None] = []
     for result in results:
-        if result is None:
-            # Indicate that a recognition failure occurred
-            result_dicts.append(None)
-            continue
-
-        successful_match = not result.unmatched_entities
-        result_dict = {
-            # Name of the matching intent (or the closest)
-            "intent": {
-                "name": result.intent.name,
-            },
-            # Slot values that would be received by the intent
-            "slots": {  # direct access to values
-                entity_key: entity.value
-                for entity_key, entity in result.entities.items()
-            },
-            # Extra slot details, such as the originally matched text
-            "details": {
-                entity_key: {
-                    "name": entity.name,
-                    "value": entity.value,
-                    "text": entity.text,
-                }
-                for entity_key, entity in result.entities.items()
-            },
-            # Entities/areas/etc. that would be targeted
-            "targets": {},
-            # True if match was successful
-            "match": successful_match,
-            # Text of the sentence template that matched (or was closest)
-            "sentence_template": "",
-            # When match is incomplete, this will contain the best slot guesses
-            "unmatched_slots": _get_unmatched_slots(result),
-        }
-
-        if successful_match:
-            result_dict["targets"] = {
-                state.entity_id: {"matched": is_matched}
-                for state, is_matched in _get_debug_targets(hass, result)
+        result_dict: dict[str, Any] | None = None
+        if isinstance(result, SentenceTriggerResult):
+            result_dict = {
+                # Matched a user-defined sentence trigger.
+                # We can't provide the response here without executing the
+                # trigger.
+                "match": True,
+                "source": "trigger",
+                "sentence_template": result.sentence_template or "",
+            }
+        elif isinstance(result, RecognizeResult):
+            successful_match = not result.unmatched_entities
+            result_dict = {
+                # Name of the matching intent (or the closest)
+                "intent": {
+                    "name": result.intent.name,
+                },
+                # Slot values that would be received by the intent
+                "slots": {  # direct access to values
+                    entity_key: entity.value
+                    for entity_key, entity in result.entities.items()
+                },
+                # Extra slot details, such as the originally matched text
+                "details": {
+                    entity_key: {
+                        "name": entity.name,
+                        "value": entity.value,
+                        "text": entity.text,
+                    }
+                    for entity_key, entity in result.entities.items()
+                },
+                # Entities/areas/etc. that would be targeted
+                "targets": {},
+                # True if match was successful
+                "match": successful_match,
+                # Text of the sentence template that matched (or was closest)
+                "sentence_template": "",
+                # When match is incomplete, this will contain the best slot guesses
+                "unmatched_slots": _get_unmatched_slots(result),
             }
 
-        if result.intent_sentence is not None:
-            result_dict["sentence_template"] = result.intent_sentence.text
+            if successful_match:
+                result_dict["targets"] = {
+                    state.entity_id: {"matched": is_matched}
+                    for state, is_matched in _get_debug_targets(hass, result)
+                }
+
+            if result.intent_sentence is not None:
+                result_dict["sentence_template"] = result.intent_sentence.text
+
+            # Inspect metadata to determine if this matched a custom sentence
+            if result.intent_metadata and result.intent_metadata.get(
+                METADATA_CUSTOM_SENTENCE
+            ):
+                result_dict["source"] = "custom"
+            else:
+                result_dict["source"] = "builtin"
 
         result_dicts.append(result_dict)
 
@@ -401,6 +421,16 @@ def _get_debug_targets(
     if "state" in entities:
         # HassGetState only
         state_names = set(cv.ensure_list(entities["state"].value))
+
+    if (
+        (name is None)
+        and (area_name is None)
+        and (not domains)
+        and (not device_classes)
+        and (not state_names)
+    ):
+        # Avoid "matching" all entities when there is no filter
+        return
 
     states = intent.async_match_states(
         hass,

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -63,6 +63,7 @@ _ENTITY_REGISTRY_UPDATE_FIELDS = ["aliases", "name", "original_name"]
 REGEX_TYPE = type(re.compile(""))
 TRIGGER_CALLBACK_TYPE = Callable[[str, RecognizeResult], Awaitable[str | None]]
 METADATA_CUSTOM_SENTENCE = "hass_custom_sentence"
+METADATA_CUSTOM_FILE = "hass_custom_file"
 
 
 def json_load(fp: IO[str]) -> JsonObjectType:
@@ -606,6 +607,11 @@ class DefaultAgent(AbstractConversationAgent):
                                 for intent_data in intent_data_list:
                                     sentence_metadata = intent_data.get("metadata", {})
                                     sentence_metadata[METADATA_CUSTOM_SENTENCE] = True
+                                    sentence_metadata[METADATA_CUSTOM_FILE] = str(
+                                        custom_sentences_path.relative_to(
+                                            custom_sentences_dir.parent
+                                        )
+                                    )
                                     intent_data["metadata"] = sentence_metadata
 
                             merge_dict(intents_dict, custom_sentences_yaml)

--- a/homeassistant/components/conversation/manifest.json
+++ b/homeassistant/components/conversation/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["hassil==1.5.3", "home-assistant-intents==2024.1.2"]
+  "requirements": ["hassil==1.6.0", "home-assistant-intents==2024.1.2"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -26,7 +26,7 @@ ha-av==10.1.1
 ha-ffmpeg==3.1.0
 habluetooth==2.4.0
 hass-nabucasa==0.75.1
-hassil==1.5.3
+hassil==1.6.0
 home-assistant-bluetooth==1.12.0
 home-assistant-frontend==20240112.0
 home-assistant-intents==2024.1.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1019,7 +1019,7 @@ hass-nabucasa==0.75.1
 hass-splunk==0.1.1
 
 # homeassistant.components.conversation
-hassil==1.5.3
+hassil==1.6.0
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -821,7 +821,7 @@ habluetooth==2.4.0
 hass-nabucasa==0.75.1
 
 # homeassistant.components.conversation
-hassil==1.5.3
+hassil==1.6.0
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.4

--- a/tests/components/conversation/snapshots/test_init.ambr
+++ b/tests/components/conversation/snapshots/test_init.ambr
@@ -1647,3 +1647,14 @@
     ]),
   })
 # ---
+# name: test_ws_hass_agent_debug_sentence_trigger
+  dict({
+    'results': list([
+      dict({
+        'match': True,
+        'sentence_template': 'hello[ world]',
+        'source': 'trigger',
+      }),
+    ]),
+  })
+# ---

--- a/tests/components/conversation/snapshots/test_init.ambr
+++ b/tests/components/conversation/snapshots/test_init.ambr
@@ -1408,6 +1408,7 @@
         'slots': dict({
           'name': 'my cool light',
         }),
+        'source': 'builtin',
         'targets': dict({
           'light.kitchen': dict({
             'matched': True,
@@ -1432,6 +1433,7 @@
         'slots': dict({
           'name': 'my cool light',
         }),
+        'source': 'builtin',
         'targets': dict({
           'light.kitchen': dict({
             'matched': True,
@@ -1462,6 +1464,7 @@
           'area': 'kitchen',
           'domain': 'light',
         }),
+        'source': 'builtin',
         'targets': dict({
           'light.kitchen': dict({
             'matched': True,
@@ -1498,6 +1501,7 @@
           'domain': 'light',
           'state': 'on',
         }),
+        'source': 'builtin',
         'targets': dict({
           'light.kitchen': dict({
             'matched': False,
@@ -1522,6 +1526,7 @@
         'slots': dict({
           'domain': 'scene',
         }),
+        'source': 'builtin',
         'targets': dict({
         }),
         'unmatched_slots': dict({
@@ -1572,6 +1577,7 @@
           'brightness': 100,
           'name': 'test light',
         }),
+        'source': 'builtin',
         'targets': dict({
           'light.demo_1234': dict({
             'matched': True,
@@ -1602,6 +1608,7 @@
         'slots': dict({
           'name': 'test light',
         }),
+        'source': 'builtin',
         'targets': dict({
         }),
         'unmatched_slots': dict({

--- a/tests/components/conversation/snapshots/test_init.ambr
+++ b/tests/components/conversation/snapshots/test_init.ambr
@@ -1545,6 +1545,35 @@
     }),
   })
 # ---
+# name: test_ws_hass_agent_debug_custom_sentence
+  dict({
+    'results': list([
+      dict({
+        'details': dict({
+          'beer_style': dict({
+            'name': 'beer_style',
+            'text': 'lager',
+            'value': 'lager',
+          }),
+        }),
+        'file': 'en/beer.yaml',
+        'intent': dict({
+          'name': 'OrderBeer',
+        }),
+        'match': True,
+        'sentence_template': "I'd like to order a {beer_style} [please]",
+        'slots': dict({
+          'beer_style': 'lager',
+        }),
+        'source': 'custom',
+        'targets': dict({
+        }),
+        'unmatched_slots': dict({
+        }),
+      }),
+    ]),
+  })
+# ---
 # name: test_ws_hass_agent_debug_null_result
   dict({
     'results': list([

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -1318,5 +1318,57 @@ async def test_ws_hass_agent_debug_custom_sentence(
 
     debug_results = msg["result"].get("results", [])
     assert len(debug_results) == 1
+    assert debug_results[0].get("match")
     assert debug_results[0].get("source") == "custom"
     assert debug_results[0].get("file") == "en/beer.yaml"
+
+
+async def test_ws_hass_agent_debug_sentence_trigger(
+    hass: HomeAssistant,
+    init_components,
+    hass_ws_client: WebSocketGenerator,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test homeassistant agent debug websocket command with a sentence trigger."""
+    calls = async_mock_service(hass, "test", "automation")
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": {
+                "trigger": {
+                    "platform": "conversation",
+                    "command": ["hello", "hello[ world]"],
+                },
+                "action": {
+                    "service": "test.automation",
+                    "data_template": {"data": "{{ trigger }}"},
+                },
+            }
+        },
+    )
+
+    client = await hass_ws_client(hass)
+
+    # Use trigger sentence
+    await client.send_json_auto_id(
+        {
+            "type": "conversation/agent/homeassistant/debug",
+            "sentences": ["hello world"],
+        }
+    )
+    await hass.async_block_till_done()
+
+    msg = await client.receive_json()
+
+    assert msg["success"]
+    assert msg["result"] == snapshot
+
+    debug_results = msg["result"].get("results", [])
+    assert len(debug_results) == 1
+    assert debug_results[0].get("match")
+    assert debug_results[0].get("source") == "trigger"
+    assert debug_results[0].get("sentence_template") == "hello[ world]"
+
+    # Trigger should not have been executed
+    assert len(calls) == 0

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -1286,3 +1286,37 @@ async def test_ws_hass_agent_debug_out_of_range(
     # Name matched, but brightness didn't
     assert results[0]["slots"] == {"name": "test light"}
     assert results[0]["unmatched_slots"] == {"brightness": 1001}
+
+
+async def test_ws_hass_agent_debug_custom_sentence(
+    hass: HomeAssistant,
+    init_components,
+    hass_ws_client: WebSocketGenerator,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test homeassistant agent debug websocket command with a custom sentence."""
+    # Expecting testing_config/custom_sentences/en/beer.yaml
+    intent.async_register(hass, OrderBeerIntentHandler())
+
+    client = await hass_ws_client(hass)
+
+    # Brightness is in range (0-100)
+    await client.send_json_auto_id(
+        {
+            "type": "conversation/agent/homeassistant/debug",
+            "sentences": [
+                "I'd like to order a lager, please.",
+            ],
+        }
+    )
+
+    msg = await client.receive_json()
+
+    assert msg["success"]
+    assert msg["result"] == snapshot
+
+    debug_results = msg["result"].get("results", [])
+    assert len(debug_results) == 1
+    assert debug_results[0].get("source") == "custom"
+    assert debug_results[0].get("file") == "en/beer.yaml"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Quality of life improvements to the internal Assist debug API:

* Recognizes sentences from sentence triggers (without running them)
* Differentiates between builtin sentences, custom sentences, and sentence triggers
    * `source` field is one of `builtin`, `custom`, `trigger` 
    * Requires bump of hassil to 1.6.0: https://github.com/home-assistant/hassil/compare/v1.5.2...1.6.0
* Reports matching sentence template for sentence triggers
* Reports relative file path of source YAML file for custom sentences (e.g., `en/my_sentences.yaml`)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
