### PR TITLE
Create an issue when database backups fail because the system runs out of resources

### DIFF
--- a/homeassistant/components/recorder/strings.json
+++ b/homeassistant/components/recorder/strings.json
@@ -15,7 +15,7 @@
     },
     "backup_failed_out_of_resources": {
       "title": "Database backup failed due to lack of resources",
-      "description": "The database backup stated at {start_time} failed due to lack of resources. This can happen if the database is too large or if the system is under heavy load. Consider upgrading the system hardware or reducing the size of the database by decreasing the number of history days to keep or creating a filter."
+      "description": "The database backup stated at {start_time} failed due to lack of resources. The backup cannot be trusted and must be restarted. This can happen if the database is too large or if the system is under heavy load. Consider upgrading the system hardware or reducing the size of the database by decreasing the number of history days to keep or creating a filter."
     }
   },
   "services": {

--- a/homeassistant/components/recorder/strings.json
+++ b/homeassistant/components/recorder/strings.json
@@ -12,6 +12,10 @@
     "maria_db_range_index_regression": {
       "title": "Update MariaDB to {min_version} or later resolve a significant performance issue",
       "description": "Older versions of MariaDB suffer from a significant performance regression when retrieving history data or purging the database. Update to MariaDB version {min_version} or later and restart Home Assistant. If you are using the MariaDB core add-on, make sure to update it to the latest version."
+    },
+    "backup_failed_out_of_resources": {
+      "title": "Database backup failed due to lack of resources",
+      "description": "The database backup stated at {start_time} failed due to lack of resources. This can happen if the database is too large or if the system is under heavy load. Consider upgrading the system hardware or reducing the size of the database by decreasing the number of history days to keep or creating a filter."
     }
   },
   "services": {

--- a/homeassistant/components/recorder/util.py
+++ b/homeassistant/components/recorder/util.py
@@ -470,6 +470,24 @@ def _async_create_mariadb_range_index_regression_issue(
     )
 
 
+@callback
+def async_create_backup_failure_issue(
+    hass: HomeAssistant,
+    local_start_time: datetime,
+) -> None:
+    """Create an issue when the backup fails because we run out of resources."""
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        "backup_failed_out_of_resources",
+        is_fixable=False,
+        severity=ir.IssueSeverity.CRITICAL,
+        learn_more_url="https://www.home-assistant.io/integrations/recorder",
+        translation_key="backup_failed_out_of_resources",
+        translation_placeholders={"start_time": str(local_start_time)},
+    )
+
+
 def setup_connection_for_dialect(
     instance: Recorder,
     dialect_name: str,

--- a/homeassistant/components/recorder/util.py
+++ b/homeassistant/components/recorder/util.py
@@ -484,7 +484,7 @@ def async_create_backup_failure_issue(
         severity=ir.IssueSeverity.CRITICAL,
         learn_more_url="https://www.home-assistant.io/integrations/recorder",
         translation_key="backup_failed_out_of_resources",
-        translation_placeholders={"start_time": str(local_start_time)},
+        translation_placeholders={"start_time": local_start_time.strftime("%H:%M:%S")},
     )
 
 

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -73,6 +73,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import Context, CoreState, Event, HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er, recorder as recorder_helper
+from homeassistant.helpers.issue_registry import async_get as async_get_issue_registry
 from homeassistant.setup import async_setup_component, setup_component
 from homeassistant.util import dt as dt_util
 from homeassistant.util.json import json_loads
@@ -1832,6 +1833,14 @@ async def test_database_lock_and_overflow(
         assert "Database queue backlog reached more than" in caplog.text
         assert not instance.unlock_database()
 
+    registry = async_get_issue_registry(hass)
+    issue = registry.async_get_issue(DOMAIN, "backup_failed_out_of_resources")
+    assert issue is not None
+    assert "start_time" in issue.translation_placeholders
+    start_time = issue.translation_placeholders["start_time"]
+    assert start_time is not None
+    assert dt_util.parse_datetime(start_time) is not None
+
 
 async def test_database_lock_and_overflow_checks_available_memory(
     async_setup_recorder_instance: RecorderInstanceGenerator,
@@ -1909,6 +1918,14 @@ async def test_database_lock_and_overflow_checks_available_memory(
 
         db_events = await instance.async_add_executor_job(_get_db_events)
         assert len(db_events) >= 2
+
+    registry = async_get_issue_registry(hass)
+    issue = registry.async_get_issue(DOMAIN, "backup_failed_out_of_resources")
+    assert issue is not None
+    assert "start_time" in issue.translation_placeholders
+    start_time = issue.translation_placeholders["start_time"]
+    assert start_time is not None
+    assert dt_util.parse_datetime(start_time) is not None
 
 
 async def test_database_lock_timeout(

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -1839,7 +1839,8 @@ async def test_database_lock_and_overflow(
     assert "start_time" in issue.translation_placeholders
     start_time = issue.translation_placeholders["start_time"]
     assert start_time is not None
-    assert dt_util.parse_datetime(start_time) is not None
+    # Should be in H:M:S format
+    assert start_time.count(":") == 2
 
 
 async def test_database_lock_and_overflow_checks_available_memory(
@@ -1925,7 +1926,8 @@ async def test_database_lock_and_overflow_checks_available_memory(
     assert "start_time" in issue.translation_placeholders
     start_time = issue.translation_placeholders["start_time"]
     assert start_time is not None
-    assert dt_util.parse_datetime(start_time) is not None
+    # Should be in H:M:S format
+    assert start_time.count(":") == 2
 
 
 async def test_database_lock_timeout(


### PR DESCRIPTION
~~This should wait to merge until after https://github.com/home-assistant/supervisor/pull/4843 so we don't have a have a lot of issues in the queue that we can do little about.~~

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

If the backup takes too long, the system can run out of resources to store the event queue because we have to queue them in memory until the database backup finishes and the write lock is released. When this happens we logged a warning in the log which was easy to miss, and users sometimes found out their database backup had failed at the worst possible time (when they needed to restore it.)

The repair issue increases the chance the user will see the problem without forcing the rest of their backup to hard fail (since it only affects the database). This is especially relevant if they're doing backups via API to do an update, or using an add-on like the Google Drive Backup or other Backup system. For testing I did backups via api and verified I got the error in the UI.

This issue is expected to be extremely rare after https://github.com/home-assistant/supervisor/pull/4843

<img width="593" alt="Screenshot 2024-01-28 at 12 54 32 PM" src="https://github.com/home-assistant/core/assets/663432/e03b257f-eee8-4f89-adb4-e1601b76115a">
<img width="635" alt="Screenshot 2024-01-28 at 12 54 47 PM" src="https://github.com/home-assistant/core/assets/663432/13828afb-172d-44a5-aef2-0557170f3ab4">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/105987 https://github.com/home-assistant/core/issues/106300
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
