### PR TITLE
Fix ZHA creating unnecessary "summ received" entity after upgrade

### DIFF
--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -838,6 +838,26 @@ class SmartEnergySummationReceived(PolledSmartEnergySummation):
     _unique_id_suffix = "summation_received"
     _attr_translation_key: str = "summation_received"
 
+    @classmethod
+    def create_entity(
+        cls,
+        unique_id: str,
+        zha_device: ZHADevice,
+        cluster_handlers: list[ClusterHandler],
+        **kwargs: Any,
+    ) -> Self | None:
+        """Entity Factory.
+
+        This attribute only started to be initialized in HA 2024.2.0,
+        so the entity would still be created on the first HA start after the upgrade for existing devices,
+        as the initialization to see if an attribute is unsupported happens later in the background.
+        To avoid creating a lot of unnecessary entities for existing devices,
+        wait until the attribute was properly initialized once for now.
+        """
+        if cluster_handlers[0].cluster.get(cls._attribute_name) is None:
+            return None
+        return super().create_entity(unique_id, zha_device, cluster_handlers, **kwargs)
+
 
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_PRESSURE)
 # pylint: disable-next=hass-invalid-inheritance # needs fixing

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -846,7 +846,6 @@ async def test_electrical_measurement_init(
             },
             {
                 "summation_delivered",
-                "summation_received",
             },
             {
                 "instantaneous_demand",
@@ -854,12 +853,11 @@ async def test_electrical_measurement_init(
         ),
         (
             smartenergy.Metering.cluster_id,
-            {"instantaneous_demand", "current_summ_delivered", "current_summ_received"},
+            {"instantaneous_demand", "current_summ_delivered"},
             {},
             {
                 "instantaneous_demand",
                 "summation_delivered",
-                "summation_received",
             },
         ),
         (
@@ -868,7 +866,6 @@ async def test_electrical_measurement_init(
             {
                 "instantaneous_demand",
                 "summation_delivered",
-                "summation_received",
             },
             {},
         ),

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -368,6 +368,7 @@ async def async_test_pi_heating_demand(hass, cluster, entity_id):
         "report_count",
         "read_plug",
         "unsupported_attrs",
+        "initial_sensor_state",
     ),
     (
         (
@@ -377,6 +378,7 @@ async def async_test_pi_heating_demand(hass, cluster, entity_id):
             1,
             None,
             None,
+            STATE_UNKNOWN,
         ),
         (
             measurement.TemperatureMeasurement.cluster_id,
@@ -385,6 +387,7 @@ async def async_test_pi_heating_demand(hass, cluster, entity_id):
             1,
             None,
             None,
+            STATE_UNKNOWN,
         ),
         (
             measurement.PressureMeasurement.cluster_id,
@@ -393,6 +396,7 @@ async def async_test_pi_heating_demand(hass, cluster, entity_id):
             1,
             None,
             None,
+            STATE_UNKNOWN,
         ),
         (
             measurement.IlluminanceMeasurement.cluster_id,
@@ -401,6 +405,7 @@ async def async_test_pi_heating_demand(hass, cluster, entity_id):
             1,
             None,
             None,
+            STATE_UNKNOWN,
         ),
         (
             smartenergy.Metering.cluster_id,
@@ -415,6 +420,7 @@ async def async_test_pi_heating_demand(hass, cluster, entity_id):
                 "status": 0x00,
             },
             {"current_summ_delivered", "current_summ_received"},
+            STATE_UNKNOWN,
         ),
         (
             smartenergy.Metering.cluster_id,
@@ -431,6 +437,7 @@ async def async_test_pi_heating_demand(hass, cluster, entity_id):
                 "unit_of_measure": 0x00,
             },
             {"instaneneous_demand", "current_summ_received"},
+            STATE_UNKNOWN,
         ),
         (
             smartenergy.Metering.cluster_id,
@@ -445,8 +452,10 @@ async def async_test_pi_heating_demand(hass, cluster, entity_id):
                 "status": 0x00,
                 "summation_formatting": 0b1_0111_010,
                 "unit_of_measure": 0x00,
+                "current_summ_received": 0,
             },
             {"instaneneous_demand", "current_summ_delivered"},
