### PR TITLE
Update ruff to 0.1.15

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.8
+    rev: v0.1.15
     hooks:
       - id: ruff
         args:

--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -51,6 +51,7 @@ class PassiveBluetoothEntityKey:
     Example:
     key: temperature
     device_id: outdoor_sensor_1
+
     """
 
     key: str

--- a/homeassistant/components/easyenergy/diagnostics.py
+++ b/homeassistant/components/easyenergy/diagnostics.py
@@ -21,6 +21,7 @@ def get_gas_price(data: EasyEnergyData, hours: int) -> float | None:
 
     Returns:
         The gas market price value.
+
     """
     if not data.gas_today:
         return None

--- a/homeassistant/components/easyenergy/sensor.py
+++ b/homeassistant/components/easyenergy/sensor.py
@@ -208,6 +208,7 @@ def get_gas_price(data: EasyEnergyData, hours: int) -> float | None:
 
     Returns:
         The gas market price value.
+
     """
     if data.gas_today is None:
         return None

--- a/homeassistant/components/energyzero/diagnostics.py
+++ b/homeassistant/components/energyzero/diagnostics.py
@@ -21,6 +21,7 @@ def get_gas_price(data: EnergyZeroData, hours: int) -> float | None:
 
     Returns:
         The gas market price value.
+
     """
     if not data.gas_today:
         return None

--- a/homeassistant/components/energyzero/sensor.py
+++ b/homeassistant/components/energyzero/sensor.py
@@ -140,6 +140,7 @@ def get_gas_price(data: EnergyZeroData, hours: int) -> float | None:
 
     Returns:
         The gas market price value.
+
     """
     if data.gas_today is None:
         return None

--- a/homeassistant/components/nuki/__init__.py
+++ b/homeassistant/components/nuki/__init__.py
@@ -332,6 +332,7 @@ class NukiCoordinator(DataUpdateCoordinator[None]):  # pylint: disable=hass-enfo
 
         Returns:
             A dict with the events to be fired. The event type is the key and the device ids are the value
+
         """
 
         events: dict[str, set[str]] = defaultdict(set)

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -502,6 +502,7 @@ class SensorEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         Note:
             suggested_unit_of_measurement is stored in the entity registry the first
             time the entity is seen, and then never updated.
+
         """
         if hasattr(self, "_attr_suggested_unit_of_measurement"):
             return self._attr_suggested_unit_of_measurement

--- a/homeassistant/components/snapcast/server.py
+++ b/homeassistant/components/snapcast/server.py
@@ -134,6 +134,7 @@ class HomeAssistantSnapcast:
         ----------
         client : Snapclient
             Snapcast client to be added to HA.
+
         """
         if not self.hass_async_add_entities:
             return

--- a/homeassistant/components/wemo/wemo_device.py
+++ b/homeassistant/components/wemo/wemo_device.py
@@ -55,6 +55,7 @@ class OptionsValidationError(Exception):
             field_key must also match one of the field names inside the Options class.
           error_key: Name of the options.error key that corresponds to this error.
           message: Message for the Exception class.
+
         """
         super().__init__(message)
         self.field_key = field_key

--- a/homeassistant/components/zwave_js/discovery_data_template.py
+++ b/homeassistant/components/zwave_js/discovery_data_template.py
@@ -564,6 +564,7 @@ class ConfigurableFanValueMappingDataTemplate(
 
     `configuration_value_to_fan_value_mapping` maps the values from
     `configuration_option` to the value mapping object.
+
     """
 
     def resolve_data(
@@ -634,6 +635,7 @@ class FixedFanValueMappingDataTemplate(
               )
           ),
       ),
