### PR TITLE
Centralize validation for modbus config

### DIFF
--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -279,7 +279,7 @@ def check_config(config: dict) -> dict:
             CONF_COMMAND_OFF,
         ):
             if conf_type in entity:
-                addr += "_" + str(entity[conf_type])
+                addr += f"_{entity[conf_type]}"
         inx = entity.get(CONF_SLAVE, None) or entity.get(CONF_DEVICE_ADDRESS, 0)
         addr += "_" + str(inx)
         loc_addr: set[str] = set()

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -286,7 +286,7 @@ def check_config(config: dict) -> dict:
 
         if CONF_TARGET_TEMP in entity:
             a = str(entity[CONF_TARGET_TEMP])
-            a += "_" + str(inx)
+            a += f"_{inx}"
             loc_addr.add(a)
         if CONF_HVAC_MODE_REGISTER in entity:
             a = str(entity[CONF_HVAC_MODE_REGISTER][CONF_ADDRESS])

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -294,7 +294,7 @@ def check_config(config: dict) -> dict:
             loc_addr.add(a)
         if CONF_FAN_MODE_REGISTER in entity:
             a = str(entity[CONF_FAN_MODE_REGISTER][CONF_ADDRESS])
-            a += "_" + str(inx)
+            a += f"_{inx}"
             loc_addr.add(a)
 
         dup_addrs = ent_addr.intersection(loc_addr)

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -203,141 +203,6 @@ def duplicate_fan_mode_validator(config: dict[str, Any]) -> dict:
     return config
 
 
-def scan_interval_validator(config: dict) -> dict:
-    """Control scan_interval."""
-    for hub in config:
-        minimum_scan_interval = DEFAULT_SCAN_INTERVAL
-        for component, conf_key in PLATFORMS:
-            if conf_key not in hub:
-                continue
-
-            for entry in hub[conf_key]:
-                scan_interval = entry.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-                if scan_interval == 0:
-                    continue
-                if scan_interval < 5:
-                    _LOGGER.warning(
-                        (
-                            "%s %s scan_interval(%d) is lower than 5 seconds, "
-                            "which may cause Home Assistant stability issues"
-                        ),
-                        component,
-                        entry.get(CONF_NAME),
-                        scan_interval,
-                    )
-                entry[CONF_SCAN_INTERVAL] = scan_interval
-                minimum_scan_interval = min(scan_interval, minimum_scan_interval)
-        if (
-            CONF_TIMEOUT in hub
-            and hub[CONF_TIMEOUT] > minimum_scan_interval - 1
-            and minimum_scan_interval > 1
-        ):
-            _LOGGER.warning(
-                "Modbus %s timeout(%d) is adjusted(%d) due to scan_interval",
-                hub.get(CONF_NAME, ""),
-                hub[CONF_TIMEOUT],
-                minimum_scan_interval - 1,
-            )
-            hub[CONF_TIMEOUT] = minimum_scan_interval - 1
-    return config
-
-
-def duplicate_entity_validator(config: dict) -> dict:
-    """Control scan_interval."""
-    for hub_index, hub in enumerate(config):
-        for component, conf_key in PLATFORMS:
-            if conf_key not in hub:
-                continue
-            names: set[str] = set()
-            errors: list[int] = []
-            addresses: set[str] = set()
-            for index, entry in enumerate(hub[conf_key]):
-                name = entry[CONF_NAME]
-                addr = str(entry[CONF_ADDRESS])
-                if CONF_INPUT_TYPE in entry:
-                    addr += "_" + str(entry[CONF_INPUT_TYPE])
-                elif CONF_WRITE_TYPE in entry:
-                    addr += "_" + str(entry[CONF_WRITE_TYPE])
-                if CONF_COMMAND_ON in entry:
-                    addr += "_" + str(entry[CONF_COMMAND_ON])
-                if CONF_COMMAND_OFF in entry:
-                    addr += "_" + str(entry[CONF_COMMAND_OFF])
-                inx = entry.get(CONF_SLAVE, None) or entry.get(CONF_DEVICE_ADDRESS, 0)
-                addr += "_" + str(inx)
-                entry_addrs: set[str] = set()
-                entry_addrs.add(addr)
-
-                if CONF_TARGET_TEMP in entry:
-                    a = str(entry[CONF_TARGET_TEMP])
-                    a += "_" + str(inx)
-                    entry_addrs.add(a)
-                if CONF_HVAC_MODE_REGISTER in entry:
-                    a = str(entry[CONF_HVAC_MODE_REGISTER][CONF_ADDRESS])
-                    a += "_" + str(inx)
-                    entry_addrs.add(a)
-                if CONF_FAN_MODE_REGISTER in entry:
-                    a = str(
-                        entry[CONF_FAN_MODE_REGISTER][CONF_ADDRESS]
-                        if isinstance(entry[CONF_FAN_MODE_REGISTER][CONF_ADDRESS], int)
-                        else entry[CONF_FAN_MODE_REGISTER][CONF_ADDRESS][0]
-                    )
-                    a += "_" + str(inx)
-                    entry_addrs.add(a)
-
-                dup_addrs = entry_addrs.intersection(addresses)
-
-                if len(dup_addrs) > 0:
-                    for addr in dup_addrs:
-                        err = (
-                            f"Modbus {component}/{name} address {addr} is duplicate, second"
-                            " entry not loaded!"
-                        )
-                        _LOGGER.warning(err)
-                    errors.append(index)
-                elif name in names:
-                    err = (
-                        f"Modbus {component}/{name}  is duplicate, second entry not"
-                        " loaded!"
-                    )
-                    _LOGGER.warning(err)
-                    errors.append(index)
-                else:
-                    names.add(name)
-                    addresses.update(entry_addrs)
-
-            for i in reversed(errors):
-                del config[hub_index][conf_key][i]
-    return config
-
-
-def duplicate_modbus_validator(config: dict) -> dict:
-    """Control modbus connection for duplicates."""
-    hosts: set[str] = set()
-    names: set[str] = set()
-    errors = []
-    for index, hub in enumerate(config):
-        name = hub.get(CONF_NAME, DEFAULT_HUB)
-        if hub[CONF_TYPE] == SERIAL:
-            host = hub[CONF_PORT]
-        else:
-            host = f"{hub[CONF_HOST]}_{hub[CONF_PORT]}"
-        if host in hosts:
-            err = f"Modbus {name} contains duplicate host/port {host}, not loaded!"
-            _LOGGER.warning(err)
-            errors.append(index)
-        elif name in names:
-            err = f"Modbus {name} is duplicate, second entry not loaded!"
-            _LOGGER.warning(err)
-            errors.append(index)
-        else:
-            hosts.add(host)
-            names.add(name)
-
-    for i in reversed(errors):
-        del config[i]
-    return config
-
-
 def register_int_list_validator(value: Any) -> Any:
     """Check if a register (CONF_ADRESS) is an int or a list having only 1 register."""
     if isinstance(value, int) and value >= 0:
@@ -354,7 +219,122 @@ def register_int_list_validator(value: Any) -> Any:
 
 def check_config(config: dict) -> dict:
     """Do final config check."""
-    config2 = duplicate_modbus_validator(config)
-    config3 = scan_interval_validator(config2)
-    config4 = duplicate_entity_validator(config3)
-    return config4
+    hosts: set[str] = set()
+    hub_names: set[str] = set()
+    hub_name_inx = 0
+    minimum_scan_interval = 0
+    ent_names: set[str] = set()
+    ent_addr: set[str] = set()
+
+    def validate_modbus(hub: dict) -> bool:
+        """Validate modbus entries."""
+        nonlocal hub_name_inx
+        host: str = (
+            hub[CONF_PORT]
+            if hub[CONF_TYPE] == SERIAL
+            else f"{hub[CONF_HOST]}_{hub[CONF_PORT]}"
+        )
+        if CONF_NAME not in hub:
+            hub[CONF_NAME] = (
+                DEFAULT_HUB if not hub_name_inx else f"{DEFAULT_HUB}_{hub_name_inx}"
+            )
+            hub_name_inx += 1
+            err = f"Modbus host/port {host} is missing name, added {hub[CONF_NAME]}!"
+            _LOGGER.warning(err)
+        name = hub[CONF_NAME]
+        if host in hosts or name in hub_names:
+            err = f"Modbus {name} host/port {host} is duplicate, not loaded!"
+            _LOGGER.warning(err)
+            return False
+        hosts.add(host)
+        hub_names.add(name)
+        return True
+
+    def validate_entity(hub_name: str, entity: dict) -> bool:
+        """Validate entity."""
+        nonlocal minimum_scan_interval, ent_names, ent_addr
+        name = entity[CONF_NAME]
+        addr = str(entity[CONF_ADDRESS])
+        scan_interval = entity.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        if scan_interval < 5:
+            _LOGGER.warning(
+                (
+                    "%s %s scan_interval(%d) is lower than 5 seconds, "
+                    "which may cause Home Assistant stability issues"
+                ),
+                hub_name,
+                name,
+                scan_interval,
+            )
+        entity[CONF_SCAN_INTERVAL] = scan_interval
+        minimum_scan_interval = min(scan_interval, minimum_scan_interval)
+        for conf_type in (
+            CONF_INPUT_TYPE,
+            CONF_WRITE_TYPE,
+            CONF_COMMAND_ON,
+            CONF_COMMAND_OFF,
+        ):
+            if conf_type in entity:
+                addr += "_" + str(entity[conf_type])
+        inx = entity.get(CONF_SLAVE, None) or entity.get(CONF_DEVICE_ADDRESS, 0)
+        addr += "_" + str(inx)
+        loc_addr: set[str] = set()
+        loc_addr.add(addr)
+
+        if CONF_TARGET_TEMP in entity:
+            a = str(entity[CONF_TARGET_TEMP])
+            a += "_" + str(inx)
+            loc_addr.add(a)
+        if CONF_HVAC_MODE_REGISTER in entity:
+            a = str(entity[CONF_HVAC_MODE_REGISTER][CONF_ADDRESS])
+            a += "_" + str(inx)
+            loc_addr.add(a)
+        if CONF_FAN_MODE_REGISTER in entity:
+            a = str(entity[CONF_FAN_MODE_REGISTER][CONF_ADDRESS])
+            a += "_" + str(inx)
+            loc_addr.add(a)
+
+        dup_addrs = ent_addr.intersection(loc_addr)
+        if len(dup_addrs) > 0:
+            for addr in dup_addrs:
+                err = (
+                    f"Modbus {hub_name}/{name} address {addr} is duplicate, second"
+                    " entry not loaded!"
+                )
+                _LOGGER.warning(err)
+            return False
+        if name in ent_names:
+            err = f"Modbus {hub_name}/{name}  is duplicate, second entry not" " loaded!"
+            _LOGGER.warning(err)
+            return False
+        ent_names.add(name)
+        ent_addr.update(loc_addr)
+        return True
+
+    hub_inx = 0
+    while hub_inx < len(config):
+        hub = config[hub_inx]
+        if not validate_modbus(hub):
+            del config[hub_inx]
+            continue
+        for _component, conf_key in PLATFORMS:
+            if conf_key not in hub:
+                continue
+            entity_inx = 0
+            entities = hub[conf_key]
+            minimum_scan_interval = 9999
+            while entity_inx < len(entities):
+                if not validate_entity(hub[CONF_NAME], entities[entity_inx]):
+                    del entities[entity_inx]
+                else:
+                    entity_inx += 1
+
+        if hub[CONF_TIMEOUT] >= minimum_scan_interval:
+            hub[CONF_TIMEOUT] = minimum_scan_interval - 1
+            _LOGGER.warning(
+                "Modbus %s timeout is adjusted(%d) due to scan_interval",
+                hub[CONF_NAME],
+                hub[CONF_TIMEOUT],
+            )
+        hub_inx += 1
+    return config

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -290,7 +290,7 @@ def check_config(config: dict) -> dict:
             loc_addr.add(a)
         if CONF_HVAC_MODE_REGISTER in entity:
             a = str(entity[CONF_HVAC_MODE_REGISTER][CONF_ADDRESS])