+            "0.0",
         ),
         (
             homeautomation.ElectricalMeasurement.cluster_id,
@@ -455,6 +464,7 @@ async def async_test_pi_heating_demand(hass, cluster, entity_id):
             7,
             {"ac_power_divisor": 1000, "ac_power_multiplier": 1},
             {"apparent_power", "rms_current", "rms_voltage"},
+            STATE_UNKNOWN,
         ),
         (
             homeautomation.ElectricalMeasurement.cluster_id,
@@ -463,6 +473,7 @@ async def async_test_pi_heating_demand(hass, cluster, entity_id):
             7,
             {"ac_power_divisor": 1000, "ac_power_multiplier": 1},
             {"active_power", "rms_current", "rms_voltage"},
+            STATE_UNKNOWN,
         ),
         (
             homeautomation.ElectricalMeasurement.cluster_id,
@@ -471,6 +482,7 @@ async def async_test_pi_heating_demand(hass, cluster, entity_id):
             7,
             {"ac_power_divisor": 1000, "ac_power_multiplier": 1},
             {"active_power", "apparent_power", "rms_current", "rms_voltage"},
+            STATE_UNKNOWN,
         ),
         (
             homeautomation.ElectricalMeasurement.cluster_id,
@@ -479,6 +491,7 @@ async def async_test_pi_heating_demand(hass, cluster, entity_id):
             7,
             {"ac_current_divisor": 1000, "ac_current_multiplier": 1},
             {"active_power", "apparent_power", "rms_voltage"},
+            STATE_UNKNOWN,
         ),
         (
             homeautomation.ElectricalMeasurement.cluster_id,
@@ -487,6 +500,7 @@ async def async_test_pi_heating_demand(hass, cluster, entity_id):
             7,
             {"ac_voltage_divisor": 10, "ac_voltage_multiplier": 1},
             {"active_power", "apparent_power", "rms_current"},
+            STATE_UNKNOWN,
         ),
         (
             general.PowerConfiguration.cluster_id,
@@ -499,6 +513,7 @@ async def async_test_pi_heating_demand(hass, cluster, entity_id):
                 "battery_quantity": 3,
             },
             None,
+            STATE_UNKNOWN,
         ),
         (
             general.PowerConfiguration.cluster_id,
@@ -511,6 +526,7 @@ async def async_test_pi_heating_demand(hass, cluster, entity_id):
                 "battery_quantity": 3,
             },
             None,
+            STATE_UNKNOWN,
         ),
         (
             general.DeviceTemperature.cluster_id,
@@ -519,6 +535,7 @@ async def async_test_pi_heating_demand(hass, cluster, entity_id):
             1,
             None,
             None,
+            STATE_UNKNOWN,
         ),
         (
             hvac.Thermostat.cluster_id,
@@ -527,6 +544,7 @@ async def async_test_pi_heating_demand(hass, cluster, entity_id):
             10,
             None,
             None,
+            STATE_UNKNOWN,
         ),
         (
             hvac.Thermostat.cluster_id,
@@ -535,6 +553,7 @@ async def async_test_pi_heating_demand(hass, cluster, entity_id):
             10,
             None,
             None,
+            STATE_UNKNOWN,
         ),
     ),
 )
@@ -548,6 +567,7 @@ async def test_sensor(
     report_count,
     read_plug,
     unsupported_attrs,
+    initial_sensor_state,
 ) -> None:
     """Test ZHA sensor platform."""
 
@@ -582,8 +602,8 @@ async def test_sensor(
     # allow traffic to flow through the gateway and devices
     await async_enable_traffic(hass, [zha_device])
 
-    # test that the sensor now have a state of unknown
-    assert hass.states.get(entity_id).state == STATE_UNKNOWN
+    # test that the sensor now have their correct initial state (mostly unknown)
+    assert hass.states.get(entity_id).state == initial_sensor_state
 
     # test sensor associated logic
     await test_func(hass, cluster, entity_id)

--- a/tests/components/zha/zha_devices_list.py
+++ b/tests/components/zha/zha_devices_list.py
@@ -243,11 +243,6 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.centralite_3210_l_summation_delivered",
             },
-            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_received"): {
-                DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
-                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
-                DEV_SIG_ENT_MAP_ID: "sensor.centralite_3210_l_summation_received",
-            },
             ("sensor", "00:11:22:33:44:55:66:77-1-0-rssi"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["basic"],
                 DEV_SIG_ENT_MAP_CLASS: "RSSISensor",
@@ -614,13 +609,6 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: (
                     "sensor.climaxtechnology_psmp5_00_00_02_02tc_summation_delivered"
-                ),
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_received"): {
-                DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
-                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
-                DEV_SIG_ENT_MAP_ID: (
-                    "sensor.climaxtechnology_psmp5_00_00_02_02tc_summation_received"
                 ),
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-0-rssi"): {
@@ -1617,11 +1605,6 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.jasco_products_45852_summation_delivered",
             },
