### PR TITLE
Migrate to new intent error response keys

### DIFF
--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -12,22 +12,15 @@ import re
 from typing import IO, Any
 
 from hassil.expression import Expression, ListReference, Sequence
-from hassil.intents import (
-    Intents,
-    ResponseType,
-    SlotList,
-    TextSlotList,
-    WildcardSlotList,
-)
+from hassil.intents import Intents, SlotList, TextSlotList, WildcardSlotList
 from hassil.recognize import (
     MISSING_ENTITY,
     RecognizeResult,
-    UnmatchedEntity,
     UnmatchedTextEntity,
     recognize_all,
 )
 from hassil.util import merge_dict
-from home_assistant_intents import get_intents, get_languages
+from home_assistant_intents import ErrorKey, get_intents, get_languages
 import yaml
 
 from homeassistant import core, setup
@@ -259,7 +252,7 @@ class DefaultAgent(AbstractConversationAgent):
             return _make_error_result(
                 language,
                 intent.IntentResponseErrorCode.NO_INTENT_MATCH,
-                self._get_error_text(ResponseType.NO_INTENT, lang_intents),
+                self._get_error_text(ErrorKey.NO_INTENT, lang_intents),
                 conversation_id,
             )
 
@@ -273,9 +266,7 @@ class DefaultAgent(AbstractConversationAgent):
                 else "",
                 result.unmatched_entities_list,
             )
