### PR TITLE
Add translations for zwave_js entities and services

### DIFF
--- a/homeassistant/components/zwave_js/button.py
+++ b/homeassistant/components/zwave_js/button.py
@@ -86,13 +86,13 @@ class ZWaveNodePingButton(ButtonEntity):
     _attr_should_poll = False
     _attr_entity_category = EntityCategory.CONFIG
     _attr_has_entity_name = True
+    _attr_translation_key = "ping"
 
     def __init__(self, driver: Driver, node: ZwaveNode) -> None:
         """Initialize a ping Z-Wave device button entity."""
         self.node = node
 
         # Entity class attributes
-        self._attr_name = "Ping"
         self._base_unique_id = get_valueless_base_unique_id(driver, node)
         self._attr_unique_id = f"{self._base_unique_id}.ping"
         # device may not be precreated in main handler yet

--- a/homeassistant/components/zwave_js/icons.json
+++ b/homeassistant/components/zwave_js/icons.json
@@ -55,5 +55,19 @@
         "default": "mdi:timer-sync"
       }
     }
+  },
+  "services": {
+    "bulk_set_partial_config_parameters": "mdi:cogs",
+    "clear_lock_usercode": "mdi:eraser",
+    "invoke_cc_api": "mdi:api",
+    "multicast_set_value": "mdi:list-box",
+    "ping": "mdi:crosshairs-gps",
+    "refresh_notifications": "mdi:bell",
+    "refresh_value": "mdi:refresh",
+    "reset_meter": "mdi:meter-electric",
+    "set_config_parameter": "mdi:cog",
+    "set_lock_configuration": "mdi:shield-lock",
+    "set_lock_usercode": "mdi:lock-smart",
+    "set_value": "mdi:form-textbox"
   }
 }

--- a/homeassistant/components/zwave_js/icons.json
+++ b/homeassistant/components/zwave_js/icons.json
@@ -1,5 +1,10 @@
 {
   "entity": {
+    "button": {
+      "ping": {
+        "default": "mdi:crosshairs-gps"
+      }
+    },
     "sensor": {
       "controller_status": {
         "default": "mdi:help-rhombus",

--- a/homeassistant/components/zwave_js/icons.json
+++ b/homeassistant/components/zwave_js/icons.json
@@ -31,13 +31,13 @@
         "default": "mdi:hand-back-left-off"
       },
       "timeout_ack": {
-        "default": "mdi:timer-cancel"
+        "default": "mdi:ear-hearing-off"
       },
       "timeout_callback": {
-        "default": "mdi:timer-cancel"
+        "default": "mdi:timer-sand-empty"
       },
       "timeout_response": {
-        "default": "mdi:timer-cancel"
+        "default": "mdi:timer-sand-empty"
       },
       "successful_messages": {
         "default": "mdi:check"

--- a/homeassistant/components/zwave_js/icons.json
+++ b/homeassistant/components/zwave_js/icons.json
@@ -50,6 +50,9 @@
       },
       "commands_dropped": {
         "default": "mdi:trash-can"
+      },
+      "last_seen": {
+        "default": "mdi:timer-sync"
       }
     }
   }

--- a/homeassistant/components/zwave_js/icons.json
+++ b/homeassistant/components/zwave_js/icons.json
@@ -20,10 +20,10 @@
         }
       },
       "can": {
-        "default": "mdi:sail-boat-sink"
+        "default": "mdi:car-brake-alert"
       },
       "nak": {
-        "default": "mdi:cancel"
+        "default": "mdi:hand-back-left-off"
       },
       "timeout_ack": {
         "default": "mdi:timer-cancel"

--- a/homeassistant/components/zwave_js/icons.json
+++ b/homeassistant/components/zwave_js/icons.json
@@ -18,6 +18,33 @@
           "dead": "mdi:robot-dead",
           "unknown": "mdi:help-rhombus"
         }
+      },
+      "can": {
+        "default": "mdi:sail-boat-sink"
+      },
+      "nak": {
+        "default": "mdi:cancel"
+      },
+      "timeout_ack": {
+        "default": "mdi:timer-cancel"
+      },
+      "timeout_callback": {
+        "default": "mdi:timer-cancel"
+      },
+      "timeout_response": {
+        "default": "mdi:timer-cancel"
+      },
+      "successful_messages": {
+        "default": "mdi:check"
+      },
+      "messages_dropped": {
+        "default": "mdi:trash-can"
+      },
+      "successful_commands": {
+        "default": "mdi:check"
+      },
+      "commands_dropped": {
+        "default": "mdi:trash-can"
       }
     }
   }

--- a/homeassistant/components/zwave_js/icons.json
+++ b/homeassistant/components/zwave_js/icons.json
@@ -6,13 +6,28 @@
       }
     },
     "sensor": {
+      "can": {
+        "default": "mdi:car-brake-alert"
+      },
+      "commands_dropped": {
+        "default": "mdi:trash-can"
+      },
       "controller_status": {
         "default": "mdi:help-rhombus",
         "state": {
+          "jammed": "mdi:lock",
           "ready": "mdi:check",
-          "unresponsive": "mdi:bell-off",
-          "jammed": "mdi:lock"
+          "unresponsive": "mdi:bell-off"
         }
+      },
+      "last_seen": {
+        "default": "mdi:timer-sync"
+      },
+      "messages_dropped": {
+        "default": "mdi:trash-can"
+      },
+      "nak": {
+        "default": "mdi:hand-back-left-off"
       },
       "node_status": {
         "default": "mdi:help-rhombus",
@@ -24,11 +39,11 @@
           "unknown": "mdi:help-rhombus"
         }
       },
