### PR TITLE
Add notification service for Bring component

### DIFF
--- a/homeassistant/components/bring/const.py
+++ b/homeassistant/components/bring/const.py
@@ -1,3 +1,12 @@
 """Constants for the Bring! integration."""
 
+from typing import Final
+
 DOMAIN = "bring"
+
+ATTR_SENDER: Final = "sender"
+ATTR_ITEM_NAME: Final = "item_name"
+ATTR_NOTIFICATION_TYPE: Final = "notification_type"
+ATTR_LIST: Final = "bring_list"
+
+SERVICE_PUSH_NOTIFICATION = "push_notification"

--- a/homeassistant/components/bring/const.py
+++ b/homeassistant/components/bring/const.py
@@ -7,6 +7,5 @@ DOMAIN = "bring"
 ATTR_SENDER: Final = "sender"
 ATTR_ITEM_NAME: Final = "item_name"
 ATTR_NOTIFICATION_TYPE: Final = "notification_type"
-ATTR_LIST: Final = "bring_list"
 
 SERVICE_PUSH_NOTIFICATION = "push_notification"

--- a/homeassistant/components/bring/const.py
+++ b/homeassistant/components/bring/const.py
@@ -5,7 +5,10 @@ from typing import Final
 DOMAIN = "bring"
 
 ATTR_SENDER: Final = "sender"
-ATTR_ITEM_NAME: Final = "item_name"
-ATTR_NOTIFICATION_TYPE: Final = "notification_type"
+ATTR_ITEM_NAME: Final = "item"
+ATTR_NOTIFICATION_TYPE: Final = "message"
 
-SERVICE_PUSH_NOTIFICATION = "push_notification"
+SERVICE_PUSH_NOTIFICATION = "send_message"
+
+MANUFACTURER: Final = "Bring! Labs AG"
+SERVICE_NAME: Final = "Bring!"

--- a/homeassistant/components/bring/const.py
+++ b/homeassistant/components/bring/const.py
@@ -9,6 +9,3 @@ ATTR_ITEM_NAME: Final = "item"
 ATTR_NOTIFICATION_TYPE: Final = "message"
 
 SERVICE_PUSH_NOTIFICATION = "send_message"
-
-MANUFACTURER: Final = "Bring! Labs AG"
-SERVICE_NAME: Final = "Bring!"

--- a/homeassistant/components/bring/icons.json
+++ b/homeassistant/components/bring/icons.json
@@ -5,5 +5,8 @@
         "default": "mdi:cart"
       }
     }
+  },
+  "services": {
+    "push_notification": "mdi:message-alert"
   }
 }

--- a/homeassistant/components/bring/icons.json
+++ b/homeassistant/components/bring/icons.json
@@ -7,6 +7,6 @@
     }
   },
   "services": {
-    "push_notification": "mdi:message-alert"
+    "send_message": "mdi:cellphone-message"
   }
 }

--- a/homeassistant/components/bring/services.yaml
+++ b/homeassistant/components/bring/services.yaml
@@ -1,14 +1,11 @@
-push_notification:
+send_message:
+  target:
+    entity:
+      domain: todo
+      integration: bring
   fields:
-    entity_id:
-      required: true
-      example: todo.bring_shoppinglist
-      selector:
-        entity:
-          domain: todo
-          integration: bring
-    notification_type:
-      example: going_shopping
+    message:
+      example: urgent_message
       required: true
       default: "going_shopping"
       selector:
@@ -19,7 +16,7 @@ push_notification:
             - "changed_list"
             - "shopping_done"
             - "urgent_message"
-    item_name:
+    item:
       example: Cilantro
       required: false
       selector:

--- a/homeassistant/components/bring/services.yaml
+++ b/homeassistant/components/bring/services.yaml
@@ -1,0 +1,26 @@
+push_notification:
+  fields:
+    bring_list:
+      required: true
+      example: todo.bring_shoppinglist
+      selector:
+        entity:
+          domain: todo
+          integration: bring
+    notification_type:
+      example: going_shopping
+      required: true
+      default: "going_shopping"
+      selector:
+        select:
+          translation_key: "notification_type_selector"
+          options:
+            - "going_shopping"
+            - "changed_list"
+            - "shopping_done"
+            - "urgent_message"
+    item_name:
+      example: Cilantro
+      required: false
+      selector:
+        text:

--- a/homeassistant/components/bring/services.yaml
+++ b/homeassistant/components/bring/services.yaml
@@ -1,6 +1,6 @@
 push_notification:
   fields:
-    bring_list:
+    entity_id:
       required: true
       example: todo.bring_shoppinglist
       selector:

--- a/homeassistant/components/bring/strings.json
+++ b/homeassistant/components/bring/strings.json
@@ -38,6 +38,12 @@
     },
     "setup_authentication_exception": {
       "message": "Authentication failed for {email}, check your email and password"
+    },
+    "notify_missing_argument_item": {
+      "message": "Failed to call service {service}. 'URGENT_MESSAGE' requires a value @ data['item']. Got None"
+    },
+    "notify_request_failed": {
+      "message": "Failed to send push notification for bring due to a connection error, try again later"
     }
   },
   "services": {
@@ -54,7 +60,7 @@
           "description": "Type of push notification to send to list members."
         },
         "item": {
-          "name": "Item (Required if message type 'Breaking news' selected)",
+          "name": "Item (Required if message type `Breaking news` selected)",
           "description": "Item name to include in a breaking news message e.g. `Breaking news - Please get cilantro!`"
         }
       }
@@ -66,19 +72,8 @@
         "going_shopping": "I'm going shopping! - Last chance for adjustments",
         "changed_list": "List changed - Check it out",
         "shopping_done": "Shopping done - you can relax",
-        "urgent_message": "Breaking news - Please get `item name` !"
+        "urgent_message": "Breaking news - Please get `item`!"
       }
-    }
-  },
-  "exceptions": {
-    "notify_missing_argument_item": {
-      "message": "This service requires field item for `Breaking news` notification, please enter a valid value for item"
-    },
-    "notify_request_failed": {
-      "message": "Failed to send push notification for bring"
-    },
-    "notify_invalid_message_type": {
-      "message": "This service requires message to be one of {notification_types}, please enter a valid value for message"
     }
   }
 }

--- a/homeassistant/components/bring/strings.json
+++ b/homeassistant/components/bring/strings.json
@@ -39,5 +39,35 @@
     "setup_authentication_exception": {
       "message": "Authentication failed for {email}, check your email and password"
     }
+  },
+  "services": {
+    "push_notification": {
+      "name": "Notifications",
+      "description": "Send a mobile push notification to members of a shared Bring! list.",
+      "fields": {
+        "bring_list": {
+          "name": "List",
+          "description": "Bring! list whose members (except sender) will be notified."
+        },
+        "notification_type": {
+          "name": "Notification type",
+          "description": "Type of push notification to send to list members."
+        },
+        "item_name": {
+          "name": "Item name (Required if message type 'Breaking news' selected)",
+          "description": "Item Name to include in an urgent message e.g. 'Breaking news - Please get cilantro!'"
+        }
+      }
+    }
+  },
+  "selector": {
+    "notification_type_selector": {
+      "options": {
+        "going_shopping": "I'm going shopping! - Last chance for adjustments",
+        "changed_list": "List changed - Check it out",
+        "shopping_done": "Shopping done - you can relax",
+        "urgent_message": "Breaking news - Please get 'item name' !"
+      }
+    }
   }
 }

