### PR TITLE
Restore support for packages being installed from urls with fragments

### DIFF
--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -53,7 +53,7 @@ def is_installed(requirement_str: str) -> bool:
         try:
             # fragment support was originally used to install zip files, and
             # we no longer do this in Home Assistant. However, custom
-            # components started using it to installed packages from git
+            # components started using it to install packages from git
             # urls with a fragment because it worked so it would be a breaking
             # change to remove it.
             # example: git+https://github.com/pypa/pip#pip>=1

--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -41,6 +41,9 @@ def is_installed(requirement_str: str) -> bool:
     expected input is a pip compatible package specifier (requirement string)
     e.g. "package==1.0.0" or "package>=1.0.0,<2.0.0"
 
+    For backward compatibility, it also accepts a URL with a fragment
+    e.g. "git+https://github.com/pypa/pip#pip>=1"
+
     Returns True when the requirement is met.
     Returns False when the package is not installed or doesn't meet req.
     """
@@ -48,6 +51,11 @@ def is_installed(requirement_str: str) -> bool:
         req = Requirement(requirement_str)
     except InvalidRequirement:
         try:
+            # This was originally used to install zip files, and
+            # we no longer use this in Home Assistant. However, custom
+            # components use it to installed packages from git
+            # urls with a fragment.
+            # example: git+https://github.com/pypa/pip#pip>=1
             req = Requirement(urlparse(requirement_str).fragment)
         except InvalidRequirement:
             _LOGGER.error("Invalid requirement '%s'", requirement_str)

--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -9,6 +9,7 @@ import os
 from pathlib import Path
 from subprocess import PIPE, Popen
 import sys
+from urllib.parse import urlparse
 
 from packaging.requirements import InvalidRequirement, Requirement
 
@@ -46,8 +47,11 @@ def is_installed(requirement_str: str) -> bool:
     try:
         req = Requirement(requirement_str)
     except InvalidRequirement:
-        _LOGGER.error("Invalid requirement '%s'", requirement_str)
-        return False
+        try:
+            req = Requirement(urlparse(requirement_str).fragment)
+        except InvalidRequirement:
+            _LOGGER.error("Invalid requirement '%s'", requirement_str)
+            return False
 
     try:
         if (installed_version := version(req.name)) is None:

--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -51,10 +51,11 @@ def is_installed(requirement_str: str) -> bool:
         req = Requirement(requirement_str)
     except InvalidRequirement:
         try:
-            # This was originally used to install zip files, and
-            # we no longer use this in Home Assistant. However, custom
-            # components use it to installed packages from git
-            # urls with a fragment.
+            # fragment support was originally used to install zip files, and
+            # we no longer do this in Home Assistant. However, custom
+            # components started using it to installed packages from git
+            # urls with a fragment because it worked so it would be a breaking
+            # change to remove it.
             # example: git+https://github.com/pypa/pip#pip>=1
             req = Requirement(urlparse(requirement_str).fragment)
         except InvalidRequirement:

--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -54,8 +54,8 @@ def is_installed(requirement_str: str) -> bool:
             # fragment support was originally used to install zip files, and
             # we no longer do this in Home Assistant. However, custom
             # components started using it to install packages from git
-            # urls with a fragment because it worked so it would be a breaking
-            # change to remove it.
+            # urls which would make it would be a breaking change to
+            # remove it.
             # example: git+https://github.com/pypa/pip#pip>=1
             req = Requirement(urlparse(requirement_str).fragment)
         except InvalidRequirement:

--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -47,19 +47,22 @@ def is_installed(requirement_str: str) -> bool:
     Returns True when the requirement is met.
     Returns False when the package is not installed or doesn't meet req.
     """
