### PR TITLE
More thorough checks in ESPHome voice assistant UDP server

### DIFF
--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -352,7 +352,6 @@ class ESPHomeManager:
         if self.voice_assistant_udp_server is not None:
             _LOGGER.warning("Voice assistant UDP server was not stopped")
             self.voice_assistant_udp_server.stop()
-            self.voice_assistant_udp_server.close()
             self.voice_assistant_udp_server = None
 
         hass = self.hass

--- a/homeassistant/components/esphome/voice_assistant.py
+++ b/homeassistant/components/esphome/voice_assistant.py
@@ -68,7 +68,7 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
     """Receive UDP packets and forward them to the voice assistant."""
 
     started = False
-    stopped = False
+    stop_requested = False
     transport: asyncio.DatagramTransport | None = None
     remote_addr: tuple[str, int] | None = None
 
@@ -95,13 +95,8 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
 
     @property
     def is_running(self) -> bool:
-        """True if the the UDP server is started and hasn't been stopped."""
-        return (
-            self.started
-            and (not self.stopped)
-            and (self.transport is not None)
-            and (not self.transport.is_closing())
-        )
+        """True if the the UDP server is started and hasn't been asked to stop."""
+        return self.started and (not self.stop_requested)
 
     async def start_server(self) -> int:
         """Start accepting connections."""
@@ -110,7 +105,7 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
             """Accept connection."""
             if self.started:
                 raise RuntimeError("Can only start once")
-            if self.stopped:
+            if self.stop_requested:
                 raise RuntimeError("No longer accepting connections")
 
             self.started = True
@@ -135,7 +130,7 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
     @callback
     def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
         """Handle incoming UDP packet."""
-        if not self.started or self.stopped:
+        if not self.is_running:
             return
         if self.remote_addr is None:
             self.remote_addr = addr
@@ -153,19 +148,19 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
     def stop(self) -> None:
         """Stop the receiver."""
         self.queue.put_nowait(b"")
-        self.started = False
-        self.stopped = True
+        self.close()
 
     def close(self) -> None:
         """Close the receiver."""
         self.started = False
-        self.stopped = True
+        self.stop_requested = True
+
         if self.transport is not None:
             self.transport.close()
 
     async def _iterate_packets(self) -> AsyncIterable[bytes]:
         """Iterate over incoming packets."""
-        if not self.started or self.stopped:
+        if not self.is_running:
             raise RuntimeError("Not running")
 
         while data := await self.queue.get():
@@ -314,7 +309,13 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
 
     async def _send_tts(self, media_id: str) -> None:
         """Send TTS audio to device via UDP."""
+        # Always send stream start/end events
+        self.handle_event(VoiceAssistantEventType.VOICE_ASSISTANT_TTS_STREAM_START, {})
+
         try:
