### PR TITLE
Allow system and helper integrations to provide entity_component icons

### DIFF
--- a/homeassistant/components/automation/icons.json
+++ b/homeassistant/components/automation/icons.json
@@ -1,0 +1,18 @@
+{
+  "entity_component": {
+    "_": {
+      "default": "mdi:robot",
+      "state": {
+        "off": "mdi:robot-off",
+        "unavailable": "mdi:robot-confused"
+      }
+    }
+  },
+  "services": {
+    "turn_on": "mdi:robot",
+    "turn_off": "mdi:robot-off",
+    "toggle": "mdi:robot",
+    "trigger": "mdi:robot",
+    "reload": "mdi:robot"
+  }
+}

--- a/script/hassfest/icons.py
+++ b/script/hassfest/icons.py
@@ -70,14 +70,14 @@ def icon_schema(integration_type: str) -> vol.Schema:
             ),
         }
 
-    base_schema = vol.Schema(
+    schema = vol.Schema(
         {
             vol.Optional("services"): state_validator,
         }
     )
 
     if integration_type in ("entity", "helper", "system"):
-        return base_schema.extend(
+        schema = schema.extend(
             {
                 vol.Required("entity_component"): vol.All(
                     cv.schema_with_slug_keys(
@@ -89,21 +89,22 @@ def icon_schema(integration_type: str) -> vol.Schema:
                 )
             }
         )
-
-    return base_schema.extend(
-        {
-            vol.Optional("entity"): vol.All(
-                cv.schema_with_slug_keys(
+    if integration_type not in ("entity", "system"):
+        schema = schema.extend(
+            {
+                vol.Optional("entity"): vol.All(
                     cv.schema_with_slug_keys(
-                        icon_schema_slug(vol.Optional),
-                        slug_validator=translation_key_validator,
+                        cv.schema_with_slug_keys(
+                            icon_schema_slug(vol.Optional),
+                            slug_validator=translation_key_validator,
+                        ),
+                        slug_validator=cv.slug,
                     ),
-                    slug_validator=cv.slug,
-                ),
-                ensure_not_same_as_default,
-            )
-        }
-    )
+                    ensure_not_same_as_default,
+                )
+            }
+        )
+    return schema
 
 
 def validate_icon_file(config: Config, integration: Integration) -> None:  # noqa: C901

--- a/script/hassfest/icons.py
+++ b/script/hassfest/icons.py
@@ -70,14 +70,14 @@ def icon_schema(integration_type: str) -> vol.Schema:
             ),
         }
 
-    schema = vol.Schema(
+    base_schema = vol.Schema(
         {
             vol.Optional("services"): state_validator,
         }
     )
 
     if integration_type in ("entity", "helper", "system"):
-        schema = schema.extend(
+        return base_schema.extend(
             {
                 vol.Required("entity_component"): vol.All(
                     cv.schema_with_slug_keys(
@@ -89,22 +89,21 @@ def icon_schema(integration_type: str) -> vol.Schema:
                 )
             }
         )
-    if integration_type != "entity":
-        schema = schema.extend(
-            {
-                vol.Optional("entity"): vol.All(
+
+    return base_schema.extend(
+        {
+            vol.Optional("entity"): vol.All(
+                cv.schema_with_slug_keys(
                     cv.schema_with_slug_keys(
-                        cv.schema_with_slug_keys(
-                            icon_schema_slug(vol.Optional),
-                            slug_validator=translation_key_validator,
-                        ),
-                        slug_validator=cv.slug,
+                        icon_schema_slug(vol.Optional),
+                        slug_validator=translation_key_validator,
                     ),
-                    ensure_not_same_as_default,
-                )
-            }
-        )
-    return schema
+                    slug_validator=cv.slug,
+                ),
+                ensure_not_same_as_default,
+            )
+        }
+    )
 
 
 def validate_icon_file(config: Config, integration: Integration) -> None:  # noqa: C901

--- a/script/hassfest/icons.py
+++ b/script/hassfest/icons.py
@@ -76,7 +76,7 @@ def icon_schema(integration_type: str) -> vol.Schema:
         }
     )
 
-    if integration_type in ("entity", "system"):
+    if integration_type in ("entity", "helper", "system"):
         schema = schema.extend(
             {
                 vol.Required("entity_component"): vol.All(

--- a/script/hassfest/icons.py
+++ b/script/hassfest/icons.py
@@ -70,14 +70,14 @@ def icon_schema(integration_type: str) -> vol.Schema:
             ),
         }
 
-    base_schema = vol.Schema(
+    schema = vol.Schema(
         {
             vol.Optional("services"): state_validator,
         }
     )
 
-    if integration_type == "entity":
-        return base_schema.extend(
+    if integration_type in ("entity", "system"):
+        return schema.extend(
             {
                 vol.Required("entity_component"): vol.All(
                     cv.schema_with_slug_keys(
@@ -89,20 +89,22 @@ def icon_schema(integration_type: str) -> vol.Schema:
                 )
             }
         )
-    return base_schema.extend(
-        {
-            vol.Optional("entity"): vol.All(
-                cv.schema_with_slug_keys(
+    if integration_type != "entity":
+        return schema.extend(
+            {
+                vol.Optional("entity"): vol.All(
                     cv.schema_with_slug_keys(
-                        icon_schema_slug(vol.Optional),
-                        slug_validator=translation_key_validator,
+                        cv.schema_with_slug_keys(
+                            icon_schema_slug(vol.Optional),
+                            slug_validator=translation_key_validator,
+                        ),
+                        slug_validator=cv.slug,
                     ),
-                    slug_validator=cv.slug,
-                ),
-                ensure_not_same_as_default,
-            )
-        }
-    )
+                    ensure_not_same_as_default,
+                )
+            }
+        )
+    return schema
 
 
 def validate_icon_file(config: Config, integration: Integration) -> None:  # noqa: C901

--- a/script/hassfest/icons.py
+++ b/script/hassfest/icons.py
@@ -77,7 +77,7 @@ def icon_schema(integration_type: str) -> vol.Schema:
     )
 
     if integration_type in ("entity", "system"):
-        return schema.extend(
+        schema = schema.extend(
             {
                 vol.Required("entity_component"): vol.All(
                     cv.schema_with_slug_keys(
@@ -90,7 +90,7 @@ def icon_schema(integration_type: str) -> vol.Schema:
             }
         )
     if integration_type != "entity":
-        return schema.extend(
+        schema = schema.extend(
             {
                 vol.Optional("entity"): vol.All(
                     cv.schema_with_slug_keys(


### PR DESCRIPTION
## Proposed change

This will allow integrations like automation, script, person, input_boolean to provide icon translations.
I added automation icons in this PR, tell me if I should make a dedicated PR for this.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
