### PR TITLE
Remove aux heat support from mqtt climate

### DIFF
--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -44,7 +44,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.unit_conversion import TemperatureConverter
@@ -77,7 +76,6 @@ from .const import (
     CONF_TEMP_STATE_TEMPLATE,
     CONF_TEMP_STATE_TOPIC,
     DEFAULT_OPTIMISTIC,
-    DOMAIN,
     PAYLOAD_NONE,
 )
 from .debug_info import log_messages
@@ -98,13 +96,11 @@ from .util import valid_publish_topic, valid_subscribe_topic
 
 _LOGGER = logging.getLogger(__name__)
 
-MQTT_CLIMATE_AUX_DOCS = "https://www.home-assistant.io/integrations/climate.mqtt/"
-
 DEFAULT_NAME = "MQTT HVAC"
 
 # Options CONF_AUX_COMMAND_TOPIC, CONF_AUX_STATE_TOPIC
 # and CONF_AUX_STATE_TEMPLATE were deprecated in HA Core 2023.9
-# Support will be removed in HA Core 2024.3
+# Support was removed in HA Core 2024.3
 CONF_AUX_COMMAND_TOPIC = "aux_command_topic"
 CONF_AUX_STATE_TEMPLATE = "aux_state_template"
 CONF_AUX_STATE_TOPIC = "aux_state_topic"
@@ -150,7 +146,6 @@ DEFAULT_INITIAL_TEMPERATURE = 21.0
 
 MQTT_CLIMATE_ATTRIBUTES_BLOCKED = frozenset(
     {
-        climate.ATTR_AUX_HEAT,
         climate.ATTR_CURRENT_HUMIDITY,
         climate.ATTR_CURRENT_TEMPERATURE,
         climate.ATTR_FAN_MODE,
@@ -174,7 +169,6 @@ MQTT_CLIMATE_ATTRIBUTES_BLOCKED = frozenset(
 )
 
 VALUE_TEMPLATE_KEYS = (
-    CONF_AUX_STATE_TEMPLATE,
     CONF_CURRENT_HUMIDITY_TEMPLATE,
     CONF_CURRENT_TEMP_TEMPLATE,
     CONF_FAN_MODE_STATE_TEMPLATE,
@@ -204,8 +198,6 @@ COMMAND_TEMPLATE_KEYS = {
 
 TOPIC_KEYS = (
     CONF_ACTION_TOPIC,
-    CONF_AUX_COMMAND_TOPIC,
-    CONF_AUX_STATE_TOPIC,
     CONF_CURRENT_HUMIDITY_TOPIC,
     CONF_CURRENT_TEMP_TOPIC,
     CONF_FAN_MODE_COMMAND_TOPIC,
@@ -266,12 +258,6 @@ def valid_humidity_state_configuration(config: ConfigType) -> ConfigType:
 
 _PLATFORM_SCHEMA_BASE = MQTT_BASE_SCHEMA.extend(
     {
-        # Options CONF_AUX_COMMAND_TOPIC, CONF_AUX_STATE_TOPIC
-        # and CONF_AUX_STATE_TEMPLATE were deprecated in HA Core 2023.9
-        # Support will be removed in HA Core 2024.3
-        vol.Optional(CONF_AUX_COMMAND_TOPIC): valid_publish_topic,
-        vol.Optional(CONF_AUX_STATE_TEMPLATE): cv.template,
-        vol.Optional(CONF_AUX_STATE_TOPIC): valid_subscribe_topic,
         vol.Optional(CONF_CURRENT_HUMIDITY_TEMPLATE): cv.template,
         vol.Optional(CONF_CURRENT_HUMIDITY_TOPIC): valid_subscribe_topic,
         vol.Optional(CONF_CURRENT_TEMP_TEMPLATE): cv.template,
@@ -369,10 +355,10 @@ PLATFORM_SCHEMA_MODERN = vol.All(
     cv.removed(CONF_POWER_STATE_TOPIC),
     # Options CONF_AUX_COMMAND_TOPIC, CONF_AUX_STATE_TOPIC
     # and CONF_AUX_STATE_TEMPLATE were deprecated in HA Core 2023.9
-    # Support will be removed in HA Core 2024.3
-    cv.deprecated(CONF_AUX_COMMAND_TOPIC),
-    cv.deprecated(CONF_AUX_STATE_TEMPLATE),
-    cv.deprecated(CONF_AUX_STATE_TOPIC),
+    # Support was removed in HA Core 2024.3
+    cv.removed(CONF_AUX_COMMAND_TOPIC),
+    cv.removed(CONF_AUX_STATE_TEMPLATE),
+    cv.removed(CONF_AUX_STATE_TOPIC),
     _PLATFORM_SCHEMA_BASE,
     valid_preset_mode_configuration,
     valid_humidity_range_configuration,
@@ -603,7 +589,6 @@ class MqttClimate(MqttTemperatureControlEntity, ClimateEntity):
 
     _attr_fan_mode: str | None = None
     _attr_hvac_mode: HVACMode | None = None
-    _attr_is_aux_heat: bool | None = None
     _attr_swing_mode: str | None = None
     _default_name = DEFAULT_NAME
     _entity_id_format = climate.ENTITY_ID_FORMAT
@@ -662,11 +647,6 @@ class MqttClimate(MqttTemperatureControlEntity, ClimateEntity):
             self._attr_swing_mode = SWING_OFF
         if self._topic[CONF_MODE_STATE_TOPIC] is None or self._optimistic:
             self._attr_hvac_mode = HVACMode.OFF
-        # Options CONF_AUX_COMMAND_TOPIC, CONF_AUX_STATE_TOPIC
-        # and CONF_AUX_STATE_TEMPLATE were deprecated in HA Core 2023.9
-        # Support will be removed in HA Core 2024.3
-        if self._topic[CONF_AUX_STATE_TOPIC] is None or self._optimistic:
-            self._attr_is_aux_heat = False
         self._feature_preset_mode = CONF_PRESET_MODE_COMMAND_TOPIC in config
         if self._feature_preset_mode:
             presets = []
@@ -736,31 +716,7 @@ class MqttClimate(MqttTemperatureControlEntity, ClimateEntity):
         if self._feature_preset_mode:
             support |= ClimateEntityFeature.PRESET_MODE
 
-        # Options CONF_AUX_COMMAND_TOPIC, CONF_AUX_STATE_TOPIC
-        # and CONF_AUX_STATE_TEMPLATE were deprecated in HA Core 2023.9
-        # Support will be removed in HA Core 2024.3
-        if (self._topic[CONF_AUX_STATE_TOPIC] is not None) or (
-            self._topic[CONF_AUX_COMMAND_TOPIC] is not None
-        ):
-            support |= ClimateEntityFeature.AUX_HEAT
         self._attr_supported_features = support
-
-    async def mqtt_async_added_to_hass(self) -> None:
-        """Handle deprecation issues."""
-        if self._attr_supported_features & ClimateEntityFeature.AUX_HEAT:
-            async_create_issue(
-                self.hass,
-                DOMAIN,
-                "deprecated_climate_aux_property_{self.entity_id}",
-                breaks_in_ha_version="2024.3.0",
-                is_fixable=False,
-                translation_key="deprecated_climate_aux_property",
-                translation_placeholders={
-                    "entity_id": self.entity_id,
-                },
-                learn_more_url=MQTT_CLIMATE_AUX_DOCS,
-                severity=IssueSeverity.WARNING,
-            )
 
     def _prepare_subscribe_topics(self) -> None:  # noqa: C901
         """(Re)Subscribe to topics."""
@@ -876,41 +832,6 @@ class MqttClimate(MqttTemperatureControlEntity, ClimateEntity):
         )
 
         @callback
-        def handle_onoff_mode_received(
-            msg: ReceiveMessage, template_name: str, attr: str
-        ) -> None:
-            """Handle receiving on/off mode via MQTT."""
-            payload = self.render_template(msg, template_name)
-            payload_on: str = self._config[CONF_PAYLOAD_ON]
-            payload_off: str = self._config[CONF_PAYLOAD_OFF]
-
-            if payload == "True":
-                payload = payload_on
-            elif payload == "False":
-                payload = payload_off
-
-            if payload == payload_on:
-                setattr(self, attr, True)
-            elif payload == payload_off:
-                setattr(self, attr, False)
-            else:
-                _LOGGER.error("Invalid %s mode: %s", attr, payload)
-
-        # Options CONF_AUX_COMMAND_TOPIC, CONF_AUX_STATE_TOPIC
-        # and CONF_AUX_STATE_TEMPLATE were deprecated in HA Core 2023.9
-        # Support will be removed in HA Core 2024.3
-        @callback
-        @log_messages(self.hass, self.entity_id)
-        @write_state_on_attr_change(self, {"_attr_is_aux_heat"})
-        def handle_aux_mode_received(msg: ReceiveMessage) -> None:
-            """Handle receiving aux mode via MQTT."""
-            handle_onoff_mode_received(
-                msg, CONF_AUX_STATE_TEMPLATE, "_attr_is_aux_heat"
-            )
-
-        self.add_subscription(topics, CONF_AUX_STATE_TOPIC, handle_aux_mode_received)
-
-        @callback
         @log_messages(self.hass, self.entity_id)
         @write_state_on_attr_change(self, {"_attr_preset_mode"})
         def handle_preset_mode_received(msg: ReceiveMessage) -> None:
@@ -1001,27 +922,6 @@ class MqttClimate(MqttTemperatureControlEntity, ClimateEntity):
         if self._optimistic_preset_mode:
             self._attr_preset_mode = preset_mode
             self.async_write_ha_state()
-
-    # Options CONF_AUX_COMMAND_TOPIC, CONF_AUX_STATE_TOPIC
-    # and CONF_AUX_STATE_TEMPLATE were deprecated in HA Core 2023.9
-    # Support will be removed in HA Core 2024.3
-    async def _set_aux_heat(self, state: bool) -> None:
-        await self._publish(
-            CONF_AUX_COMMAND_TOPIC,
-            self._config[CONF_PAYLOAD_ON] if state else self._config[CONF_PAYLOAD_OFF],
-        )
-
-        if self._optimistic or self._topic[CONF_AUX_STATE_TOPIC] is None:
-            self._attr_is_aux_heat = state
-            self.async_write_ha_state()
-
-    async def async_turn_aux_heat_on(self) -> None:
-        """Turn auxiliary heater on."""
-        await self._set_aux_heat(True)
-
-    async def async_turn_aux_heat_off(self) -> None:
-        """Turn auxiliary heater off."""
-        await self._set_aux_heat(False)
 
     async def async_turn_on(self) -> None:
         """Turn the entity on."""

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -4,10 +4,6 @@
       "title": "MQTT vacuum entities with deprecated `schema` config settings found in your configuration.yaml",
       "description": "The `schema` setting for MQTT vacuum entities is deprecated and should be removed. Please adjust your configuration.yaml and restart Home Assistant to fix this issue."
     },
-    "deprecated_climate_aux_property": {
-      "title": "MQTT entities with auxiliary heat support found",
-      "description": "Entity `{entity_id}` has auxiliary heat support enabled, which has been deprecated for MQTT climate devices. Please adjust your configuration and remove deprecated config options from your configuration and restart Home Assistant to fix this issue."
-    },
     "invalid_platform_config": {
       "title": "Invalid config found for mqtt {domain} item",
       "description": "Home Assistant detected an invalid config for a manually configured item.\n\nPlatform domain: **{domain}**\nConfiguration file: **{config_file}**\nNear line: **{line}**\nConfiguration found:\n```yaml\n{config}\n```\nError: **{error}**.\n\nMake sure the configuration is valid and [reload](/developer-tools/yaml) the manually configured MQTT items or restart Home Assistant to fix this issue."

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -9,7 +9,6 @@ import voluptuous as vol
 
 from homeassistant.components import climate, mqtt
 from homeassistant.components.climate import (
-    ATTR_AUX_HEAT,
     ATTR_CURRENT_HUMIDITY,
     ATTR_CURRENT_TEMPERATURE,
     ATTR_FAN_MODE,
@@ -1262,91 +1261,6 @@ async def test_set_preset_mode_pessimistic(
     assert state.attributes.get("preset_mode") == "home"
 
 
-# Options CONF_AUX_COMMAND_TOPIC, CONF_AUX_STATE_TOPIC
-# and CONF_AUX_STATE_TEMPLATE were deprecated in HA Core 2023.9
-# Support will be removed in HA Core 2024.3
-@pytest.mark.parametrize(
-    "hass_config",
-    [
-        help_custom_config(
-            climate.DOMAIN,
-            DEFAULT_CONFIG,
-            ({"aux_command_topic": "aux-topic", "aux_state_topic": "aux-state"},),
-        )
-    ],
-)
-async def test_set_aux_pessimistic(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
-) -> None:
-    """Test setting of the aux heating in pessimistic mode."""
-    await mqtt_mock_entry()
-
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("aux_heat") == "off"
-
-    await common.async_set_aux_heat(hass, True, ENTITY_CLIMATE)
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("aux_heat") == "off"
-
-    async_fire_mqtt_message(hass, "aux-state", "ON")
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("aux_heat") == "on"
-
-    async_fire_mqtt_message(hass, "aux-state", "OFF")
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("aux_heat") == "off"
-
-    async_fire_mqtt_message(hass, "aux-state", "nonsense")
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("aux_heat") == "off"
-
-
-# Options CONF_AUX_COMMAND_TOPIC, CONF_AUX_STATE_TOPIC
-# and CONF_AUX_STATE_TEMPLATE were deprecated in HA Core 2023.9
-# Support will be removed in HA Core 2024.3
-# "aux_command_topic": "aux-topic"
-@pytest.mark.parametrize(
-    "hass_config",
-    [
-        help_custom_config(
-            climate.DOMAIN, DEFAULT_CONFIG, ({"aux_command_topic": "aux-topic"},)
-        )
-    ],
-)
-async def test_set_aux(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
-) -> None:
-    """Test setting of the aux heating."""
-    mqtt_mock = await mqtt_mock_entry()
-
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("aux_heat") == "off"
-    await common.async_set_aux_heat(hass, True, ENTITY_CLIMATE)
-    mqtt_mock.async_publish.assert_called_once_with("aux-topic", "ON", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("aux_heat") == "on"
-
-    await common.async_set_aux_heat(hass, False, ENTITY_CLIMATE)
-    mqtt_mock.async_publish.assert_called_once_with("aux-topic", "OFF", 0, False)
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("aux_heat") == "off"
-
-    support = (
-        ClimateEntityFeature.TARGET_TEMPERATURE
-        | ClimateEntityFeature.AUX_HEAT
-        | ClimateEntityFeature.SWING_MODE
-        | ClimateEntityFeature.FAN_MODE
-        | ClimateEntityFeature.PRESET_MODE
-        | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
-        | ClimateEntityFeature.TARGET_HUMIDITY
-        | ClimateEntityFeature.TURN_OFF
-        | ClimateEntityFeature.TURN_ON
-    )
-
-    assert state.attributes.get("supported_features") == support
-
-
 @pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
 async def test_availability_when_connection_lost(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
@@ -1476,7 +1390,6 @@ async def test_get_target_temperature_low_high_with_templates(
                     "temperature_high_command_topic": "temperature-high-topic",
                     "fan_mode_command_topic": "fan-mode-topic",
                     "swing_mode_command_topic": "swing-mode-topic",
-                    "aux_command_topic": "aux-topic",
                     "preset_mode_command_topic": "preset-mode-topic",
                     "preset_modes": [
                         "eco",
@@ -1493,8 +1406,6 @@ async def test_get_target_temperature_low_high_with_templates(
                     "current_humidity_template": "{{ value_json }}",
                     "current_temperature_template": "{{ value_json }}",
                     "temperature_state_template": "{{ value_json }}",
-                    # Rendering to a bool for aux heat
-                    "aux_state_template": "{{ value == 'switchmeon' }}",
                     # Rendering preset_mode
                     "preset_mode_value_template": "{{ value_json.attribute }}",
                     "action_topic": "action",
@@ -1503,7 +1414,6 @@ async def test_get_target_temperature_low_high_with_templates(
                     "swing_mode_state_topic": "swing-state",
                     "temperature_state_topic": "temperature-state",
                     "target_humidity_state_topic": "humidity-state",
-                    "aux_state_topic": "aux-state",
                     "current_temperature_topic": "current-temperature",
                     "current_humidity_topic": "current-humidity",
                     "preset_mode_state_topic": "current-preset-mode",
@@ -1590,21 +1500,6 @@ async def test_get_with_templates(
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("preset_mode") == "eco"
 
-    # Aux mode
-
-    # Options CONF_AUX_COMMAND_TOPIC, CONF_AUX_STATE_TOPIC
-    # and CONF_AUX_STATE_TEMPLATE were deprecated in HA Core 2023.9
-    # Support will be removed in HA Core 2024.3
-    assert state.attributes.get("aux_heat") == "off"
-    async_fire_mqtt_message(hass, "aux-state", "switchmeon")
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("aux_heat") == "on"
-
-    # anything other than 'switchmeon' should turn Aux mode off
-    async_fire_mqtt_message(hass, "aux-state", "somerandomstring")
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("aux_heat") == "off"
-
     # Current temperature
     async_fire_mqtt_message(hass, "current-temperature", '"74656"')
     state = hass.states.get(ENTITY_CLIMATE)
@@ -1648,7 +1543,6 @@ async def test_get_with_templates(
                     "temperature_high_command_topic": "temperature-high-topic",
                     "fan_mode_command_topic": "fan-mode-topic",
                     "swing_mode_command_topic": "swing-mode-topic",
-                    "aux_command_topic": "aux-topic",
                     "preset_mode_command_topic": "preset-mode-topic",
                     "preset_modes": [
                         "eco",
@@ -2104,7 +1998,6 @@ async def test_unique_id(
     [
         ("action_topic", "heating", ATTR_HVAC_ACTION, "heating"),
         ("action_topic", "cooling", ATTR_HVAC_ACTION, "cooling"),
-        ("aux_state_topic", "ON", ATTR_AUX_HEAT, "on"),
         ("current_temperature_topic", "22.1", ATTR_CURRENT_TEMPERATURE, 22.1),
         ("current_humidity_topic", "60.4", ATTR_CURRENT_HUMIDITY, 60.4),
         ("fan_mode_state_topic", "low", ATTR_FAN_MODE, "low"),
@@ -2385,13 +2278,6 @@ async def test_precision_whole(
             {"swing_mode": "on"},
             "on",
             "swing_mode_command_template",
-        ),
-        (
-            climate.SERVICE_SET_AUX_HEAT,
-            "aux_command_topic",
-            {"aux_heat": "on"},
-            "ON",
-            None,
         ),
         (
             climate.SERVICE_SET_TEMPERATURE,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Aux heat, which was deprecated in Home Assistant Core 2023.9, is now removed from MQTT climate.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove aux heat support from mqtt climate

Users were warned with an issue report to update their configs, warnings were logged during the 6 month deprecation period.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
