### PR TITLE
Use send_json_auto_id in conversation tests

### DIFF
--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -733,7 +733,7 @@ async def test_ws_api(
     assert await async_setup_component(hass, "conversation", {})
     client = await hass_ws_client(hass)
 
-    await client.send_json({"id": 5, "type": "conversation/process", **payload})
+    await client.send_json_auto_id({"type": "conversation/process", **payload})
 
     msg = await client.receive_json()
 
@@ -757,13 +757,10 @@ async def test_ws_prepare(
 
     client = await hass_ws_client(hass)
 
-    msg = {
-        "id": 5,
-        "type": "conversation/prepare",
-    }
+    msg = {"type": "conversation/prepare"}
     if agent_id is not None:
         msg["agent_id"] = agent_id
-    await client.send_json(msg)
+    await client.send_json_auto_id(msg)
 
     msg = await client.receive_json()
 

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -765,7 +765,6 @@ async def test_ws_prepare(
     msg = await client.receive_json()
 
     assert msg["success"]
-    assert msg["id"] == 5
 
     # Intents should now be load
     assert agent._lang_intents.get(hass.config.language)

--- a/tests/components/conversation/test_trigger.py
+++ b/tests/components/conversation/test_trigger.py
@@ -105,9 +105,8 @@ async def test_subscribe_trigger_does_not_interfere_with_responses(
 ) -> None:
     """Test that subscribing to a trigger from the websocket API does not interfere with responses."""
     websocket_client = await hass_ws_client()
-    await websocket_client.send_json(
+    await websocket_client.send_json_auto_id(
         {
-            "id": 5,
             "type": "subscribe_trigger",
             "trigger": {"platform": "conversation", "command": ["test sentence"]},
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
