### PR TITLE
Add service status to service description

### DIFF
--- a/homeassistant/components/calendar/services.yaml
+++ b/homeassistant/components/calendar/services.yaml
@@ -37,6 +37,7 @@ create_event:
       selector:
         text:
 list_events:
+  status: deprecated
   target:
     entity:
       domain: calendar

--- a/homeassistant/components/climate/services.yaml
+++ b/homeassistant/components/climate/services.yaml
@@ -44,7 +44,7 @@ set_temperature:
           step: 0.1
           mode: box
     target_temp_high:
-      status: passive
+      status: secondary
       filter:
         supported_features:
           - climate.ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
@@ -55,7 +55,7 @@ set_temperature:
           step: 0.1
           mode: box
     target_temp_low:
-      status: passive
+      status: secondary
       filter:
         supported_features:
           - climate.ClimateEntityFeature.TARGET_TEMPERATURE_RANGE

--- a/homeassistant/components/climate/services.yaml
+++ b/homeassistant/components/climate/services.yaml
@@ -44,10 +44,10 @@ set_temperature:
           step: 0.1
           mode: box
     target_temp_high:
+      status: passive
       filter:
         supported_features:
           - climate.ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
-      advanced: true
       selector:
         number:
           min: 0
@@ -55,10 +55,10 @@ set_temperature:
           step: 0.1
           mode: box
     target_temp_low:
+      status: passive
       filter:
         supported_features:
           - climate.ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
-      advanced: true
       selector:
         number:
           min: 0

--- a/homeassistant/components/fan/services.yaml
+++ b/homeassistant/components/fan/services.yaml
@@ -94,7 +94,7 @@ increase_speed:
         - fan.FanEntityFeature.SET_SPEED
   fields:
     percentage_step:
-      status: passive
+      status: secondary
       required: false
       selector:
         number:
@@ -110,7 +110,7 @@ decrease_speed:
         - fan.FanEntityFeature.SET_SPEED
   fields:
     percentage_step:
-      status: passive
+      status: secondary
       required: false
       selector:
         number:

--- a/homeassistant/components/fan/services.yaml
+++ b/homeassistant/components/fan/services.yaml
@@ -94,7 +94,7 @@ increase_speed:
         - fan.FanEntityFeature.SET_SPEED
   fields:
     percentage_step:
-      advanced: true
+      status: passive
       required: false
       selector:
         number:
@@ -110,7 +110,7 @@ decrease_speed:
         - fan.FanEntityFeature.SET_SPEED
   fields:
     percentage_step:
-      advanced: true
+      status: passive
       required: false
       selector:
         number:

--- a/homeassistant/components/homeassistant/services.yaml
+++ b/homeassistant/components/homeassistant/services.yaml
@@ -53,7 +53,6 @@ reload_config_entry:
     device: {}
   fields:
     entry_id:
-      advanced: true
       required: false
       example: 8955375327824e14ba89e4b29cc3ec9a
       selector:

--- a/homeassistant/components/hue/services.yaml
+++ b/homeassistant/components/hue/services.yaml
@@ -32,13 +32,13 @@ activate_scene:
       selector:
         boolean:
     speed:
-      advanced: true
+      status: passive
       selector:
         number:
           min: 0
           max: 100
     brightness:
-      advanced: true
+      status: passive
       selector:
         number:
           min: 1

--- a/homeassistant/components/hue/services.yaml
+++ b/homeassistant/components/hue/services.yaml
@@ -32,13 +32,13 @@ activate_scene:
       selector:
         boolean:
     speed:
-      status: passive
+      status: secondary
       selector:
         number:
           min: 0
           max: 100
     brightness:
-      status: passive
+      status: secondary
       selector:
         number:
           min: 1

--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -27,7 +27,7 @@ turn_on:
       selector:
         color_rgb:
     rgbw_color:
-      status: legacy
+      status: secondary
       filter:
         attribute:
           supported_color_modes:
@@ -40,7 +40,7 @@ turn_on:
       selector:
         object:
     rgbww_color:
-      status: legacy
+      status: secondary
       filter:
         attribute:
           supported_color_modes:

--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -6,7 +6,7 @@ turn_on:
       domain: light
   fields:
     transition:
-      status: passive
+      status: secondary
       filter:
         supported_features:
           - light.LightEntityFeature.TRANSITION
@@ -321,7 +321,7 @@ turn_on:
           min: -225
           max: 255
     brightness_step_pct:
-      status: passive
+      status: secondary
       filter:
         attribute:
           supported_color_modes:
@@ -338,7 +338,7 @@ turn_on:
           max: 100
           unit_of_measurement: "%"
     white:
-      status: passive
+      status: secondary
       filter:
         attribute:
           supported_color_modes:
@@ -353,7 +353,7 @@ turn_on:
       selector:
         text:
     flash:
-      status: passive
+      status: secondary
       filter:
         supported_features:
           - light.LightEntityFeature.FLASH
@@ -365,7 +365,7 @@ turn_on:
             - label: "Short"
               value: "short"
     effect:
-      status: passive
+      status: secondary
       filter:
         supported_features:
           - light.LightEntityFeature.EFFECT
@@ -378,7 +378,7 @@ turn_off:
       domain: light
   fields:
     transition:
-      status: passive
+      status: secondary
       filter:
         supported_features:
           - light.LightEntityFeature.TRANSITION
@@ -388,7 +388,7 @@ turn_off:
           max: 300
           unit_of_measurement: seconds
     flash:
-      status: passive
+      status: secondary
       filter:
         supported_features:
           - light.LightEntityFeature.FLASH
@@ -406,7 +406,7 @@ toggle:
       domain: light
   fields:
     transition:
-      status: passive
+      status: secondary
       filter:
         supported_features:
           - light.LightEntityFeature.TRANSITION
@@ -677,7 +677,7 @@ toggle:
           max: 100
           unit_of_measurement: "%"
     white:
-      status: passive
+      status: secondary
       filter:
         attribute:
           supported_color_modes:
@@ -692,7 +692,7 @@ toggle:
       selector:
         text:
     flash:
-      status: passive
+      status: secondary
       filter:
         supported_features:
           - light.LightEntityFeature.FLASH
@@ -704,7 +704,7 @@ toggle:
             - label: "Short"
               value: "short"
     effect:
-      status: passive
+      status: secondary
       filter:
         supported_features:
           - light.LightEntityFeature.EFFECT

--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -6,6 +6,7 @@ turn_on:
       domain: light
   fields:
     transition:
+      status: passive
       filter:
         supported_features:
           - light.LightEntityFeature.TRANSITION
@@ -26,6 +27,7 @@ turn_on:
       selector:
         color_rgb:
     rgbw_color:
+      status: legacy
       filter:
         attribute:
           supported_color_modes:
@@ -34,11 +36,11 @@ turn_on:
             - light.ColorMode.RGB
             - light.ColorMode.RGBW
             - light.ColorMode.RGBWW
-      advanced: true
       example: "[255, 100, 100, 50]"
       selector:
         object:
     rgbww_color:
+      status: legacy
       filter:
         attribute:
           supported_color_modes:
@@ -47,11 +49,11 @@ turn_on:
             - light.ColorMode.RGB
             - light.ColorMode.RGBW
             - light.ColorMode.RGBWW
-      advanced: true
       example: "[255, 100, 100, 50, 70]"
       selector:
         object:
     color_name:
+      status: legacy
       filter:
         attribute:
           supported_color_modes:
@@ -60,7 +62,6 @@ turn_on:
             - light.ColorMode.RGB
             - light.ColorMode.RGBW
             - light.ColorMode.RGBWW
-      advanced: true
       selector:
         select:
           translation_key: color_name
@@ -215,6 +216,7 @@ turn_on:
             - "yellow"
             - "yellowgreen"
     hs_color:
+      status: legacy
       filter:
         attribute:
           supported_color_modes:
@@ -223,11 +225,11 @@ turn_on:
             - light.ColorMode.RGB
             - light.ColorMode.RGBW
             - light.ColorMode.RGBWW
-      advanced: true
       example: "[300, 70]"
       selector:
         object:
     xy_color:
+      status: legacy
       filter:
         attribute:
           supported_color_modes:
@@ -236,11 +238,11 @@ turn_on:
             - light.ColorMode.RGB
             - light.ColorMode.RGBW
             - light.ColorMode.RGBWW
-      advanced: true
       example: "[0.52, 0.43]"
       selector:
         object:
     color_temp:
+      status: legacy
       filter:
         attribute:
           supported_color_modes:
@@ -265,13 +267,13 @@ turn_on:
             - light.ColorMode.RGB
             - light.ColorMode.RGBW
             - light.ColorMode.RGBWW
-      advanced: true
       selector:
         color_temp:
           unit: "kelvin"
           min: 2000
           max: 6500
     brightness:
+      status: legacy
       filter:
         attribute:
           supported_color_modes:
@@ -282,7 +284,6 @@ turn_on:
             - light.ColorMode.RGB
             - light.ColorMode.RGBW
             - light.ColorMode.RGBWW
-      advanced: true
       selector:
         number:
           min: 0
@@ -304,6 +305,7 @@ turn_on:
           max: 100
           unit_of_measurement: "%"
     brightness_step:
+      status: legacy
       filter:
         attribute:
           supported_color_modes:
@@ -314,12 +316,12 @@ turn_on:
             - light.ColorMode.RGB
             - light.ColorMode.RGBW
             - light.ColorMode.RGBWW
-      advanced: true
       selector:
         number:
           min: -225
           max: 255
     brightness_step_pct:
+      status: passive
       filter:
         attribute:
           supported_color_modes:
@@ -336,25 +338,25 @@ turn_on:
           max: 100
           unit_of_measurement: "%"
     white:
+      status: passive
       filter:
         attribute:
           supported_color_modes:
             - light.ColorMode.WHITE
-      advanced: true
       selector:
         constant:
           value: true
           label: Enabled
     profile:
-      advanced: true
+      status: legacy
       example: relax
       selector:
         text:
     flash:
+      status: passive
       filter:
         supported_features:
           - light.LightEntityFeature.FLASH
-      advanced: true
       selector:
         select:
           options:
@@ -363,6 +365,7 @@ turn_on:
             - label: "Short"
               value: "short"
     effect:
+      status: passive
       filter:
         supported_features:
           - light.LightEntityFeature.EFFECT
@@ -375,6 +378,7 @@ turn_off:
       domain: light
   fields:
     transition:
+      status: passive
       filter:
         supported_features:
           - light.LightEntityFeature.TRANSITION
@@ -384,10 +388,10 @@ turn_off:
           max: 300
           unit_of_measurement: seconds
     flash:
+      status: passive
       filter:
         supported_features:
           - light.LightEntityFeature.FLASH
-      advanced: true
       selector:
         select:
           options:
@@ -402,6 +406,7 @@ toggle:
       domain: light
   fields:
     transition:
+      status: passive
       filter:
         supported_features:
           - light.LightEntityFeature.TRANSITION
@@ -419,11 +424,11 @@ toggle:
             - light.ColorMode.RGB
             - light.ColorMode.RGBW
             - light.ColorMode.RGBWW
-      advanced: true
       example: "[255, 100, 100]"
       selector:
         color_rgb:
     color_name:
+      status: legacy
       filter:
         attribute:
           supported_color_modes:
@@ -432,7 +437,6 @@ toggle:
             - light.ColorMode.RGB
             - light.ColorMode.RGBW
             - light.ColorMode.RGBWW
-      advanced: true
       selector:
         select:
           translation_key: color_name
