### PR TITLE
Remove deprecated event_loop fixtures in tests

### DIFF
--- a/tests/components/config/test_init.py
+++ b/tests/components/config/test_init.py
@@ -3,7 +3,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
-async def test_config_setup(hass: HomeAssistant, event_loop) -> None:
+async def test_config_setup(hass: HomeAssistant) -> None:
     """Test it sets up hassbian."""
     await async_setup_component(hass, "config", {})
     assert "config" in hass.config.components

--- a/tests/components/fido/test_sensor.py
+++ b/tests/components/fido/test_sensor.py
@@ -40,7 +40,7 @@ class FidoClientMockError(FidoClientMock):
         raise PyFidoError("Fake Error")
 
 
-async def test_fido_sensor(event_loop, hass: HomeAssistant) -> None:
+async def test_fido_sensor(hass: HomeAssistant) -> None:
     """Test the Fido number sensor."""
     with patch("homeassistant.components.fido.sensor.FidoClient", new=FidoClientMock):
         config = {

--- a/tests/components/geofency/test_init.py
+++ b/tests/components/geofency/test_init.py
@@ -116,7 +116,7 @@ def mock_dev_track(mock_device_tracker_conf):
 
 
 @pytest.fixture
-async def geofency_client(event_loop, hass, hass_client_no_auth):
+async def geofency_client(hass, hass_client_no_auth):
     """Geofency mock client (unauthenticated)."""
 
     assert await async_setup_component(
@@ -129,7 +129,7 @@ async def geofency_client(event_loop, hass, hass_client_no_auth):
 
 
 @pytest.fixture(autouse=True)
-async def setup_zones(event_loop, hass):
+async def setup_zones(hass):
     """Set up Zone config in HA."""
     assert await async_setup_component(
         hass,

--- a/tests/components/gpslogger/test_init.py
+++ b/tests/components/gpslogger/test_init.py
@@ -25,7 +25,7 @@ def mock_dev_track(mock_device_tracker_conf):
 
 
 @pytest.fixture
-async def gpslogger_client(event_loop, hass, hass_client_no_auth):
+async def gpslogger_client(hass, hass_client_no_auth):
     """Mock client for GPSLogger (unauthenticated)."""
 
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
@@ -37,7 +37,7 @@ async def gpslogger_client(event_loop, hass, hass_client_no_auth):
 
 
 @pytest.fixture(autouse=True)
-async def setup_zones(event_loop, hass):
+async def setup_zones(hass):
     """Set up Zone config in HA."""
     assert await async_setup_component(
         hass,

--- a/tests/components/http/test_security_filter.py
+++ b/tests/components/http/test_security_filter.py
@@ -1,4 +1,5 @@
 """Test security filter middleware."""
+import asyncio
 from http import HTTPStatus
 
 from aiohttp import web
@@ -75,7 +76,6 @@ async def test_bad_requests(
     fail_on_query_string,
     aiohttp_client: ClientSessionGenerator,
     caplog: pytest.LogCaptureFixture,
-    event_loop,
 ) -> None:
     """Test request paths that should be filtered."""
     app = web.Application()
@@ -93,7 +93,7 @@ async def test_bad_requests(
         man_params = ""
 
     http = urllib3.PoolManager()
-    resp = await event_loop.run_in_executor(
+    resp = await asyncio.get_running_loop().run_in_executor(
         None,
         http.request,
         "GET",
@@ -126,7 +126,6 @@ async def test_bad_requests_with_unsafe_bytes(
     fail_on_query_string,
     aiohttp_client: ClientSessionGenerator,
     caplog: pytest.LogCaptureFixture,
-    event_loop,
 ) -> None:
     """Test request with unsafe bytes in their URLs."""
     app = web.Application()
@@ -144,7 +143,7 @@ async def test_bad_requests_with_unsafe_bytes(
         man_params = ""
 
     http = urllib3.PoolManager()
-    resp = await event_loop.run_in_executor(
+    resp = await asyncio.get_running_loop().run_in_executor(
         None,
         http.request,
         "GET",

--- a/tests/components/locative/test_init.py
+++ b/tests/components/locative/test_init.py
@@ -20,7 +20,7 @@ def mock_dev_track(mock_device_tracker_conf):
 
 
 @pytest.fixture
-async def locative_client(event_loop, hass, hass_client):
+async def locative_client(hass, hass_client):
     """Locative mock client."""
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     await hass.async_block_till_done()

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -99,7 +99,7 @@ def test_validate_or_move_away_sqlite_database(
 
 
 async def test_last_run_was_recently_clean(
-    event_loop, async_setup_recorder_instance: RecorderInstanceGenerator, tmp_path: Path
+    async_setup_recorder_instance: RecorderInstanceGenerator, tmp_path: Path
 ) -> None:
     """Test we can check if the last recorder run was recently clean."""
     config = {

--- a/tests/components/traccar/test_init.py
+++ b/tests/components/traccar/test_init.py
@@ -25,7 +25,7 @@ def mock_dev_track(mock_device_tracker_conf):
 
 
 @pytest.fixture(name="client")
-async def traccar_client(event_loop, hass, hass_client_no_auth):
+async def traccar_client(hass, hass_client_no_auth):
     """Mock client for Traccar (unauthenticated)."""
 
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
@@ -37,7 +37,7 @@ async def traccar_client(event_loop, hass, hass_client_no_auth):
 
 
 @pytest.fixture(autouse=True)
-async def setup_zones(event_loop, hass):
+async def setup_zones(hass):
     """Set up Zone config in HA."""
     assert await async_setup_component(
         hass,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -517,14 +517,13 @@ def hass_fixture_setup() -> list[bool]:
 @pytest.fixture
 async def hass(
     hass_fixture_setup: list[bool],
-    event_loop: asyncio.AbstractEventLoop,
     load_registries: bool,
     hass_storage: dict[str, Any],
     request: pytest.FixtureRequest,
 ) -> AsyncGenerator[HomeAssistant, None]:
     """Create a test instance of Home Assistant."""
 
-    loop = event_loop
+    loop = asyncio.get_running_loop()
     hass_fixture_setup.append(True)
 
     orig_tz = dt_util.DEFAULT_TIME_ZONE
@@ -577,12 +576,11 @@ async def hass(
 
 
 @pytest.fixture
-async def stop_hass(
-    event_loop: asyncio.AbstractEventLoop,
-) -> AsyncGenerator[None, None]:
+async def stop_hass() -> AsyncGenerator[None, None]:
     """Make sure all hass are stopped."""
     orig_hass = ha.HomeAssistant
 
+    event_loop = asyncio.get_running_loop()
     created = []
 
     def mock_hass(*args):

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -480,7 +480,6 @@ async def test_setup_hass(
     mock_ensure_config_exists: AsyncMock,
     mock_process_ha_config_upgrade: Mock,
     caplog: pytest.LogCaptureFixture,
-    event_loop: asyncio.AbstractEventLoop,
 ) -> None:
     """Test it works."""
     verbose = Mock()
@@ -530,7 +529,6 @@ async def test_setup_hass_takes_longer_than_log_slow_startup(
     mock_ensure_config_exists: AsyncMock,
     mock_process_ha_config_upgrade: Mock,
     caplog: pytest.LogCaptureFixture,
-    event_loop: asyncio.AbstractEventLoop,
 ) -> None:
     """Test it works."""
     verbose = Mock()
@@ -569,7 +567,6 @@ async def test_setup_hass_invalid_yaml(
     mock_mount_local_lib_path: AsyncMock,
     mock_ensure_config_exists: AsyncMock,
     mock_process_ha_config_upgrade: Mock,
-    event_loop: asyncio.AbstractEventLoop,
 ) -> None:
     """Test it works."""
     with patch(
@@ -597,7 +594,6 @@ async def test_setup_hass_config_dir_nonexistent(
     mock_mount_local_lib_path: AsyncMock,
     mock_ensure_config_exists: AsyncMock,
     mock_process_ha_config_upgrade: Mock,
-    event_loop: asyncio.AbstractEventLoop,
 ) -> None:
     """Test it works."""
     mock_ensure_config_exists.return_value = False
@@ -624,7 +620,6 @@ async def test_setup_hass_recovery_mode(
     mock_mount_local_lib_path: AsyncMock,
     mock_ensure_config_exists: AsyncMock,
     mock_process_ha_config_upgrade: Mock,
-    event_loop: asyncio.AbstractEventLoop,
 ) -> None:
     """Test it works."""
     with patch("homeassistant.components.browser.setup") as browser_setup, patch(
@@ -659,7 +654,6 @@ async def test_setup_hass_safe_mode(
     mock_ensure_config_exists: AsyncMock,
     mock_process_ha_config_upgrade: Mock,
     caplog: pytest.LogCaptureFixture,
-    event_loop: asyncio.AbstractEventLoop,
 ) -> None:
     """Test it works."""
     with patch("homeassistant.components.browser.setup"), patch(
@@ -692,7 +686,6 @@ async def test_setup_hass_recovery_mode_and_safe_mode(
     mock_ensure_config_exists: AsyncMock,
     mock_process_ha_config_upgrade: Mock,
     caplog: pytest.LogCaptureFixture,
-    event_loop: asyncio.AbstractEventLoop,
 ) -> None:
     """Test it works."""
     with patch("homeassistant.components.browser.setup"), patch(
@@ -725,7 +718,6 @@ async def test_setup_hass_invalid_core_config(
     mock_mount_local_lib_path: AsyncMock,
     mock_ensure_config_exists: AsyncMock,
     mock_process_ha_config_upgrade: Mock,
-    event_loop: asyncio.AbstractEventLoop,
 ) -> None:
     """Test it works."""
     with patch("homeassistant.bootstrap.async_notify_setup_error") as mock_notify:
@@ -765,7 +757,6 @@ async def test_setup_recovery_mode_if_no_frontend(
     mock_mount_local_lib_path: AsyncMock,
     mock_ensure_config_exists: AsyncMock,
     mock_process_ha_config_upgrade: Mock,
-    event_loop: asyncio.AbstractEventLoop,
 ) -> None:
     """Test we setup recovery mode if frontend didn't load."""
     verbose = Mock()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1747,9 +1747,7 @@ async def test_bad_timezone_raises_value_error(hass: HomeAssistant) -> None:
         await hass.config.async_update(time_zone="not_a_timezone")
 
 
-async def test_start_taking_too_long(
-    event_loop, caplog: pytest.LogCaptureFixture
-) -> None:
+async def test_start_taking_too_long(caplog: pytest.LogCaptureFixture) -> None:
     """Test when async_start takes too long."""
     hass = ha.HomeAssistant("/test/ha-config")
     caplog.set_level(logging.WARNING)

--- a/tests/util/test_location.py
+++ b/tests/util/test_location.py
@@ -33,7 +33,7 @@ async def session(hass):
 
 
 @pytest.fixture
-async def raising_session(event_loop):
+async def raising_session():
     """Return an aioclient session that only fails."""
     return Mock(get=Mock(side_effect=aiohttp.ClientError))
 


### PR DESCRIPTION
## Proposed change
`pytest-asyncio` >= 0.22.0 deprecated the use of the `event_loop` fixture for async tests / fixtures. `asyncio.get_running_loop()` should be used instead.

- https://github.com/home-assistant/core/pull/109027
- https://github.com/pytest-dev/pytest-asyncio/issues/638
- https://github.com/pytest-dev/pytest-asyncio/pull/648

```
venv/lib/python3.11/site-packages/pytest_asyncio/plugin.py:229
venv/lib/python3.11/site-packages/pytest_asyncio/plugin.py:229
  /home/runner/work/core/core/venv/lib/python3.11/site-packages/pytest_asyncio/plugin.py:229:
      PytestDeprecationWarning: hass is asynchronous and explicitly requests the "event_loop" fixture.
      Asynchronous fixtures and test functions should use "asyncio.get_running_loop()" instead.
    warnings.warn(

...
```
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
