### PR TITLE
Add support to Lutron lights for color and temperature control

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -761,8 +761,8 @@ build.json @home-assistant/supervisor
 /tests/components/lupusec/ @majuss @suaveolent
 /homeassistant/components/lutron/ @cdheiser @wilburCForce
 /tests/components/lutron/ @cdheiser @wilburCForce
-/homeassistant/components/lutron_caseta/ @swails @bdraco @danaues
-/tests/components/lutron_caseta/ @swails @bdraco @danaues
+/homeassistant/components/lutron_caseta/ @swails @bdraco @danaues @eclair4151
+/tests/components/lutron_caseta/ @swails @bdraco @danaues @eclair4151
 /homeassistant/components/lyric/ @timmo001
 /tests/components/lyric/ @timmo001
 /homeassistant/components/mastodon/ @fabaff

--- a/homeassistant/components/lutron_caseta/const.py
+++ b/homeassistant/components/lutron_caseta/const.py
@@ -14,6 +14,9 @@ LUTRON_CASETA_BUTTON_EVENT = "lutron_caseta_button_event"
 
 BRIDGE_DEVICE_ID = "1"
 
+DEVICE_TYPE_WHITE_TUNE = "WhiteTune"
+DEVICE_TYPE_SPECTRUM_TUNE = "SpectrumTune"
+
 MANUFACTURER = "Lutron Electronics Co., Inc"
 
 ATTR_SERIAL = "serial"

--- a/homeassistant/components/lutron_caseta/light.py
+++ b/homeassistant/components/lutron_caseta/light.py
@@ -2,9 +2,14 @@
 from datetime import timedelta
 from typing import Any
 
+from pylutron_caseta.color_value import FullColorValue, WarmCoolColorValue
+
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
+    ATTR_COLOR_TEMP_KELVIN,
+    ATTR_HS_COLOR,
     ATTR_TRANSITION,
+    ATTR_WHITE,
     DOMAIN,
     ColorMode,
     LightEntity,