-            a += "_" + str(inx)
+            a += f"_{inx}"
             loc_addr.add(a)
         if CONF_FAN_MODE_REGISTER in entity:
             a = str(entity[CONF_FAN_MODE_REGISTER][CONF_ADDRESS])

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -226,9 +226,8 @@ def check_config(config: dict) -> dict:
     ent_names: set[str] = set()
     ent_addr: set[str] = set()
 
-    def validate_modbus(hub: dict) -> bool:
+    def validate_modbus(hub: dict, hub_name_inx: int) -> bool:
         """Validate modbus entries."""
-        nonlocal hub_name_inx
         host: str = (
             hub[CONF_PORT]
             if hub[CONF_TYPE] == SERIAL
@@ -250,9 +249,14 @@ def check_config(config: dict) -> dict:
         hub_names.add(name)
         return True
 
-    def validate_entity(hub_name: str, entity: dict) -> bool:
+    def validate_entity(
+        hub_name: str,
+        entity: dict,
+        minimum_scan_interval: int,
+        ent_names: set,
+        ent_addr: set,
+    ) -> bool:
         """Validate entity."""
-        nonlocal minimum_scan_interval, ent_names, ent_addr
         name = entity[CONF_NAME]
         addr = str(entity[CONF_ADDRESS])
         scan_interval = entity.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
@@ -314,7 +318,7 @@ def check_config(config: dict) -> dict:
     hub_inx = 0
     while hub_inx < len(config):
         hub = config[hub_inx]
-        if not validate_modbus(hub):
+        if not validate_modbus(hub, hub_name_inx):
             del config[hub_inx]
             continue
         for _component, conf_key in PLATFORMS:
@@ -324,7 +328,13 @@ def check_config(config: dict) -> dict:
             entities = hub[conf_key]
             minimum_scan_interval = 9999
             while entity_inx < len(entities):
-                if not validate_entity(hub[CONF_NAME], entities[entity_inx]):
+                if not validate_entity(
+                    hub[CONF_NAME],
+                    entities[entity_inx],
+                    minimum_scan_interval,
+                    ent_names,
+                    ent_addr,
+                ):
                     del entities[entity_inx]
                 else:
                     entity_inx += 1

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -281,7 +281,7 @@ def check_config(config: dict) -> dict:
             if conf_type in entity:
                 addr += f"_{entity[conf_type]}"
         inx = entity.get(CONF_SLAVE, None) or entity.get(CONF_DEVICE_ADDRESS, 0)
-        addr += "_" + str(inx)
+        addr += f"_{inx}"
         loc_addr: set[str] = set()
         loc_addr.add(addr)
 

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -285,17 +285,11 @@ def check_config(config: dict) -> dict:
         loc_addr: set[str] = {addr}
 
         if CONF_TARGET_TEMP in entity:
-            a = str(entity[CONF_TARGET_TEMP])
-            a += f"_{inx}"
-            loc_addr.add(a)
+            loc_addr.add(f"{entity[CONF_TARGET_TEMP]}_{inx}")
         if CONF_HVAC_MODE_REGISTER in entity:
-            a = str(entity[CONF_HVAC_MODE_REGISTER][CONF_ADDRESS])
-            a += f"_{inx}"
-            loc_addr.add(a)
+            loc_addr.add(f"{entity[CONF_HVAC_MODE_REGISTER][CONF_ADDRESS]}_{inx}")
         if CONF_FAN_MODE_REGISTER in entity:
-            a = str(entity[CONF_FAN_MODE_REGISTER][CONF_ADDRESS])
-            a += f"_{inx}"
-            loc_addr.add(a)
+            loc_addr.add(f"{entity[CONF_FAN_MODE_REGISTER][CONF_ADDRESS]}_{inx}")
 
         dup_addrs = ent_addr.intersection(loc_addr)
         if len(dup_addrs) > 0:

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -307,7 +307,7 @@ def check_config(config: dict) -> dict:
                 _LOGGER.warning(err)
             return False
         if name in ent_names:
-            err = f"Modbus {hub_name}/{name}  is duplicate, second entry not" " loaded!"
+            err = f"Modbus {hub_name}/{name} is duplicate, second entry not loaded!"
             _LOGGER.warning(err)
             return False
         ent_names.add(name)

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -282,8 +282,7 @@ def check_config(config: dict) -> dict:
                 addr += f"_{entity[conf_type]}"
         inx = entity.get(CONF_SLAVE, None) or entity.get(CONF_DEVICE_ADDRESS, 0)
         addr += f"_{inx}"
-        loc_addr: set[str] = set()
-        loc_addr.add(addr)
+        loc_addr: set[str] = {addr}
 
         if CONF_TARGET_TEMP in entity:
             a = str(entity[CONF_TARGET_TEMP])

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -79,9 +79,8 @@ from homeassistant.components.modbus.const import (
     DataType,
 )
 from homeassistant.components.modbus.validators import (
-    duplicate_entity_validator,
+    check_config,
     duplicate_fan_mode_validator,
-    duplicate_modbus_validator,
     nan_validator,
     register_int_list_validator,
     struct_validator,
@@ -340,53 +339,44 @@ async def test_exception_struct_validator(do_config) -> None:
                 CONF_TYPE: TCP,
                 CONF_HOST: TEST_MODBUS_HOST,
                 CONF_PORT: TEST_PORT_TCP,
+                CONF_TIMEOUT: 3,
             },
             {
                 CONF_NAME: TEST_MODBUS_NAME,
                 CONF_TYPE: TCP,
                 CONF_HOST: TEST_MODBUS_HOST + " 2",
                 CONF_PORT: TEST_PORT_TCP,
+                CONF_TIMEOUT: 3,
+            },
+            {
+                CONF_NAME: TEST_MODBUS_NAME + "2",
+                CONF_TYPE: TCP,
+                CONF_HOST: TEST_MODBUS_HOST,
+                CONF_PORT: TEST_PORT_TCP,
+                CONF_TIMEOUT: 3,
             },
         ],
         [
             {
-                CONF_NAME: TEST_MODBUS_NAME,
                 CONF_TYPE: TCP,
                 CONF_HOST: TEST_MODBUS_HOST,
                 CONF_PORT: TEST_PORT_TCP,
+                CONF_TIMEOUT: 3,
             },
             {
                 CONF_NAME: TEST_MODBUS_NAME + " 2",
                 CONF_TYPE: TCP,
                 CONF_HOST: TEST_MODBUS_HOST,
                 CONF_PORT: TEST_PORT_TCP,
+                CONF_TIMEOUT: 3,
             },
         ],
     ],
 )
