### PR TITLE
Pass slots to error messages instead of IDs

### DIFF
--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -285,7 +285,8 @@ class DefaultAgent(AbstractConversationAgent):
 
         # Slot values to pass to the intent
         slots = {
-            entity.name: {"value": entity.value} for entity in result.entities_list
+            entity.name: {"value": entity.value, "text": entity.text}
+            for entity in result.entities_list
         }
 
         try:
@@ -950,29 +951,27 @@ def _get_no_states_matched_response(
     """Return key and template arguments for error when intent returns no matching states."""
 
     # Device classes should be checked before domains
-    if no_states_error.device_classes:
-        device_class = next(iter(no_states_error.device_classes))  # first device class
+    if no_states_error.device_class:
         if no_states_error.area:
             # device_class in area
             return ErrorKey.NO_DEVICE_CLASS_IN_AREA, {
-                "device_class": device_class,
+                "device_class": no_states_error.device_class,
                 "area": no_states_error.area,
             }
 
         # device_class only
-        return ErrorKey.NO_DEVICE_CLASS, {"device_class": device_class}
+        return ErrorKey.NO_DEVICE_CLASS, {"device_class": no_states_error.device_class}
 
-    if no_states_error.domains:
-        domain = next(iter(no_states_error.domains))  # first domain
+    if no_states_error.domain:
         if no_states_error.area:
             # domain in area
             return ErrorKey.NO_DOMAIN_IN_AREA, {
-                "domain": domain,
+                "domain": no_states_error.domain,
                 "area": no_states_error.area,
             }
 
         # domain only
-        return ErrorKey.NO_DOMAIN, {"domain": domain}
+        return ErrorKey.NO_DOMAIN, {"domain": no_states_error.domain}
 
     # Default error
     return ErrorKey.NO_INTENT, {}

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -142,16 +142,16 @@ class NoStatesMatchedError(IntentError):
         self,
         name: str | None,
         area: str | None,
-        domain: str | None,
-        device_class: str | None,
+        domains: set[str] | None,
+        device_classes: set[str] | None,
     ) -> None:
         """Initialize error."""
         super().__init__()
 
         self.name = name
         self.area = area
-        self.domain = domain
-        self.device_class = device_class
+        self.domains = domains
+        self.device_classes = device_classes
 
 
 def _is_device_class(
@@ -422,20 +422,13 @@ class ServiceIntentHandler(IntentHandler):
         # Optional domain/device class filters.
         # Convert to sets for speed.
         domains: set[str] | None = None
-        domain_name: str | None = None
         device_classes: set[str] | None = None
-        device_class_name: str | None = None
 
         if "domain" in slots:
             domains = set(slots["domain"]["value"])
-            domain_name = slots["domain"]["text"] or next(iter(domains))
 
         if "device_class" in slots:
             device_classes = set(slots["device_class"]["value"])
-            device_class_name = slots["device_class"]["text"] or next(
-                iter(device_classes)
-            )
-
         states = list(
             async_match_states(
                 hass,
@@ -452,8 +445,8 @@ class ServiceIntentHandler(IntentHandler):
             raise NoStatesMatchedError(
                 name=name,
                 area=area_name,
-                domain=domain_name,
-                device_class=device_class_name,
+                domains=domains,
+                device_classes=device_classes,
             )
 
         response = await self.async_handle_states(intent_obj, states, area)

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -505,7 +505,7 @@ async def test_error_no_domain(
         )
         assert (
             result.response.speech["plain"]["speech"]
-            == "Sorry, I am not aware of any fans"
+            == "Sorry, I am not aware of any fan"
         )
 
 
@@ -555,7 +555,7 @@ async def test_error_no_device_class(
         )
         assert (
             result.response.speech["plain"]["speech"]
-            == "Sorry, I am not aware of any windows"
+            == "Sorry, I am not aware of any window"
         )
 
 
@@ -572,7 +572,7 @@ async def test_error_no_device_class_in_area(
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
-        == "Sorry, I am not aware of any windows in the bedroom area"
+        == "Sorry, I am not aware of any window in the bedroom area"
     )
 
 

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -482,7 +482,7 @@ async def test_error_no_domain(
     """Test error message when no devices/entities exist for a domain."""
 
     # We don't have a sentence for turning on all fans
-    fan_domain = MatchEntity(name="domain", value="fan", text="")
+    fan_domain = MatchEntity(name="domain", value="fan", text="fans")
     recognize_result = RecognizeResult(
         intent=Intent("HassTurnOn"),
         intent_data=IntentData([]),
@@ -505,7 +505,7 @@ async def test_error_no_domain(
         )
         assert (
             result.response.speech["plain"]["speech"]
-            == "Sorry, I am not aware of any fan"
+            == "Sorry, I am not aware of any fans"
         )
 
 
@@ -532,7 +532,7 @@ async def test_error_no_device_class(
     """Test error message when no entities of a device class exist."""
 
     # We don't have a sentence for opening all windows
-    window_class = MatchEntity(name="device_class", value="window", text="")
+    window_class = MatchEntity(name="device_class", value="window", text="windows")
     recognize_result = RecognizeResult(
         intent=Intent("HassTurnOn"),
         intent_data=IntentData([]),
@@ -555,7 +555,7 @@ async def test_error_no_device_class(
         )
         assert (
             result.response.speech["plain"]["speech"]
-            == "Sorry, I am not aware of any window"
+            == "Sorry, I am not aware of any windows"
         )
 
 
@@ -572,7 +572,7 @@ async def test_error_no_device_class_in_area(
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
-        == "Sorry, I am not aware of any window in the bedroom area"
+        == "Sorry, I am not aware of any windows in the bedroom area"
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
For the new Assist error messages, pass the uttered slot texts instead of the vales (i.e. IDs), so that it sounds more natural in response context. Fixes #109365 

As an interesting observation - slots which get set in intent data (e.g. by hard-coding a domain) lack user utterance only the ID gets passed back to error responses. While this may not be such big of an issue in English, it sure is in other languages.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #109365
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