@@ -48,37 +53,145 @@ async def async_setup_entry(
 
 
 class LutronCasetaLight(LutronCasetaDeviceUpdatableEntity, LightEntity):
-    """Representation of a Lutron Light, including dimmable."""
+    """Representation of a Lutron Light, including dimmable, white tune, and spectrum tune."""
 
-    _attr_color_mode = ColorMode.BRIGHTNESS
-    _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
+    def __init__(self, light, data) -> None:
+        """Initialize the light and set the supported color modes."""
+        super().__init__(light, data)
+        if light["type"] == "SpectrumTune":
+            self._attr_supported_color_modes = {
+                ColorMode.HS,
+                ColorMode.COLOR_TEMP,
+                ColorMode.BRIGHTNESS,
+                ColorMode.WHITE,
+            }
+        elif light["type"] == "WhiteTune":
+            self._attr_supported_color_modes = {
+                ColorMode.COLOR_TEMP,
+                ColorMode.BRIGHTNESS,
+                ColorMode.WHITE,
+            }
+        else:
+            self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
+
     _attr_supported_features = LightEntityFeature.TRANSITION
 
     @property
-    def brightness(self):
+    def brightness(self) -> int:
         """Return the brightness of the light."""
         return to_hass_level(self._device["current_state"])
 
-    async def _set_brightness(self, brightness, **kwargs):
+    async def _set_brightness(self, brightness, color_value, **kwargs):
         args = {}
         if ATTR_TRANSITION in kwargs:
             args["fade_time"] = timedelta(seconds=kwargs[ATTR_TRANSITION])
 
+        if brightness is not None:
+            brightness = to_lutron_level(brightness)
         await self._smartbridge.set_value(
-            self.device_id, to_lutron_level(brightness), **args
+            self.device_id, value=brightness, color_value=color_value, **args
         )
+
+    async def _set_warm_dim(self, brightness, **kwargs):
+        """Set the light to warm dim mode."""
+        args = {}
+        if ATTR_TRANSITION in kwargs:
+            args["fade_time"] = timedelta(seconds=kwargs[ATTR_TRANSITION])
+
+        if brightness is not None:
+            brightness = to_lutron_level(brightness)
+
+        await self._smartbridge.set_warm_dim(self.device_id, brightness, **args)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
-        brightness = kwargs.pop(ATTR_BRIGHTNESS, 255)
+        # first check for "white mode" (WarmDim)
+        white_color = kwargs.pop(ATTR_WHITE, None)
+        if white_color is not None:
+            await self._set_warm_dim(white_color)
+            return
 
-        await self._set_brightness(brightness, **kwargs)
+        brightness = kwargs.pop(ATTR_BRIGHTNESS, None)
+        color = None
+        hs_color = kwargs.pop(ATTR_HS_COLOR, None)
+        kelvin_color = kwargs.pop(ATTR_COLOR_TEMP_KELVIN, None)
+        if hs_color is not None:
+            color = FullColorValue(hs_color[0], hs_color[1])
+        elif kelvin_color is not None:
+            color = WarmCoolColorValue(kelvin_color)
+
+        # if user is pressing on button nothing is set, so set brightness to 255
+        if color is None and brightness is None:
+            brightness = 255
+
+        await self._set_brightness(brightness, color, **kwargs)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
-        await self._set_brightness(0, **kwargs)
+        await self._set_brightness(0, None, **kwargs)
 
     @property
-    def is_on(self):
+    def color_mode(self) -> ColorMode:
+        """Return the current color mode of the light."""
+        warm_dim = self._device.get("warm_dim", False)
+        # check if warm dim is set, if so return white mode
+        if warm_dim:
+            return ColorMode.WHITE
+
+        # check if color is set, if so return color mode
+        current_color = self._device.get("color")
+        if isinstance(current_color, WarmCoolColorValue):
+            return ColorMode.COLOR_TEMP
+
+        if isinstance(current_color, FullColorValue):
+            return ColorMode.HS
+
+        # otherwise return default brightness mode
+        return ColorMode.BRIGHTNESS
+
+    @property
+    def is_on(self) -> bool:
         """Return true if device is on."""
         return self._device["current_state"] > 0
+
+    @property
+    def hs_color(self) -> tuple[float, float] | None:
+        """Return the current color of the light."""
+        current_color = self._device.get("color")
+
+        # if bulb is set to full spectrum, return the hue and saturation
+        if isinstance(current_color, FullColorValue):
+            return (current_color.hue, current_color.saturation)
+
+        return None
+
+    @property
+    def color_temp_kelvin(self) -> int | None:
+        """Return the CT color value in kelvin."""
+        current_color = self._device.get("color")
+
+        # if bulb is set to warm cool mode, return the kelvin value
+        if isinstance(current_color, WarmCoolColorValue):
+            return current_color.kelvin
+
+        return None
+
+    @property
+    def max_color_temp_kelvin(self) -> int:
+        """Return maximum supported color temperature."""
+        white_tune_range = self._device.get("white_tuning_range")
+        # Default to 10k if not found
+        if white_tune_range is None or "Max" not in white_tune_range:
+            return 10000
+
+        return white_tune_range.get("Max")
+
+    @property
+    def min_color_temp_kelvin(self) -> int:
+        """Return minimum supported color temperature."""
+        white_tune_range = self._device.get("white_tuning_range")
+        # Default to 1.4k if not found
+        if white_tune_range is None or "Min" not in white_tune_range:
+            return 1400
+
+        return white_tune_range.get("Min")

--- a/homeassistant/components/lutron_caseta/light.py
+++ b/homeassistant/components/lutron_caseta/light.py
@@ -70,7 +70,7 @@ class LutronCasetaLight(LutronCasetaDeviceUpdatableEntity, LightEntity):
         DEVICE_TYPE_WHITE_TUNE: {ColorMode.COLOR_TEMP},
     }
 
-    def get_min_color_temp_kelvin(self, light: dict[str, Any]) -> int:
+    def _get_min_color_temp_kelvin(self, light: dict[str, Any]) -> int:
         """Return minimum supported color temperature.
 
         :param light: The light to get the minimum color temperature for.
@@ -82,7 +82,7 @@ class LutronCasetaLight(LutronCasetaDeviceUpdatableEntity, LightEntity):
 
         return white_tune_range.get("Min")
 
-    def get_max_color_temp_kelvin(self, light: dict[str, Any]) -> int:
+    def _get_max_color_temp_kelvin(self, light: dict[str, Any]) -> int:
         """Return maximum supported color temperature.
 
         :param light: The light to get the maximum color temperature for.
@@ -107,7 +107,9 @@ class LutronCasetaLight(LutronCasetaDeviceUpdatableEntity, LightEntity):
 
         light_type = light["type"]
         if light_type in self.SUPPORTED_COLOR_MODE_DICT:
-            self._attr_supported_color_modes = SUPPORTED_COLOR_MODES_BY_LIGHT_TYPE.get(light_type, {ColorMode.BRIGHTNESS})
+            self._attr_supported_color_modes = self.SUPPORTED_COLOR_MODE_DICT.get(
+                light_type, {ColorMode.BRIGHTNESS}
+            )
         else:
             self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
 