--- a/homeassistant/components/bring/strings.json
+++ b/homeassistant/components/bring/strings.json
@@ -45,7 +45,7 @@
       "name": "Notifications",
       "description": "Send a mobile push notification to members of a shared Bring! list.",
       "fields": {
-        "bring_list": {
+        "entity_id": {
           "name": "List",
           "description": "Bring! list whose members (except sender) will be notified."
         },

--- a/homeassistant/components/bring/strings.json
+++ b/homeassistant/components/bring/strings.json
@@ -41,7 +41,7 @@
     }
   },
   "services": {
-    "push_notification": {
+    "send_message": {
       "name": "[%key:component::notify::services::notify::name%]",
       "description": "Send a mobile push notification to members of a shared Bring! list.",
       "fields": {
@@ -49,13 +49,13 @@
           "name": "List",
           "description": "Bring! list whose members (except sender) will be notified."
         },
-        "notification_type": {
+        "message": {
           "name": "Notification type",
           "description": "Type of push notification to send to list members."
         },
-        "item_name": {
-          "name": "Item name (Required if message type 'Breaking news' selected)",
-          "description": "Item Name to include in an urgent message e.g. 'Breaking news - Please get cilantro!'"
+        "item": {
+          "name": "Item (Required if message type 'Breaking news' selected)",
+          "description": "Item name to include in a breaking news message e.g. `Breaking news - Please get cilantro!`"
         }
       }
     }
@@ -66,8 +66,19 @@
         "going_shopping": "I'm going shopping! - Last chance for adjustments",
         "changed_list": "List changed - Check it out",
         "shopping_done": "Shopping done - you can relax",
-        "urgent_message": "Breaking news - Please get 'item name' !"
+        "urgent_message": "Breaking news - Please get `item name` !"
       }
+    }
+  },
+  "exceptions": {
+    "notify_missing_argument_item": {
+      "message": "This service requires field item for `Breaking news` notification, please enter a valid value for item"
+    },
+    "notify_request_failed": {
+      "message": "Failed to send push notification for bring"
+    },
+    "notify_invalid_message_type": {
+      "message": "This service requires message to be one of {notification_types}, please enter a valid value for message"
     }
   }
 }

