### PR TITLE
Improve enabling of Google local fulfillment

### DIFF
--- a/homeassistant/components/cloud/client.py
+++ b/homeassistant/components/cloud/client.py
@@ -29,6 +29,8 @@ from . import alexa_config, google_config
 from .const import DISPATCHER_REMOTE_UPDATE, DOMAIN
 from .prefs import CloudPreferences
 
+_LOGGER = logging.getLogger(__name__)
+
 VALID_REPAIR_TRANSLATION_KEYS = {
     "warn_bad_custom_domain_configuration",
     "reset_bad_custom_domain_configuration",
@@ -149,6 +151,7 @@ class CloudClient(Interface):
 
     async def cloud_connected(self) -> None:
         """When cloud is connected."""
+        _LOGGER.debug("cloud_connected")
         is_new_user = await self.prefs.async_set_username(self.cloud.username)
 
         async def enable_alexa(_: Any) -> None:
@@ -196,6 +199,9 @@ class CloudClient(Interface):
 
     async def cloud_disconnected(self) -> None:
         """When cloud disconnected."""
+        _LOGGER.debug("cloud_disconnected")
+        if self._google_config:
+            self._google_config.async_disable_local_sdk()
 
     async def cloud_started(self) -> None:
         """When cloud is started."""
@@ -207,6 +213,8 @@ class CloudClient(Interface):
         """Cleanup some stuff after logout."""
         await self.prefs.async_set_username(None)
 
+        if self._google_config:
+            self._google_config.async_deinitialize()
         self._google_config = None
 
     @callback

--- a/homeassistant/components/cloud/google_config.py
+++ b/homeassistant/components/cloud/google_config.py
@@ -23,6 +23,7 @@ from homeassistant.components.homeassistant.exposed_entities import (
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import CLOUD_NEVER_EXPOSED_ENTITIES
 from homeassistant.core import (
+    CALLBACK_TYPE,
     CoreState,
     Event,
     HomeAssistant,
@@ -144,6 +145,7 @@ class CloudGoogleConfig(AbstractConfig):
         self._prefs = prefs
         self._cloud = cloud
         self._sync_entities_lock = asyncio.Lock()
+        self._on_deinitialize: list[CALLBACK_TYPE] = []
 
     @property
     def enabled(self) -> bool:
@@ -209,9 +211,11 @@ class CloudGoogleConfig(AbstractConfig):
 
     async def async_initialize(self) -> None:
         """Perform async initialization of config."""
+        _LOGGER.debug("async_initialize")
         await super().async_initialize()
 
         async def on_hass_started(hass: HomeAssistant) -> None:
+            _LOGGER.debug("async_initialize on_hass_started")
             if self._prefs.google_settings_version != GOOGLE_SETTINGS_VERSION:
                 _LOGGER.info(
                     "Start migration of Google Assistant settings from v%s to v%s",
@@ -238,11 +242,14 @@ class CloudGoogleConfig(AbstractConfig):
                 await self._prefs.async_update(
                     google_settings_version=GOOGLE_SETTINGS_VERSION
                 )
-            async_listen_entity_updates(
-                self.hass, CLOUD_GOOGLE, self._async_exposed_entities_updated
+            self._on_deinitialize.append(
+                async_listen_entity_updates(
+                    self.hass, CLOUD_GOOGLE, self._async_exposed_entities_updated
+                )
             )
 
         async def on_hass_start(hass: HomeAssistant) -> None:
+            _LOGGER.debug("async_initialize on_hass_start")
             if self.enabled and GOOGLE_DOMAIN not in self.hass.config.components:
                 await async_setup_component(self.hass, GOOGLE_DOMAIN, {})
 
@@ -255,18 +262,33 @@ class CloudGoogleConfig(AbstractConfig):
             if agent_user_id != self.agent_user_id:
                 remove_agent_user_ids.append(agent_user_id)
 
+        if remove_agent_user_ids:
+            _LOGGER.debug("remove non cloud agent_user_ids: %s", remove_agent_user_ids)
         for agent_user_id in remove_agent_user_ids:
             await self.async_disconnect_agent_user(agent_user_id)
 
-        self._prefs.async_listen_updates(self._async_prefs_updated)
-        self.hass.bus.async_listen(
-            er.EVENT_ENTITY_REGISTRY_UPDATED,
-            self._handle_entity_registry_updated,
+        self._on_deinitialize.append(
+            self._prefs.async_listen_updates(self._async_prefs_updated)
         )
-        self.hass.bus.async_listen(
-            dr.EVENT_DEVICE_REGISTRY_UPDATED,
-            self._handle_device_registry_updated,
+        self._on_deinitialize.append(
+            self.hass.bus.async_listen(
+                er.EVENT_ENTITY_REGISTRY_UPDATED,
+                self._handle_entity_registry_updated,
+            )
         )
+        self._on_deinitialize.append(
+            self.hass.bus.async_listen(
+                dr.EVENT_DEVICE_REGISTRY_UPDATED,
+                self._handle_device_registry_updated,
+            )
+        )
+
+    @callback
+    def async_deinitialize(self) -> None:
+        """Remove listeners."""
+        _LOGGER.debug("async_deinitialize")
+        while self._on_deinitialize:
+            self._on_deinitialize.pop()()
 
     def should_expose(self, state: State) -> bool:
         """If a state object should be exposed."""
@@ -365,6 +387,7 @@ class CloudGoogleConfig(AbstractConfig):
 
     async def _async_prefs_updated(self, prefs: CloudPreferences) -> None:
         """Handle updated preferences."""
+        _LOGGER.debug("_async_prefs_updated")
         if not self._cloud.is_logged_in:
             if self.is_reporting_state:
                 self.async_disable_report_state()

--- a/homeassistant/components/cloud/google_config.py
+++ b/homeassistant/components/cloud/google_config.py
@@ -253,8 +253,8 @@ class CloudGoogleConfig(AbstractConfig):
             if self.enabled and GOOGLE_DOMAIN not in self.hass.config.components:
                 await async_setup_component(self.hass, GOOGLE_DOMAIN, {})
 
-        start.async_at_start(self.hass, on_hass_start)
-        start.async_at_started(self.hass, on_hass_started)
+        self._on_deinitialize.append(start.async_at_start(self.hass, on_hass_start))
+        self._on_deinitialize.append(start.async_at_started(self.hass, on_hass_started))
 
         # Remove any stored user agent id that is not ours
         remove_agent_user_ids = []

--- a/tests/components/cloud/conftest.py
+++ b/tests/components/cloud/conftest.py
@@ -115,6 +115,13 @@ async def cloud_fixture() -> AsyncGenerator[MagicMock, None]:
         type(mock_cloud).is_connected = is_connected
         type(mock_cloud.iot).connected = is_connected
 
+        def mock_username() -> bool:
+            """Return the subscription username."""
+            return "abcdefghjkl"
+
+        username = PropertyMock(side_effect=mock_username)
+        type(mock_cloud).username = username
+
         # Properties that we mock as attributes.
         mock_cloud.expiration_date = utcnow()
         mock_cloud.subscription_expired = False

--- a/tests/components/cloud/test_init.py
+++ b/tests/components/cloud/test_init.py
@@ -103,8 +103,8 @@ async def test_remote_services(
     assert mock_disconnect.called is False
 
 
-async def test_startup_shutdown_events(hass: HomeAssistant, mock_cloud_fixture) -> None:
-    """Test if the cloud will start on startup event."""
+async def test_shutdown_event(hass: HomeAssistant, mock_cloud_fixture) -> None:
+    """Test if the cloud will stop on shutdown event."""
     with patch("hass_nabucasa.Cloud.stop") as mock_stop:
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
         await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve enabling of Google local fulfillment:
- When logging out from the cloud, we should remove all listeners from the `CloudGoogleConfig`, if we don't do this, both the old and new `CloudGoogleConfig` will try to enable local fulfillment
- Disable local fulfillment when we're disconnected from the cloud since we enable it when connected

The PR also adds some additional debug prints to improve usefulness of user logs if this issue happens again

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/102804
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