-            error_response_type, error_response_args = _get_unmatched_response(
-                result.unmatched_entities
-            )
+            error_response_type, error_response_args = _get_unmatched_response(result)
             return _make_error_result(
                 language,
                 intent.IntentResponseErrorCode.NO_VALID_TARGETS,
@@ -325,7 +316,7 @@ class DefaultAgent(AbstractConversationAgent):
             return _make_error_result(
                 language,
                 intent.IntentResponseErrorCode.FAILED_TO_HANDLE,
-                self._get_error_text(ResponseType.HANDLE_ERROR, lang_intents),
+                self._get_error_text(ErrorKey.HANDLE_ERROR, lang_intents),
                 conversation_id,
             )
         except intent.IntentUnexpectedError:
@@ -333,7 +324,7 @@ class DefaultAgent(AbstractConversationAgent):
             return _make_error_result(
                 language,
                 intent.IntentResponseErrorCode.UNKNOWN,
-                self._get_error_text(ResponseType.HANDLE_ERROR, lang_intents),
+                self._get_error_text(ErrorKey.HANDLE_ERROR, lang_intents),
                 conversation_id,
             )
 
@@ -795,7 +786,7 @@ class DefaultAgent(AbstractConversationAgent):
 
     def _get_error_text(
         self,
-        response_type: ResponseType,
+        error_key: ErrorKey,
         lang_intents: LanguageIntents | None,
         **response_args,
     ) -> str:
@@ -803,7 +794,7 @@ class DefaultAgent(AbstractConversationAgent):
         if lang_intents is None:
             return _DEFAULT_ERROR_TEXT
 
-        response_key = response_type.value
+        response_key = error_key.value
         response_str = (
             lang_intents.error_responses.get(response_key) or _DEFAULT_ERROR_TEXT
         )
@@ -916,59 +907,72 @@ def _make_error_result(
     return ConversationResult(response, conversation_id)
 
 
-def _get_unmatched_response(
-    unmatched_entities: dict[str, UnmatchedEntity],
-) -> tuple[ResponseType, dict[str, Any]]:
-    error_response_type = ResponseType.NO_INTENT
-    error_response_args: dict[str, Any] = {}
+def _get_unmatched_response(result: RecognizeResult) -> tuple[ErrorKey, dict[str, Any]]:
+    """Get key and template arguments for error when there are unmatched intent entities/slots."""
 
-    if unmatched_name := unmatched_entities.get("name"):
-        # Unmatched device or entity
-        assert isinstance(unmatched_name, UnmatchedTextEntity)
-        error_response_type = ResponseType.NO_ENTITY
-        error_response_args["entity"] = unmatched_name.text
+    # Filter out non-text and missing context entities
+    unmatched_text: dict[str, str] = {
+        key: entity.text.strip()
+        for key, entity in result.unmatched_entities.items()
+        if isinstance(entity, UnmatchedTextEntity) and entity.text != MISSING_ENTITY
+    }
 
-    elif unmatched_area := unmatched_entities.get("area"):
-        # Unmatched area
-        assert isinstance(unmatched_area, UnmatchedTextEntity)
-        error_response_type = ResponseType.NO_AREA
-        error_response_args["area"] = unmatched_area.text
+    if unmatched_area := unmatched_text.get("area"):
+        # area only
+        return ErrorKey.NO_AREA, {"area": unmatched_area}
 
-    return error_response_type, error_response_args
+    # Area may still have matched
+    matched_area: str | None = None
+    if matched_area_entity := result.entities.get("area"):
+        matched_area = matched_area_entity.text.strip()
+
+    if unmatched_name := unmatched_text.get("name"):
+        if matched_area:
+            # device in area
+            return ErrorKey.NO_DEVICE_IN_AREA, {
+                "device": unmatched_name,
+                "area": matched_area,
+            }
+
+        # device only
+        return ErrorKey.NO_DEVICE, {"device": unmatched_name}
+
+    # Default error
+    return ErrorKey.NO_INTENT, {}
 
 
 def _get_no_states_matched_response(
     no_states_error: intent.NoStatesMatchedError,
-) -> tuple[ResponseType, dict[str, Any]]:
-    """Return error response type and template arguments for error."""
-    if not (
-        no_states_error.area
-        and (no_states_error.device_classes or no_states_error.domains)
-    ):
-        # Device class and domain must be paired with an area for the error
-        # message.
-        return ResponseType.NO_INTENT, {}
+) -> tuple[ErrorKey, dict[str, Any]]:
+    """Return key and template arguments for error when intent returns no matching states."""
 
-    error_response_args: dict[str, Any] = {"area": no_states_error.area}
-
-    # Check device classes first, since it's more specific than domain
+    # Device classes should be checked before domains
     if no_states_error.device_classes:
-        # No exposed entities of a particular class in an area.
-        # Example: "close the bedroom windows"
-        #
-        # Only use the first device class for the error message
-        error_response_args["device_class"] = next(iter(no_states_error.device_classes))
+        device_class = next(iter(no_states_error.device_classes))  # first device class
+        if no_states_error.area:
+            # device_class in area
+            return ErrorKey.NO_DEVICE_CLASS_IN_AREA, {
+                "device_class": device_class,
+                "area": no_states_error.area,
+            }
 
-        return ResponseType.NO_DEVICE_CLASS, error_response_args
+        # device_class only
+        return ErrorKey.NO_DEVICE_CLASS, {"device_class": device_class}
 
-    # No exposed entities of a domain in an area.
-    # Example: "turn on lights in kitchen"
-    assert no_states_error.domains
-    #
-    # Only use the first domain for the error message
-    error_response_args["domain"] = next(iter(no_states_error.domains))
+    if no_states_error.domains:
+        domain = next(iter(no_states_error.domains))  # first domain
+        if no_states_error.area:
+            # domain in area
+            return ErrorKey.NO_DOMAIN_IN_AREA, {
+                "domain": domain,
+                "area": no_states_error.area,
+            }
 
-    return ResponseType.NO_DOMAIN, error_response_args
+        # domain only
+        return ErrorKey.NO_DOMAIN, {"domain": domain}
+
+    # Default error
+    return ErrorKey.NO_INTENT, {}
 
 
 def _collect_list_references(expression: Expression, list_names: set[str]) -> None:

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -929,13 +929,13 @@ def _get_unmatched_response(result: RecognizeResult) -> tuple[ErrorKey, dict[str
     if unmatched_name := unmatched_text.get("name"):
         if matched_area:
             # device in area
-            return ErrorKey.NO_DEVICE_IN_AREA, {
-                "device": unmatched_name,
+            return ErrorKey.NO_ENTITY_IN_AREA, {
+                "entity": unmatched_name,
                 "area": matched_area,
             }
 
         # device only
-        return ErrorKey.NO_DEVICE, {"device": unmatched_name}
+        return ErrorKey.NO_ENTITY, {"entity": unmatched_name}
 
     # Default error
     return ErrorKey.NO_INTENT, {}

--- a/homeassistant/components/conversation/manifest.json
+++ b/homeassistant/components/conversation/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["hassil==1.6.0", "home-assistant-intents==2024.1.29"]
+  "requirements": ["hassil==1.6.0", "home-assistant-intents==2024.1.31"]
 }

--- a/homeassistant/components/conversation/manifest.json
+++ b/homeassistant/components/conversation/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["hassil==1.6.0", "home-assistant-intents==2024.1.31"]
+  "requirements": ["hassil==1.6.0", "home-assistant-intents==2024.2.1"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -29,7 +29,7 @@ hass-nabucasa==0.75.1
 hassil==1.6.0
 home-assistant-bluetooth==1.12.0
 home-assistant-frontend==20240131.0
-home-assistant-intents==2024.1.29
+home-assistant-intents==2024.1.31
 httpx==0.26.0
 ifaddr==0.2.0
 janus==1.0.0

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -29,7 +29,7 @@ hass-nabucasa==0.75.1
 hassil==1.6.0
 home-assistant-bluetooth==1.12.0
 home-assistant-frontend==20240131.0
-home-assistant-intents==2024.1.31
+home-assistant-intents==2024.2.1
 httpx==0.26.0
 ifaddr==0.2.0
 janus==1.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1062,7 +1062,7 @@ holidays==0.41
 home-assistant-frontend==20240131.0
 
 # homeassistant.components.conversation
-home-assistant-intents==2024.1.29
+home-assistant-intents==2024.1.31
 
 # homeassistant.components.home_connect
 homeconnect==0.7.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1062,7 +1062,7 @@ holidays==0.41
 home-assistant-frontend==20240131.0
 
 # homeassistant.components.conversation
-home-assistant-intents==2024.1.31
+home-assistant-intents==2024.2.1
 
 # homeassistant.components.home_connect
 homeconnect==0.7.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -858,7 +858,7 @@ holidays==0.41
 home-assistant-frontend==20240131.0
 
 # homeassistant.components.conversation
-home-assistant-intents==2024.1.29
+home-assistant-intents==2024.1.31
 
 # homeassistant.components.home_connect
 homeconnect==0.7.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -858,7 +858,7 @@ holidays==0.41
 home-assistant-frontend==20240131.0
 
 # homeassistant.components.conversation
-home-assistant-intents==2024.1.31
+home-assistant-intents==2024.2.1
 
 # homeassistant.components.home_connect
 homeconnect==0.7.2

--- a/tests/components/conversation/snapshots/test_init.ambr
+++ b/tests/components/conversation/snapshots/test_init.ambr
@@ -339,7 +339,7 @@
       'speech': dict({
         'plain': dict({
           'extra_data': None,
-          'speech': 'An unexpected error occurred while handling the intent',
+          'speech': 'An unexpected error occurred',
         }),
       }),
     }),
@@ -379,7 +379,7 @@
       'speech': dict({
         'plain': dict({
           'extra_data': None,
-          'speech': 'An unexpected error occurred while handling the intent',
+          'speech': 'An unexpected error occurred',
         }),
       }),
     }),
