### PR TITLE
Don't log warning for core integrations on new feature flags in Climate

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -339,6 +339,9 @@ class ClimateEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
 
         def _report_turn_on_off(feature: str, method: str) -> None:
             """Log warning not implemented turn on/off feature."""
+            module = type(self).__module__
+            if module and "custom_components" not in module:
+                return
             report_issue = self._suggest_report_issue()
             if feature.startswith("TURN"):
                 message = (

--- a/tests/components/climate/test_init.py
+++ b/tests/components/climate/test_init.py
@@ -743,9 +743,6 @@ async def test_no_warning_on_core_integrations_for_on_off_feature_flags(
     assert state is not None
 
     assert (
-        "Entity climate.test (<class 'homeassistant.components.test.climate."
-        "test_no_warning_on_core_integrations_for_on_off_feature_flags.<locals>.MockClimateEntityTest'>)"
-        " does not set ClimateEntityFeature.TURN_OFF but implements the turn_off method."
-        " Please report it to the author of the 'test' custom integration"
-        in caplog.text
+        "does not set ClimateEntityFeature.TURN_OFF but implements the turn_off method."
+        not in caplog.text
     )

--- a/tests/components/climate/test_init.py
+++ b/tests/components/climate/test_init.py
@@ -684,3 +684,68 @@ async def test_no_warning_integration_has_migrated(
         " implements HVACMode(s): off, heat and therefore implicitly supports the off, heat methods"
         not in caplog.text
     )
+
+
+async def test_no_warning_on_core_integrations_for_on_off_feature_flags(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, config_flow_fixture: None
+) -> None:
+    """Test we don't warn on core integration on new turn_on/off feature flags."""
+
+    class MockClimateEntityTest(MockClimateEntity):
+        """Mock Climate device."""
+
+        def turn_on(self) -> None:
+            """Turn on."""
+
+        def turn_off(self) -> None:
+            """Turn off."""
+
+    async def async_setup_entry_init(
+        hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> bool:
+        """Set up test config entry."""
+        await hass.config_entries.async_forward_entry_setups(config_entry, [DOMAIN])
+        return True
+
+    async def async_setup_entry_climate_platform(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddEntitiesCallback,
+    ) -> None:
+        """Set up test climate platform via config entry."""
+        async_add_entities(
+            [MockClimateEntityTest(name="test", entity_id="climate.test")]
+        )
+
+    mock_integration(
+        hass,
+        MockModule(
+            "test",
+            async_setup_entry=async_setup_entry_init,
+        ),
+        built_in=False,
+    )
+    mock_platform(
+        hass,
+        "test.climate",
+        MockPlatform(async_setup_entry=async_setup_entry_climate_platform),
+    )
+
+    with patch.object(
+        MockClimateEntityTest, "__module__", "homeassistant.components.test.climate"
+    ):
+        config_entry = MockConfigEntry(domain="test")
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("climate.test")
+    assert state is not None
+
+    assert (
+        "Entity climate.test (<class 'homeassistant.components.test.climate."
+        "test_no_warning_on_core_integrations_for_on_off_feature_flags.<locals>.MockClimateEntityTest'>)"
+        " does not set ClimateEntityFeature.TURN_OFF but implements the turn_off method."
+        " Please report it to the author of the 'test' custom integration"
+        in caplog.text
+    )

--- a/tests/components/climate/test_init.py
+++ b/tests/components/climate/test_init.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from enum import Enum
 from types import ModuleType
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 import voluptuous as vol
@@ -415,23 +415,26 @@ async def test_warning_not_implemented_turn_on_off_feature(
         MockPlatform(async_setup_entry=async_setup_entry_climate_platform),
     )
 
-    config_entry = MockConfigEntry(domain="test")
-    config_entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    with patch.object(
+        MockClimateEntityTest, "__module__", "tests.custom_components.climate.test_init"
+    ):
+        config_entry = MockConfigEntry(domain="test")
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
     state = hass.states.get("climate.test")
     assert state is not None
 
     assert (
-        "Entity climate.test (<class 'tests.components.climate.test_init."
+        "Entity climate.test (<class 'tests.custom_components.climate.test_init."
         "test_warning_not_implemented_turn_on_off_feature.<locals>.MockClimateEntityTest'>)"
         " does not set ClimateEntityFeature.TURN_OFF but implements the turn_off method."
         " Please report it to the author of the 'test' custom integration"
         in caplog.text
     )
     assert (
-        "Entity climate.test (<class 'tests.components.climate.test_init."
+        "Entity climate.test (<class 'tests.custom_components.climate.test_init."
         "test_warning_not_implemented_turn_on_off_feature.<locals>.MockClimateEntityTest'>)"
         " does not set ClimateEntityFeature.TURN_ON but implements the turn_on method."
         " Please report it to the author of the 'test' custom integration"
@@ -520,16 +523,19 @@ async def test_implicit_warning_not_implemented_turn_on_off_feature(
         MockPlatform(async_setup_entry=async_setup_entry_climate_platform),
     )
 
-    config_entry = MockConfigEntry(domain="test")
-    config_entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    with patch.object(
+        MockClimateEntityTest, "__module__", "tests.custom_components.climate.test_init"
+    ):
+        config_entry = MockConfigEntry(domain="test")
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
     state = hass.states.get("climate.test")
     assert state is not None
 
     assert (
-        "Entity climate.test (<class 'tests.components.climate.test_init."
+        "Entity climate.test (<class 'tests.custom_components.climate.test_init."
         "test_implicit_warning_not_implemented_turn_on_off_feature.<locals>.MockClimateEntityTest'>)"
         " implements HVACMode(s): off, heat and therefore implicitly supports the turn_on/turn_off"
         " methods without setting the proper ClimateEntityFeature. Please report it to the author"
@@ -584,10 +590,13 @@ async def test_no_warning_implemented_turn_on_off_feature(
         MockPlatform(async_setup_entry=async_setup_entry_climate_platform),
     )
 
-    config_entry = MockConfigEntry(domain="test")
-    config_entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    with patch.object(
+        MockClimateEntityTest, "__module__", "tests.custom_components.climate.test_init"
+    ):
+        config_entry = MockConfigEntry(domain="test")
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
     state = hass.states.get("climate.test")
     assert state is not None
@@ -652,10 +661,13 @@ async def test_no_warning_integration_has_migrated(
         MockPlatform(async_setup_entry=async_setup_entry_climate_platform),
     )
 
-    config_entry = MockConfigEntry(domain="test")
-    config_entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    with patch.object(
+        MockClimateEntityTest, "__module__", "tests.custom_components.climate.test_init"
+    ):
+        config_entry = MockConfigEntry(domain="test")
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
     state = hass.states.get("climate.test")
     assert state is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

All core integrations should be updated before release

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
