### PR TITLE
Remove extra confirmation step in tplink authenticated discovery flow

### DIFF
--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -159,7 +159,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._discovered_device = device
                 await set_credentials(self.hass, username, password)
                 self.hass.async_create_task(self._async_reload_requires_auth_entries())
-                return await self.async_step_discovery_confirm()
+                return self._async_create_entry_from_device(self._discovered_device)
 
         placeholders = self._async_make_placeholders_from_discovery()
         self.context["title_placeholders"] = placeholders

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -141,18 +141,9 @@ async def test_discovery_auth(
         },
     )
 
-    assert result2["type"] == "form"
-    assert result2["step_id"] == "discovery_confirm"
-    assert not result2["errors"]
-
-    result3 = await hass.config_entries.flow.async_configure(
-        result2["flow_id"], user_input={}
-    )
-
-    await hass.async_block_till_done()
-    assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == DEFAULT_ENTRY_TITLE
-    assert result3["data"] == CREATE_ENTRY_DATA_AUTH
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["title"] == DEFAULT_ENTRY_TITLE
+    assert result2["data"] == CREATE_ENTRY_DATA_AUTH
 
 
 @pytest.mark.parametrize(
@@ -213,17 +204,8 @@ async def test_discovery_auth_errors(
             CONF_PASSWORD: "fake_password",
         },
     )
-    assert result3["type"] is FlowResultType.FORM
-    assert result3["step_id"] == "discovery_confirm"
-
-    await hass.async_block_till_done()
-
-    result4 = await hass.config_entries.flow.async_configure(
-        result3["flow_id"],
-        {},
-    )
-    assert result4["type"] is FlowResultType.CREATE_ENTRY
-    assert result4["data"] == CREATE_ENTRY_DATA_AUTH
+    assert result3["type"] is FlowResultType.CREATE_ENTRY
+    assert result3["data"] == CREATE_ENTRY_DATA_AUTH
 
 
 async def test_discovery_new_credentials(
@@ -325,15 +307,8 @@ async def test_discovery_new_credentials_invalid(
             CONF_PASSWORD: "fake_password",
         },
     )
-    assert result3["type"] is FlowResultType.FORM
-    assert result3["step_id"] == "discovery_confirm"
-
-    result4 = await hass.config_entries.flow.async_configure(
-        result3["flow_id"],
-        {},
-    )
-    assert result4["type"] is FlowResultType.CREATE_ENTRY
-    assert result4["data"] == CREATE_ENTRY_DATA_AUTH
+    assert result3["type"] is FlowResultType.CREATE_ENTRY
+    assert result3["data"] == CREATE_ENTRY_DATA_AUTH
 
 
 async def test_discovery_with_existing_device_present(hass: HomeAssistant) -> None:


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After discovery, and manually entering credentials, we would ask the user if they still wanted to set up the device. Instead we now create the config entry as soon as they enter correct credentials as its clear that they want to proceed.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
