### PR TITLE
Bump zha-quirks to 0.0.110

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -24,7 +24,7 @@
     "bellows==0.37.6",
     "pyserial==3.5",
     "pyserial-asyncio==0.6",
-    "zha-quirks==0.0.109",
+    "zha-quirks==0.0.110",
     "zigpy-deconz==0.22.4",
     "zigpy==0.60.7",
     "zigpy-xbee==0.20.1",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2906,7 +2906,7 @@ zeroconf==0.131.0
 zeversolar==0.3.1
 
 # homeassistant.components.zha
-zha-quirks==0.0.109
+zha-quirks==0.0.110
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2223,7 +2223,7 @@ zeroconf==0.131.0
 zeversolar==0.3.1
 
 # homeassistant.components.zha
-zha-quirks==0.0.109
+zha-quirks==0.0.110
 
 # homeassistant.components.zha
 zigpy-deconz==0.22.4

--- a/tests/components/zha/zha_devices_list.py
+++ b/tests/components/zha/zha_devices_list.py
@@ -798,31 +798,6 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "LQISensor",
                 DEV_SIG_ENT_MAP_ID: "sensor.heiman_smokesensor_em_lqi",
             },
-            ("select", "00:11:22:33:44:55:66:77-1-1282-WarningMode"): {
-                DEV_SIG_CLUSTER_HANDLERS: ["ias_wd"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHADefaultToneSelectEntity",
-                DEV_SIG_ENT_MAP_ID: "select.heiman_smokesensor_em_default_siren_tone",
-            },
-            ("select", "00:11:22:33:44:55:66:77-1-1282-SirenLevel"): {
-                DEV_SIG_CLUSTER_HANDLERS: ["ias_wd"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHADefaultSirenLevelSelectEntity",
-                DEV_SIG_ENT_MAP_ID: "select.heiman_smokesensor_em_default_siren_level",
-            },
-            ("select", "00:11:22:33:44:55:66:77-1-1282-StrobeLevel"): {
-                DEV_SIG_CLUSTER_HANDLERS: ["ias_wd"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHADefaultStrobeLevelSelectEntity",
-                DEV_SIG_ENT_MAP_ID: "select.heiman_smokesensor_em_default_strobe_level",
-            },
-            ("select", "00:11:22:33:44:55:66:77-1-1282-Strobe"): {
-                DEV_SIG_CLUSTER_HANDLERS: ["ias_wd"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHADefaultStrobeSelectEntity",
-                DEV_SIG_ENT_MAP_ID: "select.heiman_smokesensor_em_default_strobe",
-            },
-            ("siren", "00:11:22:33:44:55:66:77-1-1282"): {
-                DEV_SIG_CLUSTER_HANDLERS: ["ias_wd"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHASiren",
-                DEV_SIG_ENT_MAP_ID: "siren.heiman_smokesensor_em_siren",
-            },
         },
     },
     {


### PR DESCRIPTION
## Proposed change
Bumps ZHA dependency zha-quirks to [0.0.110](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.110).
The tests were also updated to reflect the removal of an invalid `IasWd` cluster on Heiman smoke sensors.

This PR will also unblock:
- https://github.com/home-assistant/core/pull/107641

This release should also fix issues like:
- https://github.com/home-assistant/core/issues/86880

I'll leave them open for now and close them manually later to confirm the fix works as expected for everyone.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
