### PR TITLE
Add support for different capitalisation in GeoJSON names

### DIFF
--- a/homeassistant/components/geo_json_events/geo_location.py
+++ b/homeassistant/components/geo_json_events/geo_location.py
@@ -104,8 +104,13 @@ class GeoJsonLocationEvent(GeolocationEvent):
 
     def _update_from_feed(self, feed_entry: GenericFeedEntry) -> None:
         """Update the internal state from the provided feed entry."""
-        if feed_entry.properties and "name" in feed_entry.properties:
-            self._attr_name = feed_entry.properties.get("name")
+        if hasattr(feed_entry, "properties") and (
+            feed_entry.properties.get("name") or feed_entry.properties.get("Name")
+        ):
+            # The entry name's type can vary, but our own name must be a string
+            self._attr_name = str(
+                feed_entry.properties.get("name") or feed_entry.properties.get("Name")
+            )
         else:
             self._attr_name = feed_entry.title
         self._attr_distance = feed_entry.distance_to_home


### PR DESCRIPTION
## Proposed change
I have seen some GeoJSON feeds that use capitalised name (`Name`) and some feeds that use non-capitalised name (`name`). This changes adds support for `Name`.

The GeoJSON spec itself doesn't speak to this as these are optional (albeit, often used) `properties`.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR is related to PR: follow-on from #108937

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.