### PR TITLE
Add alexa PowerController on enabled features for climate entities

### DIFF
--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -478,6 +478,14 @@ class ClimateCapabilities(AlexaEntity):
             self.entity.domain == climate.DOMAIN
             and climate.HVACMode.OFF
             in (self.entity.attributes.get(climate.ATTR_HVAC_MODES) or [])
+            or self.entity.domain == climate.DOMAIN
+            and (
+                supported_features
+                & (
+                    climate.ClimateEntityFeature.TURN_ON
+                    | climate.ClimateEntityFeature.TURN_OFF
+                )
+            )
             or self.entity.domain == water_heater.DOMAIN
             and (supported_features & water_heater.WaterHeaterEntityFeature.ON_OFF)
         ):

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -178,6 +178,8 @@ async def async_api_turn_on(
     service = SERVICE_TURN_ON
     if domain == cover.DOMAIN:
         service = cover.SERVICE_OPEN_COVER
+    elif domain == climate.DOMAIN:
+        service = climate.SERVICE_TURN_ON
     elif domain == fan.DOMAIN:
         service = fan.SERVICE_TURN_ON
     elif domain == humidifier.DOMAIN:
@@ -227,6 +229,8 @@ async def async_api_turn_off(
     service = SERVICE_TURN_OFF
     if entity.domain == cover.DOMAIN:
         service = cover.SERVICE_CLOSE_COVER
+    elif domain == climate.DOMAIN:
+        service = climate.SERVICE_TURN_OFF
     elif domain == fan.DOMAIN:
         service = fan.SERVICE_TURN_OFF
     elif domain == humidifier.DOMAIN:

--- a/tests/components/alexa/test_capabilities.py
+++ b/tests/components/alexa/test_capabilities.py
@@ -5,7 +5,11 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components.alexa import smart_home
-from homeassistant.components.climate import ATTR_CURRENT_TEMPERATURE, HVACMode
+from homeassistant.components.climate import (
+    ATTR_CURRENT_TEMPERATURE,
+    ClimateEntityFeature,
+    HVACMode,
+)
 from homeassistant.components.lock import STATE_JAMMED, STATE_LOCKING, STATE_UNLOCKING
 from homeassistant.components.media_player import MediaPlayerEntityFeature
 from homeassistant.components.valve import ValveEntityFeature
@@ -921,6 +925,52 @@ async def test_report_climate_state(hass: HomeAssistant) -> None:
     msg = await reported_properties(hass, "climate.unsupported", True)
     assert msg["event"]["header"]["name"] == "ErrorResponse"
     assert msg["event"]["payload"]["type"] == "INTERNAL_ERROR"
+
+
+async def test_report_on_off_climate_state(hass: HomeAssistant) -> None:
+    """Test ThermostatController with on/off features reports state correctly."""
+    on_off_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TURN_OFF
+    )
+    for auto_modes in (HVACMode.HEAT,):
+        hass.states.async_set(
+            "climate.onoff",
+            auto_modes,
+            {
+                "friendly_name": "Climate Downstairs",
+                "supported_features": on_off_features,
+                ATTR_CURRENT_TEMPERATURE: 34,
+                ATTR_UNIT_OF_MEASUREMENT: UnitOfTemperature.CELSIUS,
+            },
+        )
+        properties = await reported_properties(hass, "climate.onoff")
+        properties.assert_equal("Alexa.ThermostatController", "thermostatMode", "HEAT")
+        properties.assert_equal(
+            "Alexa.TemperatureSensor",
+            "temperature",
+            {"value": 34.0, "scale": "CELSIUS"},
+        )
+
+    for off_modes in [HVACMode.OFF]:
+        hass.states.async_set(
+            "climate.onoff",
+            off_modes,
+            {
+                "friendly_name": "Climate Downstairs",
+                "supported_features": on_off_features,
+                ATTR_CURRENT_TEMPERATURE: 34,
+                ATTR_UNIT_OF_MEASUREMENT: UnitOfTemperature.CELSIUS,
+            },
+        )
+        properties = await reported_properties(hass, "climate.onoff")
+        properties.assert_equal("Alexa.ThermostatController", "thermostatMode", "OFF")
+        properties.assert_equal(
+            "Alexa.TemperatureSensor",
+            "temperature",
+            {"value": 34.0, "scale": "CELSIUS"},
+        )
 
 
 async def test_report_water_heater_state(hass: HomeAssistant) -> None:

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -6,6 +6,7 @@ import pytest
 
 from homeassistant.components.alexa import smart_home, state_report
 import homeassistant.components.camera as camera
+from homeassistant.components.climate import ClimateEntityFeature
 from homeassistant.components.cover import CoverDeviceClass, CoverEntityFeature
 from homeassistant.components.media_player import MediaPlayerEntityFeature
 from homeassistant.components.vacuum import VacuumEntityFeature
@@ -20,7 +21,7 @@ from homeassistant.const import (
 from homeassistant.core import Context, Event, HomeAssistant
 from homeassistant.helpers import entityfilter
 from homeassistant.setup import async_setup_component
-from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
+from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
 
 from .test_common import (
     MockConfig,
@@ -3116,6 +3117,136 @@ async def test_thermostat(hass: HomeAssistant) -> None:
         payload={"thermostatMode": "ECO"},
     )
     assert call.data["preset_mode"] == "eco"
+
+
+async def test_onoff_thermostat(hass: HomeAssistant) -> None:
+    """Test onoff thermostat discovery."""
+    on_off_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TURN_OFF
+    )
+    hass.config.units = METRIC_SYSTEM
+    device = (
+        "climate.test_thermostat",
+        "cool",
+        {
+            "temperature": 20.0,
+            "target_temp_high": None,
+            "target_temp_low": None,
+            "current_temperature": 19.0,
+            "friendly_name": "Test Thermostat",
+            "supported_features": on_off_features,
+            "hvac_modes": ["auto"],
+            "min_temp": 7,
+            "max_temp": 30,
+        },
+    )
+    appliance = await discovery_test(device, hass)
+
+    assert appliance["endpointId"] == "climate#test_thermostat"
+    assert appliance["displayCategories"][0] == "THERMOSTAT"
+    assert appliance["friendlyName"] == "Test Thermostat"
+
+    capabilities = assert_endpoint_capabilities(
+        appliance,
+        "Alexa.PowerController",
+        "Alexa.ThermostatController",
+        "Alexa.TemperatureSensor",
+        "Alexa.EndpointHealth",
+        "Alexa",
+    )
+
+    properties = await reported_properties(hass, "climate#test_thermostat")
+    properties.assert_equal("Alexa.ThermostatController", "thermostatMode", "COOL")
+    properties.assert_equal(
+        "Alexa.ThermostatController",
+        "targetSetpoint",
+        {"value": 20.0, "scale": "CELSIUS"},
+    )
+    properties.assert_equal(
+        "Alexa.TemperatureSensor", "temperature", {"value": 19.0, "scale": "CELSIUS"}
+    )
+
+    thermostat_capability = get_capability(capabilities, "Alexa.ThermostatController")
+    assert thermostat_capability is not None
+    configuration = thermostat_capability["configuration"]
+    assert configuration["supportsScheduling"] is False
+
+    supported_modes = ["AUTO"]
+    for mode in supported_modes:
+        assert mode in configuration["supportedModes"]
+
+    call, msg = await assert_request_calls_service(
+        "Alexa.ThermostatController",
+        "SetTargetTemperature",
+        "climate#test_thermostat",
+        "climate.set_temperature",
+        hass,
+        payload={"targetSetpoint": {"value": 21.0, "scale": "CELSIUS"}},
+    )
+    assert call.data["temperature"] == 21.0
+    properties = ReportedProperties(msg["context"]["properties"])
+    properties.assert_equal(
+        "Alexa.ThermostatController",
+        "targetSetpoint",
+        {"value": 21.0, "scale": "CELSIUS"},
+    )
+
+    msg = await assert_request_fails(
+        "Alexa.ThermostatController",
+        "SetTargetTemperature",
+        "climate#test_thermostat",
+        "climate.set_temperature",
+        hass,
+        payload={"targetSetpoint": {"value": 0.0, "scale": "CELSIUS"}},
+    )
+    assert msg["event"]["payload"]["type"] == "TEMPERATURE_VALUE_OUT_OF_RANGE"
+
+    await assert_request_calls_service(
+        "Alexa.PowerController",
+        "TurnOn",
+        "climate#test_thermostat",
+        "climate.turn_on",
+        hass,
+    )
+    await assert_request_calls_service(
+        "Alexa.PowerController",
+        "TurnOff",
+        "climate#test_thermostat",
+        "climate.turn_off",
+        hass,
+    )
+
+    # Test the power controller is not enabled when there is no `off` mode
+    device = (
+        "climate.test_thermostat",
+        "cool",
+        {
+            "temperature": 20.0,
+            "target_temp_high": None,
+            "target_temp_low": None,
+            "current_temperature": 19.0,
+            "friendly_name": "Test Thermostat",
+            "supported_features": ClimateEntityFeature.TARGET_TEMPERATURE,
+            "hvac_modes": ["auto"],
+            "min_temp": 7,
+            "max_temp": 30,
+        },
+    )
+    appliance = await discovery_test(device, hass)
+
+    assert appliance["endpointId"] == "climate#test_thermostat"
+    assert appliance["displayCategories"][0] == "THERMOSTAT"
+    assert appliance["friendlyName"] == "Test Thermostat"
+
+    capabilities = assert_endpoint_capabilities(
+        appliance,
+        "Alexa.ThermostatController",
+        "Alexa.TemperatureSensor",
+        "Alexa.EndpointHealth",
+        "Alexa",
+    )
 
 
 async def test_water_heater(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Depend alexa PowerController on enabled features for climate entities. The PowerController was already enabled when `off` was in the modes list. Now it will also be added if the climate `TURN_ON` and `TURN_OFF` entity feature is set.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: Not needed

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
