### PR TITLE
Fix ZHA update entity not updating installed version

### DIFF
--- a/homeassistant/components/zha/update.py
+++ b/homeassistant/components/zha/update.py
@@ -122,6 +122,7 @@ class ZHAFirmwareUpdateEntity(ZhaEntity, UpdateEntity):
         self._latest_version_firmware = image
         self._attr_latest_version = f"0x{image.header.file_version:08x}"
         self._image_type = image.header.image_type
+        self._attr_installed_version = self.determine_installed_version()
         self.async_write_ha_state()
 
     @callback

--- a/tests/components/zha/test_update.py
+++ b/tests/components/zha/test_update.py
@@ -108,12 +108,18 @@ async def setup_test_data(
     return zha_device, cluster, fw_image, installed_fw_version
 
 
+@pytest.mark.parametrize("initial_version_unknown", (False, True))
 async def test_firmware_update_notification_from_zigpy(
-    hass: HomeAssistant, zha_device_joined_restored, zigpy_device
+    hass: HomeAssistant,
+    zha_device_joined_restored,
+    zigpy_device,
+    initial_version_unknown,
 ) -> None:
     """Test ZHA update platform - firmware update notification."""
     zha_device, cluster, fw_image, installed_fw_version = await setup_test_data(
-        zha_device_joined_restored, zigpy_device
+        zha_device_joined_restored,
+        zigpy_device,
+        skip_attribute_plugs=initial_version_unknown,
     )
 
     entity_id = find_entity_id(Platform.UPDATE, zha_device, hass)


### PR DESCRIPTION
## Proposed change
This fixes an issue where the ZHA update entity can show "unknown" for the currently installed version when there's a firmware update available.

I've also modified a test case to not plug the zigpy cache with `current_file_version`, but rather let ZHA get it from the "query image" command (checking the HA device registry that's updated on "query img").
That catches the issue fixed by this PR. The original test with plugging the attribute is also kept.

### Background

Currently, the state for the update entity only gets set/calculated when the entity is initialized.
It looks like that if there's no installed firmware version in the HA device registry and also not in the zigpy attribute cache, this gets set to "unknown".
(Even though `ZCL_INIT_ATTRS` should have initialized the `current_file_version` attribute, but maybe network issued led to a case where it didn't at first or only did when the entity was already initialized?)

If the HA "check for updates" button is then used, an image notify command is sent to all devices and the devices respond with a command querying for an update.
That causes the `OtaClientClusterHandler` to send a `SIGNAL_UPDATE_DEVICE`.
`ZHADevice/async_update_sw_build_id()` picks that up and updates the firmware version in the HA device registry.

Now, if zigpy sees that there's an update available, it calls `device_ota_update_available()` in `ZHAFirmwareUpdateEntity`.
Here, this PR now also re-determines the currently installed version.

Screenshot of the issue (installed version: unknown, new version: correct):
![image](https://github.com/home-assistant/core/assets/6409465/993e1204-662a-4948-8c41-981c954017d4)

### Future

IMO, we could also consider zigpy (or ZHA?) directly updating the attribute cache for the `current_file_version` attribute when it gets a `query_next_image` command. (This would also be useful for quirks, as the current sw version is only inside the HA device registry.)
The ZHA update entity could then listen to a signal from `attribute_updated` in the OTA cluster handler and refresh the installed version of the entity when new information about that is available.

For now, this PR fixes the issue where "unknown" (or an outdated version) could be shown as the installed version IF there's an update available.

(`device_ota_update_available()` isn't called when there's no update available, thus the installed version not refreshed, even if it somehow changed (pairing to manufacturer hub to update, then re-pairing to HA without removing).
This would be addressed by the bigger changes I mentioned above where the entity always gets refreshed on a query image command -> updating zigpy attribute -> sending signal from OTA cluster -> updating update entity)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