+            if not self.is_running:
+                return
+
             extension, data = await tts.async_get_media_source_audio(
                 self.hass,
                 media_id,
@@ -344,10 +345,6 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
             audio_bytes_size = len(audio_bytes)
 
             _LOGGER.debug("Sending %d bytes of audio", audio_bytes_size)
-
-            self.handle_event(
-                VoiceAssistantEventType.VOICE_ASSISTANT_TTS_STREAM_START, {}
-            )
 
             bytes_per_sample = stt.AudioBitRates.BITRATE_16 // 8
             sample_offset = 0

--- a/homeassistant/components/esphome/voice_assistant.py
+++ b/homeassistant/components/esphome/voice_assistant.py
@@ -313,7 +313,7 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
         self.handle_event(VoiceAssistantEventType.VOICE_ASSISTANT_TTS_STREAM_START, {})
 
         try:
-            if not self.is_running:
+            if (not self.is_running) or (self.transport is None):
                 return
 
             extension, data = await tts.async_get_media_source_audio(
@@ -356,7 +356,6 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
                 samples_in_chunk = len(chunk) // bytes_per_sample
                 samples_left -= samples_in_chunk
 
-                assert self.transport is not None  # checked with is_running
                 self.transport.sendto(chunk, self.remote_addr)
                 await asyncio.sleep(
                     samples_in_chunk / stt.AudioSampleRates.SAMPLERATE_16000 * 0.9

--- a/tests/components/esphome/test_voice_assistant.py
+++ b/tests/components/esphome/test_voice_assistant.py
@@ -70,6 +70,19 @@ def voice_assistant_udp_server_v2(
     return voice_assistant_udp_server(entry=mock_voice_assistant_v2_entry)
 
 
+@pytest.fixture
+def test_wav() -> bytes:
+    """Return one second of empty WAV audio."""
+    with io.BytesIO() as wav_io:
+        with wave.open(wav_io, "wb") as wav_file:
+            wav_file.setframerate(16000)
+            wav_file.setsampwidth(2)
+            wav_file.setnchannels(1)
+            wav_file.writeframes(bytes(_ONE_SECOND))
+
+        return wav_io.getvalue()
+
+
 async def test_pipeline_events(
     hass: HomeAssistant,
     voice_assistant_udp_server_v1: VoiceAssistantUDPServer,
@@ -241,11 +254,13 @@ async def test_udp_server_multiple(
     ):
         await voice_assistant_udp_server_v1.start_server()
 
-    with patch(
-        "homeassistant.components.esphome.voice_assistant.UDP_PORT",
-        new=unused_udp_port_factory(),
-    ), pytest.raises(RuntimeError):
-        pass
+    with (
+        patch(
+            "homeassistant.components.esphome.voice_assistant.UDP_PORT",
+            new=unused_udp_port_factory(),
+        ),
+        pytest.raises(RuntimeError),
+    ):
         await voice_assistant_udp_server_v1.start_server()
 
 
@@ -257,10 +272,13 @@ async def test_udp_server_after_stopped(
 ) -> None:
     """Test that the UDP server raises an error if started after stopped."""
     voice_assistant_udp_server_v1.close()
-    with patch(
-        "homeassistant.components.esphome.voice_assistant.UDP_PORT",
-        new=unused_udp_port_factory(),
-    ), pytest.raises(RuntimeError):
+    with (
+        patch(
+            "homeassistant.components.esphome.voice_assistant.UDP_PORT",
+            new=unused_udp_port_factory(),
+        ),
+        pytest.raises(RuntimeError),
+    ):
         await voice_assistant_udp_server_v1.start_server()
 
 
@@ -362,35 +380,33 @@ async def test_send_tts_not_called_when_empty(
 async def test_send_tts(
     hass: HomeAssistant,
     voice_assistant_udp_server_v2: VoiceAssistantUDPServer,
+    test_wav,
 ) -> None:
     """Test the UDP server calls sendto to transmit audio data to device."""
-    with io.BytesIO() as wav_io:
-        with wave.open(wav_io, "wb") as wav_file:
-            wav_file.setframerate(16000)
-            wav_file.setsampwidth(2)
-            wav_file.setnchannels(1)
-            wav_file.writeframes(bytes(_ONE_SECOND))
-
-        wav_bytes = wav_io.getvalue()
-
     with patch(
         "homeassistant.components.esphome.voice_assistant.tts.async_get_media_source_audio",
-        return_value=("wav", wav_bytes),
+        return_value=("wav", test_wav),
     ):
+        voice_assistant_udp_server_v2.started = True
         voice_assistant_udp_server_v2.transport = Mock(spec=asyncio.DatagramTransport)
-
-        voice_assistant_udp_server_v2._event_callback(
-            PipelineEvent(
-                type=PipelineEventType.TTS_END,
-                data={
-                    "tts_output": {"media_id": _TEST_MEDIA_ID, "url": _TEST_OUTPUT_URL}
-                },
+        with patch.object(
+            voice_assistant_udp_server_v2.transport, "is_closing", return_value=False
+        ):
+            voice_assistant_udp_server_v2._event_callback(
+                PipelineEvent(
+                    type=PipelineEventType.TTS_END,
+                    data={
+                        "tts_output": {
+                            "media_id": _TEST_MEDIA_ID,
+                            "url": _TEST_OUTPUT_URL,
+                        }
+                    },
+                )
             )
-        )
 
-        await voice_assistant_udp_server_v2._tts_done.wait()
+            await voice_assistant_udp_server_v2._tts_done.wait()
 
-        voice_assistant_udp_server_v2.transport.sendto.assert_called()
+            voice_assistant_udp_server_v2.transport.sendto.assert_called()
 
 
 async def test_send_tts_wrong_sample_rate(
@@ -400,17 +416,20 @@ async def test_send_tts_wrong_sample_rate(
     """Test the UDP server calls sendto to transmit audio data to device."""
     with io.BytesIO() as wav_io:
         with wave.open(wav_io, "wb") as wav_file:
-            wav_file.setframerate(22050)  # should be 16000
+            wav_file.setframerate(22050)
             wav_file.setsampwidth(2)
             wav_file.setnchannels(1)
             wav_file.writeframes(bytes(_ONE_SECOND))
 
         wav_bytes = wav_io.getvalue()
-
-    with patch(
-        "homeassistant.components.esphome.voice_assistant.tts.async_get_media_source_audio",
-        return_value=("wav", wav_bytes),
-    ), pytest.raises(ValueError):
+    with (
+        patch(
+            "homeassistant.components.esphome.voice_assistant.tts.async_get_media_source_audio",
+            return_value=("wav", wav_bytes),
+        ),
+        pytest.raises(ValueError),
+    ):
+        voice_assistant_udp_server_v2.started = True
         voice_assistant_udp_server_v2.transport = Mock(spec=asyncio.DatagramTransport)
 
         voice_assistant_udp_server_v2._event_callback(
@@ -431,10 +450,14 @@ async def test_send_tts_wrong_format(
     voice_assistant_udp_server_v2: VoiceAssistantUDPServer,
 ) -> None:
     """Test that only WAV audio will be streamed."""
-    with patch(
-        "homeassistant.components.esphome.voice_assistant.tts.async_get_media_source_audio",
-        return_value=("raw", bytes(1024)),
-    ), pytest.raises(ValueError):
+    with (
+        patch(
+            "homeassistant.components.esphome.voice_assistant.tts.async_get_media_source_audio",
+            return_value=("raw", bytes(1024)),
+        ),
+        pytest.raises(ValueError),
+    ):
+        voice_assistant_udp_server_v2.started = True
         voice_assistant_udp_server_v2.transport = Mock(spec=asyncio.DatagramTransport)
 
         voice_assistant_udp_server_v2._event_callback(
@@ -450,6 +473,33 @@ async def test_send_tts_wrong_format(
         await voice_assistant_udp_server_v2._tts_task  # raises ValueError
 
 
+async def test_send_tts_not_started(
+    hass: HomeAssistant,
+    voice_assistant_udp_server_v2: VoiceAssistantUDPServer,
+    test_wav,
+) -> None:
+    """Test the UDP server does not call sendto when not started."""
+    with patch(
+        "homeassistant.components.esphome.voice_assistant.tts.async_get_media_source_audio",
+        return_value=("wav", test_wav),
+    ):
+        voice_assistant_udp_server_v2.started = False
+        voice_assistant_udp_server_v2.transport = Mock(spec=asyncio.DatagramTransport)
+
+        voice_assistant_udp_server_v2._event_callback(
+            PipelineEvent(
+                type=PipelineEventType.TTS_END,
+                data={
+                    "tts_output": {"media_id": _TEST_MEDIA_ID, "url": _TEST_OUTPUT_URL}
+                },
+            )
+        )
+
+        await voice_assistant_udp_server_v2._tts_done.wait()
+
+        voice_assistant_udp_server_v2.transport.sendto.assert_not_called()
+
+
 async def test_wake_word(
     hass: HomeAssistant,
     voice_assistant_udp_server_v2: VoiceAssistantUDPServer,
@@ -459,11 +509,12 @@ async def test_wake_word(
     async def async_pipeline_from_audio_stream(*args, start_stage, **kwargs):
         assert start_stage == PipelineStage.WAKE_WORD
 
-    with patch(
-        "homeassistant.components.esphome.voice_assistant.async_pipeline_from_audio_stream",
-        new=async_pipeline_from_audio_stream,
-    ), patch(
-        "asyncio.Event.wait"  # TTS wait event
+    with (
+        patch(
+            "homeassistant.components.esphome.voice_assistant.async_pipeline_from_audio_stream",
+            new=async_pipeline_from_audio_stream,
+        ),
+        patch("asyncio.Event.wait"),  # TTS wait event
     ):
         voice_assistant_udp_server_v2.transport = Mock()
 
@@ -515,10 +566,15 @@ async def test_wake_word_abort_exception(
     async def async_pipeline_from_audio_stream(*args, **kwargs):
         raise WakeWordDetectionAborted
 
-    with patch(
-        "homeassistant.components.esphome.voice_assistant.async_pipeline_from_audio_stream",
-        new=async_pipeline_from_audio_stream,
-    ), patch.object(voice_assistant_udp_server_v2, "handle_event") as mock_handle_event:
+    with (
+        patch(
+            "homeassistant.components.esphome.voice_assistant.async_pipeline_from_audio_stream",
+            new=async_pipeline_from_audio_stream,
+        ),
+        patch.object(
+            voice_assistant_udp_server_v2, "handle_event"
+        ) as mock_handle_event,
+    ):
         voice_assistant_udp_server_v2.transport = Mock()
 
         await voice_assistant_udp_server_v2.run_pipeline(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
An issue has been reported in which ESPHome voice assistants get "out of step" with TTS responses, i.e. they respond to the current voice command with the TTS from the previous one. Additionally, multiple "Voice assistant UDP server was not stopped" warnings are reported in the logs.

A possible cause is that the TTS streaming task does not currently check if its UDP server has been stopped while it's streaming. This PR adds a new `is_running` property to the UDP voice assistant server that is only `True` when the UDP server is started, not stopped, and its socket is still connected. If any of these conditions fail, TTS streaming is halted.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
