### PR TITLE
Fix schema validation for product_id in picnic integration

### DIFF
--- a/homeassistant/components/picnic/services.py
+++ b/homeassistant/components/picnic/services.py
@@ -42,9 +42,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
         schema=vol.Schema(
             {
                 vol.Required(ATTR_CONFIG_ENTRY_ID): cv.string,
-                vol.Exclusive(
-                    ATTR_PRODUCT_ID, ATTR_PRODUCT_IDENTIFIERS
-                ): cv.positive_int,
+                vol.Exclusive(ATTR_PRODUCT_ID, ATTR_PRODUCT_IDENTIFIERS): cv.string,
                 vol.Exclusive(ATTR_PRODUCT_NAME, ATTR_PRODUCT_IDENTIFIERS): cv.string,
                 vol.Optional(ATTR_AMOUNT): vol.All(vol.Coerce(int), vol.Range(min=1)),
             }

--- a/homeassistant/components/picnic/services.py
+++ b/homeassistant/components/picnic/services.py
@@ -71,7 +71,7 @@ async def handle_add_product(
         raise PicnicServiceException("No product found or no product ID given!")
 
     await hass.async_add_executor_job(
-        api_client.add_product, str(product_id), call.data.get("amount", 1)
+        api_client.add_product, product_id, call.data.get("amount", 1)
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes the schema validation for the `product_id` field of the `picnic` integration. In contrast to what the service adding a product to the shopping list currently expects, Picnic actually uses not only numbers for their IDs, but also characters (see `s1028538` in the following API output):

```
>>> picnic.search("Trauben rot")
[{'type': 'CATEGORY', 'id': 'Trauben rot', 'links': [{'type': 'SEARCH', 'href': 'https://storefront-prod.de.picnicinternational.com/api/15/search?search_term=Trauben+rot'}], 'name': 'Trauben rot', 'items': [{'type': 'SINGLE_ARTICLE', 'id': 's1028538', 'decorators': [{'type': 'FRESH_LABEL', 'period': 'P3D'}, {'type': 'UNIT_QUANTITY', 'unit_quantity_text': '500g'}], 'name': 'Trauben rot kernlos', 'display_price': 279, 'price': 279, 'image_id': 'ee870ca05306a7332e5be623e8240c73d58a639c1c98979ed2c30d5efff1f138', 'max_count': 99, 'unit_quantity': '500g', 'unit_quantity_sub': '5.58€/kg', 'tags': []}, {'type': 'SINGLE_ARTICLE', 'id': 's1025963', 'decorators': [{'type': 'PRODUCT_SIZE', 'text': 'XL'}, {'type': 'PRODUCT_CHARACTERISTICS', 'characteristics': [{'type': 'ORGANIC', 'score': None, 'rating': None, 'baby_month': None}, {'type': 'BABY', 'score': None, 'rating': None, 'baby_month': '6+'}]}, {'type': 'UNIT_QUANTITY', 'unit_quantity_text': '6 x 500ml'}], 'name': 'Hipp Bio Frucht + mit Eisen Rote Traube in Apfel', 'display_price': 745, 'price': 745, 'image_id': '8f358558e8b58ff16b79599343b37725bfef9e15148d63710bc36d7336faf8bd', 'max_count': 99, 'unit_quantity': '6 x 500ml', 'unit_quantity_sub': '2.48€/L', 'tags': []}, {'type': 'ITEM_SUGGESTION_DIALOG', 'id': 'item_suggestion_dialog'}], 'level': 1, 'is_included_in_category_tree': False, 'hidden': False}]
```

The service already casts the ID to a string anyway, so the only thing changed is the validation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: None found
- This PR is related to issue: None found
- Link to documentation pull request: None

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
