### PR TITLE
Fix unifiprotect license plate detection when plate is detected at event end

### DIFF
--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -751,8 +751,7 @@ class ProtectLicensePlateEventSensor(EventEntityMixin, SensorEntity):
 
     @callback
     def _async_update_device_from_protect(self, device: ProtectModelWithId) -> None:
-        # do not call ProtectDeviceSensor method since we want event to get value here
-        EventEntityMixin._async_update_device_from_protect(self, device)
+        super()._async_update_device_from_protect(device)
 
         if (
             (event := self._event) is not None

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -523,7 +523,7 @@ NVR_DISABLED_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
 LICENSE_PLATE_EVENT_SENSORS: tuple[ProtectSensorEventEntityDescription, ...] = (
     ProtectSensorEventEntityDescription(
         key="smart_obj_licenseplate",
-        name="License Plate Detected",
+        name="License Plate",
         icon="mdi:car",
         translation_key="license_plate",
         ufp_value="is_license_plate_currently_detected",

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -755,7 +755,6 @@ class ProtectLicensePlateEventSensor(EventEntityMixin, SensorEntity):
 
         if (
             (event := self._event) is not None
-            and self.entity_description.get_is_on(device, event)
             and (metadata := event.metadata) is not None
             and (license_plate := metadata.license_plate) is not None
         ):

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -756,9 +756,9 @@ class ProtectLicensePlateEventSensor(EventEntityMixin, SensorEntity):
 
         if (
             (event := self._event) is not None
+            and self.entity_description.get_is_on(device, event)
             and (metadata := event.metadata) is not None
             and (license_plate := metadata.license_plate) is not None
-            and self.entity_description.get_is_on(device, event)
         ):
             self._attr_native_value = license_plate.name
             return

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -681,7 +681,7 @@ def _async_event_entities(
             if not event_desc.has_required(device):
                 continue
 
-            entities.append(ProtectEventSensor(data, device, event_desc))
+            entities.append(ProtectLicensePlateEventSensor(data, device, event_desc))
             _LOGGER.debug(
                 "Adding sensor entity %s for %s",
                 description.name,
@@ -744,8 +744,8 @@ class ProtectNVRSensor(ProtectNVREntity, SensorEntity):
         return (self._attr_available, self._attr_native_value)
 
 
-class ProtectEventSensor(EventEntityMixin, SensorEntity):
-    """A UniFi Protect Device Sensor with access tokens."""
+class ProtectLicensePlateEventSensor(EventEntityMixin, SensorEntity):
+    """A UniFi Protect License Plate Device Sensor with access tokens."""
 
     entity_description: ProtectSensorEventEntityDescription
 
@@ -753,30 +753,19 @@ class ProtectEventSensor(EventEntityMixin, SensorEntity):
     def _async_update_device_from_protect(self, device: ProtectModelWithId) -> None:
         # do not call ProtectDeviceSensor method since we want event to get value here
         EventEntityMixin._async_update_device_from_protect(self, device)
-        event = self._event
-        entity_description = self.entity_description
-        is_on = entity_description.get_is_on(self.device, self._event)
-        is_license_plate = (
-            entity_description.ufp_event_obj == "last_license_plate_detect_event"
-        )
+
         if (
-            not is_on
-            or event is None
-            or (
-                is_license_plate
-                and (event.metadata is None or event.metadata.license_plate is None)
-            )
+            (event := self._event) is not None
+            and (metadata := event.metadata) is not None
+            and (license_plate := metadata.license_plate) is not None
+            and self.entity_description.get_is_on(device, event)
         ):
-            self._attr_native_value = OBJECT_TYPE_NONE
-            self._event = None
-            self._attr_extra_state_attributes = {}
+            self._attr_native_value = license_plate.name
             return
 
-        if is_license_plate:
-            # type verified above
-            self._attr_native_value = event.metadata.license_plate.name  # type: ignore[union-attr]
-        else:
-            self._attr_native_value = event.smart_detect_types[0].value
+        self._attr_native_value = OBJECT_TYPE_NONE
+        self._event = None
+        self._attr_extra_state_attributes = {}
 
     @callback
     def _async_get_state_attrs(self) -> tuple[Any, ...]:

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -520,7 +520,7 @@ NVR_DISABLED_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
     ),
 )
 
-EVENT_SENSORS: tuple[ProtectSensorEventEntityDescription, ...] = (
+LICENSE_PLATE_EVENT_SENSORS: tuple[ProtectSensorEventEntityDescription, ...] = (
     ProtectSensorEventEntityDescription(
         key="smart_obj_licenseplate",
         name="License Plate Detected",
@@ -677,7 +677,7 @@ def _async_event_entities(
         if not device.feature_flags.has_smart_detect:
             continue
 
-        for event_desc in EVENT_SENSORS:
+        for event_desc in LICENSE_PLATE_EVENT_SENSORS:
             if not event_desc.has_required(device):
                 continue
 

--- a/tests/components/unifiprotect/test_sensor.py
+++ b/tests/components/unifiprotect/test_sensor.py
@@ -19,7 +19,7 @@ from homeassistant.components.unifiprotect.sensor import (
     ALL_DEVICES_SENSORS,
     CAMERA_DISABLED_SENSORS,
     CAMERA_SENSORS,
-    EVENT_SENSORS,
+    LICENSE_PLATE_EVENT_SENSORS,
     MOTION_TRIP_SENSORS,
     NVR_DISABLED_SENSORS,
     NVR_SENSORS,
@@ -517,7 +517,7 @@ async def test_camera_update_licenseplate(
     assert_entity_counts(hass, Platform.SENSOR, 23, 13)
 
     _, entity_id = ids_from_device_description(
-        Platform.SENSOR, camera, EVENT_SENSORS[0]
+        Platform.SENSOR, camera, LICENSE_PLATE_EVENT_SENSORS[0]
     )
 
     event_metadata = EventMetadata(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The license plate detection would sometimes come in at the event `end` so `is_on` would return `False` because the check is always false if [`end` is not None](https://github.com/AngellusMortis/pyunifiprotect/blob/612194659c0bbc44747889e00f4533edff0dff9d/pyunifiprotect/data/devices.py#L1162), but a plate would be detected. It appears this is due to a recent change in protect and looking at my log, >95% of them now come with `end`.  To solve this, remove the `is_on` check and show the plate if one is in the metadata.  The trade off is that the plate will be displayed on the sensor until the next event but seemed better than it not working for most detections.

`2024-02-02 12:31:13.938 DEBUG (MainThread) [homeassistant.components.unifiprotect.data] event WS msg: {'model': <ModelType.EVENT: 'event'>, 'id': '65bcd267009b4003e400d312', 'type': <EventType.SMART_DETECT: 'smartDetectZone'>, 'start': datetime.datetime(2024, 2, 2, 11, 30, 44, 887000, tzinfo=datetime.timezone.utc), 'end': datetime.datetime(2024, 2, 2, 11, 31, 15, 429000, tzinfo=datetime.timezone.utc), 'score': 94, 'heatmap_id': None, 'camera_id': '6557561b01341203e4001466', 'smart_detect_types': [<SmartDetectObjectType.VEHICLE: 'vehicle'>, <SmartDetectObjectType.LICENSE_PLATE: 'licensePlate'>, <SmartDetectObjectType.PERSON: 'person'>, <SmartDetectObjectType.ANIMAL: 'animal'>], 'smart_detect_event_ids': [], 'thumbnail_id': None, 'user_id': None, 'timestamp': None, 'metadata': {'client_platform': None, 'reason': None, 'app_update': None, 'light_id': None, 'light_name': None, 'type': None, 'sensor_id': None, 'sensor_name': None, 'sensor_type': None, 'doorlock_id': None, 'doorlock_name': None, 'from_value': None, 'to_value': None, 'mount_type': None, 'status': None, 'alarm_type': None, 'device_id': None, 'mac': None, 'license_plate': {'name': 'SX367F', 'confidence_level': 97}, 'detected_thumbnails': None}, 'deleted_at': None, 'deletion_type': None, 'category': None, 'sub_category': None}`

We only have one event sensor type now, license plate detections.

Since it had branching, remove the unused branching. In the future there might be new ones and if so we can add back ProtectEventSensor entities and keep the license plate one separate since it functions a bit different than the original design


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #109290
- This PR is related to issue: #
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