@@ -587,6 +591,7 @@ toggle:
             - "yellow"
             - "yellowgreen"
     hs_color:
+      status: legacy
       filter:
         attribute:
           supported_color_modes:
@@ -595,11 +600,11 @@ toggle:
             - light.ColorMode.RGB
             - light.ColorMode.RGBW
             - light.ColorMode.RGBWW
-      advanced: true
       example: "[300, 70]"
       selector:
         object:
     xy_color:
+      status: legacy
       filter:
         attribute:
           supported_color_modes:
@@ -608,11 +613,11 @@ toggle:
             - light.ColorMode.RGB
             - light.ColorMode.RGBW
             - light.ColorMode.RGBWW
-      advanced: true
       example: "[0.52, 0.43]"
       selector:
         object:
     color_temp:
+      status: legacy
       filter:
         attribute:
           supported_color_modes:
@@ -622,7 +627,6 @@ toggle:
             - light.ColorMode.RGB
             - light.ColorMode.RGBW
             - light.ColorMode.RGBWW
-      advanced: true
       selector:
         color_temp:
     kelvin:
@@ -635,13 +639,13 @@ toggle:
             - light.ColorMode.RGB
             - light.ColorMode.RGBW
             - light.ColorMode.RGBWW
-      advanced: true
       selector:
         color_temp:
           unit: "kelvin"
           min: 2000
           max: 6500
     brightness:
+      status: legacy
       filter:
         attribute:
           supported_color_modes:
@@ -652,7 +656,6 @@ toggle:
             - light.ColorMode.RGB
             - light.ColorMode.RGBW
             - light.ColorMode.RGBWW
-      advanced: true
       selector:
         number:
           min: 0
@@ -674,25 +677,25 @@ toggle:
           max: 100
           unit_of_measurement: "%"
     white:
+      status: passive
       filter:
         attribute:
           supported_color_modes:
             - light.ColorMode.WHITE
-      advanced: true
       selector:
         constant:
           value: true
           label: Enabled
     profile:
-      advanced: true
+      status: legacy
       example: relax
       selector:
         text:
     flash:
+      status: passive
       filter:
         supported_features:
           - light.LightEntityFeature.FLASH
-      advanced: true
       selector:
         select:
           options:
@@ -701,6 +704,7 @@ toggle:
             - label: "Short"
               value: "short"
     effect:
+      status: passive
       filter:
         supported_features:
           - light.LightEntityFeature.EFFECT

--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -53,7 +53,7 @@ turn_on:
       selector:
         object:
     color_name:
-      status: legacy
+      status: hidden
       filter:
         attribute:
           supported_color_modes:
@@ -216,7 +216,7 @@ turn_on:
             - "yellow"
             - "yellowgreen"
     hs_color:
-      status: legacy
+      status: hidden
       filter:
         attribute:
           supported_color_modes:
@@ -229,7 +229,7 @@ turn_on:
       selector:
         object:
     xy_color:
-      status: legacy
+      status: hidden
       filter:
         attribute:
           supported_color_modes:
@@ -242,7 +242,7 @@ turn_on:
       selector:
         object:
     color_temp:
-      status: legacy
+      status: hidden
       filter:
         attribute:
           supported_color_modes:
@@ -273,7 +273,7 @@ turn_on:
           min: 2000
           max: 6500
     brightness:
-      status: legacy
+      status: hidden
       filter:
         attribute:
           supported_color_modes:
@@ -305,7 +305,7 @@ turn_on:
           max: 100
           unit_of_measurement: "%"
     brightness_step:
-      status: legacy
+      status: hidden
       filter:
         attribute:
           supported_color_modes:
@@ -348,7 +348,7 @@ turn_on:
           value: true
           label: Enabled
     profile:
-      status: legacy
+      status: hidden
       example: relax
       selector:
         text:
@@ -428,7 +428,7 @@ toggle:
       selector:
         color_rgb:
     color_name:
-      status: legacy
+      status: hidden
       filter:
         attribute:
           supported_color_modes:
@@ -591,7 +591,7 @@ toggle:
             - "yellow"
             - "yellowgreen"
     hs_color:
-      status: legacy
+      status: hidden
       filter:
         attribute:
           supported_color_modes:
@@ -604,7 +604,7 @@ toggle:
       selector:
         object:
     xy_color:
-      status: legacy
+      status: hidden
       filter:
         attribute:
           supported_color_modes:
@@ -617,7 +617,7 @@ toggle:
       selector:
         object:
     color_temp:
-      status: legacy
+      status: hidden
       filter:
         attribute:
           supported_color_modes:
@@ -645,7 +645,7 @@ toggle:
           min: 2000
           max: 6500
     brightness:
-      status: legacy
+      status: hidden
       filter:
         attribute:
           supported_color_modes:
@@ -687,7 +687,7 @@ toggle:
           value: true
           label: Enabled
     profile:
-      status: legacy
+      status: hidden
       example: relax
       selector:
         text:

--- a/homeassistant/components/motioneye/services.yaml
+++ b/homeassistant/components/motioneye/services.yaml
@@ -6,8 +6,8 @@ set_text_overlay:
       integration: motioneye
   fields:
     left_text:
+      status: passive
       required: false
-      advanced: false
       example: "timestamp"
       default: ""
       selector:
@@ -18,16 +18,16 @@ set_text_overlay:
             - "timestamp"
             - "custom-text"
     custom_left_text:
+      status: passive
       required: false
-      advanced: false
       example: "Hello on the left!"
       default: ""
       selector:
         text:
           multiline: true
     right_text:
+      status: passive
       required: false
-      advanced: false
       example: "timestamp"
       default: ""
       selector:
@@ -38,8 +38,8 @@ set_text_overlay:
             - "timestamp"
             - "custom-text"
     custom_right_text:
+      status: passive
       required: false
-      advanced: false
       example: "Hello on the right!"
       default: ""
       selector:
@@ -54,8 +54,8 @@ action:
       integration: motioneye
   fields:
     action:
+      status: passive
       required: true
-      advanced: false
       example: "snapshot"
       default: ""
       selector:

--- a/homeassistant/components/motioneye/services.yaml
+++ b/homeassistant/components/motioneye/services.yaml
@@ -6,7 +6,7 @@ set_text_overlay:
       integration: motioneye
   fields:
     left_text:
-      status: passive
+      status: secondary
       required: false
       example: "timestamp"
       default: ""
@@ -18,7 +18,7 @@ set_text_overlay:
             - "timestamp"
             - "custom-text"
     custom_left_text:
-      status: passive
+      status: secondary
       required: false
       example: "Hello on the left!"
       default: ""
@@ -26,7 +26,7 @@ set_text_overlay:
         text:
           multiline: true
     right_text:
-      status: passive
+      status: secondary
       required: false
       example: "timestamp"
       default: ""
@@ -38,7 +38,7 @@ set_text_overlay:
             - "timestamp"
             - "custom-text"
     custom_right_text:
-      status: passive
+      status: secondary
       required: false
       example: "Hello on the right!"
       default: ""
@@ -54,7 +54,7 @@ action:
       integration: motioneye
   fields:
     action:
-      status: passive
+      status: secondary
       required: true
       example: "snapshot"
       default: ""

--- a/homeassistant/components/mqtt/services.yaml
+++ b/homeassistant/components/mqtt/services.yaml
@@ -12,12 +12,12 @@ publish:
       selector:
         text:
     payload_template:
-      status: passive
+      status: secondary
       example: "{{ states('sensor.temperature') }}"
       selector:
         template:
     qos:
-      status: passive
+      status: secondary
       default: 0
       selector:
         select:

--- a/homeassistant/components/mqtt/services.yaml
+++ b/homeassistant/components/mqtt/services.yaml
@@ -12,12 +12,12 @@ publish:
       selector:
         text:
     payload_template:
-      advanced: true
+      status: passive
       example: "{{ states('sensor.temperature') }}"
       selector:
         template:
     qos:
-      advanced: true
+      status: passive
       default: 0
       selector:
         select:

--- a/homeassistant/components/scene/services.yaml
+++ b/homeassistant/components/scene/services.yaml
@@ -39,7 +39,7 @@ create:
       selector:
         text:
     entities:
-      advanced: true
+      status: passive
       example: |
         light.tv_back_light: "on"
         light.ceiling:

--- a/homeassistant/components/scene/services.yaml
+++ b/homeassistant/components/scene/services.yaml
@@ -39,7 +39,7 @@ create:
       selector:
         text:
     entities:
-      status: passive
+      status: secondary
       example: |
         light.tv_back_light: "on"
         light.ceiling:

--- a/homeassistant/components/squeezebox/services.yaml
+++ b/homeassistant/components/squeezebox/services.yaml
@@ -10,7 +10,7 @@ call_method:
       selector:
         text:
     parameters:
-      status: passive
+      status: secondary
       example: '["loadtracks", "album.titlesearch=Revolver"]'
       selector:
         object:
@@ -26,7 +26,7 @@ call_query:
       selector:
         text:
     parameters:
-      status: passive
+      status: secondary
       example: '["0", "20", "search:Revolver"]'
       selector:
         object:

--- a/homeassistant/components/squeezebox/services.yaml
+++ b/homeassistant/components/squeezebox/services.yaml
@@ -10,8 +10,8 @@ call_method:
       selector:
         text:
     parameters:
+      status: passive
       example: '["loadtracks", "album.titlesearch=Revolver"]'
-      advanced: true
       selector:
         object:
 call_query:
@@ -26,8 +26,8 @@ call_query:
       selector:
         text:
     parameters:
+      status: passive
       example: '["0", "20", "search:Revolver"]'
-      advanced: true
       selector:
         object:
 sync:

--- a/homeassistant/components/toon/services.yaml
+++ b/homeassistant/components/toon/services.yaml
@@ -1,7 +1,7 @@
 update:
   fields:
     display:
-      advanced: true
+      status: passive
       example: eneco-001-123456
       selector:
         text:

--- a/homeassistant/components/toon/services.yaml
+++ b/homeassistant/components/toon/services.yaml
@@ -1,7 +1,7 @@
 update:
   fields:
     display:
-      status: passive
+      status: secondary
       example: eneco-001-123456
       selector:
         text:

--- a/homeassistant/components/tts/services.yaml
+++ b/homeassistant/components/tts/services.yaml
@@ -21,7 +21,7 @@ say:
       selector:
         text:
     options:
-      advanced: true
+      status: passive
       example: platform specific
       selector:
         object:
@@ -50,7 +50,7 @@ speak:
       selector:
         text:
     options:
-      advanced: true
+      status: passive
       example: platform specific
       selector:
         object:

--- a/homeassistant/components/tts/services.yaml
+++ b/homeassistant/components/tts/services.yaml
@@ -21,7 +21,7 @@ say:
       selector:
         text:
     options:
-      status: passive
+      status: secondary
       example: platform specific
       selector:
         object:
@@ -50,7 +50,7 @@ speak:
       selector:
         text:
     options:
-      status: passive
+      status: secondary
       example: platform specific
       selector:
         object:

--- a/homeassistant/components/weather/services.yaml
+++ b/homeassistant/components/weather/services.yaml
@@ -1,4 +1,5 @@
 get_forecast:
+  status: deprecated
   target:
     entity:
       domain: weather

--- a/homeassistant/components/webostv/services.yaml
+++ b/homeassistant/components/webostv/services.yaml
@@ -30,7 +30,7 @@ command:
     payload:
       example: >-
         target: https://www.google.com
-      status: passive
+      status: secondary
       selector:
         object:
 

--- a/homeassistant/components/webostv/services.yaml
+++ b/homeassistant/components/webostv/services.yaml
@@ -30,7 +30,7 @@ command:
     payload:
       example: >-
         target: https://www.google.com
-      advanced: true
+      status: passive
       selector:
         object:
 

--- a/homeassistant/components/zwave_js/services.yaml
+++ b/homeassistant/components/zwave_js/services.yaml
@@ -105,7 +105,7 @@ set_config_parameter:
       selector:
         text:
     bitmask:
-      status: passive
+      status: secondary
       selector:
         text:
     value:

--- a/homeassistant/components/zwave_js/services.yaml
+++ b/homeassistant/components/zwave_js/services.yaml
@@ -105,7 +105,7 @@ set_config_parameter:
       selector:
         text:
     bitmask:
-      advanced: true
+      status: passive
       selector:
         text:
     value:

--- a/script/hassfest/services.py
+++ b/script/hassfest/services.py
@@ -69,9 +69,7 @@ CORE_INTEGRATION_SERVICE_SCHEMA = vol.Any(
 CUSTOM_INTEGRATION_SERVICE_SCHEMA = vol.Any(
     vol.Schema(
         {
-            vol.Optional("status", default="active"): vol.In(
-                ("active", "legacy", "deprecated")
-            ),
+            vol.Optional("status"): vol.In({"active", "legacy", "deprecated"}),
             vol.Optional("description"): str,
             vol.Optional("name"): str,
             vol.Optional("target"): vol.Any(

--- a/script/hassfest/services.py
+++ b/script/hassfest/services.py
@@ -28,7 +28,9 @@ def exists(value: Any) -> Any:
 
 CORE_INTEGRATION_FIELD_SCHEMA = vol.Schema(
     {
-        vol.Optional("status"): vol.In(("active", "passive", "legacy", "deprecated")),
+        vol.Optional("status"): vol.In(
+            {"primary", "secondary", "legacy", "deprecated"}
+        ),
         vol.Optional("example"): exists,
         vol.Optional("default"): exists,
         vol.Optional("required"): bool,
@@ -56,7 +58,7 @@ CUSTOM_INTEGRATION_FIELD_SCHEMA = CORE_INTEGRATION_FIELD_SCHEMA.extend(
 CORE_INTEGRATION_SERVICE_SCHEMA = vol.Any(
     vol.Schema(
         {
-            vol.Optional("status"): vol.In({"active", "legacy", "deprecated"}),
+            vol.Optional("status"): vol.In({"primary", "legacy", "deprecated"}),
             vol.Optional("target"): vol.Any(
                 selector.TargetSelector.CONFIG_SCHEMA, None
             ),
@@ -69,7 +71,7 @@ CORE_INTEGRATION_SERVICE_SCHEMA = vol.Any(
 CUSTOM_INTEGRATION_SERVICE_SCHEMA = vol.Any(
     vol.Schema(
         {
-            vol.Optional("status"): vol.In({"active", "legacy", "deprecated"}),
+            vol.Optional("status"): vol.In({"primary", "legacy", "deprecated"}),
             vol.Optional("description"): str,
             vol.Optional("name"): str,
             vol.Optional("target"): vol.Any(

--- a/script/hassfest/services.py
+++ b/script/hassfest/services.py
@@ -28,10 +28,10 @@ def exists(value: Any) -> Any:
 
 CORE_INTEGRATION_FIELD_SCHEMA = vol.Schema(
     {
+        vol.Optional("status"): vol.In(("active", "passive", "legacy", "deprecated")),
         vol.Optional("example"): exists,
         vol.Optional("default"): exists,
         vol.Optional("required"): bool,
-        vol.Optional("advanced"): bool,
         vol.Optional(CONF_SELECTOR): selector.validate_selector,
         vol.Optional("filter"): {
             vol.Exclusive("attribute", "field_filter"): {
@@ -46,6 +46,8 @@ CORE_INTEGRATION_FIELD_SCHEMA = vol.Schema(
 
 CUSTOM_INTEGRATION_FIELD_SCHEMA = CORE_INTEGRATION_FIELD_SCHEMA.extend(
     {
+        # No longer in use, but kept for backwards compatibility
+        vol.Optional("advanced"): bool,
         vol.Optional("description"): str,
         vol.Optional("name"): str,
     }
@@ -54,6 +56,7 @@ CUSTOM_INTEGRATION_FIELD_SCHEMA = CORE_INTEGRATION_FIELD_SCHEMA.extend(
 CORE_INTEGRATION_SERVICE_SCHEMA = vol.Any(
     vol.Schema(
         {
+            vol.Optional("status"): vol.In({"active", "legacy", "deprecated"}),
             vol.Optional("target"): vol.Any(
                 selector.TargetSelector.CONFIG_SCHEMA, None
             ),
@@ -66,6 +69,9 @@ CORE_INTEGRATION_SERVICE_SCHEMA = vol.Any(
 CUSTOM_INTEGRATION_SERVICE_SCHEMA = vol.Any(
     vol.Schema(
         {
+            vol.Optional("status", default="active"): vol.In(
+                ("active", "legacy", "deprecated")
+            ),
             vol.Optional("description"): str,
             vol.Optional("name"): str,
             vol.Optional("target"): vol.Any(

--- a/script/hassfest/services.py
+++ b/script/hassfest/services.py
@@ -29,7 +29,7 @@ def exists(value: Any) -> Any:
 CORE_INTEGRATION_FIELD_SCHEMA = vol.Schema(
     {
         vol.Optional("status"): vol.In(
-            {"primary", "secondary", "legacy", "deprecated"}
+            {"primary", "secondary", "hidden", "deprecated"}
         ),
         vol.Optional("example"): exists,
         vol.Optional("default"): exists,
@@ -58,7 +58,7 @@ CUSTOM_INTEGRATION_FIELD_SCHEMA = CORE_INTEGRATION_FIELD_SCHEMA.extend(
 CORE_INTEGRATION_SERVICE_SCHEMA = vol.Any(
     vol.Schema(
         {
-            vol.Optional("status"): vol.In({"primary", "legacy", "deprecated"}),
+            vol.Optional("status"): vol.In({"primary", "hidden", "deprecated"}),
             vol.Optional("target"): vol.Any(
                 selector.TargetSelector.CONFIG_SCHEMA, None
             ),
@@ -71,7 +71,7 @@ CORE_INTEGRATION_SERVICE_SCHEMA = vol.Any(
 CUSTOM_INTEGRATION_SERVICE_SCHEMA = vol.Any(
     vol.Schema(
         {
-            vol.Optional("status"): vol.In({"primary", "legacy", "deprecated"}),
+            vol.Optional("status"): vol.In({"primary", "hidden", "deprecated"}),
             vol.Optional("description"): str,
             vol.Optional("name"): str,
             vol.Optional("target"): vol.Any(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds a `status` field to the service description YAML files.

It allows to define the status of a service or a field of a service.

For services:

- `primary` (_default_): This service is available and actively in use.
- `hidden`: The service is around, still works. Not deprecated, no direct plans to remove it. But in general, shouldn't be used anymore.
- `deprecated`: The service is marked for deletion.

For service fields:

- `primary` (_default_): The field of this service is available, actively in use, and primary. It should always be displayed in the frontend.
- `secondary`: The field of this service is available, actively in use, but secondary. The field will be hidden by default behind a "show more fields"-a-like button.
- `hidden`: The field of this service is still around and still works. Not deprecated, no direct plans to remove it. We are keeping it here for existing uses, no direct plans to remove it. In general, shouldn't be used anymore.
- `deprecated`: This field is marked for deletion.


The above makes the previous `advanced` flag obsolete. It has been removed from core, and all places it was used have been mapped to the above.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
