### PR TITLE
Improve color mode handling in light groups

### DIFF
--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -30,6 +30,7 @@ from homeassistant.components.light import (
     ColorMode,
     LightEntity,
     LightEntityFeature,
+    filter_supported_color_modes,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -162,6 +163,9 @@ class LightGroup(GroupEntity, LightEntity):
         if mode:
             self.mode = all
 
+        self._attr_color_mode = ColorMode.UNKNOWN
+        self._attr_supported_color_modes = {ColorMode.ONOFF}
+
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Forward the turn_on command to all lights in the light group."""
         data = {
@@ -261,26 +265,36 @@ class LightGroup(GroupEntity, LightEntity):
             effects_count = Counter(itertools.chain(all_effects))
             self._attr_effect = effects_count.most_common(1)[0][0]
 
-        self._attr_color_mode = None
-        all_color_modes = list(find_state_attributes(on_states, ATTR_COLOR_MODE))
-        if all_color_modes:
-            # Report the most common color mode, select brightness and onoff last
-            color_mode_count = Counter(itertools.chain(all_color_modes))
-            if ColorMode.ONOFF in color_mode_count:
-                color_mode_count[ColorMode.ONOFF] = -1
-            if ColorMode.BRIGHTNESS in color_mode_count:
-                color_mode_count[ColorMode.BRIGHTNESS] = 0
-            self._attr_color_mode = color_mode_count.most_common(1)[0][0]
-
-        self._attr_supported_color_modes = None
+        supported_color_modes = {ColorMode.ONOFF}
         all_supported_color_modes = list(
             find_state_attributes(states, ATTR_SUPPORTED_COLOR_MODES)
         )
         if all_supported_color_modes:
             # Merge all color modes.
-            self._attr_supported_color_modes = cast(
-                set[str], set().union(*all_supported_color_modes)
+            supported_color_modes = filter_supported_color_modes(
+                cast(set[ColorMode], set().union(*all_supported_color_modes))
             )
+        self._attr_supported_color_modes = supported_color_modes
+
+        self._attr_color_mode = ColorMode.UNKNOWN
+        all_color_modes = list(find_state_attributes(on_states, ATTR_COLOR_MODE))
+        if all_color_modes:
+            # Report the most common color mode, select brightness and onoff last
+            color_mode_count = Counter(itertools.chain(all_color_modes))
+            if ColorMode.ONOFF in color_mode_count:
+                if ColorMode.ONOFF in supported_color_modes:
+                    color_mode_count[ColorMode.ONOFF] = -1
+                else:
+                    color_mode_count.pop(ColorMode.ONOFF)
+            if ColorMode.BRIGHTNESS in color_mode_count:
+                if ColorMode.BRIGHTNESS in supported_color_modes:
+                    color_mode_count[ColorMode.BRIGHTNESS] = 0
+                else:
+                    color_mode_count.pop(ColorMode.BRIGHTNESS)
+            if color_mode_count:
+                self._attr_color_mode = color_mode_count.most_common(1)[0][0]
+            else:
+                self._attr_color_mode = next(iter(supported_color_modes))
 
         self._attr_supported_features = LightEntityFeature(0)
         for support in find_state_attributes(states, ATTR_SUPPORTED_FEATURES):

--- a/tests/components/group/test_config_flow.py
+++ b/tests/components/group/test_config_flow.py
@@ -479,7 +479,7 @@ LIGHT_ATTRS = [
         "supported_color_modes": ["onoff"],
         "supported_features": 0,
     },
-    {"color_mode": "onoff"},
+    {"color_mode": "unknown"},
 ]
 LOCK_ATTRS = [{"supported_features": 1}, {}]
 MEDIA_PLAYER_ATTRS = [{"supported_features": 0}, {}]

--- a/tests/components/group/test_light.py
+++ b/tests/components/group/test_light.py
@@ -28,9 +28,6 @@ from homeassistant.components.light import (
     SERVICE_TOGGLE,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
-    SUPPORT_BRIGHTNESS,
-    SUPPORT_COLOR,
-    SUPPORT_COLOR_TEMP,
     ColorMode,
 )
 from homeassistant.const import (
@@ -278,10 +275,8 @@ async def test_brightness(
     entity0.brightness = 255
 
     entity1 = platform.ENTITIES[1]
-    entity1.supported_features = SUPPORT_BRIGHTNESS
-    # Set color modes to none to trigger backwards compatibility in LightEntity
-    entity1.supported_color_modes = None
-    entity1.color_mode = None
+    entity1.supported_color_modes = {ColorMode.BRIGHTNESS}
+    entity1.color_mode = ColorMode.BRIGHTNESS
 
     assert await async_setup_component(
         hass,
@@ -352,10 +347,8 @@ async def test_color_hs(hass: HomeAssistant, enable_custom_integrations: None) -
     entity0.hs_color = (0, 100)
 
     entity1 = platform.ENTITIES[1]
-    entity1.supported_features = SUPPORT_COLOR
-    # Set color modes to none to trigger backwards compatibility in LightEntity
-    entity1.supported_color_modes = None
-    entity1.color_mode = None
+    entity1.supported_color_modes = {ColorMode.HS}
+    entity1.color_mode = ColorMode.HS
 
     assert await async_setup_component(
         hass,
@@ -703,10 +696,8 @@ async def test_color_temp(
     entity0.color_temp_kelvin = 2
 
     entity1 = platform.ENTITIES[1]
-    entity1.supported_features = SUPPORT_COLOR_TEMP
-    # Set color modes to none to trigger backwards compatibility in LightEntity
-    entity1.supported_color_modes = None
-    entity1.color_mode = None
+    entity1.supported_color_modes = {ColorMode.COLOR_TEMP}
+    entity1.color_mode = ColorMode.COLOR_TEMP
 
     assert await async_setup_component(
         hass,
@@ -846,10 +837,8 @@ async def test_min_max_mireds(
     entity0._attr_max_color_temp_kelvin = 5
 
     entity1 = platform.ENTITIES[1]
-    entity1.supported_features = SUPPORT_COLOR_TEMP
-    # Set color modes to none to trigger backwards compatibility in LightEntity
-    entity1.supported_color_modes = None
-    entity1.color_mode = None
+    entity1.supported_color_modes = {ColorMode.COLOR_TEMP}
+    entity1.color_mode = ColorMode.COLOR_TEMP
     entity1._attr_min_color_temp_kelvin = 1
     entity1._attr_max_color_temp_kelvin = 1234567890
 
@@ -1021,15 +1010,15 @@ async def test_supported_color_modes(
 
     entity0 = platform.ENTITIES[0]
     entity0.supported_color_modes = {ColorMode.COLOR_TEMP, ColorMode.HS}
+    entity0.color_mode = ColorMode.UNKNOWN
 
     entity1 = platform.ENTITIES[1]
     entity1.supported_color_modes = {ColorMode.RGBW, ColorMode.RGBWW}
+    entity1.color_mode = ColorMode.UNKNOWN
 
     entity2 = platform.ENTITIES[2]
-    entity2.supported_features = SUPPORT_BRIGHTNESS
-    # Set color modes to none to trigger backwards compatibility in LightEntity
-    entity2.supported_color_modes = None
-    entity2.color_mode = None
+    entity2.supported_color_modes = {ColorMode.BRIGHTNESS}
+    entity2.color_mode = ColorMode.UNKNOWN
 
     assert await async_setup_component(
         hass,
@@ -1051,7 +1040,6 @@ async def test_supported_color_modes(
 
     state = hass.states.get("light.light_group")
     assert set(state.attributes[ATTR_SUPPORTED_COLOR_MODES]) == {
-        "brightness",
         "color_temp",
         "hs",
         "rgbw",
@@ -1198,6 +1186,7 @@ async def test_color_mode2(
     await hass.async_block_till_done()
 
     state = hass.states.get("light.light_group")
+    assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == [ColorMode.COLOR_TEMP]
     assert state.attributes[ATTR_COLOR_MODE] == ColorMode.COLOR_TEMP
 
     await hass.services.async_call(
@@ -1208,7 +1197,8 @@ async def test_color_mode2(
     )
     await hass.async_block_till_done()
     state = hass.states.get("light.light_group")
-    assert state.attributes[ATTR_COLOR_MODE] == ColorMode.BRIGHTNESS
+    assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == [ColorMode.COLOR_TEMP]
+    assert state.attributes[ATTR_COLOR_MODE] == ColorMode.COLOR_TEMP
 
 
 async def test_supported_features(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve color mode handling in light groups:
- Unconditionally initialize color mode and supported color modes in the constructor
- Filter the set of supported color modes and the color mode according to `LightEntity` rules

Also update the tests to not configure mock lights without support for color modes

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
