### PR TITLE
Add icon and state translations for zwave_js sensors

### DIFF
--- a/homeassistant/components/zwave_js/icons.json
+++ b/homeassistant/components/zwave_js/icons.json
@@ -1,0 +1,24 @@
+{
+  "entity": {
+    "sensor": {
+      "controller_status": {
+        "default": "mdi:help-rhombus",
+        "state": {
+          "ready": "mdi:check",
+          "unresponsive": "mdi:bell-off",
+          "jammed": "mdi:lock"
+        }
+      },
+      "node_status": {
+        "default": "mdi:help-rhombus",
+        "state": {
+          "alive": "mdi:heart-pulse",
+          "asleep": "mdi:sleep",
+          "awake": "mdi:eye",
+          "dead": "mdi:robot-dead",
+          "unknown": "mdi:help-rhombus"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -6,7 +6,7 @@ from typing import cast
 
 import voluptuous as vol
 from zwave_js_server.client import Client as ZwaveClient
-from zwave_js_server.const import CommandClass, ControllerStatus, NodeStatus
+from zwave_js_server.const import CommandClass
 from zwave_js_server.const.command_class.meter import (
     RESET_METER_OPTION_TARGET_VALUE,
     RESET_METER_OPTION_TYPE,
@@ -90,20 +90,6 @@ from .entity import ZWaveBaseEntity
 from .helpers import get_device_info, get_valueless_base_unique_id
 
 PARALLEL_UPDATES = 0
-
-CONTROLLER_STATUS_ICON: dict[ControllerStatus, str] = {
-    ControllerStatus.READY: "mdi:check",
-    ControllerStatus.UNRESPONSIVE: "mdi:bell-off",
-    ControllerStatus.JAMMED: "mdi:lock",
-}
-
-NODE_STATUS_ICON: dict[NodeStatus, str] = {
-    NodeStatus.ALIVE: "mdi:heart-pulse",
-    NodeStatus.ASLEEP: "mdi:sleep",
-    NodeStatus.AWAKE: "mdi:eye",
-    NodeStatus.DEAD: "mdi:robot-dead",
-    NodeStatus.UNKNOWN: "mdi:help-rhombus",
-}
 
 
 # These descriptions should include device class.
@@ -784,6 +770,7 @@ class ZWaveNodeStatusSensor(SensorEntity):
     _attr_should_poll = False
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_has_entity_name = True
+    _attr_translation_key = "node_status"
 
     def __init__(
         self, config_entry: ConfigEntry, driver: Driver, node: ZwaveNode
@@ -793,7 +780,6 @@ class ZWaveNodeStatusSensor(SensorEntity):
         self.node = node
 
         # Entity class attributes
-        self._attr_name = "Node status"
         self._base_unique_id = get_valueless_base_unique_id(driver, node)
         self._attr_unique_id = f"{self._base_unique_id}.node_status"
         # device may not be precreated in main handler yet
@@ -814,11 +800,6 @@ class ZWaveNodeStatusSensor(SensorEntity):
         """Call when status event is received."""
         self._attr_native_value = self.node.status.name.lower()
         self.async_write_ha_state()
-
-    @property
-    def icon(self) -> str | None:
-        """Icon of the entity."""
-        return NODE_STATUS_ICON[self.node.status]
 
     async def async_added_to_hass(self) -> None:
         """Call when entity is added."""
@@ -852,6 +833,7 @@ class ZWaveControllerStatusSensor(SensorEntity):
     _attr_should_poll = False
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_has_entity_name = True
+    _attr_translation_key = "controller_status"
 
     def __init__(self, config_entry: ConfigEntry, driver: Driver) -> None:
         """Initialize a generic Z-Wave device entity."""
@@ -861,7 +843,6 @@ class ZWaveControllerStatusSensor(SensorEntity):
         assert node
 
         # Entity class attributes
-        self._attr_name = "Status"
         self._base_unique_id = get_valueless_base_unique_id(driver, node)
         self._attr_unique_id = f"{self._base_unique_id}.controller_status"
         # device may not be precreated in main handler yet
@@ -882,11 +863,6 @@ class ZWaveControllerStatusSensor(SensorEntity):
         """Call when status event is received."""
         self._attr_native_value = self.controller.status.name.lower()
         self.async_write_ha_state()
-
-    @property
-    def icon(self) -> str | None:
-        """Icon of the entity."""
-        return CONTROLLER_STATUS_ICON[self.controller.status]
 
     async def async_added_to_hass(self) -> None:
         """Call when entity is added."""

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -1,4 +1,26 @@
 {
+  "entity": {
+    "sensor": {
+      "node_status": {
+        "name": "Node status",
+        "state": {
+          "alive": "Alive",
+          "asleep": "Asleep",
+          "awake": "Awake",
+          "dead": "Dead",
+          "unknown": "Unknown"
+        }
+      },
+      "controller_status": {
+        "name": "Status",
+        "state": {
+          "ready": "Ready",
+          "unresponsive": "Unresponsive",
+          "jammed": "Jammed"
+        }
+      }
+    }
+  },
   "config": {
     "flow_title": "{name}",
     "step": {

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -25,7 +25,6 @@ from homeassistant.components.zwave_js.helpers import get_valueless_base_unique_
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
-    ATTR_ICON,
     ATTR_UNIT_OF_MEASUREMENT,
     PERCENTAGE,
     STATE_UNAVAILABLE,
@@ -318,7 +317,6 @@ async def test_controller_status_sensor(
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "ready"
-    assert state.attributes[ATTR_ICON] == "mdi:check"
 
     event = Event(
         "status changed",
@@ -328,7 +326,6 @@ async def test_controller_status_sensor(
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "unresponsive"
-    assert state.attributes[ATTR_ICON] == "mdi:bell-off"
 
     # Test transitions work
     event = Event(
@@ -339,7 +336,6 @@ async def test_controller_status_sensor(
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "jammed"
-    assert state.attributes[ATTR_ICON] == "mdi:lock"
 
     # Disconnect the client and make sure the entity is still available
     await client.disconnect()
@@ -365,33 +361,24 @@ async def test_node_status_sensor(
     )
     node.receive_event(event)
     assert hass.states.get(node_status_entity_id).state == "dead"
-    assert (
-        hass.states.get(node_status_entity_id).attributes[ATTR_ICON] == "mdi:robot-dead"
-    )
 
     event = Event(
         "wake up", data={"source": "node", "event": "wake up", "nodeId": node.node_id}
     )
     node.receive_event(event)
     assert hass.states.get(node_status_entity_id).state == "awake"
-    assert hass.states.get(node_status_entity_id).attributes[ATTR_ICON] == "mdi:eye"
 
     event = Event(
         "sleep", data={"source": "node", "event": "sleep", "nodeId": node.node_id}
     )
     node.receive_event(event)
     assert hass.states.get(node_status_entity_id).state == "asleep"
-    assert hass.states.get(node_status_entity_id).attributes[ATTR_ICON] == "mdi:sleep"
 
     event = Event(
         "alive", data={"source": "node", "event": "alive", "nodeId": node.node_id}
     )
     node.receive_event(event)
     assert hass.states.get(node_status_entity_id).state == "alive"
-    assert (
-        hass.states.get(node_status_entity_id).attributes[ATTR_ICON]
-        == "mdi:heart-pulse"
-    )
 
     # Disconnect the client and make sure the entity is still available
     await client.disconnect()


### PR DESCRIPTION
## Proposed change
Adds icon and state translations for the node and controller status sensors


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
