### PR TITLE
Keep track of TimerHandles independent from event loop

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -988,12 +988,7 @@ class HomeAssistant:
     def _cancel_cancellable_timers(self) -> None:
         """Cancel timer handles marked as cancellable."""
         for handle in self._timers:
-            if (
-                not handle.cancelled()
-                and (args := handle._args)  # pylint: disable=protected-access
-                and type(job := args[0]) is HassJob  # noqa: E721
-                and job.cancel_on_shutdown
-            ):
+            if not handle.cancelled():
                 handle.cancel()
 
     def _async_log_running_tasks(self, stage: str) -> None:

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1464,6 +1464,19 @@ def _run_async_call_action(
 
 
 @callback
+def _async_schedule_and_track_handle(
+    hass: HomeAssistant,
+    when: float,
+    job: HassJob[[datetime], Coroutine[Any, Any, None] | None],
+) -> CALLBACK_TYPE:
+    """Schedule the callback and keep track of the TimeHandle."""
+    handle = hass.loop.call_at(when, _run_async_call_action, hass, job)
+    if job.cancel_on_shutdown:
+        hass.async_track_timer_handle(handle)
+    return handle.cancel
+
+
+@callback
 @bind_hass
 def async_call_at(
     hass: HomeAssistant,
@@ -1480,10 +1493,7 @@ def async_call_at(
         if isinstance(action, HassJob)
         else HassJob(action, f"call_at {loop_time}")
     )
-    handle = hass.loop.call_at(loop_time, _run_async_call_action, hass, job)
-    if job.cancel_on_shutdown:
-        hass.async_track_timer_handle(handle)
-    return handle.cancel
+    return _async_schedule_and_track_handle(hass, loop_time, job)
 
 
 @callback
@@ -1505,11 +1515,7 @@ def async_call_later(
         if isinstance(action, HassJob)
         else HassJob(action, f"call_later {delay}")
     )
-    loop = hass.loop
-    handle = loop.call_at(loop.time() + delay, _run_async_call_action, hass, job)
-    if job.cancel_on_shutdown:
-        hass.async_track_timer_handle(handle)
-    return handle.cancel
+    return _async_schedule_and_track_handle(hass, hass.loop.time() + delay, job)
 
 
 call_later = threaded_listener_factory(async_call_later)

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1481,7 +1481,8 @@ def async_call_at(
         else HassJob(action, f"call_at {loop_time}")
     )
     handle = hass.loop.call_at(loop_time, _run_async_call_action, hass, job)
-    hass.async_track_timer_handle(handle)
+    if job.cancel_on_shutdown:
+        hass.async_track_timer_handle(handle)
     return handle.cancel
 
 
@@ -1506,7 +1507,8 @@ def async_call_later(
     )
     loop = hass.loop
     handle = loop.call_at(loop.time() + delay, _run_async_call_action, hass, job)
-    hass.async_track_timer_handle(handle)
+    if job.cancel_on_shutdown:
+        hass.async_track_timer_handle(handle)
     return handle.cancel
 
 

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1480,7 +1480,9 @@ def async_call_at(
         if isinstance(action, HassJob)
         else HassJob(action, f"call_at {loop_time}")
     )
-    return hass.loop.call_at(loop_time, _run_async_call_action, hass, job).cancel
+    handle = hass.loop.call_at(loop_time, _run_async_call_action, hass, job)
+    hass.async_track_timer_handle(handle)
+    return handle.cancel
 
 
 @callback
@@ -1503,7 +1505,9 @@ def async_call_later(
         else HassJob(action, f"call_later {delay}")
     )
     loop = hass.loop
-    return loop.call_at(loop.time() + delay, _run_async_call_action, hass, job).cancel
+    handle = loop.call_at(loop.time() + delay, _run_async_call_action, hass, job)
+    hass.async_track_timer_handle(handle)
+    return handle.cancel
 
 
 call_later = threaded_listener_factory(async_call_later)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2673,6 +2673,8 @@ async def test_cancellable_hassjob(hass: HomeAssistant) -> None:
     )
     timer2 = hass.loop.call_later(60, run_job, HassJob(ha.callback(job)))
 
+    hass.async_track_timer_handle(timer1)
+
     await hass.async_stop()
 
     assert timer1.cancelled()


### PR DESCRIPTION
## Proposed change
Currently we're relaying on the event loop to keep track / get the scheduled TimerHandles. This could / is a problem if we consider switching to uvloop, besides the `_scheduled` property of the `asyncio` event loop is a protected property, so this may break anytime (what I don't expect to)

So this PR proposes to keep track of the TimeHandles, they need to be cancelled at shutdown, on our own. 
I use a `WeakSet` here, so we don't have to remove the reference from the set ourselves after a TimeHandle has ended.

I tried also a different solution within `uvloop` (create a function to return the scheduled TimeHandlers), but lead me to other issues e.g. `_args` or `args` weren't available for the `uvloop` TimeHandlers.

I may have forgotten something, or it may not be the ideal solution, so I'll leave this here for comments.

~With this solution the implementation of `uvloop` would be quite simple, the problem with `<broadcast>` described in https://github.com/home-assistant/core/pull/93173 seems to be solved. I have tried this with a small test and can send packets to the `<broadcast>` address without any problems~

The `<broadcast>` issue within uvloop mentioned in #93173 should be solved by https://github.com/MagicStack/uvloop/pull/592. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