-            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_received"): {
-                DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
-                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
-                DEV_SIG_ENT_MAP_ID: "sensor.jasco_products_45852_summation_received",
-            },
             ("sensor", "00:11:22:33:44:55:66:77-1-0-rssi"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["basic"],
                 DEV_SIG_ENT_MAP_CLASS: "RSSISensor",
@@ -1682,11 +1665,6 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.jasco_products_45856_summation_delivered",
             },
-            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_received"): {
-                DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
-                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
-                DEV_SIG_ENT_MAP_ID: "sensor.jasco_products_45856_summation_received",
-            },
             ("sensor", "00:11:22:33:44:55:66:77-1-0-rssi"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["basic"],
                 DEV_SIG_ENT_MAP_CLASS: "RSSISensor",
@@ -1746,11 +1724,6 @@ DEVICES = [
                 DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.jasco_products_45857_summation_delivered",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_received"): {
-                DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
-                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
-                DEV_SIG_ENT_MAP_ID: "sensor.jasco_products_45857_summation_received",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-0-rssi"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["basic"],
@@ -2369,11 +2342,6 @@ DEVICES = [
                 DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_relay_c2acn01_summation_delivered",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_received"): {
-                DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
-                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
-                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_relay_c2acn01_summation_received",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-1794"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
@@ -4511,11 +4479,6 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.sercomm_corp_sz_esw01_summation_delivered",
             },
-            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_received"): {
-                DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
-                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
-                DEV_SIG_ENT_MAP_ID: "sensor.sercomm_corp_sz_esw01_summation_received",
-            },
             ("sensor", "00:11:22:33:44:55:66:77-1-0-rssi"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["basic"],
                 DEV_SIG_ENT_MAP_CLASS: "RSSISensor",
@@ -5362,11 +5325,6 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.sengled_e11_g13_summation_delivered",
             },
-            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_received"): {
-                DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
-                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
-                DEV_SIG_ENT_MAP_ID: "sensor.sengled_e11_g13_summation_received",
-            },
             ("sensor", "00:11:22:33:44:55:66:77-1-0-rssi"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["basic"],
                 DEV_SIG_ENT_MAP_CLASS: "RSSISensor",
@@ -5420,11 +5378,6 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.sengled_e12_n14_summation_delivered",
             },
-            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_received"): {
-                DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
-                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
-                DEV_SIG_ENT_MAP_ID: "sensor.sengled_e12_n14_summation_received",
-            },
             ("sensor", "00:11:22:33:44:55:66:77-1-0-rssi"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["basic"],
                 DEV_SIG_ENT_MAP_CLASS: "RSSISensor",
@@ -5477,11 +5430,6 @@ DEVICES = [
                 DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.sengled_z01_a19nae26_summation_delivered",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_received"): {
-                DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
-                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
-                DEV_SIG_ENT_MAP_ID: "sensor.sengled_z01_a19nae26_summation_received",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-0-rssi"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["basic"],


### PR DESCRIPTION
## Proposed change
Do not create the ZHA `current_summ_received` entity until initialized once to avoid unnecessary/ghost entities.

The `current_summ_received` attribute only started to be initialized in HA 2024.2.0.
Due to ZHA attribute initialization happening in the background for existing devices (to read the attribute and see if it's supported/unsupported), this entity would always get created directly after the upgrade for all power-measuring devices.
If HA is then restarted, the entity would turn into a ghost entity, as ZHA then detected that it's unsupported.

To avoid creating a lot of unnecessary entities for existing devices, this PR waits until that specific attribute was properly initialized once for now before creating the entity.
We can't do this for all (sensor) entities, as we want some entities to be created, even if no report was sent yet. Our test cases also test for that behavior.

This is relevant for HA Core 2024.2.0 (betas), so also marked this for 2024.2.0 to avoid the issue of creating that entity unnecessarily.
For anyone affected on current betas, the ghost entity can be removed using the UI.


### Tests

Due to this entity differing from our other "normal" (non-diagnostic) entities (which are always created, even if the attribute isn't initialized), I've had to adapt the tests for this new behavior.
More details are provided in a commit message where the tests are updated.

The entities are removed from the ZHA devices list, as the attributes are all `None` there by default, so this entity isn't created in that case.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/107576
   (and kind of: https://github.com/zigpy/zha-device-handlers/issues/2549)
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added (modified) to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