@@ -519,7 +519,7 @@
       'speech': dict({
         'plain': dict({
           'extra_data': None,
-          'speech': 'Sorry, I am not aware of any device or entity called late added alias',
+          'speech': 'Sorry, I am not aware of any device called late added alias',
         }),
       }),
     }),
@@ -539,7 +539,7 @@
       'speech': dict({
         'plain': dict({
           'extra_data': None,
-          'speech': 'Sorry, I am not aware of any device or entity called kitchen light',
+          'speech': 'Sorry, I am not aware of any device called kitchen light',
         }),
       }),
     }),
@@ -679,7 +679,7 @@
       'speech': dict({
         'plain': dict({
           'extra_data': None,
-          'speech': 'Sorry, I am not aware of any device or entity called late added light',
+          'speech': 'Sorry, I am not aware of any device called late added light',
         }),
       }),
     }),
@@ -759,7 +759,7 @@
       'speech': dict({
         'plain': dict({
           'extra_data': None,
-          'speech': 'Sorry, I am not aware of any device or entity called kitchen light',
+          'speech': 'Sorry, I am not aware of any device called kitchen light',
         }),
       }),
     }),
@@ -779,7 +779,7 @@
       'speech': dict({
         'plain': dict({
           'extra_data': None,
-          'speech': 'Sorry, I am not aware of any device or entity called my cool light',
+          'speech': 'Sorry, I am not aware of any device called my cool light',
         }),
       }),
     }),
@@ -919,7 +919,7 @@
       'speech': dict({
         'plain': dict({
           'extra_data': None,
-          'speech': 'Sorry, I am not aware of any device or entity called kitchen light',
+          'speech': 'Sorry, I am not aware of any device called kitchen light',
         }),
       }),
     }),
@@ -969,7 +969,7 @@
       'speech': dict({
         'plain': dict({
           'extra_data': None,
-          'speech': 'Sorry, I am not aware of any device or entity called renamed light',
+          'speech': 'Sorry, I am not aware of any device called renamed light',
         }),
       }),
     }),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**NOTE**: This PR will fail in CI until the intents PR has been merged: https://github.com/home-assistant/intents/pull/1906  Both PRs must be merged close in time to avoid breakages in nightly.

We are migrating intent error keys to be more precise, and adding some new ones. See the linked PR for a complete list and English versions of the error messages. This PR implements some of the new error codes and adds tests for them.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
