### PR TITLE
Handle non-str to str conversion in Slugify handler

### DIFF
--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -44,7 +44,7 @@ def slugify(text: str | None, *, separator: str = "_") -> str:
     """Slugify a given text."""
     if text == "" or text is None:
         return ""
-    slug = unicode_slug.slugify(text, separator=separator)
+    slug = unicode_slug.slugify(str(text), separator=separator)
     return "unknown" if slug == "" else slug
 
 


### PR DESCRIPTION
## Proposed change
It is possible for integrations to send non-str values to the Slugify handler, and that's okay (e.g. an int); however, the Slugify library only ever supports str. Sending an int generates an `TypeError: decoding to str: need a bytes-like object, int found` exception.

https://github.com/home-assistant/core/blob/a793a5445f4a9f33f2e1c334c0d569ec772335fe/homeassistant/util/__init__.py#L43-L48

This method passes on _any_ values from, for example an entity name (including those names that are not str), to the function `unicode_slug.slugify`. However, [`slugify` does not, and will not, support any non-str values](https://github.com/un33k/python-slugify/issues/144).

## Example exception
```
Logger: homeassistant
Source: util/__init__.py:47
First occurred: 17:07:48 (3956 occurrences)
Last logged: 17:17:41

Error doing job: Task exception was never retrieved Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 507, in async_add_entities
    await asyncio.gather(*tasks)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 658, in _async_add_entity
    entry = entity_registry.async_get_or_create(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity_registry.py", line 661, in async_get_or_create
    entity_id = self.async_generate_entity_id(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity_registry.py", line 581, in async_generate_entity_id
    preferred_string = f"{domain}.{slugify(suggested_object_id)}"
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/util/__init__.py", line 47, in slugify
    slug = unicode_slug.slugify(text, separator=separator)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/slugify/slugify.py", line 104, in slugify
    text = _unicode(text, 'utf-8', 'ignore')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: decoding to str: need a bytes-like object, int found
```

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR is related to PR: https://github.com/home-assistant/core/pull/108937

## Checklist
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.