### PR TITLE
Revert "Add webhook support to tedee integration (#106846)"

### DIFF
--- a/homeassistant/components/tedee/__init__.py
+++ b/homeassistant/components/tedee/__init__.py
@@ -1,25 +1,12 @@
 """Init the tedee component."""
-from collections.abc import Awaitable, Callable
-from http import HTTPStatus
 import logging
-from typing import Any
 
-from aiohttp.hdrs import METH_POST
-from aiohttp.web import Request, Response
-from pytedee_async.exception import TedeeWebhookException
-
-from homeassistant.components.http import HomeAssistantView
-from homeassistant.components.webhook import (
-    async_generate_url as webhook_generate_url,
-    async_register as webhook_register,
-    async_unregister as webhook_unregister,
-)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_WEBHOOK_ID, EVENT_HOMEASSISTANT_STOP, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from .const import DOMAIN, NAME
+from .const import DOMAIN
 from .coordinator import TedeeApiCoordinator
 
 PLATFORMS = [
@@ -50,38 +37,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
-    async def unregister_webhook(_: Any) -> None:
-        await coordinator.async_unregister_webhook()
-        webhook_unregister(hass, entry.data[CONF_WEBHOOK_ID])
-
-    async def register_webhook() -> None:
-        webhook_url = webhook_generate_url(hass, entry.data[CONF_WEBHOOK_ID])
-        webhook_name = "Tedee"
-        if entry.title != NAME:
-            webhook_name = f"{NAME} {entry.title}"
-
-        webhook_register(
-            hass,
-            DOMAIN,
-            webhook_name,
-            entry.data[CONF_WEBHOOK_ID],
-            get_webhook_handler(coordinator),
-            allowed_methods=[METH_POST],
-        )
-        _LOGGER.debug("Registered Tedee webhook at hass: %s", webhook_url)
-
-        try:
-            await coordinator.async_register_webhook(webhook_url)
-        except TedeeWebhookException as ex:
-            _LOGGER.warning("Failed to register Tedee webhook from bridge: %s", ex)
-        else:
-            entry.async_on_unload(
-                hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, unregister_webhook)
-            )
-
-    entry.async_create_background_task(
-        hass, register_webhook(), "tedee_register_webhook"
-    )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
@@ -90,34 +45,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
 
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
-
-
-def get_webhook_handler(
-    coordinator: TedeeApiCoordinator,
-) -> Callable[[HomeAssistant, str, Request], Awaitable[Response | None]]:
-    """Return webhook handler."""
-
-    async def async_webhook_handler(
-        hass: HomeAssistant, webhook_id: str, request: Request
-    ) -> Response | None:
-        # Handle http post calls to the path.
-        if not request.body_exists:
-            return HomeAssistantView.json(
-                result="No Body", status_code=HTTPStatus.BAD_REQUEST
-            )
-
-        body = await request.json()
-        try:
-            coordinator.webhook_received(body)
-        except TedeeWebhookException as ex:
-            return HomeAssistantView.json(
-                result=str(ex), status_code=HTTPStatus.BAD_REQUEST
-            )
-
-        return HomeAssistantView.json(result="OK", status_code=HTTPStatus.OK)
-
-    return async_webhook_handler

--- a/homeassistant/components/tedee/config_flow.py
+++ b/homeassistant/components/tedee/config_flow.py
@@ -11,9 +11,8 @@ from pytedee_async import (
 )
 import voluptuous as vol
 
-from homeassistant.components.webhook import async_generate_id as webhook_generate_id
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
-from homeassistant.const import CONF_HOST, CONF_WEBHOOK_ID
+from homeassistant.const import CONF_HOST
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -62,10 +61,7 @@ class TedeeConfigFlow(ConfigFlow, domain=DOMAIN):
                     return self.async_abort(reason="reauth_successful")
                 await self.async_set_unique_id(local_bridge.serial)
                 self._abort_if_unique_id_configured()
