### PR TITLE
Improve base entity state in Vogel's MotionMount integration

### DIFF
--- a/homeassistant/components/motionmount/entity.py
+++ b/homeassistant/components/motionmount/entity.py
@@ -3,7 +3,7 @@
 import motionmount
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_CONNECTIONS, ATTR_IDENTIFIERS, ATTR_NAME
+from homeassistant.const import ATTR_CONNECTIONS, ATTR_IDENTIFIERS
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo, format_mac
 from homeassistant.helpers.entity import Entity
@@ -49,29 +49,24 @@ class MotionMountEntity(Entity):
 
     def update_name(self) -> None:
         """Update the name of the associated device."""
-        # Check whether we need to update our name
-        if self.device_info and self.device_info[ATTR_NAME] != self.mm.name:
-            device_info = self.device_info
-            device_info[ATTR_NAME] = self.mm.name
-            self._attr_device_info = device_info
+        # Update the name in the device registry if needed
 
-            # Also update the name in the device registry if needed
-            mac = format_mac(self.mm.mac.hex())
-            device_registry = dr.async_get(self.hass)
+        mac = format_mac(self.mm.mac.hex())
+        device_registry = dr.async_get(self.hass)
 
-            # Find the device
-            if mac == EMPTY_MAC:
-                device = device_registry.async_get_device(
-                    identifiers={(DOMAIN, self._base_unique_id)}
-                )
-            else:
-                device = device_registry.async_get_device(
-                    connections={(dr.CONNECTION_NETWORK_MAC, mac)}
-                )
+        # Find the device...
+        if mac == EMPTY_MAC:
+            device = device_registry.async_get_device(
+                identifiers={(DOMAIN, self._base_unique_id)}
+            )
+        else:
+            device = device_registry.async_get_device(
+                connections={(dr.CONNECTION_NETWORK_MAC, mac)}
+            )
 
-            # And perform update
-            if device is not None and device.name != self.mm.name:
-                device_registry.async_update_device(device.id, name=self.mm.name)
+        # ...and perform update
+        if device is not None and device.name != self.mm.name:
+            device_registry.async_update_device(device.id, name=self.mm.name)
 
     async def async_added_to_hass(self) -> None:
         """Store register state change callback."""

--- a/homeassistant/components/motionmount/entity.py
+++ b/homeassistant/components/motionmount/entity.py
@@ -1,5 +1,7 @@
 """Support for MotionMount sensors."""
 
+from typing import TYPE_CHECKING
+
 import motionmount
 
 from homeassistant.config_entries import ConfigEntry
@@ -50,7 +52,7 @@ class MotionMountEntity(Entity):
     def update_name(self) -> None:
         """Update the name of the associated device."""
         if TYPE_CHECKING:
-            assert self.device_entry 
+            assert self.device_entry
         # Update the name in the device registry if needed
         if self.device_entry.name != self.mm.name:
             device_registry = dr.async_get(self.hass)

--- a/homeassistant/components/motionmount/entity.py
+++ b/homeassistant/components/motionmount/entity.py
@@ -50,23 +50,9 @@ class MotionMountEntity(Entity):
     def update_name(self) -> None:
         """Update the name of the associated device."""
         # Update the name in the device registry if needed
-
-        mac = format_mac(self.mm.mac.hex())
-        device_registry = dr.async_get(self.hass)
-
-        # Find the device...
-        if mac == EMPTY_MAC:
-            device = device_registry.async_get_device(
-                identifiers={(DOMAIN, self._base_unique_id)}
-            )
-        else:
-            device = device_registry.async_get_device(
-                connections={(dr.CONNECTION_NETWORK_MAC, mac)}
-            )
-
-        # ...and perform update
-        if device is not None and device.name != self.mm.name:
-            device_registry.async_update_device(device.id, name=self.mm.name)
+        if self.device_entry is not None and self.device_entry.name != self.mm.name:
+            device_registry = dr.async_get(self.hass)
+            device_registry.async_update_device(self.device_entry.id, name=self.mm.name)
 
     async def async_added_to_hass(self) -> None:
         """Store register state change callback."""

--- a/homeassistant/components/motionmount/entity.py
+++ b/homeassistant/components/motionmount/entity.py
@@ -3,7 +3,7 @@
 import motionmount
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_CONNECTIONS, ATTR_IDENTIFIERS
+from homeassistant.const import ATTR_CONNECTIONS, ATTR_IDENTIFIERS, ATTR_NAME
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo, format_mac
 from homeassistant.helpers.entity import Entity
@@ -42,12 +42,40 @@ class MotionMountEntity(Entity):
                 (dr.CONNECTION_NETWORK_MAC, mac)
             }
 
+    def update_name(self) -> None:
+        """Update the name of the associated device."""
+        # Check whether we need to update our name
+        if self.device_info and self.device_info[ATTR_NAME] != self.mm.name:
+            device_info = self.device_info
+            device_info[ATTR_NAME] = self.mm.name
+            self._attr_device_info = device_info
+
+            # Also update the name in the device registry if needed
+            mac = format_mac(self.mm.mac.hex())
+            device_registry = dr.async_get(self.hass)
+
+            # Find the device
+            if mac == EMPTY_MAC:
+                device = device_registry.async_get_device(
+                    identifiers={(DOMAIN, self._base_unique_id)}
+                )
+            else:
+                device = device_registry.async_get_device(
+                    connections={(dr.CONNECTION_NETWORK_MAC, mac)}
+                )
+
+            # And perform update
+            if device is not None and device.name != self.mm.name:
+                device_registry.async_update_device(device.id, name=self.mm.name)
+
     async def async_added_to_hass(self) -> None:
         """Store register state change callback."""
         self.mm.add_listener(self.async_write_ha_state)
+        self.mm.add_listener(self.update_name)
         await super().async_added_to_hass()
 
     async def async_will_remove_from_hass(self) -> None:
         """Remove register state change callback."""
         self.mm.remove_listener(self.async_write_ha_state)
+        self.mm.remove_listener(self.update_name)
         await super().async_will_remove_from_hass()

--- a/homeassistant/components/motionmount/entity.py
+++ b/homeassistant/components/motionmount/entity.py
@@ -49,8 +49,10 @@ class MotionMountEntity(Entity):
 
     def update_name(self) -> None:
         """Update the name of the associated device."""
+        if TYPE_CHECKING:
+            assert self.device_entry 
         # Update the name in the device registry if needed
-        if self.device_entry is not None and self.device_entry.name != self.mm.name:
+        if self.device_entry.name != self.mm.name:
             device_registry = dr.async_get(self.hass)
             device_registry.async_update_device(self.device_entry.id, name=self.mm.name)
 

--- a/homeassistant/components/motionmount/entity.py
+++ b/homeassistant/components/motionmount/entity.py
@@ -42,6 +42,11 @@ class MotionMountEntity(Entity):
                 (dr.CONNECTION_NETWORK_MAC, mac)
             }
 
+    @property
+    def available(self) -> bool:
+        """Return True if the MotionMount is available (we're connected)."""
+        return self.mm.is_connected
+
     def update_name(self) -> None:
         """Update the name of the associated device."""
         # Check whether we need to update our name


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR improves the base state of the entity.
When the user changes the name of the device the entity notices this and updates the device registry.
When the connection to the device is lost the `available` property is set to reflect this.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
