### PR TITLE
Use pipeline name and sound format from satellite

### DIFF
--- a/homeassistant/components/assist_pipeline/__init__.py
+++ b/homeassistant/components/assist_pipeline/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterable
+from typing import Any
 
 import voluptuous as vol
 
@@ -85,7 +86,7 @@ async def async_pipeline_from_audio_stream(
     stt_stream: AsyncIterable[bytes],
     pipeline_id: str | None = None,
     conversation_id: str | None = None,
-    tts_audio_output: str | None = None,
+    tts_audio_output: str | dict[str, Any] | None = None,
     wake_word_settings: WakeWordSettings | None = None,
     audio_settings: AudioSettings | None = None,
     device_id: str | None = None,

--- a/homeassistant/components/wyoming/satellite.py
+++ b/homeassistant/components/wyoming/satellite.py
@@ -308,6 +308,17 @@ class WyomingSatellite:
         pipeline = assist_pipeline.async_get_pipeline(self.hass, pipeline_id)
         assert pipeline is not None
 
+        # Text-to-speech audio format
+        tts_audio_output = {tts.ATTR_PREFERRED_FORMAT: "wav"}
+        if run_pipeline.snd_format is not None:
+            # Satellite has requested a specific sample rate, etc.
+            tts_audio_output[
+                tts.ATTR_PREFERRED_SAMPLE_RATE
+            ] = run_pipeline.snd_format.rate
+            tts_audio_output[
+                tts.ATTR_PREFERRED_SAMPLE_CHANNELS
+            ] = run_pipeline.snd_format.channels
+
         # We will push audio in through a queue
         self._audio_queue = asyncio.Queue()
         stt_stream = self._stt_stream()
@@ -337,7 +348,7 @@ class WyomingSatellite:
                 stt_stream=stt_stream,
                 start_stage=start_stage,
                 end_stage=end_stage,
-                tts_audio_output="wav",
+                tts_audio_output=tts_audio_output,
                 pipeline_id=pipeline_id,
                 audio_settings=assist_pipeline.AudioSettings(
                     noise_suppression_level=self.device.noise_suppression_level,

--- a/homeassistant/components/wyoming/satellite.py
+++ b/homeassistant/components/wyoming/satellite.py
@@ -287,11 +287,24 @@ class WyomingSatellite:
         if end_stage is None:
             raise ValueError(f"Invalid end stage: {end_stage}")
 
-        pipeline_id = pipeline_select.get_chosen_pipeline(
-            self.hass,
-            DOMAIN,
-            self.device.satellite_id,
-        )
+        pipeline_id: str | None = None
+        if run_pipeline.name:
+            # Find pipeline by name
+            for pipeline in assist_pipeline.async_get_pipelines(self.hass):
+                if pipeline.name == run_pipeline.name:
+                    pipeline_id = pipeline.id
+                    break
+
+            if pipeline_id is None:
+                raise ValueError(f"No pipeline named {run_pipeline.name}")
+        else:
+            # Use configured pipeline
+            pipeline_id = pipeline_select.get_chosen_pipeline(
+                self.hass,
+                DOMAIN,
+                self.device.satellite_id,
+            )
+
         pipeline = assist_pipeline.async_get_pipeline(self.hass, pipeline_id)
         assert pipeline is not None
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR enables HA to use two extra fields from the `run-pipeline` message that Wyoming satellites send:

1. The `name` field lets the satellite specify a different pipeline name than the one configured. When using local wake word detection, this allows different wake words to run different pipelines.
2. The `snd_format` field contains the preferred audio output format for the satellite. HA currently sends low quality 16Khz audio (default for ESPHome), but this enables the satellite to request higher quality text-to-speech audio. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
