### PR TITLE
Specify end_time when importing Elvia data to deal with drift

### DIFF
--- a/homeassistant/components/elvia/importer.py
+++ b/homeassistant/components/elvia/importer.py
@@ -40,9 +40,12 @@ class ElviaImporter:
 
     async def _fetch_hourly_data(self, since: datetime) -> list[MeterValueTimeSeries]:
         """Fetch hourly data."""
-        LOGGER.debug("Fetching hourly data since %s", since)
+        start_time = since.isoformat()
+        end_time = dt_util.utcnow().isoformat()
+        LOGGER.debug("Fetching hourly data  %s - %s", start_time, end_time)
         all_data = await self.client.get_meter_values(
-            start_time=since.isoformat(),
+            start_time=start_time,
+            end_time=end_time,
             metering_point_ids=[self.metering_point_id],
         )
         return all_data["meteringpoints"][0]["metervalue"]["timeSeries"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

While testing other things I noticed this in my logs:

```
2024-02-02 08:59:22.873 ERROR (MainThread) [homeassistant.components.elvia] Unknown error Body is malformed 400 {"type":"https://tools.ietf.org/html/rfc7231#section-6.5.1","title":"One or more validation errors occurred.","status":400,"traceId":"00-033625d75ca95aa077a0da35d3d5f255-e1a9de961431fda5-00","errors":{"":["Requested start time must be before end time. Start: 02/02/2024 08:00:00 +00:00, End: 02/02/2024 09:00:00 +01:00"]}}
Traceback (most recent call last):
  File "/workspaces/new-core/homeassistant/components/elvia/__init__.py", line 36, in async_setup_entry
    await importer.import_meter_values()
  File "/workspaces/new-core/homeassistant/components/elvia/importer.py", line 73, in import_meter_values
    hourly_data = await self._fetch_hourly_data(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/new-core/homeassistant/components/elvia/importer.py", line 44, in _fetch_hourly_data
    all_data = await self.client.get_meter_values(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.local/lib/python3.11/site-packages/elvia/meter_value.py", line 102, in get_meter_values
    await verify_response(response, 200)
  File "/home/vscode/.local/lib/python3.11/site-packages/elvia/request_handler.py", line 10, in verify_response
    raise InvalidRequestBody(
elvia.error.InvalidRequestBody: Body is malformed 400 {"type":"https://tools.ietf.org/html/rfc7231#section-6.5.1","title":"One or more validation errors occurred.","status":400,"traceId":"00-033625d75ca95aa077a0da35d3d5f255-e1a9de961431fda5-00","errors":{"":["Requested start time must be before end time. Start: 02/02/2024 08:00:00 +00:00, End: 02/02/2024 09:00:00 +01:00"]}}
```

This seems to happen if you start your instance close to a new hour, which makes the start and ends identically.
As the end time can be any past time, we now set that to "now" to handle this.


Note: Added to 2024.2.0 milestone as this new integration was added in that release.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
