### PR TITLE
Improve color mode handling in MockLight

### DIFF
--- a/tests/components/group/test_light.py
+++ b/tests/components/group/test_light.py
@@ -279,6 +279,9 @@ async def test_brightness(
 
     entity1 = platform.ENTITIES[1]
     entity1.supported_features = SUPPORT_BRIGHTNESS
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity1.supported_color_modes = None
+    entity1.color_mode = None
 
     assert await async_setup_component(
         hass,
@@ -350,6 +353,9 @@ async def test_color_hs(hass: HomeAssistant, enable_custom_integrations: None) -
 
     entity1 = platform.ENTITIES[1]
     entity1.supported_features = SUPPORT_COLOR
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity1.supported_color_modes = None
+    entity1.color_mode = None
 
     assert await async_setup_component(
         hass,
@@ -698,6 +704,9 @@ async def test_color_temp(
 
     entity1 = platform.ENTITIES[1]
     entity1.supported_features = SUPPORT_COLOR_TEMP
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity1.supported_color_modes = None
+    entity1.color_mode = None
 
     assert await async_setup_component(
         hass,
@@ -838,6 +847,9 @@ async def test_min_max_mireds(
 
     entity1 = platform.ENTITIES[1]
     entity1.supported_features = SUPPORT_COLOR_TEMP
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity1.supported_color_modes = None
+    entity1.color_mode = None
     entity1._attr_min_color_temp_kelvin = 1
     entity1._attr_max_color_temp_kelvin = 1234567890
 
@@ -1015,6 +1027,9 @@ async def test_supported_color_modes(
 
     entity2 = platform.ENTITIES[2]
     entity2.supported_features = SUPPORT_BRIGHTNESS
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity2.supported_color_modes = None
+    entity2.color_mode = None
 
     assert await async_setup_component(
         hass,

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -127,6 +127,9 @@ async def test_services(
         | light.LightEntityFeature.EFFECT
         | light.LightEntityFeature.TRANSITION
     )
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    ent2.supported_color_modes = None
+    ent2.color_mode = None
     ent3.supported_features = (
         light.LightEntityFeature.FLASH | light.LightEntityFeature.TRANSITION
     )
@@ -905,9 +908,15 @@ async def test_light_brightness_step(
     platform.ENTITIES.append(platform.MockLight("Test_1", STATE_ON))
     entity0 = platform.ENTITIES[0]
     entity0.supported_features = light.SUPPORT_BRIGHTNESS
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity0.supported_color_modes = None
+    entity0.color_mode = None
     entity0.brightness = 100
     entity1 = platform.ENTITIES[1]
     entity1.supported_features = light.SUPPORT_BRIGHTNESS
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity1.supported_color_modes = None
+    entity1.color_mode = None
     entity1.brightness = 50
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -967,6 +976,9 @@ async def test_light_brightness_pct_conversion(
     platform.init()
     entity = platform.ENTITIES[0]
     entity.supported_features = light.SUPPORT_BRIGHTNESS
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity.supported_color_modes = None
+    entity.color_mode = None
     entity.brightness = 100
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1133,17 +1145,29 @@ async def test_light_backwards_compatibility_supported_color_modes(
 
     entity1 = platform.ENTITIES[1]
     entity1.supported_features = light.SUPPORT_BRIGHTNESS
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity1.supported_color_modes = None
+    entity1.color_mode = None
 
     entity2 = platform.ENTITIES[2]
     entity2.supported_features = light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR_TEMP
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity2.supported_color_modes = None
+    entity2.color_mode = None
 
     entity3 = platform.ENTITIES[3]
     entity3.supported_features = light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity3.supported_color_modes = None
+    entity3.color_mode = None
 
     entity4 = platform.ENTITIES[4]
     entity4.supported_features = (
         light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR | light.SUPPORT_COLOR_TEMP
     )
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity4.supported_color_modes = None
+    entity4.color_mode = None
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1204,20 +1228,32 @@ async def test_light_backwards_compatibility_color_mode(
 
     entity1 = platform.ENTITIES[1]
     entity1.supported_features = light.SUPPORT_BRIGHTNESS
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity1.supported_color_modes = None
+    entity1.color_mode = None
     entity1.brightness = 100
 
     entity2 = platform.ENTITIES[2]
     entity2.supported_features = light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR_TEMP
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity2.supported_color_modes = None
+    entity2.color_mode = None
     entity2.color_temp_kelvin = 10000
 
     entity3 = platform.ENTITIES[3]
     entity3.supported_features = light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity3.supported_color_modes = None
+    entity3.color_mode = None
     entity3.hs_color = (240, 100)
 
     entity4 = platform.ENTITIES[4]
     entity4.supported_features = (
         light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR | light.SUPPORT_COLOR_TEMP
     )
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity4.supported_color_modes = None
+    entity4.color_mode = None
     entity4.hs_color = (240, 100)
     entity4.color_temp_kelvin = 10000
 
@@ -1464,6 +1500,9 @@ async def test_light_service_call_color_conversion(
 
     entity4 = platform.ENTITIES[4]
     entity4.supported_features = light.SUPPORT_COLOR
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity4.supported_color_modes = None
+    entity4.color_mode = None
 
     entity5 = platform.ENTITIES[5]
     entity5.supported_color_modes = {light.ColorMode.RGBW}
@@ -1905,6 +1944,9 @@ async def test_light_service_call_color_conversion_named_tuple(
 
     entity4 = platform.ENTITIES[4]
     entity4.supported_features = light.SUPPORT_COLOR
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity4.supported_color_modes = None
+    entity4.color_mode = None
 
     entity5 = platform.ENTITIES[5]
     entity5.supported_color_modes = {light.ColorMode.RGBW}
@@ -2330,6 +2372,9 @@ async def test_light_state_color_conversion(
     entity3 = platform.ENTITIES[3]
     entity3.hs_color = (240, 100)
     entity3.supported_features = light.SUPPORT_COLOR
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity3.supported_color_modes = None
+    entity3.color_mode = None
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve color mode handling in MockLight such that `MockLight` no longer triggers the legacy compatibility mode in `LightEntity` for lights which don't support color modes

Some tests which were relying on the legacy behavior are also adjusted in this PR

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