-                return self.async_create_entry(
-                    title=NAME,
-                    data={**user_input, CONF_WEBHOOK_ID: webhook_generate_id()},
-                )
+                return self.async_create_entry(title=NAME, data=user_input)
 
         return self.async_show_form(
             step_id="user",

--- a/homeassistant/components/tedee/coordinator.py
+++ b/homeassistant/components/tedee/coordinator.py
@@ -3,7 +3,6 @@ from collections.abc import Awaitable, Callable
 from datetime import timedelta
 import logging
 import time
-from typing import Any
 
 from pytedee_async import (
     TedeeClient,
@@ -11,7 +10,6 @@ from pytedee_async import (
     TedeeDataUpdateException,
     TedeeLocalAuthException,
     TedeeLock,
-    TedeeWebhookException,
 )
 from pytedee_async.bridge import TedeeBridge
 
@@ -25,7 +23,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import CONF_LOCAL_ACCESS_TOKEN, DOMAIN
 
-SCAN_INTERVAL = timedelta(seconds=30)
+SCAN_INTERVAL = timedelta(seconds=20)
 GET_LOCKS_INTERVAL_SECONDS = 3600
 
 _LOGGER = logging.getLogger(__name__)
@@ -55,7 +53,6 @@ class TedeeApiCoordinator(DataUpdateCoordinator[dict[int, TedeeLock]]):
         self._next_get_locks = time.time()
         self._locks_last_update: set[int] = set()
         self.new_lock_callbacks: list[Callable[[int], None]] = []
-        self.tedee_webhook_id: int | None = None
 
     @property
     def bridge(self) -> TedeeBridge:
@@ -105,27 +102,6 @@ class TedeeApiCoordinator(DataUpdateCoordinator[dict[int, TedeeLock]]):
             raise UpdateFailed("Error while updating data: %s" % str(ex)) from ex
         except (TedeeClientException, TimeoutError) as ex:
             raise UpdateFailed("Querying API failed. Error: %s" % str(ex)) from ex
-
-    def webhook_received(self, message: dict[str, Any]) -> None:
-        """Handle webhook message."""
-        self.tedee_client.parse_webhook_message(message)
-        self.async_set_updated_data(self.tedee_client.locks_dict)
-
-    async def async_register_webhook(self, webhook_url: str) -> None:
-        """Register the webhook at the Tedee bridge."""
-        self.tedee_webhook_id = await self.tedee_client.register_webhook(webhook_url)
-
-    async def async_unregister_webhook(self) -> None:
-        """Unregister the webhook at the Tedee bridge."""
-        if self.tedee_webhook_id is not None:
-            try:
-                await self.tedee_client.delete_webhook(self.tedee_webhook_id)
-            except TedeeWebhookException as ex:
-                _LOGGER.warning(
-                    "Failed to unregister Tedee webhook from bridge: %s", ex
-                )
-            else:
-                _LOGGER.debug("Unregistered Tedee webhook")
 
     def _async_add_remove_locks(self) -> None:
         """Add new locks, remove non-existing locks."""

--- a/homeassistant/components/tedee/manifest.json
+++ b/homeassistant/components/tedee/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tedee",
   "codeowners": ["@patrickhilker", "@zweckj"],
   "config_flow": true,
-  "dependencies": ["http", "webhook"],
+  "dependencies": ["http"],
   "documentation": "https://www.home-assistant.io/integrations/tedee",
   "iot_class": "local_push",
   "requirements": ["pytedee-async==0.2.13"]

--- a/tests/components/tedee/conftest.py
+++ b/tests/components/tedee/conftest.py
@@ -10,12 +10,10 @@ from pytedee_async.lock import TedeeLock
 import pytest
 
 from homeassistant.components.tedee.const import CONF_LOCAL_ACCESS_TOKEN, DOMAIN
-from homeassistant.const import CONF_HOST, CONF_WEBHOOK_ID
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_fixture
-
-WEBHOOK_ID = "bq33efxmdi3vxy55q2wbnudbra7iv8mjrq9x0gea33g4zqtd87093pwveg8xcb33"
 
 
 @pytest.fixture
@@ -27,7 +25,6 @@ def mock_config_entry() -> MockConfigEntry:
         data={
             CONF_LOCAL_ACCESS_TOKEN: "api_token",
             CONF_HOST: "192.168.1.42",
-            CONF_WEBHOOK_ID: WEBHOOK_ID,
         },
         unique_id="0000-0000",
     )
@@ -62,8 +59,6 @@ def mock_tedee(request) -> Generator[MagicMock, None, None]:
         tedee.get_local_bridge.return_value = TedeeBridge(0, "0000-0000", "Bridge-AB1C")
 
         tedee.parse_webhook_message.return_value = None
-        tedee.register_webhook.return_value = 1
-        tedee.delete_webhooks.return_value = None
 
         locks_json = json.loads(load_fixture("locks.json", DOMAIN))
 

--- a/tests/components/tedee/test_config_flow.py
+++ b/tests/components/tedee/test_config_flow.py
@@ -1,5 +1,5 @@
 """Test the Tedee config flow."""
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from pytedee_async import (
     TedeeClientException,
@@ -10,11 +10,9 @@ import pytest
 
 from homeassistant.components.tedee.const import CONF_LOCAL_ACCESS_TOKEN, DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
-from homeassistant.const import CONF_HOST, CONF_WEBHOOK_ID
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-
-from .conftest import WEBHOOK_ID
 
 from tests.common import MockConfigEntry
 
@@ -24,30 +22,25 @@ LOCAL_ACCESS_TOKEN = "api_token"
 
 async def test_flow(hass: HomeAssistant, mock_tedee: MagicMock) -> None:
     """Test config flow with one bridge."""
-    with patch(
-        "homeassistant.components.tedee.config_flow.webhook_generate_id",
-        return_value=WEBHOOK_ID,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}
-        )
-        await hass.async_block_till_done()
-        assert result["type"] == FlowResultType.FORM
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.FORM
 
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_HOST: "192.168.1.62",
-                CONF_LOCAL_ACCESS_TOKEN: "token",
-            },
-        )
-
-        assert result2["type"] == FlowResultType.CREATE_ENTRY
-        assert result2["data"] == {
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
             CONF_HOST: "192.168.1.62",
             CONF_LOCAL_ACCESS_TOKEN: "token",
-            CONF_WEBHOOK_ID: WEBHOOK_ID,
-        }
+        },
+    )
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["data"] == {
+        CONF_HOST: "192.168.1.62",
+        CONF_LOCAL_ACCESS_TOKEN: "token",
+    }
 
 
 async def test_flow_already_configured(

--- a/tests/components/tedee/test_init.py
+++ b/tests/components/tedee/test_init.py
@@ -1,27 +1,15 @@
 """Test initialization of tedee."""
-from http import HTTPStatus
-from typing import Any
 from unittest.mock import MagicMock
-from urllib.parse import urlparse
 
-from pytedee_async.exception import (
-    TedeeAuthException,
-    TedeeClientException,
-    TedeeWebhookException,
-)
+from pytedee_async.exception import TedeeAuthException, TedeeClientException
 import pytest
 from syrupy import SnapshotAssertion
 
-from homeassistant.components.webhook import async_generate_url
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from .conftest import WEBHOOK_ID
-
 from tests.common import MockConfigEntry
-from tests.typing import ClientSessionGenerator
 
 
 async def test_load_unload_config_entry(
@@ -62,62 +50,6 @@ async def test_config_entry_not_ready(
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_cleanup_on_shutdown(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_tedee: MagicMock,
-) -> None:
-    """Test the webhook is cleaned up on shutdown."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert mock_config_entry.state is ConfigEntryState.LOADED
-
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
-    await hass.async_block_till_done()
-    mock_tedee.delete_webhook.assert_called_once()
-
-
-async def test_webhook_cleanup_errors(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_tedee: MagicMock,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test the webhook is cleaned up on shutdown."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert mock_config_entry.state is ConfigEntryState.LOADED
-
-    mock_tedee.delete_webhook.side_effect = TedeeWebhookException("")
-
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
-    await hass.async_block_till_done()
-    mock_tedee.delete_webhook.assert_called_once()
-    assert "Failed to unregister Tedee webhook from bridge" in caplog.text
-
-
-async def test_webhook_registration_errors(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_tedee: MagicMock,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test the webhook is cleaned up on shutdown."""
-    mock_tedee.register_webhook.side_effect = TedeeWebhookException("")
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert mock_config_entry.state is ConfigEntryState.LOADED
-
-    mock_tedee.register_webhook.assert_called_once()
-    assert "Failed to register Tedee webhook from bridge" in caplog.text
-
-
 async def test_bridge_device(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -135,37 +67,3 @@ async def test_bridge_device(
     )
     assert device
     assert device == snapshot
-
-
-@pytest.mark.parametrize(
-    ("body", "expected_code", "side_effect"),
-    [
-        ({"hello": "world"}, HTTPStatus.OK, None),  # Success
-        (None, HTTPStatus.BAD_REQUEST, None),  # Missing data
-        ({}, HTTPStatus.BAD_REQUEST, TedeeWebhookException),  # Error
-    ],
-)
-async def test_webhook_post(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_tedee: MagicMock,
-    hass_client_no_auth: ClientSessionGenerator,
-    body: dict[str, Any],
-    expected_code: HTTPStatus,
-    side_effect: Exception,
-) -> None:
-    """Test webhook callback."""
-
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    client = await hass_client_no_auth()
-    webhook_url = async_generate_url(hass, WEBHOOK_ID)
-    mock_tedee.parse_webhook_message.side_effect = side_effect
-    resp = await client.post(urlparse(webhook_url).path, json=body)
-
-    # Wait for remaining tasks to complete.
-    await hass.async_block_till_done()
-
-    assert resp.status == expected_code

--- a/tests/components/tedee/test_lock.py
+++ b/tests/components/tedee/test_lock.py
@@ -1,10 +1,9 @@
 """Tests for tedee lock."""
 from datetime import timedelta
 from unittest.mock import MagicMock
-from urllib.parse import urlparse
 
 from freezegun.api import FrozenDateTimeFactory
-from pytedee_async import TedeeLock, TedeeLockState
+from pytedee_async import TedeeLock
 from pytedee_async.exception import (
     TedeeClientException,
     TedeeDataUpdateException,
@@ -18,21 +17,15 @@ from homeassistant.components.lock import (
     SERVICE_LOCK,
     SERVICE_OPEN,
     SERVICE_UNLOCK,
-    STATE_LOCKED,
     STATE_LOCKING,
-    STATE_UNLOCKED,
     STATE_UNLOCKING,
 )
-from homeassistant.components.webhook import async_generate_url
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from .conftest import WEBHOOK_ID
-
 from tests.common import MockConfigEntry, async_fire_time_changed
-from tests.typing import ClientSessionGenerator
 
 pytestmark = pytest.mark.usefixtures("init_integration")
 
@@ -273,28 +266,3 @@ async def test_new_lock(
     assert state
     state = hass.states.get("lock.lock_6g7h")
     assert state
-
-
-async def test_webhook_update(
-    hass: HomeAssistant,
-    mock_tedee: MagicMock,
-    hass_client_no_auth: ClientSessionGenerator,
-) -> None:
-    """Test updated data set through webhook."""
-
-    state = hass.states.get("lock.lock_1a2b")
-    assert state
-    assert state.state == STATE_UNLOCKED
-
-    webhook_data = {"dummystate": 6}
-    mock_tedee.locks_dict[
-        12345
-    ].state = TedeeLockState.LOCKED  # is updated in the lib, so mock and assert in L296
-    client = await hass_client_no_auth()
-    webhook_url = async_generate_url(hass, WEBHOOK_ID)
-    await client.post(urlparse(webhook_url).path, json=webhook_data)
-    mock_tedee.parse_webhook_message.assert_called_once_with(webhook_data)
-
-    state = hass.states.get("lock.lock_1a2b")
-    assert state
-    assert state.state == STATE_LOCKED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR reverts commit 00c2ba69f7e4749308a4a4d1f59b43b9c44dd0bf (PR #106846)

If you'd prefer disabling the webhhok by feature flag instead of reverting the commit just let me know.

### Problem
The bridge firmware currently can not cope with the long webhook URIs and/or https (compared to the ones in the custom component) for longer periods of time/operations and will after some time crash/become completely unresponsive to the point where it needs a factory reset. I already made Tedee aware of this issue, but until we come up with a viable solution, we need to disable/remove it again.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