+    if "#" in requirement_str:
+        # This is a URL with a fragment
+        # example: git+https://github.com/pypa/pip#pip>=1
+
+        # This was originally used to install zip files, and
+        # we no longer use this in Home Assistant. However, custom
+        # components use it to installed packages from git
+        # urls with a fragment.
+
+        requirement_str = urlparse(requirement_str).fragment
+
     try:
         req = Requirement(requirement_str)
     except InvalidRequirement:
-        try:
-            # This was originally used to install zip files, and
-            # we no longer use this in Home Assistant. However, custom
-            # components use it to installed packages from git
-            # urls with a fragment.
-            # example: git+https://github.com/pypa/pip#pip>=1
-            req = Requirement(urlparse(requirement_str).fragment)
-        except InvalidRequirement:
-            _LOGGER.error("Invalid requirement '%s'", requirement_str)
-            return False
+        _LOGGER.error("Invalid requirement '%s'", requirement_str)
+        return False
 
     try:
         if (installed_version := version(req.name)) is None:

--- a/tests/util/test_package.py
+++ b/tests/util/test_package.py
@@ -21,6 +21,8 @@ TEST_ZIP_REQ = "file://{}#{}".format(
     os.path.join(RESOURCE_DIR, "pyhelloworld3.zip"), TEST_NEW_REQ
 )
 
+TEST_GIT_REQ = "git+https://github.com/pypa/pip#pip>=1"
+
 
 @pytest.fixture
 def mock_sys():
@@ -230,9 +232,10 @@ def test_check_package_global() -> None:
     assert not package.is_installed(f"{installed_package}<{installed_version}")
 
 
-def test_check_package_zip() -> None:
-    """Test for an installed zip package."""
+def test_check_package_fragment() -> None:
+    """Test for an installed package with a fragment."""
     assert not package.is_installed(TEST_ZIP_REQ)
+    assert package.is_installed(TEST_GIT_REQ)
 
 
 def test_get_is_installed() -> None:

--- a/tests/util/test_package.py
+++ b/tests/util/test_package.py
@@ -21,8 +21,6 @@ TEST_ZIP_REQ = "file://{}#{}".format(
     os.path.join(RESOURCE_DIR, "pyhelloworld3.zip"), TEST_NEW_REQ
 )
 
-TEST_GIT_REQ = "git+https://github.com/pypa/pip#pip>=1"
-
 
 @pytest.fixture
 def mock_sys():
@@ -219,7 +217,7 @@ async def test_async_get_user_site(mock_env_copy) -> None:
     assert ret == os.path.join(deps_dir, "lib_dir")
 
 
-def test_check_package_global() -> None:
+def test_check_package_global(caplog: pytest.LogCaptureFixture) -> None:
     """Test for an installed package."""
     pkg = metadata("homeassistant")
     installed_package = pkg["name"]
@@ -231,11 +229,19 @@ def test_check_package_global() -> None:
     assert package.is_installed(f"{installed_package}<={installed_version}")
     assert not package.is_installed(f"{installed_package}<{installed_version}")
 
+    assert package.is_installed("-1 invalid_package") is False
+    assert "Invalid requirement '-1 invalid_package'" in caplog.text
 
-def test_check_package_fragment() -> None:
+
+def test_check_package_fragment(caplog: pytest.LogCaptureFixture) -> None:
     """Test for an installed package with a fragment."""
     assert not package.is_installed(TEST_ZIP_REQ)
-    assert package.is_installed(TEST_GIT_REQ)
+    assert package.is_installed("git+https://github.com/pypa/pip#pip>=1")
+    assert not package.is_installed("git+https://github.com/pypa/pip#-1 invalid")
+    assert (
+        "Invalid requirement 'git+https://github.com/pypa/pip#-1 invalid'"
+        in caplog.text
+    )
 
 
 def test_get_is_installed() -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a partial revert of #107427

This was removed because it was assumed nobody was using the old zip method anymore but it turns out this was also being used for git urls with fragments in custom components. As this wasn't expected to be a breaking change, revert the removal (along with some comments and tests so we know its not only zip files) to restore support for it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
