### PR TITLE
Bump deebot_client to 5.1.0

### DIFF
--- a/homeassistant/components/ecovacs/config_flow.py
+++ b/homeassistant/components/ecovacs/config_flow.py
@@ -75,7 +75,7 @@ async def _validate_input(
     rest_config = create_rest_config(
         aiohttp_client.async_get_clientsession(hass),
         device_id=device_id,
-        country=country,
+        alpha_2_country=country,
         override_rest_url=rest_url,
     )
 
@@ -266,6 +266,10 @@ class EcovacsConfigFlow(ConfigFlow, domain=DOMAIN):
         # If not we will inform the user about the mismatch.
         error = None
         placeholders = None
+
+        # Convert the country to upper case as ISO 3166-1 alpha-2 country codes are upper case
+        user_input[CONF_COUNTRY] = user_input[CONF_COUNTRY].upper()
+
         if len(user_input[CONF_COUNTRY]) != 2:
             error = "invalid_country_length"
             placeholders = {"countries_url": "https://www.iso.org/obp/ui/#search/code/"}

--- a/homeassistant/components/ecovacs/controller.py
+++ b/homeassistant/components/ecovacs/controller.py
@@ -49,7 +49,7 @@ class EcovacsController:
             create_rest_config(
                 aiohttp_client.async_get_clientsession(self._hass),
                 device_id=self._device_id,
-                country=country,
+                alpha_2_country=country,
                 override_rest_url=config.get(CONF_OVERRIDE_REST_URL),
             ),
             config[CONF_USERNAME],

--- a/homeassistant/components/ecovacs/manifest.json
+++ b/homeassistant/components/ecovacs/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/ecovacs",
   "iot_class": "cloud_push",
   "loggers": ["sleekxmppfs", "sucks", "deebot_client"],
-  "requirements": ["py-sucks==0.9.8", "deebot-client==5.0.0"]
+  "requirements": ["py-sucks==0.9.8", "deebot-client==5.1.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -684,7 +684,7 @@ debugpy==1.8.0
 # decora==0.6
 
 # homeassistant.components.ecovacs
-deebot-client==5.0.0
+deebot-client==5.1.0
 
 # homeassistant.components.ihc
 # homeassistant.components.namecheapdns

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -559,7 +559,7 @@ dbus-fast==2.21.1
 debugpy==1.8.0
 
 # homeassistant.components.ecovacs
-deebot-client==5.0.0
+deebot-client==5.1.0
 
 # homeassistant.components.ihc
 # homeassistant.components.namecheapdns

--- a/tests/components/ecovacs/test_init.py
+++ b/tests/components/ecovacs/test_init.py
@@ -80,6 +80,7 @@ async def test_invalid_auth(
         ({}, 0),
         ({DOMAIN: IMPORT_DATA.copy()}, 1),
     ],
+    ids=["no_config", "import_config"],
 )
 async def test_async_setup_import(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump library to fix https://github.com/home-assistant/core/issues/109336

Release: https://github.com/DeebotUniverse/client.py/releases/tag/5.1.0
Diff: https://github.com/DeebotUniverse/client.py/compare/5.0.0...5.1.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #109336
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
