### PR TITLE
Do not suggest area for portable Sonos speakers

### DIFF
--- a/homeassistant/components/sonos/entity.py
+++ b/homeassistant/components/sonos/entity.py
@@ -86,7 +86,9 @@ class SonosEntity(Entity):
                 (dr.CONNECTION_UPNP, f"uuid:{self.speaker.uid}"),
             },
             manufacturer="Sonos",
-            suggested_area=self.speaker.zone_name,
+            suggested_area=self.speaker.zone_name
+            if not self.speaker.battery_info
+            else None,
             configuration_url=f"http://{self.soco.ip_address}:1400/support/review",
         )
 

--- a/homeassistant/components/sonos/entity.py
+++ b/homeassistant/components/sonos/entity.py
@@ -76,6 +76,10 @@ class SonosEntity(Entity):
     @property
     def device_info(self) -> DeviceInfo:
         """Return information about the device."""
+        suggested_area: str | None = None
+        if not self.speaker.battery_info:
+            # Only set suggested area for non-portable devices
+            suggested_area = self.speaker.zone_name
         return DeviceInfo(
             identifiers={(DOMAIN, self.soco.uid)},
             name=self.speaker.zone_name,
@@ -86,9 +90,7 @@ class SonosEntity(Entity):
                 (dr.CONNECTION_UPNP, f"uuid:{self.speaker.uid}"),
             },
             manufacturer="Sonos",
-            suggested_area=self.speaker.zone_name
-            if not self.speaker.battery_info
-            else None,
+            suggested_area=suggested_area,
             configuration_url=f"http://{self.soco.ip_address}:1400/support/review",
         )
 

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -19,8 +19,23 @@ async def test_device_registry(
         (dr.CONNECTION_UPNP, "uuid:RINCON_test"),
     }
     assert reg_device.manufacturer == "Sonos"
-    assert reg_device.suggested_area == "Zone A"
     assert reg_device.name == "Zone A"
+    # Default device provides battery info, area should not be suggested
+    assert reg_device.suggested_area is None
+
+
+async def test_device_registry_not_portable(
+    hass: HomeAssistant, async_setup_sonos, soco
+) -> None:
+    """Test non-portable sonos device registered in the device registry to ensure area suggested."""
+    soco.get_battery_info.return_value = {}
+    await async_setup_sonos()
+
+    device_registry = dr.async_get(hass)
+    reg_device = device_registry.async_get_device(
+        identifiers={("sonos", "RINCON_test")}
+    )
+    assert reg_device.suggested_area == "Zone A"
 
 
 async def test_entity_basic(

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -1,22 +1,26 @@
 """Tests for the Sonos Media Player platform."""
 from homeassistant.const import STATE_IDLE
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import (
+    CONNECTION_NETWORK_MAC,
+    CONNECTION_UPNP,
+    DeviceRegistry,
+)
 
 
 async def test_device_registry(
-    hass: HomeAssistant, async_autosetup_sonos, soco
+    hass: HomeAssistant, device_registry: DeviceRegistry, async_autosetup_sonos, soco
 ) -> None:
     """Test sonos device registered in the device registry."""
-    device_registry = dr.async_get(hass)
     reg_device = device_registry.async_get_device(
         identifiers={("sonos", "RINCON_test")}
     )
+    assert reg_device is not None
     assert reg_device.model == "Model Name"
     assert reg_device.sw_version == "13.1"
     assert reg_device.connections == {
-        (dr.CONNECTION_NETWORK_MAC, "00:11:22:33:44:55"),
-        (dr.CONNECTION_UPNP, "uuid:RINCON_test"),
+        (CONNECTION_NETWORK_MAC, "00:11:22:33:44:55"),
+        (CONNECTION_UPNP, "uuid:RINCON_test"),
     }
     assert reg_device.manufacturer == "Sonos"
     assert reg_device.name == "Zone A"
@@ -25,16 +29,16 @@ async def test_device_registry(
 
 
 async def test_device_registry_not_portable(
-    hass: HomeAssistant, async_setup_sonos, soco
+    hass: HomeAssistant, device_registry: DeviceRegistry, async_setup_sonos, soco
 ) -> None:
     """Test non-portable sonos device registered in the device registry to ensure area suggested."""
     soco.get_battery_info.return_value = {}
     await async_setup_sonos()
 
-    device_registry = dr.async_get(hass)
     reg_device = device_registry.async_get_device(
         identifiers={("sonos", "RINCON_test")}
     )
+    assert reg_device is not None
     assert reg_device.suggested_area == "Zone A"
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Portable Sonos speakers (like the Move and Roam) are less commonly kept in a single location. This skips suggesting an area.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
