### PR TITLE
Add support for ignoring zwave_js device config file changes

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -639,7 +639,9 @@ class NodeEvents:
         # After ensuring the node is set up in HA, we should check if the node's
         # device config has changed, and if so, issue a repair registry entry for a
         # possible reinterview
-        if not node.is_controller_node and await node.async_has_device_config_changed():
+        if (
+            not node.is_controller_node and await node.async_has_device_config_changed()
+        ) or node.node_id == 2:
             device_name = device.name_by_user or device.name or "Unnamed device"
             async_create_issue(
                 self.hass,

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -639,9 +639,7 @@ class NodeEvents:
         # After ensuring the node is set up in HA, we should check if the node's
         # device config has changed, and if so, issue a repair registry entry for a
         # possible reinterview
-        if (
-            not node.is_controller_node and await node.async_has_device_config_changed()
-        ) or node.node_id == 2:
+        if not node.is_controller_node and await node.async_has_device_config_changed():
             device_name = device.name_by_user or device.name or "Unnamed device"
             async_create_issue(
                 self.hass,

--- a/homeassistant/components/zwave_js/repairs.py
+++ b/homeassistant/components/zwave_js/repairs.py
@@ -1,12 +1,12 @@
 """Repairs for Z-Wave JS."""
 from __future__ import annotations
 
-import voluptuous as vol
-
 from homeassistant import data_entry_flow
 from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 
+from .const import DOMAIN
 from .helpers import async_get_node_from_device_id
 
 
@@ -22,28 +22,40 @@ class DeviceConfigFileChangedFlow(RepairsFlow):
         self, user_input: dict[str, str] | None = None
     ) -> data_entry_flow.FlowResult:
         """Handle the first step of a fix flow."""
-        return await self.async_step_confirm()
+        return await self.async_step_menu()
+
+    async def async_step_menu(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the menu step of a fix flow."""
+        return self.async_show_menu(
+            step_id="confirm",
+            menu_options=["confirm", "ignore"],
+            description_placeholders={"device_name": self.device_name},
+        )
 
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
     ) -> data_entry_flow.FlowResult:
         """Handle the confirm step of a fix flow."""
-        if user_input is not None:
-            try:
-                node = async_get_node_from_device_id(self.hass, self.device_id)
-            except ValueError:
-                return self.async_abort(
-                    reason="cannot_connect",
-                    description_placeholders={"device_name": self.device_name},
-                )
-            self.hass.async_create_task(node.async_refresh_info())
-            return self.async_create_entry(title="", data={})
+        try:
+            node = async_get_node_from_device_id(self.hass, self.device_id)
+        except ValueError:
+            return self.async_abort(
+                reason="cannot_connect",
+                description_placeholders={"device_name": self.device_name},
+            )
+        self.hass.async_create_task(node.async_refresh_info())
+        return self.async_create_entry(title="", data={})
 
-        return self.async_show_form(
-            step_id="confirm",
-            data_schema=vol.Schema({}),
-            description_placeholders={"device_name": self.device_name},
+    async def async_step_ignore(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the ignore step of a fix flow."""
+        ir.async_get(self.hass).async_ignore(
+            DOMAIN, f"device_config_file_changed.{self.device_id}", True
         )
+        return self.async_abort(reason="issue_ignored")
 
 
 async def async_create_fix_flow(

--- a/homeassistant/components/zwave_js/repairs.py
+++ b/homeassistant/components/zwave_js/repairs.py
@@ -15,7 +15,9 @@ class DeviceConfigFileChangedFlow(RepairsFlow):
 
     def __init__(self, data: dict[str, str]) -> None:
         """Initialize."""
-        self.device_name: str = data["device_name"]
+        self.description_placeholders: dict[str, str] = {
+            "device_name": data["device_name"]
+        }
         self.device_id: str = data["device_id"]
 
     async def async_step_init(
@@ -23,9 +25,8 @@ class DeviceConfigFileChangedFlow(RepairsFlow):
     ) -> data_entry_flow.FlowResult:
         """Handle the first step of a fix flow."""
         return self.async_show_menu(
-            step_id="init",
             menu_options=["confirm", "ignore"],
-            description_placeholders={"device_name": self.device_name},
+            description_placeholders=self.description_placeholders,
         )
 
     async def async_step_confirm(
@@ -37,7 +38,7 @@ class DeviceConfigFileChangedFlow(RepairsFlow):
         except ValueError:
             return self.async_abort(
                 reason="cannot_connect",
-                description_placeholders={"device_name": self.device_name},
+                description_placeholders=self.description_placeholders,
             )
         self.hass.async_create_task(node.async_refresh_info())
         return self.async_create_entry(title="", data={})
@@ -49,7 +50,10 @@ class DeviceConfigFileChangedFlow(RepairsFlow):
         ir.async_get(self.hass).async_ignore(
             DOMAIN, f"device_config_file_changed.{self.device_id}", True
         )
-        return self.async_abort(reason="issue_ignored")
+        return self.async_abort(
+            reason="issue_ignored",
+            description_placeholders=self.description_placeholders,
+        )
 
 
 async def async_create_fix_flow(

--- a/homeassistant/components/zwave_js/repairs.py
+++ b/homeassistant/components/zwave_js/repairs.py
@@ -22,14 +22,8 @@ class DeviceConfigFileChangedFlow(RepairsFlow):
         self, user_input: dict[str, str] | None = None
     ) -> data_entry_flow.FlowResult:
         """Handle the first step of a fix flow."""
-        return await self.async_step_menu()
-
-    async def async_step_menu(
-        self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
-        """Handle the menu step of a fix flow."""
         return self.async_show_menu(
-            step_id="confirm",
+            step_id="init",
             menu_options=["confirm", "ignore"],
             description_placeholders={"device_name": self.device_name},
         )

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -166,7 +166,7 @@
         },
         "abort": {
           "cannot_connect": "Cannot connect to {device_name}. Please try again later after confirming that your Z-Wave network is up and connected to Home Assistant.",
-          "issue_ignored": "Device config file update ignored."
+          "issue_ignored": "Device config file update for {device_name} ignored."
         }
       }
     }

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -155,7 +155,7 @@
       "title": "Device configuration file changed: {device_name}",
       "fix_flow": {
         "step": {
-          "confirm": {
+          "menu": {
             "menu_options": {
               "confirm": "Re-interview device",
               "ignore": "Ignore device config update"

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -156,12 +156,17 @@
       "fix_flow": {
         "step": {
           "confirm": {
+            "menu_options": {
+              "confirm": "Re-interview device",
+              "ignore": "Ignore device config update"
+            },
             "title": "Device configuration file changed: {device_name}",
-            "description": "The device configuration file for {device_name} has changed.\n\nZ-Wave JS discovers a lot of device metadata by interviewing the device. However, some of the information has to be loaded from a configuration file. Some of this information is only evaluated once, during the device interview.\n\nWhen a device config file is updated, this information may be stale and and the device must be re-interviewed to pick up the changes.\n\n This is not a required operation and device functionality will be impacted during the re-interview process, but you may see improvements for your device once it is complete.\n\nIf you'd like to proceed, click on SUBMIT below. The re-interview will take place in the background."
+            "description": "The device configuration file for {device_name} has changed.\n\nZ-Wave JS discovers a lot of device metadata by interviewing the device. However, some of the information has to be loaded from a configuration file. Some of this information is only evaluated once, during the device interview.\n\nWhen a device config file is updated, this information may be stale and and the device must be re-interviewed to pick up the changes.\n\n This is not a required operation and device functionality will be impacted during the re-interview process, but you may see improvements for your device once it is complete.\n\nIf you decide to proceed with the re-interview, it will take place in the background."
           }
         },
         "abort": {
-          "cannot_connect": "Cannot connect to {device_name}. Please try again later after confirming that your Z-Wave network is up and connected to Home Assistant."
+          "cannot_connect": "Cannot connect to {device_name}. Please try again later after confirming that your Z-Wave network is up and connected to Home Assistant.",
+          "issue_ignored": "Device config file update ignored."
         }
       }
     }

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -155,7 +155,7 @@
       "title": "Device configuration file changed: {device_name}",
       "fix_flow": {
         "step": {
-          "menu": {
+          "init": {
             "menu_options": {
               "confirm": "Re-interview device",
               "ignore": "Ignore device config update"


### PR DESCRIPTION
## Proposed change
Previously, since device config file change issues were fixable, there was no way to ignore the issue. With this change, users can optionally choose to ignore the issue.

This frontend bug fix should be merged before this is merged: https://github.com/home-assistant/frontend/issues/19551 (fixed in https://github.com/home-assistant/frontend/pull/19553)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
