### PR TITLE
Add new OUIs for tplink

### DIFF
--- a/homeassistant/components/tplink/manifest.json
+++ b/homeassistant/components/tplink/manifest.json
@@ -157,6 +157,10 @@
       "macaddress": "54AF97*"
     },
     {
+      "hostname": "l[59]*",
+      "macaddress": "54AF97*"
+    },
+    {
       "hostname": "k[lps]*",
       "macaddress": "AC15A2*"
     },
@@ -177,7 +181,7 @@
       "macaddress": "5CE931*"
     },
     {
-      "hostname": "l5*",
+      "hostname": "l[59]*",
       "macaddress": "3C52A1*"
     },
     {
@@ -185,12 +189,32 @@
       "macaddress": "5C628B*"
     },
     {
+      "hostname": "tp*",
+      "macaddress": "5C628B*"
+    },
+    {
       "hostname": "p1*",
+      "macaddress": "482254*"
+    },
+    {
+      "hostname": "s5*",
       "macaddress": "482254*"
     },
     {
       "hostname": "p1*",
       "macaddress": "30DE4B*"
+    },
+    {
+      "hostname": "p1*",
+      "macaddress": "3C52A1*"
+    },
+    {
+      "hostname": "tp*",
+      "macaddress": "3C52A1*"
+    },
+    {
+      "hostname": "s5*",
+      "macaddress": "3C52A1*"
     },
     {
       "hostname": "l9*",
@@ -199,6 +223,46 @@
     {
       "hostname": "l9*",
       "macaddress": "3460F9*"
+    },
+    {
+      "hostname": "hs*",
+      "macaddress": "704F57*"
+    },
+    {
+      "hostname": "k[lps]*",
+      "macaddress": "74DA88*"
+    },
+    {
+      "hostname": "p3*",
+      "macaddress": "788CB5*"
+    },
+    {
+      "hostname": "p1*",
+      "macaddress": "CC32E5*"
+    },
+    {
+      "hostname": "k[lps]*",
+      "macaddress": "CC32E5*"
+    },
+    {
+      "hostname": "hs*",
+      "macaddress": "CC32E5*"
+    },
+    {
+      "hostname": "k[lps]*",
+      "macaddress": "D80D17*"
+    },
+    {
+      "hostname": "k[lps]*",
+      "macaddress": "D84732*"
+    },
+    {
+      "hostname": "p1*",
+      "macaddress": "F0A731*"
+    },
+    {
+      "hostname": "l9*",
+      "macaddress": "F0A731*"
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/tplink",

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -790,6 +790,11 @@ DHCP: list[dict[str, str | bool]] = [
     },
     {
         "domain": "tplink",
+        "hostname": "l[59]*",
+        "macaddress": "54AF97*",
+    },
+    {
+        "domain": "tplink",
         "hostname": "k[lps]*",
         "macaddress": "AC15A2*",
     },
@@ -815,7 +820,7 @@ DHCP: list[dict[str, str | bool]] = [
     },
     {
         "domain": "tplink",
-        "hostname": "l5*",
+        "hostname": "l[59]*",
         "macaddress": "3C52A1*",
     },
     {
@@ -825,13 +830,38 @@ DHCP: list[dict[str, str | bool]] = [
     },
     {
         "domain": "tplink",
+        "hostname": "tp*",
+        "macaddress": "5C628B*",
+    },
+    {
+        "domain": "tplink",
         "hostname": "p1*",
+        "macaddress": "482254*",
+    },
+    {
+        "domain": "tplink",
+        "hostname": "s5*",
         "macaddress": "482254*",
     },
     {
         "domain": "tplink",
         "hostname": "p1*",
         "macaddress": "30DE4B*",
+    },
+    {
+        "domain": "tplink",
+        "hostname": "p1*",
+        "macaddress": "3C52A1*",
+    },
+    {
+        "domain": "tplink",
+        "hostname": "tp*",
+        "macaddress": "3C52A1*",
+    },
+    {
+        "domain": "tplink",
+        "hostname": "s5*",
+        "macaddress": "3C52A1*",
     },
     {
         "domain": "tplink",
@@ -842,6 +872,56 @@ DHCP: list[dict[str, str | bool]] = [
         "domain": "tplink",
         "hostname": "l9*",
         "macaddress": "3460F9*",
+    },
+    {
+        "domain": "tplink",
+        "hostname": "hs*",
+        "macaddress": "704F57*",
+    },
+    {
+        "domain": "tplink",
+        "hostname": "k[lps]*",
+        "macaddress": "74DA88*",
+    },
+    {
+        "domain": "tplink",
+        "hostname": "p3*",
+        "macaddress": "788CB5*",
+    },
+    {
+        "domain": "tplink",
+        "hostname": "p1*",
+        "macaddress": "CC32E5*",
+    },
+    {
+        "domain": "tplink",
+        "hostname": "k[lps]*",
+        "macaddress": "CC32E5*",
+    },
+    {
+        "domain": "tplink",
+        "hostname": "hs*",
+        "macaddress": "CC32E5*",
+    },
+    {
+        "domain": "tplink",
+        "hostname": "k[lps]*",
+        "macaddress": "D80D17*",
+    },
+    {
+        "domain": "tplink",
+        "hostname": "k[lps]*",
+        "macaddress": "D84732*",
+    },
+    {
+        "domain": "tplink",
+        "hostname": "p1*",
+        "macaddress": "F0A731*",
+    },
+    {
+        "domain": "tplink",
+        "hostname": "l9*",
+        "macaddress": "F0A731*",
     },
     {
         "domain": "tuya",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add more known OUIs for tplink's dhcp discovery, synced from https://github.com/python-kasa/python-kasa/pull/677
This makes the existence of support more visible, especially for users with newly supported tapo devices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
