### PR TITLE
Fix error when passing a whole number to location selector

### DIFF
--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -879,9 +879,9 @@ class LocationSelector(Selector[LocationSelectorConfig]):
     )
     DATA_SCHEMA = vol.Schema(
         {
-            vol.Required("latitude"): float,
-            vol.Required("longitude"): float,
-            vol.Optional("radius"): float,
+            vol.Required("latitude"): vol.Coerce(float),
+            vol.Required("longitude"): vol.Coerce(float),
+            vol.Optional("radius"): vol.Coerce(float),
         }
     )
 

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -858,6 +858,12 @@ def test_language_selector_schema(schema, valid_selections, invalid_selections) 
                     "longitude": 2.0,
                     "radius": 3.0,
                 },
+                {"latitude": 1.0, "longitude": "1.0"},
+                {
+                    "latitude": 1,
+                    "longitude": 2,
+                    "radius": 3,
+                },
             ),
             (
                 None,
@@ -865,7 +871,6 @@ def test_language_selector_schema(schema, valid_selections, invalid_selections) 
                 {},
                 {"latitude": 1.0},
                 {"longitude": 1.0},
-                {"latitude": 1.0, "longitude": "1.0"},
             ),
         ),
     ),

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -858,7 +858,6 @@ def test_language_selector_schema(schema, valid_selections, invalid_selections) 
                     "longitude": 2.0,
                     "radius": 3.0,
                 },
-                {"latitude": 1.0, "longitude": "1.0"},
                 {
                     "latitude": 1,
                     "longitude": 2,
@@ -878,18 +877,7 @@ def test_language_selector_schema(schema, valid_selections, invalid_selections) 
 def test_location_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test location selector."""
 
-    def location_converter(x):
-        if isinstance(x, dict):
-            converted_location: dict[str, float] = {}
-            for key in x:
-                converted_location[key] = float(x[key])
-            return converted_location
-        else:
-            return x
-
-    _test_selector(
-        "location", schema, valid_selections, invalid_selections, location_converter
-    )
+    _test_selector("location", schema, valid_selections, invalid_selections)
 
 
 @pytest.mark.parametrize(

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -879,9 +879,13 @@ def test_location_selector_schema(schema, valid_selections, invalid_selections) 
     """Test location selector."""
 
     def location_converter(x):
-        for key in x:
-            x[key] = float(x[key])
-        return x
+        if isinstance(x, dict):
+            converted_location: dict[str, float] = {}
+            for key in x:
+                converted_location[key] = float(x[key])
+            return converted_location
+        else:
+            return x
 
     _test_selector(
         "location", schema, valid_selections, invalid_selections, location_converter

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -878,7 +878,14 @@ def test_language_selector_schema(schema, valid_selections, invalid_selections) 
 def test_location_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test location selector."""
 
-    _test_selector("location", schema, valid_selections, invalid_selections)
+    def location_converter(x):
+        for key in x:
+            x[key] = float(x[key])
+        return x
+
+    _test_selector(
+        "location", schema, valid_selections, invalid_selections, location_converter
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Location selector will complain if latitude/longitude/radius are passed as a whole number, as the typing only accepts float (and not int)

The input I think should instead be coerced to float, so that it doesn't reject whole numbers. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #101301
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
