### PR TITLE
Fix "deprecated" typo in ZHA smartenergy comment

### DIFF
--- a/homeassistant/components/zha/core/cluster_handlers/smartenergy.py
+++ b/homeassistant/components/zha/core/cluster_handlers/smartenergy.py
@@ -173,7 +173,7 @@ class MeteringClusterHandler(ClusterHandler):
         127: "Mirrored Electric Metering",
         128: "Mirrored Gas Metering",
         129: "Mirrored Water Metering",
-        130: "Mirrored Thermal Metering",  # depreciated
+        130: "Mirrored Thermal Metering",  # deprecated
         131: "Mirrored Pressure Metering",
         132: "Mirrored Heat Metering",
         133: "Mirrored Cooling Metering",

--- a/homeassistant/components/zha/core/cluster_handlers/smartenergy.py
+++ b/homeassistant/components/zha/core/cluster_handlers/smartenergy.py
@@ -157,7 +157,7 @@ class MeteringClusterHandler(ClusterHandler):
         0: "Electric Metering",
         1: "Gas Metering",
         2: "Water Metering",
-        3: "Thermal Metering",  # depreciated
+        3: "Thermal Metering",  # deprecated
         4: "Pressure Metering",
         5: "Heat Metering",
         6: "Cooling Metering",


### PR DESCRIPTION
## Proposed change
Fixes a typo in a comment for ZHA smartenergy types.

Review comment / PR:
- https://github.com/home-assistant/core/pull/109126#discussion_r1472007739


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
