### PR TITLE
Small speed up to listing config entries in the websocket api

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
     from .components.zeroconf import ZeroconfServiceInfo
     from .helpers.service_info.mqtt import MqttServiceInfo
 
+
 _LOGGER = logging.getLogger(__name__)
 
 SOURCE_BLUETOOTH = "bluetooth"
@@ -238,6 +239,7 @@ class ConfigEntry:
         "_integration_for_domain",
         "_tries",
         "_setup_again_job",
+        "_supports_options",
     )
 
     def __init__(
@@ -318,6 +320,9 @@ class ConfigEntry:
         # Supports remove device
         self.supports_remove_device: bool | None = None
 
+        # Supports options
+        self._supports_options: bool | None = None
+
         # Listeners to call on update
         self.update_listeners: list[UpdateListenerType] = []
 
@@ -350,6 +355,17 @@ class ConfigEntry:
             f"<ConfigEntry entry_id={self.entry_id} version={self.version} domain={self.domain} "
             f"title={self.title} state={self.state} unique_id={self.unique_id}>"
         )
+
+    @property
+    def supports_options(self) -> bool:
+        """Return if entry supports config options."""
+        if self._supports_options is None:
+            handler = HANDLERS.get(self.domain)
+            # work out if handler has support for options flow
+            self._supports_options = bool(
+                handler is not None and handler.async_supports_options_flow(self)
+            )
+        return self._supports_options
 
     async def async_setup(
         self,

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -359,13 +359,10 @@ class ConfigEntry:
     @property
     def supports_options(self) -> bool:
         """Return if entry supports config options."""
-        if self._supports_options is None:
-            handler = HANDLERS.get(self.domain)
+        if self._supports_options is None and (handler := HANDLERS.get(self.domain)):
             # work out if handler has support for options flow
-            self._supports_options = (
-                handler is not None and handler.async_supports_options_flow(self)
-            )
-        return self._supports_options
+            self._supports_options = handler.async_supports_options_flow(self)
+        return self._supports_options or False
 
     async def async_setup(
         self,

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -362,7 +362,7 @@ class ConfigEntry:
         if self._supports_options is None:
             handler = HANDLERS.get(self.domain)
             # work out if handler has support for options flow
-            self._supports_options = bool(
+            self._supports_options = (
                 handler is not None and handler.async_supports_options_flow(self)
             )
         return self._supports_options

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1177,6 +1177,7 @@ async def test_create_entry_options(
 
         entries = hass.config_entries.async_entries("comp")
         assert len(entries) == 1
+        assert entries[0].supports_options is False
         assert entries[0].data == {"example": "data"}
         assert entries[0].options == {"example": "option"}
 
@@ -1203,6 +1204,10 @@ async def test_entry_options(
 
             return OptionsFlowHandler()
 
+        def async_supports_options_flow(self, entry: MockConfigEntry) -> bool:
+            """Test options flow."""
+            return True
+
     config_entries.HANDLERS["test"] = TestFlow()
     flow = await manager.options.async_create_flow(
         entry.entry_id, context={"source": "test"}, data=None
@@ -1217,6 +1222,7 @@ async def test_entry_options(
 
     assert entry.data == {"first": True}
     assert entry.options == {"second": True}
+    assert entry.supports_options is True
 
 
 async def test_entry_options_abort(

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -734,6 +734,7 @@ async def test_as_dict(snapshot: SnapshotAssertion) -> None:
         "_integration_for_domain",
         "_tries",
         "_setup_again_job",
+        "_supports_options",
     }
 
     entry = MockConfigEntry(entry_id="mock-entry")


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Avoid doing the check for `supports_options` every time the api is hit for every config entry
- Reduce one iteration of all the entries

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