--- a/homeassistant/components/bring/strings.json
+++ b/homeassistant/components/bring/strings.json
@@ -42,7 +42,7 @@
   },
   "services": {
     "push_notification": {
-      "name": "Notifications",
+      "name": "[%key:component::notify::services::notify::name%]",
       "description": "Send a mobile push notification to members of a shared Bring! list.",
       "fields": {
         "entity_id": {

--- a/homeassistant/components/bring/todo.py
+++ b/homeassistant/components/bring/todo.py
@@ -273,14 +273,7 @@ class BringTodoListEntity(
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="notify_missing_argument_item",
-            ) from e
-        except TypeError as e:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="notify_invalid_message_type",
                 translation_placeholders={
-                    "notification_types": ", ".join(
-                        x.value for x in BringNotificationType
-                    ),
+                    "service": f"{DOMAIN}.{SERVICE_PUSH_NOTIFICATION}",
                 },
             ) from e

--- a/homeassistant/components/bring/todo.py
+++ b/homeassistant/components/bring/todo.py
@@ -6,9 +6,11 @@ from typing import TYPE_CHECKING
 import uuid
 
 from bring_api.exceptions import BringRequestException
-from bring_api.types import BringItem, BringItemOperation
+from bring_api.types import BringItem, BringItemOperation, BringNotificationType
+import voluptuous as vol
 
 from homeassistant.components.todo import (
+    DOMAIN as DOMAIN_TODO,
     TodoItem,
     TodoItemStatus,
     TodoListEntity,
@@ -17,10 +19,17 @@ from homeassistant.components.todo import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import (
+    ATTR_ITEM_NAME,
+    ATTR_LIST,
+    ATTR_NOTIFICATION_TYPE,
+    DOMAIN,
+    SERVICE_PUSH_NOTIFICATION,
+)
 from .coordinator import BringData, BringDataUpdateCoordinator
 
 
@@ -44,6 +53,22 @@ async def async_setup_entry(
             unique_id=unique_id,
         )
         for bring_list in coordinator.data.values()
+    )
+
+    platform = entity_platform.async_get_current_platform()
+
+    platform.async_register_entity_service(
+        SERVICE_PUSH_NOTIFICATION,
+        vol.Schema(
+            {
+                vol.Required(ATTR_LIST): cv.entities_domain(DOMAIN_TODO),
+                vol.Required(ATTR_NOTIFICATION_TYPE): vol.All(
+                    vol.Upper, cv.enum(BringNotificationType)
+                ),
+                vol.Optional(ATTR_ITEM_NAME): cv.string,
+            }
+        ),
+        "async_send_push_notification",
     )
 
 
@@ -231,3 +256,21 @@ class BringTodoListEntity(
             ) from e
 
         await self.coordinator.async_refresh()
+
+    async def async_send_push_notification(
+        self,
+        notification_type: BringNotificationType,
+        item_name: str | None = None,
+    ) -> None:
+        """Send a push notification to members of the To-Do list."""
+        try:
+            await self.hass.async_add_executor_job(
+                self.coordinator.bring.notify,
+                self.bring_list["listUuid"],
+                notification_type,
+                item_name or "",
+            )
+        except BringRequestException as e:
+            raise HomeAssistantError(
+                "Unable to send push notification for bring"
+            ) from e

--- a/homeassistant/components/bring/todo.py
+++ b/homeassistant/components/bring/todo.py
@@ -17,6 +17,7 @@ from homeassistant.components.todo import (
     TodoListEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, entity_platform
@@ -25,7 +26,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     ATTR_ITEM_NAME,
-    ATTR_LIST,
     ATTR_NOTIFICATION_TYPE,
     DOMAIN,
     SERVICE_PUSH_NOTIFICATION,
@@ -61,7 +61,7 @@ async def async_setup_entry(
         SERVICE_PUSH_NOTIFICATION,
         vol.Schema(
             {
-                vol.Required(ATTR_LIST): cv.entities_domain(DOMAIN_TODO),
+                vol.Required(ATTR_ENTITY_ID): cv.entities_domain(DOMAIN_TODO),
                 vol.Required(ATTR_NOTIFICATION_TYPE): vol.All(
                     vol.Upper, cv.enum(BringNotificationType)
                 ),
@@ -264,13 +264,12 @@ class BringTodoListEntity(
     ) -> None:
         """Send a push notification to members of the To-Do list."""
         try:
-            await self.hass.async_add_executor_job(
-                self.coordinator.bring.notify,
-                self.bring_list["listUuid"],
-                notification_type,
-                item_name or "",
+            await self.coordinator.bring.notifyAsync(
+                self.bring_list["listUuid"], notification_type, item_name or None
             )
         except BringRequestException as e:
             raise HomeAssistantError(
                 "Unable to send push notification for bring"
             ) from e
+        except ValueError as e:
+            raise HomeAssistantError("Item name required") from e

--- a/homeassistant/components/bring/todo.py
+++ b/homeassistant/components/bring/todo.py
@@ -263,9 +263,13 @@ class BringTodoListEntity(
         item_name: str | None = None,
     ) -> None:
         """Send a push notification to members of the To-Do list."""
+        if notification_type is BringNotificationType.URGENT_MESSAGE and not item_name:
+            raise HomeAssistantError(
+                "Item name is required for Breaking news notification"
+            )
         try:
-            await self.coordinator.bring.notifyAsync(
-                self.bring_list["listUuid"], notification_type, item_name or None
+            await self.coordinator.bring.notify(
+                self._list_uuid, notification_type, item_name or None
             )
         except BringRequestException as e:
             raise HomeAssistantError(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a notification service to the Bring component 

The Bring App supports sending 4 types of predefined push notifications to other members of a shared shopping list. This adds an entity service to invoke these notifications from Home Assistant.

Documentation PR: 
https://github.com/home-assistant/home-assistant.io/pull/31522
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/31522

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x]  The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
