### PR TITLE
Bump aioelectricitymaps to 0.3.0

### DIFF
--- a/homeassistant/components/co2signal/config_flow.py
+++ b/homeassistant/components/co2signal/config_flow.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from aioelectricitymaps import ElectricityMaps
-from aioelectricitymaps.exceptions import ElectricityMapsError, InvalidToken
+from aioelectricitymaps import (
+    ElectricityMaps,
+    ElectricityMapsError,
+    ElectricityMapsInvalidTokenError,
+)
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -146,7 +149,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             try:
                 await fetch_latest_carbon_intensity(self.hass, em, data)
-            except InvalidToken:
+            except ElectricityMapsInvalidTokenError:
                 errors["base"] = "invalid_auth"
             except ElectricityMapsError:
                 errors["base"] = "unknown"

--- a/homeassistant/components/co2signal/coordinator.py
+++ b/homeassistant/components/co2signal/coordinator.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 
-from aioelectricitymaps import ElectricityMaps
-from aioelectricitymaps.exceptions import ElectricityMapsError, InvalidToken
-from aioelectricitymaps.models import CarbonIntensityResponse
+from aioelectricitymaps import (
+    CarbonIntensityResponse,
+    ElectricityMaps,
+    ElectricityMapsError,
+    ElectricityMapsInvalidTokenError,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -43,7 +46,7 @@ class CO2SignalCoordinator(DataUpdateCoordinator[CarbonIntensityResponse]):
             return await fetch_latest_carbon_intensity(
                 self.hass, self.client, self.config_entry.data
             )
-        except InvalidToken as err:
+        except ElectricityMapsInvalidTokenError as err:
             raise ConfigEntryAuthFailed from err
         except ElectricityMapsError as err:
             raise UpdateFailed(str(err)) from err

--- a/homeassistant/components/co2signal/manifest.json
+++ b/homeassistant/components/co2signal/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["aioelectricitymaps"],
-  "requirements": ["aioelectricitymaps==0.2.0"]
+  "requirements": ["aioelectricitymaps==0.3.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -233,7 +233,7 @@ aioeagle==1.1.0
 aioecowitt==2023.5.0
 
 # homeassistant.components.co2signal
-aioelectricitymaps==0.2.0
+aioelectricitymaps==0.3.0
 
 # homeassistant.components.emonitor
 aioemonitor==1.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -212,7 +212,7 @@ aioeagle==1.1.0
 aioecowitt==2023.5.0
 
 # homeassistant.components.co2signal
-aioelectricitymaps==0.2.0
+aioelectricitymaps==0.3.0
 
 # homeassistant.components.emonitor
 aioemonitor==1.0.5

--- a/tests/components/co2signal/test_config_flow.py
+++ b/tests/components/co2signal/test_config_flow.py
@@ -1,10 +1,10 @@
 """Test the CO2 Signal config flow."""
 from unittest.mock import AsyncMock, patch
 
-from aioelectricitymaps.exceptions import (
-    ElectricityMapsDecodeError,
+from aioelectricitymaps import (
+    ElectricityMapsConnectionError,
     ElectricityMapsError,
-    InvalidToken,
+    ElectricityMapsInvalidTokenError,
 )
 import pytest
 
@@ -134,11 +134,11 @@ async def test_form_country(hass: HomeAssistant) -> None:
     ("side_effect", "err_code"),
     [
         (
-            InvalidToken,
+            ElectricityMapsInvalidTokenError,
             "invalid_auth",
         ),
         (ElectricityMapsError("Something else"), "unknown"),
-        (ElectricityMapsDecodeError("Boom"), "unknown"),
+        (ElectricityMapsConnectionError("Boom"), "unknown"),
     ],
     ids=[
         "invalid auth",

--- a/tests/components/co2signal/test_sensor.py
+++ b/tests/components/co2signal/test_sensor.py
@@ -2,10 +2,11 @@
 from datetime import timedelta
 from unittest.mock import AsyncMock
 
-from aioelectricitymaps.exceptions import (
-    ElectricityMapsDecodeError,
+from aioelectricitymaps import (
+    ElectricityMapsConnectionError,
+    ElectricityMapsConnectionTimeoutError,
     ElectricityMapsError,
-    InvalidToken,
+    ElectricityMapsInvalidTokenError,
 )
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -42,7 +43,8 @@ async def test_sensor(
 @pytest.mark.parametrize(
     "error",
     [
-        ElectricityMapsDecodeError,
+        ElectricityMapsConnectionTimeoutError,
+        ElectricityMapsConnectionError,
         ElectricityMapsError,
         Exception,
     ],
@@ -93,8 +95,12 @@ async def test_sensor_reauth_triggered(
     assert (state := hass.states.get("sensor.electricity_maps_co2_intensity"))
     assert state.state == "45.9862319009581"
 
-    electricity_maps.latest_carbon_intensity_by_coordinates.side_effect = InvalidToken
-    electricity_maps.latest_carbon_intensity_by_country_code.side_effect = InvalidToken
+    electricity_maps.latest_carbon_intensity_by_coordinates.side_effect = (
+        ElectricityMapsInvalidTokenError
+    )
+    electricity_maps.latest_carbon_intensity_by_country_code.side_effect = (
+        ElectricityMapsInvalidTokenError
+    )
 
     freezer.tick(timedelta(minutes=20))
     async_fire_time_changed(hass)


### PR DESCRIPTION
## Proposed change
Bumping `aioelectricitymaps` to add a guard agains non-200 HTTP responses, they are not well handled atm.
It also corrects a naming error in the upstream package.

https://github.com/jpbede/aioelectricitymaps/releases/tag/v0.3.0
https://github.com/jpbede/aioelectricitymaps/compare/v0.2.0...v0.3.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