--- a/homeassistant/components/lutron_caseta/light.py
+++ b/homeassistant/components/lutron_caseta/light.py
@@ -70,7 +70,7 @@ class LutronCasetaLight(LutronCasetaDeviceUpdatableEntity, LightEntity):
         DEVICE_TYPE_WHITE_TUNE: {ColorMode.COLOR_TEMP},
     }
 
-    def get_min_color_temp_kelvin(self, light) -> int:
+    def get_min_color_temp_kelvin(self, light: dict[str, Any]) -> int:
         """Return minimum supported color temperature.
 
         :param light: The light to get the minimum color temperature for.
@@ -82,7 +82,7 @@ class LutronCasetaLight(LutronCasetaDeviceUpdatableEntity, LightEntity):
 
         return white_tune_range.get("Min")
 
-    def get_max_color_temp_kelvin(self, light) -> int:
+    def get_max_color_temp_kelvin(self, light: dict[str, Any]) -> int:
         """Return maximum supported color temperature.
 
         :param light: The light to get the maximum color temperature for.
@@ -94,7 +94,7 @@ class LutronCasetaLight(LutronCasetaDeviceUpdatableEntity, LightEntity):
 
         return white_tune_range.get("Max")
 
-    def __init__(self, light, data) -> None:
+    def __init__(self, light: dict[str, Any], data: LutronCasetaData) -> None:
         """Initialize the light and set the supported color modes.
 
         :param light: The lutron light device to initialize.
@@ -102,14 +102,12 @@ class LutronCasetaLight(LutronCasetaDeviceUpdatableEntity, LightEntity):
         """
         super().__init__(light, data)
 
-        self._attr_min_color_temp_kelvin = self.get_min_color_temp_kelvin(light)
-        self._attr_max_color_temp_kelvin = self.get_max_color_temp_kelvin(light)
+        self._attr_min_color_temp_kelvin = self._get_min_color_temp_kelvin(light)
+        self._attr_max_color_temp_kelvin = self._get_max_color_temp_kelvin(light)
 
         light_type = light["type"]
         if light_type in self.SUPPORTED_COLOR_MODE_DICT:
-            self._attr_supported_color_modes = self.SUPPORTED_COLOR_MODE_DICT[
-                light_type
-            ]
+            self._attr_supported_color_modes = SUPPORTED_COLOR_MODES_BY_LIGHT_TYPE.get(light_type, {ColorMode.BRIGHTNESS})
         else:
             self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
 
@@ -118,8 +116,8 @@ class LutronCasetaLight(LutronCasetaDeviceUpdatableEntity, LightEntity):
             DEVICE_TYPE_SPECTRUM_TUNE,
         ]
 
-        self.supports_warm_dim = light_type in [DEVICE_TYPE_SPECTRUM_TUNE]
-        self.supports_spectrum_tune = light_type in [DEVICE_TYPE_SPECTRUM_TUNE]
+        self.supports_warm_dim = light_type == DEVICE_TYPE_SPECTRUM_TUNE
+        self.supports_spectrum_tune = light_type == DEVICE_TYPE_SPECTRUM_TUNE
 
     @property
     def brightness(self) -> int:
@@ -137,7 +135,7 @@ class LutronCasetaLight(LutronCasetaDeviceUpdatableEntity, LightEntity):
             self.device_id, value=brightness, color_value=color_value, **args
         )
 
-    async def _set_warm_dim(self, brightness, **kwargs):
+    async def _set_warm_dim(self, brightness: int | None, **kwargs: Any):
         """Set the light to warm dim mode."""
         args = {}
         if ATTR_TRANSITION in kwargs:

--- a/homeassistant/components/lutron_caseta/manifest.json
+++ b/homeassistant/components/lutron_caseta/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "lutron_caseta",
   "name": "Lutron Cas\u00e9ta",
-  "codeowners": ["@swails", "@bdraco", "@danaues"],
+  "codeowners": ["@swails", "@bdraco", "@danaues", "@eclair4151"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/lutron_caseta",
   "homekit": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds color and temperature color to Lutron lights which support it (Currently Ketra bulbs and Lumaris tape strips)
Warm-Dim white mode is also supported and mapped to the "White Mode"

You can see the testing and discussion in the pylutron-caseta PR here:
https://github.com/gurumitts/pylutron-caseta/pull/154

@Uberjay and @RBaragona also tested this HA branch to confirm it was working for thier ketra and lumaris devices.

Here's a demo of the color control working:
https://photos.google.com/share/AF1QipOJVpEUTPxKxGEpe2Tdip2JAs3PIa9uOo1OeMaNaCcgZq1rMKrnXxS-m7peCI39sg?key=NXo2YjJMMEh0N2llcjhpcnJMZXF3aUZCTDNHTTZn



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