+
     """
 
     def get_fan_value_mapping(

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -364,6 +364,7 @@ def domain_key(config_key: Any) -> str:
     'hue  1' returns 'hue'
     'hue ' raises
     'hue  ' raises
+
     """
     if not isinstance(config_key, str):
         raise vol.Invalid("invalid domain", path=[config_key])

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -2295,6 +2295,7 @@ def iif(
         {{ is_state("device_tracker.frenck", "home") | iif("yes", "no") }}
         {{ iif(1==2, "yes", "no") }}
         {{ (1 == 1) | iif("yes", "no") }}
+
     """
     if value is None and if_none is not _SENTINEL:
         return if_none

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,5 +1,5 @@
 # Automatically generated from .pre-commit-config.yaml by gen_requirements_all.py, do not edit
 
 codespell==2.2.2
-ruff==0.1.8
+ruff==0.1.15
 yamllint==1.32.0

--- a/tests/components/blackbird/test_media_player.py
+++ b/tests/components/blackbird/test_media_player.py
@@ -287,10 +287,10 @@ async def test_state(hass: HomeAssistant, media_player_entity, mock_blackbird) -
 async def test_supported_features(media_player_entity) -> None:
     """Test supported features property."""
     assert (
-        MediaPlayerEntityFeature.TURN_ON
+        media_player_entity.supported_features
+        == MediaPlayerEntityFeature.TURN_ON
         | MediaPlayerEntityFeature.TURN_OFF
         | MediaPlayerEntityFeature.SELECT_SOURCE
-        == media_player_entity.supported_features
     )
 
 

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -2285,6 +2285,7 @@ async def test_cast_platform_play_media_local_media(
     quick_play_mock.assert_called()
     app_data = quick_play_mock.call_args[0][2]
     # No authSig appended
-    assert app_data[
-        "media_id"
-    ] == f"{network.get_url(hass)}/api/hls/bla/master_playlist.m3u8?token=bla"
+    assert (
+        app_data["media_id"]
+        == f"{network.get_url(hass)}/api/hls/bla/master_playlist.m3u8?token=bla"
+    )

--- a/tests/components/directv/test_media_player.py
+++ b/tests/components/directv/test_media_player.py
@@ -172,7 +172,8 @@ async def test_supported_features(
     # Features supported for main DVR
     state = hass.states.get(MAIN_ENTITY_ID)
     assert (
-        MediaPlayerEntityFeature.PAUSE
+        state.attributes.get("supported_features")
+        == MediaPlayerEntityFeature.PAUSE
         | MediaPlayerEntityFeature.TURN_ON
         | MediaPlayerEntityFeature.TURN_OFF
         | MediaPlayerEntityFeature.PLAY_MEDIA
@@ -180,19 +181,18 @@ async def test_supported_features(
         | MediaPlayerEntityFeature.NEXT_TRACK
         | MediaPlayerEntityFeature.PREVIOUS_TRACK
         | MediaPlayerEntityFeature.PLAY
-        == state.attributes.get("supported_features")
     )
 
     # Feature supported for clients.
     state = hass.states.get(CLIENT_ENTITY_ID)
     assert (
-        MediaPlayerEntityFeature.PAUSE
+        state.attributes.get("supported_features")
+        == MediaPlayerEntityFeature.PAUSE
         | MediaPlayerEntityFeature.PLAY_MEDIA
         | MediaPlayerEntityFeature.STOP
         | MediaPlayerEntityFeature.NEXT_TRACK
         | MediaPlayerEntityFeature.PREVIOUS_TRACK
         | MediaPlayerEntityFeature.PLAY
-        == state.attributes.get("supported_features")
     )
 
 

--- a/tests/components/monoprice/test_media_player.py
+++ b/tests/components/monoprice/test_media_player.py
@@ -360,13 +360,13 @@ async def test_supported_features(hass: HomeAssistant) -> None:
 
     state = hass.states.get(ZONE_1_ID)
     assert (
-        MediaPlayerEntityFeature.VOLUME_MUTE
+        state.attributes["supported_features"]
+        == MediaPlayerEntityFeature.VOLUME_MUTE
         | MediaPlayerEntityFeature.VOLUME_SET
         | MediaPlayerEntityFeature.VOLUME_STEP
         | MediaPlayerEntityFeature.TURN_ON
         | MediaPlayerEntityFeature.TURN_OFF
         | MediaPlayerEntityFeature.SELECT_SOURCE
-        == state.attributes["supported_features"]
     )
 
 

--- a/tests/components/nx584/test_binary_sensor.py
+++ b/tests/components/nx584/test_binary_sensor.py
@@ -27,6 +27,7 @@ def fake_zones():
 
     Returns:
         list: List of fake zones
+
     """
     return [
         {"name": "front", "number": 1},
@@ -44,6 +45,7 @@ def client(fake_zones):
 
     Yields:
         MagicMock: Client Mock
+
     """
     with mock.patch.object(nx584_client, "Client") as _mock_client:
         client = nx584_client.Client.return_value

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -189,7 +189,8 @@ async def test_supported_features(
     # Features supported for Rokus
     state = hass.states.get(MAIN_ENTITY_ID)
     assert (
-        MediaPlayerEntityFeature.PREVIOUS_TRACK
+        state.attributes.get("supported_features")
+        == MediaPlayerEntityFeature.PREVIOUS_TRACK
         | MediaPlayerEntityFeature.NEXT_TRACK
         | MediaPlayerEntityFeature.VOLUME_STEP
         | MediaPlayerEntityFeature.VOLUME_MUTE
@@ -200,7 +201,6 @@ async def test_supported_features(
         | MediaPlayerEntityFeature.TURN_ON
         | MediaPlayerEntityFeature.TURN_OFF
         | MediaPlayerEntityFeature.BROWSE_MEDIA
-        == state.attributes.get("supported_features")
     )
 
 
@@ -214,7 +214,8 @@ async def test_tv_supported_features(
     state = hass.states.get(TV_ENTITY_ID)
     assert state
     assert (
-        MediaPlayerEntityFeature.PREVIOUS_TRACK
+        state.attributes.get("supported_features")
+        == MediaPlayerEntityFeature.PREVIOUS_TRACK
         | MediaPlayerEntityFeature.NEXT_TRACK
         | MediaPlayerEntityFeature.VOLUME_STEP
         | MediaPlayerEntityFeature.VOLUME_MUTE
@@ -225,7 +226,6 @@ async def test_tv_supported_features(
         | MediaPlayerEntityFeature.TURN_ON
         | MediaPlayerEntityFeature.TURN_OFF
         | MediaPlayerEntityFeature.BROWSE_MEDIA
-        == state.attributes.get("supported_features")
     )
 
 

--- a/tests/components/ws66i/test_media_player.py
+++ b/tests/components/ws66i/test_media_player.py
@@ -260,13 +260,13 @@ async def test_supported_features(hass: HomeAssistant) -> None:
 
     state = hass.states.get(ZONE_1_ID)
     assert (
-        MediaPlayerEntityFeature.VOLUME_MUTE
+        state.attributes["supported_features"]
+        == MediaPlayerEntityFeature.VOLUME_MUTE
         | MediaPlayerEntityFeature.VOLUME_SET
         | MediaPlayerEntityFeature.VOLUME_STEP
         | MediaPlayerEntityFeature.TURN_ON
         | MediaPlayerEntityFeature.TURN_OFF
         | MediaPlayerEntityFeature.SELECT_SOURCE
-        == state.attributes["supported_features"]
     )
 
 


### PR DESCRIPTION
## Proposed change
https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md#0115

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