-async def test_duplicate_modbus_validator(do_config) -> None:
+async def test_check_config(do_config) -> None:
     """Test duplicate modbus validator."""
-    duplicate_modbus_validator(do_config)
+    check_config(do_config)
     assert len(do_config) == 1
-
-
-@pytest.mark.parametrize(
-    "do_config",
-    [
-        {
-            CONF_ADDRESS: 11,
-            CONF_FAN_MODE_VALUES: {
-                CONF_FAN_MODE_ON: 7,
-                CONF_FAN_MODE_OFF: 9,
-                CONF_FAN_MODE_HIGH: 9,
-            },
-        }
-    ],
-)
-async def test_duplicate_fan_mode_validator(do_config) -> None:
-    """Test duplicate modbus validator."""
-    duplicate_fan_mode_validator(do_config)
-    assert len(do_config[CONF_FAN_MODE_VALUES]) == 2
 
 
 @pytest.mark.parametrize(
@@ -398,6 +388,7 @@ async def test_duplicate_fan_mode_validator(do_config) -> None:
                 CONF_TYPE: TCP,
                 CONF_HOST: TEST_MODBUS_HOST,
                 CONF_PORT: TEST_PORT_TCP,
+                CONF_TIMEOUT: 3,
                 CONF_SENSORS: [
                     {
                         CONF_NAME: TEST_ENTITY_NAME,
@@ -418,27 +409,8 @@ async def test_duplicate_fan_mode_validator(do_config) -> None:
                 CONF_TYPE: TCP,
                 CONF_HOST: TEST_MODBUS_HOST,
                 CONF_PORT: TEST_PORT_TCP,
+                CONF_TIMEOUT: 3,
                 CONF_SENSORS: [
-                    {
-                        CONF_NAME: TEST_ENTITY_NAME,
-                        CONF_ADDRESS: 117,
-                        CONF_SLAVE: 0,
-                    },
-                    {
-                        CONF_NAME: TEST_ENTITY_NAME + " 2",
-                        CONF_ADDRESS: 117,
-                        CONF_SLAVE: 0,
-                    },
-                ],
-            }
-        ],
-        [
-            {
-                CONF_NAME: TEST_MODBUS_NAME,
-                CONF_TYPE: TCP,
-                CONF_HOST: TEST_MODBUS_HOST,
-                CONF_PORT: TEST_PORT_TCP,
-                CONF_CLIMATES: [
                     {
                         CONF_NAME: TEST_ENTITY_NAME,
                         CONF_ADDRESS: 117,
@@ -454,13 +426,10 @@ async def test_duplicate_fan_mode_validator(do_config) -> None:
         ],
     ],
 )
-async def test_duplicate_entity_validator(do_config) -> None:
+async def test_check_config_sensor(do_config) -> None:
     """Test duplicate entity validator."""
-    duplicate_entity_validator(do_config)
-    if CONF_SENSORS in do_config[0]:
-        assert len(do_config[0][CONF_SENSORS]) == 1
-    elif CONF_CLIMATES in do_config[0]:
-        assert len(do_config[0][CONF_CLIMATES]) == 1
+    check_config(do_config)
+    assert len(do_config[0][CONF_SENSORS]) == 1
 
 
 @pytest.mark.parametrize(
@@ -472,6 +441,28 @@ async def test_duplicate_entity_validator(do_config) -> None:
                 CONF_TYPE: TCP,
                 CONF_HOST: TEST_MODBUS_HOST,
                 CONF_PORT: TEST_PORT_TCP,
+                CONF_TIMEOUT: 3,
+                CONF_CLIMATES: [
+                    {
+                        CONF_NAME: TEST_ENTITY_NAME,
+                        CONF_ADDRESS: 117,
+                        CONF_SLAVE: 0,
+                    },
+                    {
+                        CONF_NAME: TEST_ENTITY_NAME,
+                        CONF_ADDRESS: 119,
+                        CONF_SLAVE: 0,
+                    },
+                ],
+            }
+        ],
+        [
+            {
+                CONF_NAME: TEST_MODBUS_NAME,
+                CONF_TYPE: TCP,
+                CONF_HOST: TEST_MODBUS_HOST,
+                CONF_PORT: TEST_PORT_TCP,
+                CONF_TIMEOUT: 3,
                 CONF_CLIMATES: [
                     {
                         CONF_NAME: TEST_ENTITY_NAME,
@@ -492,6 +483,7 @@ async def test_duplicate_entity_validator(do_config) -> None:
                 CONF_TYPE: TCP,
                 CONF_HOST: TEST_MODBUS_HOST,
                 CONF_PORT: TEST_PORT_TCP,
+                CONF_TIMEOUT: 3,
                 CONF_CLIMATES: [
                     {
                         CONF_NAME: TEST_ENTITY_NAME,
@@ -526,6 +518,7 @@ async def test_duplicate_entity_validator(do_config) -> None:
                 CONF_TYPE: TCP,
                 CONF_HOST: TEST_MODBUS_HOST,
                 CONF_PORT: TEST_PORT_TCP,
+                CONF_TIMEOUT: 3,
                 CONF_CLIMATES: [
                     {
                         CONF_NAME: TEST_ENTITY_NAME,
@@ -561,6 +554,7 @@ async def test_duplicate_entity_validator(do_config) -> None:
                 CONF_TYPE: TCP,
                 CONF_HOST: TEST_MODBUS_HOST,
                 CONF_PORT: TEST_PORT_TCP,
+                CONF_TIMEOUT: 3,
                 CONF_CLIMATES: [
                     {
                         CONF_NAME: TEST_ENTITY_NAME,
@@ -592,10 +586,29 @@ async def test_duplicate_entity_validator(do_config) -> None:
         ],
     ],
 )
-async def test_duplicate_entity_validator_with_climate(do_config) -> None:
+async def test_check_config_climate(do_config) -> None:
     """Test duplicate entity validator."""
-    duplicate_entity_validator(do_config)
+    check_config(do_config)
     assert len(do_config[0][CONF_CLIMATES]) == 1
+
+
+@pytest.mark.parametrize(
+    "do_config",
+    [
+        {
+            CONF_ADDRESS: 11,
+            CONF_FAN_MODE_VALUES: {
+                CONF_FAN_MODE_ON: 7,
+                CONF_FAN_MODE_OFF: 9,
+                CONF_FAN_MODE_HIGH: 9,
+            },
+        }
+    ],
+)
+async def test_duplicate_fan_mode_validator(do_config) -> None:
+    """Test duplicate modbus validator."""
+    duplicate_fan_mode_validator(do_config)
+    assert len(do_config[CONF_FAN_MODE_VALUES]) == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Instead of having multiple global config validators, that each traverse the config tree, changed to have only one global
validators that traverses the config tree only once.

This is part of an effort to centralise / simplify all config checks


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
