### PR TITLE
Add HDR type attribute to Kodi

### DIFF
--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -631,13 +631,18 @@ class KodiEntity(MediaPlayerEntity):
 
     @property
     def extra_state_attributes(self):
-        """Extra state attributes."""
-        hdrtype = self._item.get("streamdetails", {}).get("video", [{}])[0].get("hdrtype")
-        if hdrtype is None:
-            return {}
-        if hdrtype == "":
-            hdrtype = "sdr"
-        return {"hdr_type": hdrtype}
+        """Return the state attributes."""
+        state_atrr = {}
+        if self.state == MediaPlayerState.OFF:
+            return state_atrr
+
+        hdr_type = self._item.get("streamdetails", {}).get("video", [{}])[0].get("hdrtype")
+        if hdr_type == "":
+            state_atrr["hdr_type"] = "sdr"
+        else:
+            state_atrr["hdr_type"] = hdr_type
+
+        return state_atrr
 
     async def async_turn_on(self) -> None:
         """Turn the media player on."""

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -632,19 +632,19 @@ class KodiEntity(MediaPlayerEntity):
     @property
     def extra_state_attributes(self):
         """Return the state attributes."""
-        state_atrr = {}
+        state_attr = {}
         if self.state == MediaPlayerState.OFF:
-            return state_atrr
+            return state_attr
 
         hdr_type = (
             self._item.get("streamdetails", {}).get("video", [{}])[0].get("hdrtype")
         )
         if hdr_type == "":
-            state_atrr["hdr_type"] = "sdr"
+            state_attr["hdr_type"] = "sdr"
         else:
-            state_atrr["hdr_type"] = hdr_type
+            state_attr["hdr_type"] = hdr_type
 
-        return state_atrr
+        return state_attr
 
     async def async_turn_on(self) -> None:
         """Turn the media player on."""

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -632,7 +632,12 @@ class KodiEntity(MediaPlayerEntity):
     @property
     def extra_state_attributes(self):
         """Extra state attributes."""
-        return {"hdr_type": self._item.get("streamdetails", {}).get("video", [{}])[0].get("hdrtype")}
+        hdrtype = self._item.get("streamdetails", {}).get("video", [{}])[0].get("hdrtype")
+        if hdrtype is None:
+            return {}
+        if hdrtype == "":
+            hdrtype = "sdr"
+        return {"hdr_type": hdrtype}
 
     async def async_turn_on(self) -> None:
         """Turn the media player on."""

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -512,6 +512,7 @@ class KodiEntity(MediaPlayerEntity):
                     "album",
                     "season",
                     "episode",
+                    "streamdetails",
                 ],
             )
         else:
@@ -627,6 +628,11 @@ class KodiEntity(MediaPlayerEntity):
             return artists[0]
 
         return None
+
+    @property
+    def extra_state_attributes(self):
+        """Extra state attributes."""
+        return {"HDR_type": self._item.get("streamdetails", {}).get("video", [{}])[0].get("hdrtype")}
 
     async def async_turn_on(self) -> None:
         """Turn the media player on."""

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -636,7 +636,9 @@ class KodiEntity(MediaPlayerEntity):
         if self.state == MediaPlayerState.OFF:
             return state_atrr
 
-        hdr_type = self._item.get("streamdetails", {}).get("video", [{}])[0].get("hdrtype")
+        hdr_type = (
+            self._item.get("streamdetails", {}).get("video", [{}])[0].get("hdrtype")
+        )
         if hdr_type == "":
             state_atrr["hdr_type"] = "sdr"
         else:

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -632,7 +632,7 @@ class KodiEntity(MediaPlayerEntity):
     @property
     def extra_state_attributes(self):
         """Extra state attributes."""
-        return {"HDR_type": self._item.get("streamdetails", {}).get("video", [{}])[0].get("hdrtype")}
+        return {"hdr_type": self._item.get("streamdetails", {}).get("video", [{}])[0].get("hdrtype")}
 
     async def async_turn_on(self) -> None:
         """Turn the media player on."""

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -642,7 +642,7 @@ class KodiEntity(MediaPlayerEntity):
         if hdr_type == "":
             state_attr["dynamic_range"] = "sdr"
         else:
-            state_attr["hdr_type"] = hdr_type
+            state_attr["dynamic_range"] = hdr_type
 
         return state_attr
 

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -640,7 +640,7 @@ class KodiEntity(MediaPlayerEntity):
             self._item.get("streamdetails", {}).get("video", [{}])[0].get("hdrtype")
         )
         if hdr_type == "":
-            state_attr["hdr_type"] = "sdr"
+            state_attr["dynamic_range"] = "sdr"
         else:
             state_attr["hdr_type"] = hdr_type
 

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -630,9 +630,9 @@ class KodiEntity(MediaPlayerEntity):
         return None
 
     @property
-    def extra_state_attributes(self) -> dict[str, str]:
+    def extra_state_attributes(self) -> dict[str, str | None]:
         """Return the state attributes."""
-        state_attr = {}
+        state_attr: dict[str, str | None] = {}
         if self.state == MediaPlayerState.OFF:
             return state_attr
 

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -630,7 +630,7 @@ class KodiEntity(MediaPlayerEntity):
         return None
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> dict[str, str]:
         """Return the state attributes."""
         state_attr = {}
         if self.state == MediaPlayerState.OFF:

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -261,6 +261,7 @@ class KodiEntity(MediaPlayerEntity):
 
     _attr_has_entity_name = True
     _attr_name = None
+    _attr_translation_key = "media_player"
     _attr_supported_features = (
         MediaPlayerEntityFeature.BROWSE_MEDIA
         | MediaPlayerEntityFeature.NEXT_TRACK

--- a/homeassistant/components/kodi/strings.json
+++ b/homeassistant/components/kodi/strings.json
@@ -83,5 +83,14 @@
         }
       }
     }
+  },
+  "entity": {
+    "media_player": {
+      "media_player": {
+        "state_attributes": {
+          "dynamic_range": { "name": "Dynamic range" }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add HDR type attribute to Kodi.
Shows if the current playing media is SDR, HDR10, HDR10+ or DV
(not exactly sure what all possible types are that kodi reports, I tested with SDR and HDR10)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
