### PR TITLE
Replace modbus number_validator by HA standard

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -136,7 +136,6 @@ from .validators import (
     check_config,
     duplicate_fan_mode_validator,
     nan_validator,
-    number_validator,
     register_int_list_validator,
     struct_validator,
 )
@@ -187,8 +186,8 @@ BASE_STRUCT_SCHEMA = BASE_COMPONENT_SCHEMA.extend(
             ]
         ),
         vol.Optional(CONF_STRUCTURE): cv.string,
-        vol.Optional(CONF_SCALE, default=1): number_validator,
-        vol.Optional(CONF_OFFSET, default=0): number_validator,
+        vol.Optional(CONF_SCALE, default=1): cv.positive_float,
+        vol.Optional(CONF_OFFSET, default=0): vol.All(vol.Coerce(float)),
         vol.Optional(CONF_PRECISION): cv.positive_int,
         vol.Optional(
             CONF_SWAP,
@@ -242,8 +241,8 @@ CLIMATE_SCHEMA = vol.All(
         {
             vol.Required(CONF_TARGET_TEMP): cv.positive_int,
             vol.Optional(CONF_TARGET_TEMP_WRITE_REGISTERS, default=False): cv.boolean,
-            vol.Optional(CONF_MAX_TEMP, default=35): number_validator,
-            vol.Optional(CONF_MIN_TEMP, default=5): number_validator,
+            vol.Optional(CONF_MAX_TEMP, default=35): cv.positive_float,
+            vol.Optional(CONF_MIN_TEMP, default=5): cv.positive_float,
             vol.Optional(CONF_STEP, default=0.5): vol.Coerce(float),
             vol.Optional(CONF_TEMPERATURE_UNIT, default=DEFAULT_TEMP_UNIT): cv.string,
             vol.Optional(CONF_HVAC_ONOFF_REGISTER): cv.positive_int,
@@ -343,10 +342,10 @@ SENSOR_SCHEMA = vol.All(
             vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
             vol.Exclusive(CONF_VIRTUAL_COUNT, "vir_sen_count"): cv.positive_int,
             vol.Exclusive(CONF_SLAVE_COUNT, "vir_sen_count"): cv.positive_int,
-            vol.Optional(CONF_MIN_VALUE): number_validator,
-            vol.Optional(CONF_MAX_VALUE): number_validator,
+            vol.Optional(CONF_MIN_VALUE): cv.positive_float,
+            vol.Optional(CONF_MAX_VALUE): cv.positive_float,
             vol.Optional(CONF_NAN_VALUE): nan_validator,
-            vol.Optional(CONF_ZERO_SUPPRESS): number_validator,
+            vol.Optional(CONF_ZERO_SUPPRESS): cv.positive_float,
         }
     ),
 )

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -187,7 +187,7 @@ BASE_STRUCT_SCHEMA = BASE_COMPONENT_SCHEMA.extend(
         ),
         vol.Optional(CONF_STRUCTURE): cv.string,
         vol.Optional(CONF_SCALE, default=1): cv.positive_float,
-        vol.Optional(CONF_OFFSET, default=0): vol.All(vol.Coerce(float)),
+        vol.Optional(CONF_OFFSET, default=0): vol.Coerce(float),
         vol.Optional(CONF_PRECISION): cv.positive_int,
         vol.Optional(
             CONF_SWAP,

--- a/homeassistant/components/modbus/base_platform.py
+++ b/homeassistant/components/modbus/base_platform.py
@@ -198,9 +198,9 @@ class BaseStructPlatform(BasePlatform, RestoreEntity):
         )
         if self._value_is_int:
             if self._min_value:
-                self._min_value = int(round(self._min_value))
+                self._min_value = round(self._min_value)
             if self._max_value:
-                self._max_value = int(round(self._max_value))
+                self._max_value = round(self._max_value)
 
     def _swap_registers(self, registers: list[int], slave_count: int) -> list[int]:
         """Do swap as needed."""

--- a/homeassistant/components/modbus/base_platform.py
+++ b/homeassistant/components/modbus/base_platform.py
@@ -182,12 +182,25 @@ class BaseStructPlatform(BasePlatform, RestoreEntity):
         self._data_type = config[CONF_DATA_TYPE]
         self._structure: str = config[CONF_STRUCTURE]
         self._scale = config[CONF_SCALE]
-        self._precision = config.get(CONF_PRECISION, 2 if self._scale < 1 else 0)
+        self._precision = config.get(CONF_PRECISION, 2)
         self._offset = config[CONF_OFFSET]
         self._slave_count = config.get(CONF_SLAVE_COUNT, None) or config.get(
             CONF_VIRTUAL_COUNT, 0
         )
         self._slave_size = self._count = config[CONF_COUNT]
+        self._value_is_int: bool = self._data_type in (
+            DataType.INT16,
+            DataType.INT32,
+            DataType.INT64,
+            DataType.UINT16,
+            DataType.UINT32,
+            DataType.UINT64,
+        )
+        if self._value_is_int:
+            if self._min_value:
+                self._min_value = int(round(self._min_value))
+            if self._max_value:
+                self._max_value = int(round(self._max_value))
 
     def _swap_registers(self, registers: list[int], slave_count: int) -> list[int]:
         """Do swap as needed."""
@@ -227,7 +240,7 @@ class BaseStructPlatform(BasePlatform, RestoreEntity):
             return str(self._max_value)
         if self._zero_suppress is not None and abs(val) <= self._zero_suppress:
             return "0"
-        if self._precision == 0:
+        if self._precision == 0 or self._value_is_int:
             return str(int(round(val, 0)))
         return f"{float(val):.{self._precision}f}"
 

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -126,7 +126,7 @@ class ModbusRegisterSensor(BaseStructPlatform, RestoreSensor, SensorEntity):
             if result:
                 result_array = list(
                     map(
-                        float if self._precision and not self._value_is_int else int,
+                        float if not self._value_is_int else int,
                         result.split(","),
                     )
                 )

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -125,7 +125,10 @@ class ModbusRegisterSensor(BaseStructPlatform, RestoreSensor, SensorEntity):
         if self._coordinator:
             if result:
                 result_array = list(
-                    map(float if self._precision else int, result.split(","))
+                    map(
+                        float if self._precision and not self._value_is_int else int,
+                        result.split(","),
+                    )
                 )
                 self._attr_native_value = result_array[0]
                 self._coordinator.async_set_updated_data(result_array)

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -172,23 +172,6 @@ def struct_validator(config: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def number_validator(value: Any) -> int | float:
-    """Coerce a value to number without losing precision."""
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float):
-        return value
-
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        pass
-    try:
-        return float(value)
-    except (TypeError, ValueError) as err:
-        raise vol.Invalid(f"invalid number {value}") from err
-
-
 def nan_validator(value: Any) -> int:
     """Convert nan string to number (can be hex string or int)."""
     if isinstance(value, int):

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -83,7 +83,6 @@ from homeassistant.components.modbus.validators import (
     duplicate_fan_mode_validator,
     duplicate_modbus_validator,
     nan_validator,
-    number_validator,
     register_int_list_validator,
     struct_validator,
 )
@@ -155,28 +154,6 @@ async def test_register_int_list_validator() -> None:
 
     with pytest.raises(vol.Invalid):
         register_int_list_validator(["aq"])
-
-
-async def test_number_validator() -> None:
-    """Test number validator."""
-
-    for value, value_type in (
-        (15, int),
-        (15.1, float),
-        ("15", int),
-        ("15.1", float),
-        (-15, int),
-        (-15.1, float),
-        ("-15", int),
-        ("-15.1", float),
-    ):
-        assert isinstance(number_validator(value), value_type)
-
-    try:
-        number_validator("x15.1")
-    except vol.Invalid:
-        return
-    pytest.fail("Number_validator not throwing exception")
 
 
 async def test_nan_validator() -> None:

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -357,7 +357,7 @@ async def test_config_wrong_struct_sensor(
             },
             [7],
             False,
-            "34.0000",
+            "34",
         ),
         (
             {
@@ -379,7 +379,7 @@ async def test_config_wrong_struct_sensor(
             },
             [9],
             False,
-            "18.5",
+            "18",
         ),
         (
             {
@@ -390,7 +390,7 @@ async def test_config_wrong_struct_sensor(
             },
             [1],
             False,
-            "2.40",
+            "2",
         ),
         (
             {
@@ -401,7 +401,7 @@ async def test_config_wrong_struct_sensor(
             },
             [2],
             False,
-            "-8.3",
+            "-8",
         ),
         (
             {
@@ -445,7 +445,7 @@ async def test_config_wrong_struct_sensor(
             },
             [0x89AB, 0xCDEF, 0x0123, 0x4567],
             False,
-            "9920249030613615975",
+            "9920249030613616640",
         ),
         (
             {
@@ -456,7 +456,7 @@ async def test_config_wrong_struct_sensor(
             },
             [0x0123, 0x4567, 0x89AB, 0xCDEF],
             False,
-            "163971058432973793",
+            "163971058432973792",
         ),
         (
             {
@@ -676,7 +676,7 @@ async def test_config_wrong_struct_sensor(
             },
             [0x00AB, 0xCDEF],
             False,
-            "112593.75",
+            "112594",
         ),
         (
             {
@@ -686,7 +686,7 @@ async def test_config_wrong_struct_sensor(
             },
             [0x00AB, 0xCDEF],
             False,
-            "112593.75",
+            "112594",
         ),
     ],
 )
@@ -727,7 +727,7 @@ async def test_all_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> None:
                 int.from_bytes(struct.pack(">f", float("nan"))[2:4]),
             ],
             False,
-            ["34899771392", "0"],
+            ["34899771392.0", "0.0"],
         ),
         (
             {
@@ -742,7 +742,7 @@ async def test_all_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> None:
                 int.from_bytes(struct.pack(">f", float("nan"))[2:4]),
             ],
             False,
-            ["34899771392", "0"],
+            ["34899771392.0", "0.0"],
         ),
         (
             {
@@ -937,7 +937,7 @@ async def test_virtual_sensor(
             },
             [0x0102, 0x0304, 0x0506, 0x0708],
             False,
-            [str(0x0708050603040102)],
+            [str(0x0708050603040100)],
         ),
         (
             {
@@ -970,7 +970,7 @@ async def test_virtual_sensor(
             },
             [0x0102, 0x0304, 0x0506, 0x0708, 0x0901, 0x0902, 0x0903, 0x0904],
             False,
-            [str(0x0708050603040102), str(0x0904090309020901)],
+            [str(0x0708050603040100), str(0x0904090309020900)],
         ),
         (
             {
@@ -1035,10 +1035,10 @@ async def test_virtual_sensor(
             ],
             False,
             [
-                str(0x0604060306020601),
-                str(0x0704070307020701),
-                str(0x0804080308020801),
-                str(0x0904090309020901),
+                str(0x0604060306020600),
+                str(0x0704070307020700),
+                str(0x0804080308020800),
+                str(0x0904090309020900),
             ],
         ),
     ],
@@ -1202,7 +1202,7 @@ async def test_unpack_ok(hass: HomeAssistant, mock_do_cycle, expected) -> None:
                 0x0000,
                 0x000A,
             ],
-            "0,10",
+            "0,10.00",
         ),
         (
             {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replace the number_validator function with HA standard in the Voluptuous config.

This PR ensures that sensors with a int as datatype, always return an int and not a float.

Scale and offset are now always floats (int are accepted but converted), which means it is possible to configure e.g. scale=0,1 with integer datatypes.

A number of test cases have been adjusted due to the now strict int / float returns.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
