### PR TITLE
Fix custom attribute lookup in Traccar Server

### DIFF
--- a/homeassistant/components/traccar_server/coordinator.py
+++ b/homeassistant/components/traccar_server/coordinator.py
@@ -93,10 +93,9 @@ class TraccarServerCoordinator(DataUpdateCoordinator[TraccarServerCoordinatorDat
             skip_accuracy_filter = False
 
             for custom_attr in self.custom_attributes:
-                attr[custom_attr] = getattr(
-                    device["attributes"],
+                attr[custom_attr] = device["attributes"].get(
                     custom_attr,
-                    getattr(position["attributes"], custom_attr, None),
+                    position["attributes"].get(custom_attr, None),
                 )
                 if custom_attr in self.skip_accuracy_filter_for:
                     skip_accuracy_filter = True
@@ -151,13 +150,16 @@ class TraccarServerCoordinator(DataUpdateCoordinator[TraccarServerCoordinatorDat
             device = get_device(event["deviceId"], devices)
             self.hass.bus.async_fire(
                 # This goes against two of the HA core guidelines:
-                # 1. Event names should be prefixed with the domain name of the integration
+                # 1. Event names should be prefixed with the domain name of
+                #    the integration
                 # 2. This should be event entities
-                # However, to not break it for those who currently use the "old" integration, this is kept as is.
+                #
+                # However, to not break it for those who currently use
+                # the "old" integration, this is kept as is.
                 f"traccar_{EVENTS[event['type']]}",
                 {
                     "device_traccar_id": event["deviceId"],
-                    "device_name": getattr(device, "name", None),
+                    "device_name": device["name"] if device else None,
                     "type": event["type"],
                     "serverTime": event["eventTime"],
                     "attributes": event["attributes"],

--- a/homeassistant/components/traccar_server/device_tracker.py
+++ b/homeassistant/components/traccar_server/device_tracker.py
@@ -51,12 +51,13 @@ class TraccarServerDeviceTracker(TraccarServerEntity, TrackerEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return device specific attributes."""
+        geofence_name = self.traccar_geofence["name"] if self.traccar_geofence else None
         return {
             **self.traccar_attributes,
             ATTR_ADDRESS: self.traccar_position["address"],
             ATTR_ALTITUDE: self.traccar_position["altitude"],
             ATTR_CATEGORY: self.traccar_device["category"],
-            ATTR_GEOFENCE: getattr(self.traccar_geofence, "name", None),
+            ATTR_GEOFENCE: geofence_name,
             ATTR_MOTION: self.traccar_position["attributes"].get("motion", False),
             ATTR_SPEED: self.traccar_position["speed"],
             ATTR_STATUS: self.traccar_device["status"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`getattr` no longer works on the models returned from `pytraccar` as they now are dictionaries.
This PR replaces those instaces with `dict.get(...)`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #109326
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