-      "can": {
-        "default": "mdi:car-brake-alert"
+      "successful_commands": {
+        "default": "mdi:check"
       },
-      "nak": {
-        "default": "mdi:hand-back-left-off"
+      "successful_messages": {
+        "default": "mdi:check"
       },
       "timeout_ack": {
         "default": "mdi:ear-hearing-off"
@@ -38,21 +53,6 @@
       },
       "timeout_response": {
         "default": "mdi:timer-sand-empty"
-      },
-      "successful_messages": {
-        "default": "mdi:check"
-      },
-      "messages_dropped": {
-        "default": "mdi:trash-can"
-      },
-      "successful_commands": {
-        "default": "mdi:check"
-      },
-      "commands_dropped": {
-        "default": "mdi:trash-can"
-      },
-      "last_seen": {
-        "default": "mdi:timer-sync"
       }
     }
   },

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -349,55 +349,61 @@ class ZWaveJSStatisticsSensorEntityDescription(SensorEntityDescription):
 ENTITY_DESCRIPTION_CONTROLLER_STATISTICS_LIST = [
     ZWaveJSStatisticsSensorEntityDescription(
         key="messagesTX",
-        name="Successful messages (TX)",
+        translation_key="successful_messages",
+        translation_placeholders={"direction": "TX"},
         state_class=SensorStateClass.TOTAL,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
         key="messagesRX",
-        name="Successful messages (RX)",
+        translation_key="successful_messages",
+        translation_placeholders={"direction": "RX"},
         state_class=SensorStateClass.TOTAL,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
         key="messagesDroppedTX",
-        name="Messages dropped (TX)",
+        translation_key="messages_dropped",
+        translation_placeholders={"direction": "TX"},
         state_class=SensorStateClass.TOTAL,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
         key="messagesDroppedRX",
-        name="Messages dropped (RX)",
+        translation_key="messages_dropped",
+        translation_placeholders={"direction": "RX"},
         state_class=SensorStateClass.TOTAL,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
-        key="NAK",
-        name="Messages not accepted",
+        key="NAK", translation_key="nak", state_class=SensorStateClass.TOTAL
+    ),
+    ZWaveJSStatisticsSensorEntityDescription(
+        key="CAN", translation_key="can", state_class=SensorStateClass.TOTAL
+    ),
+    ZWaveJSStatisticsSensorEntityDescription(
+        key="timeoutACK",
+        translation_key="timeout_ack",
         state_class=SensorStateClass.TOTAL,
-    ),
-    ZWaveJSStatisticsSensorEntityDescription(
-        key="CAN", name="Collisions", state_class=SensorStateClass.TOTAL
-    ),
-    ZWaveJSStatisticsSensorEntityDescription(
-        key="timeoutACK", name="Missing ACKs", state_class=SensorStateClass.TOTAL
     ),
     ZWaveJSStatisticsSensorEntityDescription(
         key="timeoutResponse",
-        name="Timed out responses",
+        translation_key="timeout_response",
         state_class=SensorStateClass.TOTAL,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
         key="timeoutCallback",
-        name="Timed out callbacks",
+        translation_key="timeout_callback",
         state_class=SensorStateClass.TOTAL,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
         key="backgroundRSSI.channel0.average",
-        name="Average background RSSI (channel 0)",
+        translation_key="average_background_rssi",
+        translation_placeholders={"channel": "0"},
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         convert=convert_dict_of_dicts,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
         key="backgroundRSSI.channel0.current",
-        name="Current background RSSI (channel 0)",
+        translation_key="current_background_rssi",
+        translation_placeholders={"channel": "0"},
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         state_class=SensorStateClass.MEASUREMENT,
@@ -405,14 +411,16 @@ ENTITY_DESCRIPTION_CONTROLLER_STATISTICS_LIST = [
     ),
     ZWaveJSStatisticsSensorEntityDescription(
         key="backgroundRSSI.channel1.average",
-        name="Average background RSSI (channel 1)",
+        translation_key="average_background_rssi",
+        translation_placeholders={"channel": "1"},
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         convert=convert_dict_of_dicts,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
         key="backgroundRSSI.channel1.current",
-        name="Current background RSSI (channel 1)",
+        translation_key="current_background_rssi",
+        translation_placeholders={"channel": "1"},
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         state_class=SensorStateClass.MEASUREMENT,
@@ -420,14 +428,16 @@ ENTITY_DESCRIPTION_CONTROLLER_STATISTICS_LIST = [
     ),
     ZWaveJSStatisticsSensorEntityDescription(
         key="backgroundRSSI.channel2.average",
-        name="Average background RSSI (channel 2)",
+        translation_key="average_background_rssi",
+        translation_placeholders={"channel": "2"},
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         convert=convert_dict_of_dicts,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
         key="backgroundRSSI.channel2.current",
-        name="Current background RSSI (channel 2)",
+        translation_key="current_background_rssi",
+        translation_placeholders={"channel": "2"},
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         state_class=SensorStateClass.MEASUREMENT,
@@ -439,39 +449,43 @@ ENTITY_DESCRIPTION_CONTROLLER_STATISTICS_LIST = [
 ENTITY_DESCRIPTION_NODE_STATISTICS_LIST = [
     ZWaveJSStatisticsSensorEntityDescription(
         key="commandsRX",
-        name="Successful commands (RX)",
+        translation_key="successful_commands",
+        translation_placeholders={"direction": "RX"},
         state_class=SensorStateClass.TOTAL,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
         key="commandsTX",
-        name="Successful commands (TX)",
+        translation_key="successful_commands",
+        translation_placeholders={"direction": "TX"},
         state_class=SensorStateClass.TOTAL,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
         key="commandsDroppedRX",
-        name="Commands dropped (RX)",
+        translation_key="commands_dropped",
+        translation_placeholders={"direction": "RX"},
         state_class=SensorStateClass.TOTAL,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
         key="commandsDroppedTX",
-        name="Commands dropped (TX)",
+        translation_key="commands_dropped",
+        translation_placeholders={"direction": "TX"},
         state_class=SensorStateClass.TOTAL,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
         key="timeoutResponse",
-        name="Timed out responses",
+        translation_key="timeout_response",
         state_class=SensorStateClass.TOTAL,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
         key="rtt",
-        name="Round Trip Time",
+        translation_key="rtt",
         native_unit_of_measurement=UnitOfTime.MILLISECONDS,
         device_class=SensorDeviceClass.DURATION,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
         key="rssi",
-        name="RSSI",
+        translation_key="rssi",
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         state_class=SensorStateClass.MEASUREMENT,

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -492,7 +492,7 @@ ENTITY_DESCRIPTION_NODE_STATISTICS_LIST = [
     ),
     ZWaveJSStatisticsSensorEntityDescription(
         key="lastSeen",
-        name="Last Seen",
+        translation_key="last_seen",
         device_class=SensorDeviceClass.TIMESTAMP,
         convert=(
             lambda statistics, key: (

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -62,6 +62,9 @@
       },
       "rssi": {
         "name": "RSSI"
+      },
+      "last_seen": {
+        "name": "Last seen"
       }
     }
   },

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -53,7 +53,7 @@
         "name": "Commands dropped ({direction})"
       },
       "rtt": {
-        "name": "Round Trip Time"
+        "name": "Round trip time"
       },
       "rssi": {
         "name": "RSSI"

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -1,5 +1,10 @@
 {
   "entity": {
+    "button": {
+      "ping": {
+        "name": "Ping"
+      }
+    },
     "sensor": {
       "node_status": {
         "name": "Node status",

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -18,6 +18,45 @@
           "unresponsive": "Unresponsive",
           "jammed": "Jammed"
         }
+      },
+      "average_background_rssi": {
+        "name": "Average background RSSI (channel {channel})"
+      },
+      "current_background_rssi": {
+        "name": "Current background RSSI (channel {channel})"
+      },
+      "can": {
+        "name": "Collisions"
+      },
+      "nak": {
+        "name": "Messages not accepted"
+      },
+      "timeout_ack": {
+        "name": "Missing ACKs"
+      },
+      "timeout_callback": {
+        "name": "Timed out callbacks"
+      },
+      "timeout_response": {
+        "name": "Timed out responses"
+      },
+      "successful_messages": {
+        "name": "Successful messages ({direction})"
+      },
+      "messages_dropped": {
+        "name": "Messages dropped ({direction})"
+      },
+      "successful_commands": {
+        "name": "Successful commands ({direction})"
+      },
+      "commands_dropped": {
+        "name": "Commands dropped ({direction})"
+      },
+      "rtt": {
+        "name": "Round Trip Time"
+      },
+      "rssi": {
+        "name": "RSSI"
       }
     }
   },

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -1,4 +1,97 @@
 {
+  "config": {
+    "abort": {
+      "addon_get_discovery_info_failed": "Failed to get Z-Wave JS add-on discovery info.",
+      "addon_info_failed": "Failed to get Z-Wave JS add-on info.",
+      "addon_install_failed": "Failed to install the Z-Wave JS add-on.",
+      "addon_set_config_failed": "Failed to set Z-Wave JS configuration.",
+      "addon_start_failed": "Failed to start the Z-Wave JS add-on.",
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "discovery_requires_supervisor": "Discovery requires the supervisor.",
+      "not_zwave_device": "Discovered device is not a Z-Wave device.",
+      "not_zwave_js_addon": "Discovered add-on is not the official Z-Wave JS add-on."
+    },
+    "error": {
+      "addon_start_failed": "Failed to start the Z-Wave JS add-on. Check the configuration.",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_ws_url": "Invalid websocket URL",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "flow_title": "{name}",
+    "progress": {
+      "install_addon": "Please wait while the Z-Wave JS add-on installation finishes. This can take several minutes.",
+      "start_addon": "Please wait while the Z-Wave JS add-on start completes. This may take some seconds."
+    },
+    "step": {
+      "configure_addon": {
+        "data": {
+          "s0_legacy_key": "S0 Key (Legacy)",
+          "s2_access_control_key": "S2 Access Control Key",
+          "s2_authenticated_key": "S2 Authenticated Key",
+          "s2_unauthenticated_key": "S2 Unauthenticated Key",
+          "usb_path": "[%key:common::config_flow::data::usb_path%]"
+        },
+        "description": "The add-on will generate security keys if those fields are left empty.",
+        "title": "Enter the Z-Wave JS add-on configuration"
+      },
+      "hassio_confirm": {
+        "title": "Set up Z-Wave JS integration with the Z-Wave JS add-on"
+      },
+      "install_addon": {
+        "title": "The Z-Wave JS add-on installation has started"
+      },
+      "manual": {
+        "data": {
+          "url": "[%key:common::config_flow::data::url%]"
+        }
+      },
+      "on_supervisor": {
+        "data": {
+          "use_addon": "Use the Z-Wave JS Supervisor add-on"
+        },
+        "description": "Do you want to use the Z-Wave JS Supervisor add-on?",
+        "title": "Select connection method"
+      },
+      "start_addon": {
+        "title": "The Z-Wave JS add-on is starting."
+      },
+      "usb_confirm": {
+        "description": "Do you want to set up {name} with the Z-Wave JS add-on?"
+      },
+      "zeroconf_confirm": {
+        "description": "Do you want to add the Z-Wave JS Server with home ID {home_id} found at {url} to Home Assistant?",
+        "title": "Discovered Z-Wave JS Server"
+      }
+    }
+  },
+  "device_automation": {
+    "action_type": {
+      "clear_lock_usercode": "Clear usercode on {entity_name}",
+      "ping": "Ping device",
+      "refresh_value": "Refresh the value(s) for {entity_name}",
+      "reset_meter": "Reset meters on {subtype}",
+      "set_config_parameter": "Set value of config parameter {subtype}",
+      "set_lock_usercode": "Set a usercode on {entity_name}",
+      "set_value": "Set value of a Z-Wave Value"
+    },
+    "condition_type": {
+      "config_parameter": "Config parameter {subtype} value",
+      "node_status": "Node status",
+      "value": "Current value of a Z-Wave Value"
+    },
+    "trigger_type": {
+      "event.notification.entry_control": "Sent an Entry Control notification",
+      "event.notification.notification": "Sent a notification",
+      "event.value_notification.basic": "Basic CC event on {subtype}",
+      "event.value_notification.central_scene": "Central Scene action on {subtype}",
+      "event.value_notification.scene_activation": "Scene Activation on {subtype}",
+      "state.node_status": "Node status changed",
+      "zwave_js.value_updated.config_parameter": "Value change on config parameter {subtype}",
+      "zwave_js.value_updated.value": "Value change on a Z-Wave JS Value"
+    }
+  },
   "entity": {
     "button": {
       "ping": {
@@ -6,6 +99,35 @@
       }
     },
     "sensor": {
+      "average_background_rssi": {
+        "name": "Average background RSSI (channel {channel})"
+      },
+      "can": {
+        "name": "Collisions"
+      },
+      "commands_dropped": {
+        "name": "Commands dropped ({direction})"
+      },
+      "controller_status": {
+        "name": "Status",
+        "state": {
+          "jammed": "Jammed",
+          "ready": "Ready",
+          "unresponsive": "Unresponsive"
+        }
+      },
+      "current_background_rssi": {
+        "name": "Current background RSSI (channel {channel})"
+      },
+      "last_seen": {
+        "name": "Last seen"
+      },
+      "messages_dropped": {
+        "name": "Messages dropped ({direction})"
+      },
+      "nak": {
+        "name": "Messages not accepted"
+      },
       "node_status": {
         "name": "Node status",
         "state": {
@@ -16,25 +138,17 @@
           "unknown": "Unknown"
         }
       },
-      "controller_status": {
-        "name": "Status",
-        "state": {
-          "ready": "Ready",
-          "unresponsive": "Unresponsive",
-          "jammed": "Jammed"
-        }
+      "rssi": {
+        "name": "RSSI"
       },
-      "average_background_rssi": {
-        "name": "Average background RSSI (channel {channel})"
+      "rtt": {
+        "name": "Round trip time"
       },
-      "current_background_rssi": {
-        "name": "Current background RSSI (channel {channel})"
+      "successful_commands": {
+        "name": "Successful commands ({direction})"
       },
-      "can": {
-        "name": "Collisions"
-      },
-      "nak": {
-        "name": "Messages not accepted"
+      "successful_messages": {
+        "name": "Successful messages ({direction})"
       },
       "timeout_ack": {
         "name": "Missing ACKs"
@@ -44,448 +158,334 @@
       },
       "timeout_response": {
         "name": "Timed out responses"
-      },
-      "successful_messages": {
-        "name": "Successful messages ({direction})"
-      },
-      "messages_dropped": {
-        "name": "Messages dropped ({direction})"
-      },
-      "successful_commands": {
-        "name": "Successful commands ({direction})"
-      },
-      "commands_dropped": {
-        "name": "Commands dropped ({direction})"
-      },
-      "rtt": {
-        "name": "Round trip time"
-      },
-      "rssi": {
-        "name": "RSSI"
-      },
-      "last_seen": {
-        "name": "Last seen"
       }
-    }
-  },
-  "config": {
-    "flow_title": "{name}",
-    "step": {
-      "manual": {
-        "data": {
-          "url": "[%key:common::config_flow::data::url%]"
-        }
-      },
-      "usb_confirm": {
-        "description": "Do you want to set up {name} with the Z-Wave JS add-on?"
-      },
-      "on_supervisor": {
-        "title": "Select connection method",
-        "description": "Do you want to use the Z-Wave JS Supervisor add-on?",
-        "data": {
-          "use_addon": "Use the Z-Wave JS Supervisor add-on"
-        }
-      },
-      "install_addon": {
-        "title": "The Z-Wave JS add-on installation has started"
-      },
-      "configure_addon": {
-        "title": "Enter the Z-Wave JS add-on configuration",
-        "description": "The add-on will generate security keys if those fields are left empty.",
-        "data": {
-          "usb_path": "[%key:common::config_flow::data::usb_path%]",
-          "s0_legacy_key": "S0 Key (Legacy)",
-          "s2_authenticated_key": "S2 Authenticated Key",
-          "s2_unauthenticated_key": "S2 Unauthenticated Key",
-          "s2_access_control_key": "S2 Access Control Key"
-        }
-      },
-      "start_addon": {
-        "title": "The Z-Wave JS add-on is starting."
-      },
-      "hassio_confirm": {
-        "title": "Set up Z-Wave JS integration with the Z-Wave JS add-on"
-      },
-      "zeroconf_confirm": {
-        "description": "Do you want to add the Z-Wave JS Server with home ID {home_id} found at {url} to Home Assistant?",
-        "title": "Discovered Z-Wave JS Server"
-      }
-    },
-    "error": {
-      "addon_start_failed": "Failed to start the Z-Wave JS add-on. Check the configuration.",
-      "invalid_ws_url": "Invalid websocket URL",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
-    },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
-      "addon_info_failed": "Failed to get Z-Wave JS add-on info.",
-      "addon_install_failed": "Failed to install the Z-Wave JS add-on.",
-      "addon_set_config_failed": "Failed to set Z-Wave JS configuration.",
-      "addon_start_failed": "Failed to start the Z-Wave JS add-on.",
-      "addon_get_discovery_info_failed": "Failed to get Z-Wave JS add-on discovery info.",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "discovery_requires_supervisor": "Discovery requires the supervisor.",
-      "not_zwave_device": "Discovered device is not a Z-Wave device.",
-      "not_zwave_js_addon": "Discovered add-on is not the official Z-Wave JS add-on."
-    },
-    "progress": {
-      "install_addon": "Please wait while the Z-Wave JS add-on installation finishes. This can take several minutes.",
-      "start_addon": "Please wait while the Z-Wave JS add-on start completes. This may take some seconds."
-    }
-  },
-  "options": {
-    "step": {
-      "manual": {
-        "data": {
-          "url": "[%key:common::config_flow::data::url%]"
-        }
-      },
-      "on_supervisor": {
-        "title": "[%key:component::zwave_js::config::step::on_supervisor::title%]",
-        "description": "[%key:component::zwave_js::config::step::on_supervisor::description%]",
-        "data": {
-          "use_addon": "[%key:component::zwave_js::config::step::on_supervisor::data::use_addon%]"
-        }
-      },
-      "install_addon": {
-        "title": "[%key:component::zwave_js::config::step::install_addon::title%]"
-      },
-      "configure_addon": {
-        "title": "[%key:component::zwave_js::config::step::configure_addon::title%]",
-        "description": "[%key:component::zwave_js::config::step::configure_addon::description%]",
-        "data": {
-          "usb_path": "[%key:common::config_flow::data::usb_path%]",
-          "s0_legacy_key": "[%key:component::zwave_js::config::step::configure_addon::data::s0_legacy_key%]",
-          "s2_authenticated_key": "[%key:component::zwave_js::config::step::configure_addon::data::s2_authenticated_key%]",
-          "s2_unauthenticated_key": "[%key:component::zwave_js::config::step::configure_addon::data::s2_unauthenticated_key%]",
-          "s2_access_control_key": "[%key:component::zwave_js::config::step::configure_addon::data::s2_access_control_key%]",
-          "log_level": "Log level",
-          "emulate_hardware": "Emulate Hardware"
-        }
-      },
-      "start_addon": {
-        "title": "[%key:component::zwave_js::config::step::start_addon::title%]"
-      }
-    },
-    "error": {
-      "invalid_ws_url": "[%key:component::zwave_js::config::error::invalid_ws_url%]",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
-    },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "addon_info_failed": "[%key:component::zwave_js::config::abort::addon_info_failed%]",
-      "addon_install_failed": "[%key:component::zwave_js::config::abort::addon_install_failed%]",
-      "addon_set_config_failed": "[%key:component::zwave_js::config::abort::addon_set_config_failed%]",
-      "addon_start_failed": "[%key:component::zwave_js::config::abort::addon_start_failed%]",
-      "addon_get_discovery_info_failed": "[%key:component::zwave_js::config::abort::addon_get_discovery_info_failed%]",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "different_device": "The connected USB device is not the same as previously configured for this config entry. Please instead create a new config entry for the new device."
-    },
-    "progress": {
-      "install_addon": "[%key:component::zwave_js::config::progress::install_addon%]",
-      "start_addon": "[%key:component::zwave_js::config::progress::start_addon%]"
-    }
-  },
-  "device_automation": {
-    "trigger_type": {
-      "event.notification.entry_control": "Sent an Entry Control notification",
-      "event.notification.notification": "Sent a notification",
-      "event.value_notification.basic": "Basic CC event on {subtype}",
-      "event.value_notification.central_scene": "Central Scene action on {subtype}",
-      "event.value_notification.scene_activation": "Scene Activation on {subtype}",
-      "zwave_js.value_updated.config_parameter": "Value change on config parameter {subtype}",
-      "zwave_js.value_updated.value": "Value change on a Z-Wave JS Value",
-      "state.node_status": "Node status changed"
-    },
-    "condition_type": {
-      "node_status": "Node status",
-      "config_parameter": "Config parameter {subtype} value",
-      "value": "Current value of a Z-Wave Value"
-    },
-    "action_type": {
-      "clear_lock_usercode": "Clear usercode on {entity_name}",
-      "set_lock_usercode": "Set a usercode on {entity_name}",
-      "set_config_parameter": "Set value of config parameter {subtype}",
-      "set_value": "Set value of a Z-Wave Value",
-      "refresh_value": "Refresh the value(s) for {entity_name}",
-      "ping": "Ping device",
-      "reset_meter": "Reset meters on {subtype}"
     }
   },
   "issues": {
-    "invalid_server_version": {
-      "title": "Newer version of Z-Wave JS Server needed",
-      "description": "The version of Z-Wave JS Server you are currently running is too old for this version of Home Assistant. Please update the Z-Wave JS Server to the latest version to fix this issue."
-    },
     "device_config_file_changed": {
-      "title": "Device configuration file changed: {device_name}",
       "fix_flow": {
+        "abort": {
+          "cannot_connect": "Cannot connect to {device_name}. Please try again later after confirming that your Z-Wave network is up and connected to Home Assistant.",
+          "issue_ignored": "Device config file update for {device_name} ignored."
+        },
         "step": {
           "init": {
+            "description": "The device configuration file for {device_name} has changed.\n\nZ-Wave JS discovers a lot of device metadata by interviewing the device. However, some of the information has to be loaded from a configuration file. Some of this information is only evaluated once, during the device interview.\n\nWhen a device config file is updated, this information may be stale and and the device must be re-interviewed to pick up the changes.\n\n This is not a required operation and device functionality will be impacted during the re-interview process, but you may see improvements for your device once it is complete.\n\nIf you decide to proceed with the re-interview, it will take place in the background.",
             "menu_options": {
               "confirm": "Re-interview device",
               "ignore": "Ignore device config update"
             },
-            "title": "Device configuration file changed: {device_name}",
-            "description": "The device configuration file for {device_name} has changed.\n\nZ-Wave JS discovers a lot of device metadata by interviewing the device. However, some of the information has to be loaded from a configuration file. Some of this information is only evaluated once, during the device interview.\n\nWhen a device config file is updated, this information may be stale and and the device must be re-interviewed to pick up the changes.\n\n This is not a required operation and device functionality will be impacted during the re-interview process, but you may see improvements for your device once it is complete.\n\nIf you decide to proceed with the re-interview, it will take place in the background."
+            "title": "Device configuration file changed: {device_name}"
           }
-        },
-        "abort": {
-          "cannot_connect": "Cannot connect to {device_name}. Please try again later after confirming that your Z-Wave network is up and connected to Home Assistant.",
-          "issue_ignored": "Device config file update for {device_name} ignored."
         }
+      },
+      "title": "Device configuration file changed: {device_name}"
+    },
+    "invalid_server_version": {
+      "description": "The version of Z-Wave JS Server you are currently running is too old for this version of Home Assistant. Please update the Z-Wave JS Server to the latest version to fix this issue.",
+      "title": "Newer version of Z-Wave JS Server needed"
+    }
+  },
+  "options": {
+    "abort": {
+      "addon_get_discovery_info_failed": "[%key:component::zwave_js::config::abort::addon_get_discovery_info_failed%]",
+      "addon_info_failed": "[%key:component::zwave_js::config::abort::addon_info_failed%]",
+      "addon_install_failed": "[%key:component::zwave_js::config::abort::addon_install_failed%]",
+      "addon_set_config_failed": "[%key:component::zwave_js::config::abort::addon_set_config_failed%]",
+      "addon_start_failed": "[%key:component::zwave_js::config::abort::addon_start_failed%]",
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "different_device": "The connected USB device is not the same as previously configured for this config entry. Please instead create a new config entry for the new device."
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_ws_url": "[%key:component::zwave_js::config::error::invalid_ws_url%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "progress": {
+      "install_addon": "[%key:component::zwave_js::config::progress::install_addon%]",
+      "start_addon": "[%key:component::zwave_js::config::progress::start_addon%]"
+    },
+    "step": {
+      "configure_addon": {
+        "data": {
+          "emulate_hardware": "Emulate Hardware",
+          "log_level": "Log level",
+          "s0_legacy_key": "[%key:component::zwave_js::config::step::configure_addon::data::s0_legacy_key%]",
+          "s2_access_control_key": "[%key:component::zwave_js::config::step::configure_addon::data::s2_access_control_key%]",
+          "s2_authenticated_key": "[%key:component::zwave_js::config::step::configure_addon::data::s2_authenticated_key%]",
+          "s2_unauthenticated_key": "[%key:component::zwave_js::config::step::configure_addon::data::s2_unauthenticated_key%]",
+          "usb_path": "[%key:common::config_flow::data::usb_path%]"
+        },
+        "description": "[%key:component::zwave_js::config::step::configure_addon::description%]",
+        "title": "[%key:component::zwave_js::config::step::configure_addon::title%]"
+      },
+      "install_addon": {
+        "title": "[%key:component::zwave_js::config::step::install_addon::title%]"
+      },
+      "manual": {
+        "data": {
+          "url": "[%key:common::config_flow::data::url%]"
+        }
+      },
+      "on_supervisor": {
+        "data": {
+          "use_addon": "[%key:component::zwave_js::config::step::on_supervisor::data::use_addon%]"
+        },
+        "description": "[%key:component::zwave_js::config::step::on_supervisor::description%]",
+        "title": "[%key:component::zwave_js::config::step::on_supervisor::title%]"
+      },
+      "start_addon": {
+        "title": "[%key:component::zwave_js::config::step::start_addon::title%]"
       }
     }
   },
   "services": {
-    "clear_lock_usercode": {
-      "name": "Clear lock user code",
-      "description": "Clears a user code from a lock.",
-      "fields": {
-        "code_slot": {
-          "name": "Code slot",
-          "description": "Code slot to clear code from."
-        }
-      }
-    },
-    "set_lock_usercode": {
-      "name": "Set lock user code",
-      "description": "Sets a user code on a lock.",
-      "fields": {
-        "code_slot": {
-          "name": "[%key:component::zwave_js::services::clear_lock_usercode::fields::code_slot::name%]",
-          "description": "Code slot to set the code."
-        },
-        "usercode": {
-          "name": "Code",
-          "description": "Lock code to set."
-        }
-      }
-    },
-    "set_config_parameter": {
-      "name": "Set device configuration parameter",
-      "description": "Changes the configuration parameters of your Z-Wave devices.",
-      "fields": {
-        "endpoint": {
-          "name": "Endpoint",
-          "description": "The configuration parameter's endpoint."
-        },
-        "parameter": {
-          "name": "Parameter",
-          "description": "The name (or ID) of the configuration parameter you want to configure."
-        },
-        "bitmask": {
-          "name": "Bitmask",
-          "description": "Target a specific bitmask (see the documentation for more information). Cannot be combined with value_size or value_format."
-        },
-        "value": {
-          "name": "Value",
-          "description": "The new value to set for this configuration parameter."
-        },
-        "value_size": {
-          "name": "Value size",
-          "description": "Size of the value, either 1, 2, or 4. Used in combination with value_format when a config parameter is not defined in your device's configuration file. Cannot be combined with bitmask."
-        },
-        "value_format": {
-          "name": "Value format",
-          "description": "Format of the value, 0 for signed integer, 1 for unsigned integer, 2 for enumerated, 3 for bitfield. Used in combination with value_size when a config parameter is not defined in your device's configuration file. Cannot be combined with bitmask."
-        }
-      }
-    },
     "bulk_set_partial_config_parameters": {
-      "name": "Bulk set partial configuration parameters (advanced).",
       "description": "Allows for bulk setting partial parameters. Useful when multiple partial parameters have to be set at the same time.",
       "fields": {
         "endpoint": {
-          "name": "[%key:component::zwave_js::services::set_config_parameter::fields::endpoint::name%]",
-          "description": "[%key:component::zwave_js::services::set_config_parameter::fields::endpoint::description%]"
+          "description": "[%key:component::zwave_js::services::set_config_parameter::fields::endpoint::description%]",
+          "name": "[%key:component::zwave_js::services::set_config_parameter::fields::endpoint::name%]"
         },
         "parameter": {
-          "name": "[%key:component::zwave_js::services::set_config_parameter::fields::parameter::name%]",
-          "description": "[%key:component::zwave_js::services::set_config_parameter::fields::parameter::description%]"
+          "description": "[%key:component::zwave_js::services::set_config_parameter::fields::parameter::description%]",
+          "name": "[%key:component::zwave_js::services::set_config_parameter::fields::parameter::name%]"
         },
         "value": {
-          "name": "[%key:component::zwave_js::services::set_config_parameter::fields::value::name%]",
-          "description": "The new value(s) to set for this configuration parameter. Can either be a raw integer value to represent the bulk change or a mapping where the key is the bitmask (either in hex or integer form) and the value is the new value you want to set for that partial parameter."
+          "description": "The new value(s) to set for this configuration parameter. Can either be a raw integer value to represent the bulk change or a mapping where the key is the bitmask (either in hex or integer form) and the value is the new value you want to set for that partial parameter.",
+          "name": "[%key:component::zwave_js::services::set_config_parameter::fields::value::name%]"
         }
-      }
+      },
+      "name": "Bulk set partial configuration parameters (advanced)."
     },
-    "refresh_value": {
-      "name": "Refresh values",
-      "description": "Force updates the values of a Z-Wave entity.",
+    "clear_lock_usercode": {
+      "description": "Clears a user code from a lock.",
       "fields": {
-        "entity_id": {
-          "name": "Entities",
-          "description": "Entities to refresh."
-        },
-        "refresh_all_values": {
-          "name": "Refresh all values?",
-          "description": "Whether to refresh all values (true) or just the primary value (false)."
+        "code_slot": {
+          "description": "Code slot to clear code from.",
+          "name": "Code slot"
         }
-      }
-    },
-    "set_value": {
-      "name": "Set a value (advanced)",
-      "description": "Changes any value that Z-Wave JS recognizes on a Z-Wave device. This service has minimal validation so only use this service if you know what you are doing.",
-      "fields": {
-        "command_class": {
-          "name": "Command class",
-          "description": "The ID of the command class for the value."
-        },
-        "endpoint": {
-          "name": "[%key:component::zwave_js::services::set_config_parameter::fields::endpoint::name%]",
-          "description": "The endpoint for the value."
-        },
-        "property": {
-          "name": "Property",
-          "description": "The ID of the property for the value."
-        },
-        "property_key": {
-          "name": "Property key",
-          "description": "The ID of the property key for the value."
-        },
-        "value": {
-          "name": "[%key:component::zwave_js::services::set_config_parameter::fields::value::name%]",
-          "description": "The new value to set."
-        },
-        "options": {
-          "name": "Options",
-          "description": "Set value options map. Refer to the Z-Wave JS documentation for more information on what options can be set."
-        },
-        "wait_for_result": {
-          "name": "Wait for result?",
-          "description": "Whether or not to wait for a response from the node. If not included in the payload, the integration will decide whether to wait or not. If set to `true`, note that the service call can take a while if setting a value on an asleep battery device."
-        }
-      }
-    },
-    "multicast_set_value": {
-      "name": "Set a value on multiple devices via multicast (advanced)",
-      "description": "Changes any value that Z-Wave JS recognizes on multiple Z-Wave devices using multicast, so all devices receive the message simultaneously. This service has minimal validation so only use this service if you know what you are doing.",
-      "fields": {
-        "broadcast": {
-          "name": "Broadcast?",
-          "description": "Whether command should be broadcast to all devices on the network."
-        },
-        "command_class": {
-          "name": "[%key:component::zwave_js::services::set_value::fields::command_class::name%]",
-          "description": "[%key:component::zwave_js::services::set_value::fields::command_class::description%]"
-        },
-        "endpoint": {
-          "name": "[%key:component::zwave_js::services::set_config_parameter::fields::endpoint::name%]",
-          "description": "[%key:component::zwave_js::services::set_value::fields::endpoint::description%]"
-        },
-        "property": {
-          "name": "[%key:component::zwave_js::services::set_value::fields::property::name%]",
-          "description": "[%key:component::zwave_js::services::set_value::fields::property::description%]"
-        },
-        "property_key": {
-          "name": "[%key:component::zwave_js::services::set_value::fields::property_key::name%]",
-          "description": "[%key:component::zwave_js::services::set_value::fields::property_key::description%]"
-        },
-        "options": {
-          "name": "[%key:component::zwave_js::services::set_value::fields::options::name%]",
-          "description": "[%key:component::zwave_js::services::set_value::fields::options::description%]"
-        },
-        "value": {
-          "name": "[%key:component::zwave_js::services::set_config_parameter::fields::value::name%]",
-          "description": "[%key:component::zwave_js::services::set_value::fields::value::description%]"
-        }
-      }
-    },
-    "ping": {
-      "name": "Ping a node",
-      "description": "Forces Z-Wave JS to try to reach a node. This can be used to update the status of the node in Z-Wave JS when you think it doesn't accurately reflect reality, e.g. reviving a failed/dead node or marking the node as asleep."
-    },
-    "reset_meter": {
-      "name": "Reset meters on a node",
-      "description": "Resets the meters on a node.",
-      "fields": {
-        "meter_type": {
-          "name": "Meter type",
-          "description": "The type of meter to reset. Not all meters support the ability to pick a meter type to reset."
-        },
-        "value": {
-          "name": "Target value",
-          "description": "The value that meters should be reset to. Not all meters support the ability to be reset to a specific value."
-        }
-      }
+      },
+      "name": "Clear lock user code"
     },
     "invoke_cc_api": {
-      "name": "Invoke a Command Class API on a node (advanced)",
       "description": "Calls a Command Class API on a node. Some Command Classes can't be fully controlled via the `set_value` service and require direct calls to the Command Class API.",
       "fields": {
         "command_class": {
-          "name": "[%key:component::zwave_js::services::set_value::fields::command_class::name%]",
-          "description": "The ID of the command class that you want to issue a command to."
+          "description": "The ID of the command class that you want to issue a command to.",
+          "name": "[%key:component::zwave_js::services::set_value::fields::command_class::name%]"
         },
         "endpoint": {
-          "name": "[%key:component::zwave_js::services::set_config_parameter::fields::endpoint::name%]",
-          "description": "The endpoint to call the API on. If an endpoint is specified, that endpoint will be targeted for all nodes associated with the target areas, devices, and/or entities. If an endpoint is not specified, the root endpoint (0) will be targeted for nodes associated with target areas and devices, and the endpoint for the primary value of each entity will be targeted."
+          "description": "The endpoint to call the API on. If an endpoint is specified, that endpoint will be targeted for all nodes associated with the target areas, devices, and/or entities. If an endpoint is not specified, the root endpoint (0) will be targeted for nodes associated with target areas and devices, and the endpoint for the primary value of each entity will be targeted.",
+          "name": "[%key:component::zwave_js::services::set_config_parameter::fields::endpoint::name%]"
         },
         "method_name": {
-          "name": "Method name",
-          "description": "The name of the API method to call. Refer to the Z-Wave JS Command Class API documentation (https://zwave-js.github.io/node-zwave-js/#/api/CCs/index) for available methods."
+          "description": "The name of the API method to call. Refer to the Z-Wave JS Command Class API documentation (https://zwave-js.github.io/node-zwave-js/#/api/CCs/index) for available methods.",
+          "name": "Method name"
         },
         "parameters": {
-          "name": "Parameters",
-          "description": "A list of parameters to pass to the API method. Refer to the Z-Wave JS Command Class API documentation (https://zwave-js.github.io/node-zwave-js/#/api/CCs/index) for parameters."
+          "description": "A list of parameters to pass to the API method. Refer to the Z-Wave JS Command Class API documentation (https://zwave-js.github.io/node-zwave-js/#/api/CCs/index) for parameters.",
+          "name": "Parameters"
         }
-      }
+      },
+      "name": "Invoke a Command Class API on a node (advanced)"
+    },
+    "multicast_set_value": {
+      "description": "Changes any value that Z-Wave JS recognizes on multiple Z-Wave devices using multicast, so all devices receive the message simultaneously. This service has minimal validation so only use this service if you know what you are doing.",
+      "fields": {
+        "broadcast": {
+          "description": "Whether command should be broadcast to all devices on the network.",
+          "name": "Broadcast?"
+        },
+        "command_class": {
+          "description": "[%key:component::zwave_js::services::set_value::fields::command_class::description%]",
+          "name": "[%key:component::zwave_js::services::set_value::fields::command_class::name%]"
+        },
+        "endpoint": {
+          "description": "[%key:component::zwave_js::services::set_value::fields::endpoint::description%]",
+          "name": "[%key:component::zwave_js::services::set_config_parameter::fields::endpoint::name%]"
+        },
+        "options": {
+          "description": "[%key:component::zwave_js::services::set_value::fields::options::description%]",
+          "name": "[%key:component::zwave_js::services::set_value::fields::options::name%]"
+        },
+        "property": {
+          "description": "[%key:component::zwave_js::services::set_value::fields::property::description%]",
+          "name": "[%key:component::zwave_js::services::set_value::fields::property::name%]"
+        },
+        "property_key": {
+          "description": "[%key:component::zwave_js::services::set_value::fields::property_key::description%]",
+          "name": "[%key:component::zwave_js::services::set_value::fields::property_key::name%]"
+        },
+        "value": {
+          "description": "[%key:component::zwave_js::services::set_value::fields::value::description%]",
+          "name": "[%key:component::zwave_js::services::set_config_parameter::fields::value::name%]"
+        }
+      },
+      "name": "Set a value on multiple devices via multicast (advanced)"
+    },
+    "ping": {
+      "description": "Forces Z-Wave JS to try to reach a node. This can be used to update the status of the node in Z-Wave JS when you think it doesn't accurately reflect reality, e.g. reviving a failed/dead node or marking the node as asleep.",
+      "name": "Ping a node"
     },
     "refresh_notifications": {
-      "name": "Refresh notifications on a node (advanced)",
       "description": "Refreshes notifications on a node based on notification type and optionally notification event.",
       "fields": {
-        "notification_type": {
-          "name": "Notification Type",
-          "description": "The Notification Type number as defined in the Z-Wave specs."
-        },
         "notification_event": {
-          "name": "Notification Event",
-          "description": "The Notification Event number as defined in the Z-Wave specs."
+          "description": "The Notification Event number as defined in the Z-Wave specs.",
+          "name": "Notification Event"
+        },
+        "notification_type": {
+          "description": "The Notification Type number as defined in the Z-Wave specs.",
+          "name": "Notification Type"
         }
-      }
+      },
+      "name": "Refresh notifications on a node (advanced)"
+    },
+    "refresh_value": {
+      "description": "Force updates the values of a Z-Wave entity.",
+      "fields": {
+        "entity_id": {
+          "description": "Entities to refresh.",
+          "name": "Entities"
+        },
+        "refresh_all_values": {
+          "description": "Whether to refresh all values (true) or just the primary value (false).",
+          "name": "Refresh all values?"
+        }
+      },
+      "name": "Refresh values"
+    },
+    "reset_meter": {
+      "description": "Resets the meters on a node.",
+      "fields": {
+        "meter_type": {
+          "description": "The type of meter to reset. Not all meters support the ability to pick a meter type to reset.",
+          "name": "Meter type"
+        },
+        "value": {
+          "description": "The value that meters should be reset to. Not all meters support the ability to be reset to a specific value.",
+          "name": "Target value"
+        }
+      },
+      "name": "Reset meters on a node"
+    },
+    "set_config_parameter": {
+      "description": "Changes the configuration parameters of your Z-Wave devices.",
+      "fields": {
+        "bitmask": {
+          "description": "Target a specific bitmask (see the documentation for more information). Cannot be combined with value_size or value_format.",
+          "name": "Bitmask"
+        },
+        "endpoint": {
+          "description": "The configuration parameter's endpoint.",
+          "name": "Endpoint"
+        },
+        "parameter": {
+          "description": "The name (or ID) of the configuration parameter you want to configure.",
+          "name": "Parameter"
+        },
+        "value": {
+          "description": "The new value to set for this configuration parameter.",
+          "name": "Value"
+        },
+        "value_format": {
+          "description": "Format of the value, 0 for signed integer, 1 for unsigned integer, 2 for enumerated, 3 for bitfield. Used in combination with value_size when a config parameter is not defined in your device's configuration file. Cannot be combined with bitmask.",
+          "name": "Value format"
+        },
+        "value_size": {
+          "description": "Size of the value, either 1, 2, or 4. Used in combination with value_format when a config parameter is not defined in your device's configuration file. Cannot be combined with bitmask.",
+          "name": "Value size"
+        }
+      },
+      "name": "Set device configuration parameter"
     },
     "set_lock_configuration": {
-      "name": "Set lock configuration",
       "description": "Sets the configuration for a lock.",
       "fields": {
-        "operation_type": {
-          "name": "Operation Type",
-          "description": "The operation type of the lock."
-        },
-        "lock_timeout": {
-          "name": "Lock timeout",
-          "description": "Seconds until lock mode times out. Should only be used if operation type is `timed`."
-        },
-        "outside_handles_can_open_door_configuration": {
-          "name": "Outside handles can open door configuration",
-          "description": "A list of four booleans which indicate which outside handles can open the door."
-        },
-        "inside_handles_can_open_door_configuration": {
-          "name": "Inside handles can open door configuration",
-          "description": "A list of four booleans which indicate which inside handles can open the door."
-        },
         "auto_relock_time": {
-          "name": "Auto relock time",
-          "description": "Duration in seconds until lock returns to secure state. Only enforced when operation type is `constant`."
-        },
-        "hold_and_release_time": {
-          "name": "Hold and release time",
-          "description": "Duration in seconds the latch stays retracted."
-        },
-        "twist_assist": {
-          "name": "Twist assist",
-          "description": "Enable Twist Assist."
+          "description": "Duration in seconds until lock returns to secure state. Only enforced when operation type is `constant`.",
+          "name": "Auto relock time"
         },
         "block_to_block": {
-          "name": "Block to block",
-          "description": "Enable block-to-block functionality."
+          "description": "Enable block-to-block functionality.",
+          "name": "Block to block"
+        },
+        "hold_and_release_time": {
+          "description": "Duration in seconds the latch stays retracted.",
+          "name": "Hold and release time"
+        },
+        "inside_handles_can_open_door_configuration": {
+          "description": "A list of four booleans which indicate which inside handles can open the door.",
+          "name": "Inside handles can open door configuration"
+        },
+        "lock_timeout": {
+          "description": "Seconds until lock mode times out. Should only be used if operation type is `timed`.",
+          "name": "Lock timeout"
+        },
+        "operation_type": {
+          "description": "The operation type of the lock.",
+          "name": "Operation Type"
+        },
+        "outside_handles_can_open_door_configuration": {
+          "description": "A list of four booleans which indicate which outside handles can open the door.",
+          "name": "Outside handles can open door configuration"
+        },
+        "twist_assist": {
+          "description": "Enable Twist Assist.",
+          "name": "Twist assist"
         }
-      }
+      },
+      "name": "Set lock configuration"
+    },
+    "set_lock_usercode": {
+      "description": "Sets a user code on a lock.",
+      "fields": {
+        "code_slot": {
+          "description": "Code slot to set the code.",
+          "name": "[%key:component::zwave_js::services::clear_lock_usercode::fields::code_slot::name%]"
+        },
+        "usercode": {
+          "description": "Lock code to set.",
+          "name": "Code"
+        }
+      },
+      "name": "Set lock user code"
+    },
+    "set_value": {
+      "description": "Changes any value that Z-Wave JS recognizes on a Z-Wave device. This service has minimal validation so only use this service if you know what you are doing.",
+      "fields": {
+        "command_class": {
+          "description": "The ID of the command class for the value.",
+          "name": "Command class"
+        },
+        "endpoint": {
+          "description": "The endpoint for the value.",
+          "name": "[%key:component::zwave_js::services::set_config_parameter::fields::endpoint::name%]"
+        },
+        "options": {
+          "description": "Set value options map. Refer to the Z-Wave JS documentation for more information on what options can be set.",
+          "name": "Options"
+        },
+        "property": {
+          "description": "The ID of the property for the value.",
+          "name": "Property"
+        },
+        "property_key": {
+          "description": "The ID of the property key for the value.",
+          "name": "Property key"
+        },
+        "value": {
+          "description": "The new value to set.",
+          "name": "[%key:component::zwave_js::services::set_config_parameter::fields::value::name%]"
+        },
+        "wait_for_result": {
+          "description": "Whether or not to wait for a response from the node. If not included in the payload, the integration will decide whether to wait or not. If set to `true`, note that the service call can take a while if setting a value on an asleep battery device.",
+          "name": "Wait for result?"
+        }
+      },
+      "name": "Set a value (advanced)"
     }
   }
 }


### PR DESCRIPTION
## Proposed change
Uses translation strings for statistic sensors and ping button names and icons. Also adds service icons


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
