### PR TITLE
Handle GeoJSON int to str conversion when the name is an int

### DIFF
--- a/homeassistant/components/geo_json_events/geo_location.py
+++ b/homeassistant/components/geo_json_events/geo_location.py
@@ -105,7 +105,8 @@ class GeoJsonLocationEvent(GeolocationEvent):
     def _update_from_feed(self, feed_entry: GenericFeedEntry) -> None:
         """Update the internal state from the provided feed entry."""
         if feed_entry.properties and "name" in feed_entry.properties:
-            self._attr_name = feed_entry.properties.get("name")
+            # The entry name's type can vary, but our own name must be a string
+            self._attr_name = str(feed_entry.properties["name"])
         else:
             self._attr_name = feed_entry.title
         self._attr_distance = feed_entry.distance_to_home

--- a/tests/components/geo_json_events/test_geo_location.py
+++ b/tests/components/geo_json_events/test_geo_location.py
@@ -58,7 +58,9 @@ async def test_entity_lifecycle(
         (-31.0, 150.0),
         {ATTR_NAME: "Properties 1"},
     )
-    mock_entry_2 = _generate_mock_feed_entry("2345", "Title 2", 20.5, (-31.1, 150.1))
+    mock_entry_2 = _generate_mock_feed_entry(
+        "2345", "271310188", 20.5, (-31.1, 150.1), {ATTR_NAME: 271310188}
+    )
     mock_entry_3 = _generate_mock_feed_entry("3456", "Title 3", 25.5, (-31.2, 150.2))
     mock_entry_4 = _generate_mock_feed_entry("4567", "Title 4", 12.5, (-31.3, 150.3))
 
@@ -89,14 +91,14 @@ async def test_entity_lifecycle(
         }
         assert round(abs(float(state.state) - 15.5), 7) == 0
 
-        state = hass.states.get(f"{GEO_LOCATION_DOMAIN}.title_2")
+        state = hass.states.get(f"{GEO_LOCATION_DOMAIN}.271310188")
         assert state is not None
-        assert state.name == "Title 2"
+        assert state.name == "271310188"
         assert state.attributes == {
             ATTR_EXTERNAL_ID: "2345",
             ATTR_LATITUDE: -31.1,
             ATTR_LONGITUDE: 150.1,
-            ATTR_FRIENDLY_NAME: "Title 2",
+            ATTR_FRIENDLY_NAME: "271310188",
             ATTR_UNIT_OF_MEASUREMENT: UnitOfLength.KILOMETERS,
             ATTR_SOURCE: "geo_json_events",
         }


### PR DESCRIPTION
## Proposed change
Handles an error that could occur on setting up the config entry when generating the entity_id slug from the name if the name from the GeoJSON feed was an int (not a str).

This was an unexpected regression from https://github.com/home-assistant/core/pull/108753 and should be included before the new release in order to avoid breaking the integration unexpectedly.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue:

```
Logger: homeassistant
Source: util/__init__.py:47
First occurred: 17:07:48 (3956 occurrences)
Last logged: 17:17:41

Error doing job: Task exception was never retrieved Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 507, in async_add_entities
    await asyncio.gather(*tasks)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 658, in _async_add_entity
    entry = entity_registry.async_get_or_create(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity_registry.py", line 661, in async_get_or_create
    entity_id = self.async_generate_entity_id(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity_registry.py", line 581, in async_generate_entity_id
    preferred_string = f"{domain}.{slugify(suggested_object_id)}"
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/util/__init__.py", line 47, in slugify
    slug = unicode_slug.slugify(text, separator=separator)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/slugify/slugify.py", line 104, in slugify
    text = _unicode(text, 'utf-8', 'ignore')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: decoding to str: need a bytes-like object, int found
```

- This PR fixes issue: also addresses code quality comments from https://github.com/home-assistant/core/pull/108753/files/39a1c272560fadd8b77f2cbc9b6d18f9bf81f1a7#r1466299648
- This PR is related to issue: https://github.com/un33k/python-slugify/issues/144
- This PR is related to PR: https://github.com/home-assistant/core/pull/108753

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure