### PR TITLE
Move climate feature flags to child classes for airzone_cloud

### DIFF
--- a/homeassistant/components/airzone_cloud/climate.py
+++ b/homeassistant/components/airzone_cloud/climate.py
@@ -144,13 +144,7 @@ class AirzoneClimate(AirzoneEntity, ClimateEntity):
     """Define an Airzone Cloud climate."""
 
     _attr_name = None
-    _attr_supported_features = (
-        ClimateEntityFeature.TARGET_TEMPERATURE
-        | ClimateEntityFeature.TURN_OFF
-        | ClimateEntityFeature.TURN_ON
-    )
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
-    _enable_turn_on_off_backwards_compatibility = False
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -179,6 +173,13 @@ class AirzoneClimate(AirzoneEntity, ClimateEntity):
 
 class AirzoneDeviceClimate(AirzoneClimate):
     """Define an Airzone Cloud Device base class."""
+
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TURN_OFF
+        | ClimateEntityFeature.TURN_ON
+    )
+    _enable_turn_on_off_backwards_compatibility = False
 
     async def async_turn_on(self) -> None:
         """Turn the entity on."""
@@ -216,6 +217,13 @@ class AirzoneDeviceClimate(AirzoneClimate):
 
 class AirzoneDeviceGroupClimate(AirzoneClimate):
     """Define an Airzone Cloud DeviceGroup base class."""
+
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TURN_OFF
+        | ClimateEntityFeature.TURN_ON
+    )
+    _enable_turn_on_off_backwards_compatibility = False
 
     async def async_turn_on(self) -> None:
         """Turn the entity on."""

--- a/homeassistant/components/airzone_cloud/climate.py
+++ b/homeassistant/components/airzone_cloud/climate.py
@@ -145,6 +145,7 @@ class AirzoneClimate(AirzoneEntity, ClimateEntity):
 
     _attr_name = None
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _enable_turn_on_off_backwards_compatibility = False
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -179,7 +180,6 @@ class AirzoneDeviceClimate(AirzoneClimate):
         | ClimateEntityFeature.TURN_OFF
         | ClimateEntityFeature.TURN_ON
     )
-    _enable_turn_on_off_backwards_compatibility = False
 
     async def async_turn_on(self) -> None:
         """Turn the entity on."""
@@ -223,7 +223,6 @@ class AirzoneDeviceGroupClimate(AirzoneClimate):
         | ClimateEntityFeature.TURN_OFF
         | ClimateEntityFeature.TURN_ON
     )
-    _enable_turn_on_off_backwards_compatibility = False
 
     async def async_turn_on(self) -> None:
         """Turn the entity on."""


### PR DESCRIPTION
## Proposed change
This moves all climate feature flags for the airzone_cloud integration from the base class to the child classes.
The base class doesn't actually implement a `set_temperature`, `turn_on`, nor `turn_off` method.
The backwards compatibility flag stays in the base class though.

Those feature flags should go into the child classes instead where the methods are implemented.
Review comment: https://github.com/home-assistant/core/pull/109424/files#r1477044452 (Thanks for the catch btw!)

I've also moved the already previously existing `ClimateEntityFeature.TARGET_TEMPERATURE` flag from the base class into the child classes then, as `async_set_temperature` is only overridden in the child classes.

I've marked this PR as a draft for now, so everyone can ensure that this is the change we want.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
