### PR TITLE
Fix Tuya QR code expiry, use native QR selector

### DIFF
--- a/homeassistant/components/tuya/config_flow.py
+++ b/homeassistant/components/tuya/config_flow.py
@@ -2,15 +2,14 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from io import BytesIO
 from typing import Any
 
-import segno
 from tuya_sharing import LoginControl
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import selector
 
 from .const import (
     CONF_ENDPOINT,
@@ -33,7 +32,6 @@ class TuyaConfigFlow(ConfigFlow, domain=DOMAIN):
 
     __user_code: str
     __qr_code: str
-    __qr_image: str
     __reauth_entry: ConfigEntry | None = None
 
     def __init__(self) -> None:
@@ -82,9 +80,17 @@ class TuyaConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is None:
             return self.async_show_form(
                 step_id="scan",
-                description_placeholders={
-                    TUYA_RESPONSE_QR_CODE: self.__qr_image,
-                },
+                data_schema=vol.Schema(
+                    {
+                        vol.Optional("QR"): selector.QrCodeSelector(
+                            config=selector.QrCodeSelectorConfig(
+                                data=f"tuyaSmart--qrLogin?token={self.__qr_code}",
+                                scale=5,
+                                error_correction_level=selector.QrErrorCorrectionLevel.QUARTILE,
+                            )
+                        )
+                    }
+                ),
             )
 
         ret, info = await self.hass.async_add_executor_job(
@@ -94,11 +100,23 @@ class TuyaConfigFlow(ConfigFlow, domain=DOMAIN):
             self.__user_code,
         )
         if not ret:
+            # Try to get a new QR code on failure
+            await self.__async_get_qr_code(self.__user_code)
             return self.async_show_form(
                 step_id="scan",
                 errors={"base": "login_error"},
+                data_schema=vol.Schema(
+                    {
+                        vol.Optional("QR"): selector.QrCodeSelector(
+                            config=selector.QrCodeSelectorConfig(
+                                data=f"tuyaSmart--qrLogin?token={self.__qr_code}",
+                                scale=5,
+                                error_correction_level=selector.QrErrorCorrectionLevel.QUARTILE,
+                            )
+                        )
+                    }
+                ),
                 description_placeholders={
-                    TUYA_RESPONSE_QR_CODE: self.__qr_image,
                     TUYA_RESPONSE_MSG: info.get(TUYA_RESPONSE_MSG, "Unknown error"),
                     TUYA_RESPONSE_CODE: info.get(TUYA_RESPONSE_CODE, 0),
                 },
@@ -189,24 +207,4 @@ class TuyaConfigFlow(ConfigFlow, domain=DOMAIN):
         if success := response.get(TUYA_RESPONSE_SUCCESS, False):
             self.__user_code = user_code
             self.__qr_code = response[TUYA_RESPONSE_RESULT][TUYA_RESPONSE_QR_CODE]
-            self.__qr_image = _generate_qr_code(self.__qr_code)
         return success, response
-
-
-def _generate_qr_code(data: str) -> str:
-    """Create an SVG QR code that can be scanned with the Smart Life app."""
-    qr_code = segno.make(f"tuyaSmart--qrLogin?token={data}", error="h")
-    with BytesIO() as buffer:
-        qr_code.save(
-            buffer,
-            kind="svg",
-            border=5,
-            scale=5,
-            xmldecl=False,
-            svgns=False,
-            svgclass=None,
-            lineclass=None,
-            svgversion=2,
-            dark="#1abcf2",
-        )
-        return str(buffer.getvalue().decode("ascii"))

--- a/homeassistant/components/tuya/manifest.json
+++ b/homeassistant/components/tuya/manifest.json
@@ -43,5 +43,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "loggers": ["tuya_iot"],
-  "requirements": ["tuya-device-sharing-sdk==0.1.9", "segno==1.5.3"]
+  "requirements": ["tuya-device-sharing-sdk==0.1.9"]
 }

--- a/homeassistant/components/tuya/strings.json
+++ b/homeassistant/components/tuya/strings.json
@@ -14,7 +14,7 @@
         }
       },
       "scan": {
-        "description": "Use Smart Life app or Tuya Smart app to scan the following QR-code to complete the login:\n\n {qrcode} \n\nContinue to the next step once you have completed this step in the app."
+        "description": "Use Smart Life app or Tuya Smart app to scan the following QR-code to complete the login.\n\nContinue to the next step once you have completed this step in the app."
       }
     },
     "error": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2494,9 +2494,6 @@ scsgate==0.1.0
 # homeassistant.components.backup
 securetar==2023.3.0
 
-# homeassistant.components.tuya
-segno==1.5.3
-
 # homeassistant.components.sendgrid
 sendgrid==6.8.2
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1901,9 +1901,6 @@ screenlogicpy==0.10.0
 # homeassistant.components.backup
 securetar==2023.3.0
 
-# homeassistant.components.tuya
-segno==1.5.3
-
 # homeassistant.components.emulated_kasa
 # homeassistant.components.sense
 sense-energy==0.12.2

--- a/tests/components/tuya/test_config_flow.py
+++ b/tests/components/tuya/test_config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from tests.common import ANY, MockConfigEntry
+from tests.common import MockConfigEntry
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
@@ -37,7 +37,6 @@ async def test_user_flow(
 
     assert result2.get("type") == FlowResultType.FORM
     assert result2.get("step_id") == "scan"
-    assert result2.get("description_placeholders") == {"qrcode": ANY}
 
     result3 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -157,7 +156,6 @@ async def test_reauth_flow(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "scan"
-    assert result.get("description_placeholders") == {"qrcode": ANY}
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -206,7 +204,6 @@ async def test_reauth_flow_migration(
 
     assert result2.get("type") == FlowResultType.FORM
     assert result2.get("step_id") == "scan"
-    assert result2.get("description_placeholders") == {"qrcode": ANY}
 
     result3 = await hass.config_entries.flow.async_configure(
         result["flow_id"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR changes the handling of QR codes in the Tuya integration.
It removes the need to inline SVGs to make a QR code. Instead, it uses the QRCode selector.

This selector was introduced on the day the beta was cut, hence it missed it. This solves it being unscannable on certain themes.

When an error occurs, it tries to get a new QR code (it falls back to the previous one, in case that fails). This can, for example, happen when an QR code expires.

Both issues have been reported during beta.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #109261 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
