### PR TITLE
Avoid duplicate entity names in proximity

### DIFF
--- a/homeassistant/components/proximity/config_flow.py
+++ b/homeassistant/components/proximity/config_flow.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.selector import (
     NumberSelector,
     NumberSelectorConfig,
 )
+from homeassistant.util import slugify
 
 from .const import (
     CONF_IGNORED_ZONES,
@@ -91,17 +92,17 @@ class ProximityConfigFlow(ConfigFlow, domain=DOMAIN):
 
             title = cast(State, self.hass.states.get(user_input[CONF_ZONE])).name
 
-            existing_entry_titles = [
-                e.title.lower() for e in self._async_current_entries()
+            slugified_existing_entry_titles = [
+                slugify(e.title) for e in self._async_current_entries()
             ]
-            if any(t for t in existing_entry_titles if t == title.lower()):
-                for possible_title in [f"{title}{i}" for i in range(2, 11)]:
-                    if possible_title.lower() in existing_entry_titles:
-                        continue
-                    title = possible_title
-                    break
 
-            return self.async_create_entry(title=title, data=user_input)
+            possible_title = title
+            tries = 1
+            while slugify(possible_title) in slugified_existing_entry_titles:
+                tries += 1
+                possible_title = f"{title} {tries}"
+
+            return self.async_create_entry(title=possible_title, data=user_input)
 
         return self.async_show_form(
             step_id="user",

--- a/homeassistant/components/proximity/config_flow.py
+++ b/homeassistant/components/proximity/config_flow.py
@@ -95,7 +95,7 @@ class ProximityConfigFlow(ConfigFlow, domain=DOMAIN):
                 e.title.lower() for e in self._async_current_entries()
             ]
             if any(t for t in existing_entry_titles if t == title.lower()):
-                for possible_title in [f"{title}{i}" for i in range(10)]:
+                for possible_title in [f"{title}{i}" for i in range(2, 11)]:
                     if possible_title.lower() in existing_entry_titles:
                         continue
                     title = possible_title

--- a/tests/components/proximity/test_config_flow.py
+++ b/tests/components/proximity/test_config_flow.py
@@ -203,7 +203,7 @@ async def test_avoid_duplicated_title(hass: HomeAssistant) -> None:
 
     MockConfigEntry(
         domain=DOMAIN,
-        title="home3",
+        title="home 3",
         data={
             CONF_ZONE: "zone.home",
             CONF_TRACKED_ENTITIES: ["device_tracker.test2"],
@@ -229,7 +229,7 @@ async def test_avoid_duplicated_title(hass: HomeAssistant) -> None:
             },
         )
         assert result["type"] == FlowResultType.CREATE_ENTRY
-        assert result["title"] == "home2"
+        assert result["title"] == "home 2"
 
         await hass.async_block_till_done()
 
@@ -246,6 +246,6 @@ async def test_avoid_duplicated_title(hass: HomeAssistant) -> None:
             },
         )
         assert result["type"] == FlowResultType.CREATE_ENTRY
-        assert result["title"] == "home4"
+        assert result["title"] == "home 4"
 
         await hass.async_block_till_done()

--- a/tests/components/proximity/test_config_flow.py
+++ b/tests/components/proximity/test_config_flow.py
@@ -185,3 +185,67 @@ async def test_abort_duplicated_entry(hass: HomeAssistant) -> None:
         assert result["reason"] == "already_configured"
 
         await hass.async_block_till_done()
+
+
+async def test_avoid_duplicated_title(hass: HomeAssistant) -> None:
+    """Test if we avoid duplicate titles."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        title="home",
+        data={
+            CONF_ZONE: "zone.home",
+            CONF_TRACKED_ENTITIES: ["device_tracker.test1"],
+            CONF_IGNORED_ZONES: ["zone.work"],
+            CONF_TOLERANCE: 10,
+        },
+        unique_id=f"{DOMAIN}_home",
+    ).add_to_hass(hass)
+
+    MockConfigEntry(
+        domain=DOMAIN,
+        title="home1",
+        data={
+            CONF_ZONE: "zone.home",
+            CONF_TRACKED_ENTITIES: ["device_tracker.test2"],
+            CONF_IGNORED_ZONES: ["zone.work"],
+            CONF_TOLERANCE: 10,
+        },
+        unique_id=f"{DOMAIN}_home",
+    ).add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.proximity.async_setup_entry", return_value=True
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_ZONE: "zone.home",
+                CONF_TRACKED_ENTITIES: ["device_tracker.test3"],
+                CONF_IGNORED_ZONES: [],
+                CONF_TOLERANCE: 10,
+            },
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["title"] == "home0"
+
+        await hass.async_block_till_done()
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_ZONE: "zone.home",
+                CONF_TRACKED_ENTITIES: ["device_tracker.test4"],
+                CONF_IGNORED_ZONES: [],
+                CONF_TOLERANCE: 10,
+            },
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["title"] == "home2"
+
+        await hass.async_block_till_done()

--- a/tests/components/proximity/test_config_flow.py
+++ b/tests/components/proximity/test_config_flow.py
@@ -203,7 +203,7 @@ async def test_avoid_duplicated_title(hass: HomeAssistant) -> None:
 
     MockConfigEntry(
         domain=DOMAIN,
-        title="home1",
+        title="home3",
         data={
             CONF_ZONE: "zone.home",
             CONF_TRACKED_ENTITIES: ["device_tracker.test2"],
@@ -229,7 +229,7 @@ async def test_avoid_duplicated_title(hass: HomeAssistant) -> None:
             },
         )
         assert result["type"] == FlowResultType.CREATE_ENTRY
-        assert result["title"] == "home0"
+        assert result["title"] == "home2"
 
         await hass.async_block_till_done()
 
@@ -246,6 +246,6 @@ async def test_avoid_duplicated_title(hass: HomeAssistant) -> None:
             },
         )
         assert result["type"] == FlowResultType.CREATE_ENTRY
-        assert result["title"] == "home2"
+        assert result["title"] == "home4"
 
         await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In beta channel on discord, users reported use cases where they have multiple proximity configurations for the same zone, but with different tracked entities and ignored zones. So we cannot use the monitored zones name in DeviceInfo, because it will lead to duplicated entity names (_those they are consecutively numbered eq `sensor.home_nearest` and `sensor.home_nearest_2`_).
To avoid this, we check if same title (_zone name_) is already used and consecutively number the title (_this is limited to a range from 2 to 10_):

![image](https://github.com/home-assistant/core/assets/35783820/15afdd97-0d11-4feb-ba36-9c366883b21e)

![image](https://github.com/home-assistant/core/assets/35783820/e5e03e5c-192c-450f-a482-071d0f3da5e1)

![image](https://github.com/home-assistant/core/assets/35783820/a06bc274-a5c9-4086-b3db-1753450086a2)


This change is not considered as breaking change, because the new sensor entities, as also the config entry is not part of the stable release (_it's new in the current beta_)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
