### PR TITLE
Fix ZHA cover inversion handling missing attributes

### DIFF
--- a/homeassistant/components/zha/core/cluster_handlers/closures.py
+++ b/homeassistant/components/zha/core/cluster_handlers/closures.py
@@ -267,8 +267,6 @@ class WindowCoveringClusterHandler(ClusterHandler):
         )
 
     @property
-    def window_covering_type(self) -> WindowCovering.WindowCoveringType:
+    def window_covering_type(self) -> WindowCovering.WindowCoveringType | None:
         """Return the window covering type."""
-        return WindowCovering.WindowCoveringType(
-            self.cluster.get(WindowCovering.AttributeDefs.window_covering_type.name)
-        )
+        return self.cluster.get(WindowCovering.AttributeDefs.window_covering_type.name)

--- a/homeassistant/components/zha/core/cluster_handlers/closures.py
+++ b/homeassistant/components/zha/core/cluster_handlers/closures.py
@@ -270,8 +270,3 @@ class WindowCoveringClusterHandler(ClusterHandler):
     def window_covering_type(self) -> WindowCovering.WindowCoveringType | None:
         """Return the window covering type."""
         return self.cluster.get(WindowCovering.AttributeDefs.window_covering_type.name)
-
-    @property
-    def window_covering_mode(self) -> WindowCovering.WindowCoveringMode | None:
-        """Return the window covering mode."""
-        return self.cluster.get(WindowCovering.AttributeDefs.window_covering_mode.name)

--- a/homeassistant/components/zha/core/cluster_handlers/closures.py
+++ b/homeassistant/components/zha/core/cluster_handlers/closures.py
@@ -270,3 +270,8 @@ class WindowCoveringClusterHandler(ClusterHandler):
     def window_covering_type(self) -> WindowCovering.WindowCoveringType | None:
         """Return the window covering type."""
         return self.cluster.get(WindowCovering.AttributeDefs.window_covering_type.name)
+
+    @property
+    def window_covering_mode(self) -> WindowCovering.WindowCoveringMode | None:
+        """Return the window covering mode."""
+        return self.cluster.get(WindowCovering.AttributeDefs.window_covering_mode.name)

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -604,6 +604,42 @@ class WindowCoveringInversionSwitch(ZHASwitchConfigurationEntity):
     _attr_translation_key = "inverted"
     _attr_icon: str = "mdi:arrow-up-down"
 
+    @classmethod
+    def create_entity(
+        cls,
+        unique_id: str,
+        zha_device: ZHADevice,
+        cluster_handlers: list[ClusterHandler],
+        **kwargs: Any,
+    ) -> Self | None:
+        """Entity Factory.
+
+        Return entity if it is a supported configuration, otherwise return None
+        """
+        cluster_handler = cluster_handlers[0]
+        window_covering_mode_attr = (
+            WindowCovering.AttributeDefs.window_covering_mode.name
+        )
+        # this entity needs 2 attributes to function
+        if (
+            cls._attribute_name in cluster_handler.cluster.unsupported_attributes
+            or cls._attribute_name not in cluster_handler.cluster.attributes_by_name
+            or cluster_handler.cluster.get(cls._attribute_name) is None
+            or window_covering_mode_attr
+            in cluster_handler.cluster.unsupported_attributes
+            or window_covering_mode_attr
+            not in cluster_handler.cluster.attributes_by_name
+            or cluster_handler.cluster.get(window_covering_mode_attr) is None
+        ):
+            _LOGGER.debug(
+                "%s is not supported - skipping %s entity creation",
+                cls._attribute_name,
+                cls.__name__,
+            )
+            return None
+
+        return cls(unique_id, zha_device, cluster_handlers, **kwargs)
+
     @property
     def is_on(self) -> bool:
         """Return if the switch is on based on the statemachine."""

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -635,17 +635,19 @@ class WindowCoveringInversionSwitch(ZHASwitchConfigurationEntity):
 
     async def _async_on_off(self, invert: bool) -> None:
         """Turn the entity on or off."""
-        name: str = WindowCovering.AttributeDefs.window_covering_mode.name
-        current_mode: WindowCoveringMode = WindowCoveringMode(
-            self._cluster_handler.cluster.get(name)
-        )
-        send_command: bool = False
+        if (current_mode := self._cluster_handler.window_covering_mode) is None:
+            await self.async_update()
+
+        current_mode = self._cluster_handler.window_covering_mode
+
         if invert and WindowCoveringMode.Motor_direction_reversed not in current_mode:
             current_mode |= WindowCoveringMode.Motor_direction_reversed
-            send_command = True
         elif not invert and WindowCoveringMode.Motor_direction_reversed in current_mode:
             current_mode &= ~WindowCoveringMode.Motor_direction_reversed
-            send_command = True
-        if send_command:
-            await self._cluster_handler.write_attributes_safe({name: current_mode})
-            await self.async_update()
+        else:
+            return
+
+        await self._cluster_handler.write_attributes_safe(
+            {WindowCovering.AttributeDefs.window_covering_mode.name: current_mode}
+        )
+        await self.async_update()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
#108238 relies on the `window_covering_type` attribute, which is usually not present in the attribute cache until it is explicitly read. Similarly, inversion relies on `window_covering_mode`.

This PR ensures `None` is properly handled with both. In a future PR, existing devices should be re-initialized automatically to account for these new attributes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
