### PR TITLE
Use builtin TimeoutError [e-i]

### DIFF
--- a/homeassistant/components/eliqonline/sensor.py
+++ b/homeassistant/components/eliqonline/sensor.py
@@ -1,7 +1,6 @@
 """Monitors home energy use for the ELIQ Online service."""
 from __future__ import annotations
 
-import asyncio
 from datetime import timedelta
 import logging
 
@@ -83,5 +82,5 @@ class EliqSensor(SensorEntity):
             _LOGGER.debug("Updated power from server %d W", self.native_value)
         except KeyError:
             _LOGGER.warning("Invalid response from ELIQ Online API")
-        except (OSError, asyncio.TimeoutError) as error:
+        except (OSError, TimeoutError) as error:
             _LOGGER.warning("Could not connect to the ELIQ Online API: %s", error)

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -296,7 +296,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         if not await async_wait_for_elk_to_sync(elk, LOGIN_TIMEOUT, SYNC_TIMEOUT):
             return False
-    except asyncio.TimeoutError as exc:
+    except TimeoutError as exc:
         raise ConfigEntryNotReady(f"Timed out connecting to {conf[CONF_HOST]}") from exc
 
     elk_temp_unit = elk.panel.temperature_units
@@ -389,7 +389,7 @@ async def async_wait_for_elk_to_sync(
         try:
             async with asyncio.timeout(timeout):
                 await event.wait()
-        except asyncio.TimeoutError:
+        except TimeoutError:
             _LOGGER.debug("Timed out waiting for %s event", name)
             elk.disconnect()
             raise

--- a/homeassistant/components/elkm1/config_flow.py
+++ b/homeassistant/components/elkm1/config_flow.py
@@ -1,7 +1,6 @@
 """Config flow for Elk-M1 Control integration."""
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import Any
 
@@ -244,7 +243,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             info = await validate_input(user_input, self.unique_id)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             return {"base": "cannot_connect"}, None
         except InvalidAuth:
             return {CONF_PASSWORD: "invalid_auth"}, None

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -934,7 +934,7 @@ async def wait_for_state_change_or_timeout(
     try:
         async with asyncio.timeout(STATE_CHANGE_WAIT_TIMEOUT):
             await ev.wait()
-    except asyncio.TimeoutError:
+    except TimeoutError:
         pass
     finally:
         unsub()

--- a/homeassistant/components/escea/config_flow.py
+++ b/homeassistant/components/escea/config_flow.py
@@ -31,7 +31,7 @@ async def _async_has_devices(hass: HomeAssistant) -> bool:
 
     discovery_service = await async_start_discovery_service(hass)
 
-    with suppress(asyncio.TimeoutError):
+    with suppress(TimeoutError):
         async with asyncio.timeout(TIMEOUT_DISCOVERY):
             await controller_ready.wait()
 

--- a/homeassistant/components/evil_genius_labs/config_flow.py
+++ b/homeassistant/components/evil_genius_labs/config_flow.py
@@ -63,7 +63,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             info = await validate_input(self.hass, user_input)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             errors["base"] = "timeout"
         except CannotConnect:
             errors["base"] = "cannot_connect"

--- a/homeassistant/components/flick_electric/config_flow.py
+++ b/homeassistant/components/flick_electric/config_flow.py
@@ -46,7 +46,7 @@ class FlickConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         try:
             async with asyncio.timeout(60):
                 token = await auth.async_get_access_token()
-        except asyncio.TimeoutError as err:
+        except TimeoutError as err:
             raise CannotConnect() from err
         except AuthException as err:
             raise InvalidAuth() from err

--- a/homeassistant/components/flock/notify.py
+++ b/homeassistant/components/flock/notify.py
@@ -58,5 +58,5 @@ class FlockNotificationService(BaseNotificationService):
                     response.status,
                     result,
                 )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             _LOGGER.error("Timeout accessing Flock at %s", self._url)

--- a/homeassistant/components/flux_led/const.py
+++ b/homeassistant/components/flux_led/const.py
@@ -1,6 +1,5 @@
 """Constants of the FluxLed/MagicHome Integration."""
 
-import asyncio
 import socket
 from typing import Final
 
@@ -38,7 +37,7 @@ DEFAULT_EFFECT_SPEED: Final = 50
 FLUX_LED_DISCOVERY: Final = "flux_led_discovery"
 
 FLUX_LED_EXCEPTIONS: Final = (
-    asyncio.TimeoutError,
+    TimeoutError,
     socket.error,
     RuntimeError,
     BrokenPipeError,

--- a/homeassistant/components/foobot/sensor.py
+++ b/homeassistant/components/foobot/sensor.py
@@ -1,7 +1,6 @@
 """Support for the Foobot indoor air quality monitor."""
 from __future__ import annotations
 
-import asyncio
 from datetime import timedelta
 import logging
 from typing import Any
@@ -118,7 +117,7 @@ async def async_setup_platform(
             )
     except (
         aiohttp.client_exceptions.ClientConnectorError,
-        asyncio.TimeoutError,
+        TimeoutError,
         FoobotClient.TooManyRequests,
         FoobotClient.InternalError,
     ) as err:
@@ -175,7 +174,7 @@ class FoobotData:
             )
         except (
             aiohttp.client_exceptions.ClientConnectorError,
-            asyncio.TimeoutError,
+            TimeoutError,
             self._client.TooManyRequests,
             self._client.InternalError,
         ):

--- a/homeassistant/components/forked_daapd/media_player.py
+++ b/homeassistant/components/forked_daapd/media_player.py
@@ -668,7 +668,7 @@ class ForkedDaapdMaster(MediaPlayerEntity):
         try:
             async with asyncio.timeout(CALLBACK_TIMEOUT):
                 await self._paused_event.wait()  # wait for paused
-        except asyncio.TimeoutError:
+        except TimeoutError:
             self._pause_requested = False
         self._paused_event.clear()
 
@@ -764,7 +764,7 @@ class ForkedDaapdMaster(MediaPlayerEntity):
             async with asyncio.timeout(TTS_TIMEOUT):
                 await self._tts_playing_event.wait()
             # we have started TTS, now wait for completion
-        except asyncio.TimeoutError:
+        except TimeoutError:
             self._tts_requested = False
             _LOGGER.warning("TTS request timed out")
         await asyncio.sleep(

--- a/homeassistant/components/freedns/__init__.py
+++ b/homeassistant/components/freedns/__init__.py
@@ -96,7 +96,7 @@ async def _update_freedns(hass, session, url, auth_token):
     except aiohttp.ClientError:
         _LOGGER.warning("Can't connect to FreeDNS API")
 
-    except asyncio.TimeoutError:
+    except TimeoutError:
         _LOGGER.warning("Timeout from FreeDNS API at %s", url)
 
     return False

--- a/homeassistant/components/fully_kiosk/config_flow.py
+++ b/homeassistant/components/fully_kiosk/config_flow.py
@@ -58,7 +58,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except (
             ClientConnectorError,
             FullyKioskError,
-            asyncio.TimeoutError,
+            TimeoutError,
         ) as error:
             LOGGER.debug(error.args, exc_info=True)
             errors["base"] = "cannot_connect"

--- a/homeassistant/components/gardena_bluetooth/__init__.py
+++ b/homeassistant/components/gardena_bluetooth/__init__.py
@@ -1,7 +1,6 @@
 """The Gardena Bluetooth integration."""
 from __future__ import annotations
 
-import asyncio
 import logging
 
 from bleak.backends.device import BLEDevice
@@ -60,7 +59,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
         uuids = await client.get_all_characteristics_uuid()
         await client.update_timestamp(dt_util.now())
-    except (asyncio.TimeoutError, CommunicationFailure, DeviceUnavailable) as exception:
+    except (TimeoutError, CommunicationFailure, DeviceUnavailable) as exception:
         await client.disconnect()
         raise ConfigEntryNotReady(
             f"Unable to connect to device {address} due to {exception}"

--- a/homeassistant/components/gios/config_flow.py
+++ b/homeassistant/components/gios/config_flow.py
@@ -45,7 +45,7 @@ class GiosFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     title=gios.station_name,
                     data=user_input,
                 )
-            except (ApiError, ClientConnectorError, asyncio.TimeoutError):
+            except (ApiError, ClientConnectorError, TimeoutError):
                 errors["base"] = "cannot_connect"
             except NoStationError:
                 errors[CONF_STATION_ID] = "wrong_station_id"

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -1,7 +1,6 @@
 """Support for Google Actions Smart Home Control."""
 from __future__ import annotations
 
-import asyncio
 from datetime import timedelta
 from http import HTTPStatus
 import logging
@@ -216,7 +215,7 @@ class GoogleConfig(AbstractConfig):
         except ClientResponseError as error:
             _LOGGER.error("Request for %s failed: %d", url, error.status)
             return error.status
-        except (asyncio.TimeoutError, ClientError):
+        except (TimeoutError, ClientError):
             _LOGGER.error("Could not contact %s", url)
             return HTTPStatus.INTERNAL_SERVER_ERROR
 

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -255,7 +255,7 @@ async def handle_devices_execute(
         for entity_id, result in zip(executions, execute_results):
             if result is not None:
                 results[entity_id] = result
-    except asyncio.TimeoutError:
+    except TimeoutError:
         pass
 
     final_results = list(results.values())

--- a/homeassistant/components/google_cloud/tts.py
+++ b/homeassistant/components/google_cloud/tts.py
@@ -292,7 +292,7 @@ class GoogleCloudTTSProvider(Provider):
                 )
                 return _encoding, response.audio_content
 
-        except asyncio.TimeoutError as ex:
+        except TimeoutError as ex:
             _LOGGER.error("Timeout for Google Cloud TTS call: %s", ex)
         except Exception as ex:  # pylint: disable=broad-except
             _LOGGER.exception("Error occurred during Google Cloud TTS call: %s", ex)

--- a/homeassistant/components/google_domains/__init__.py
+++ b/homeassistant/components/google_domains/__init__.py
@@ -80,7 +80,7 @@ async def _update_google_domains(hass, session, domain, user, password, timeout)
     except aiohttp.ClientError:
         _LOGGER.warning("Can't connect to Google Domains API")
 
-    except asyncio.TimeoutError:
+    except TimeoutError:
         _LOGGER.warning("Timeout from Google Domains API for domain: %s", domain)
 
     return False

--- a/homeassistant/components/govee_light_local/__init__.py
+++ b/homeassistant/components/govee_light_local/__init__.py
@@ -28,7 +28,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         async with asyncio.timeout(delay=5):
             while not coordinator.devices:
                 await asyncio.sleep(delay=1)
-    except asyncio.TimeoutError as ex:
+    except TimeoutError as ex:
         raise ConfigEntryNotReady from ex
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator

--- a/homeassistant/components/govee_light_local/config_flow.py
+++ b/homeassistant/components/govee_light_local/config_flow.py
@@ -44,7 +44,7 @@ async def _async_has_devices(hass: HomeAssistant) -> bool:
         async with asyncio.timeout(delay=5):
             while not controller.devices:
                 await asyncio.sleep(delay=1)
-    except asyncio.TimeoutError:
+    except TimeoutError:
         _LOGGER.debug("No devices found")
 
     devices_count = len(controller.devices)

--- a/homeassistant/components/harmony/data.py
+++ b/homeassistant/components/harmony/data.py
@@ -1,7 +1,6 @@
 """Harmony data object which contains the Harmony Client."""
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Iterable
 import logging
 
@@ -121,7 +120,7 @@ class HarmonyData(HarmonySubscriberMixin):
         connected = False
         try:
             connected = await self._client.connect()
-        except (asyncio.TimeoutError, aioexc.TimeOut) as err:
+        except (TimeoutError, aioexc.TimeOut) as err:
             await self._client.close()
             raise ConfigEntryNotReady(
                 f"{self._name}: Connection timed-out to {self._address}:8088"

--- a/homeassistant/components/hassio/handler.py
+++ b/homeassistant/components/hassio/handler.py
@@ -593,7 +593,7 @@ class HassIO:
 
             return await request.json(encoding="utf-8")
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             _LOGGER.error("Timeout on %s request", command)
 
         except aiohttp.ClientError as err:

--- a/homeassistant/components/hassio/http.py
+++ b/homeassistant/components/hassio/http.py
@@ -1,7 +1,6 @@
 """HTTP Support for Hass.io."""
 from __future__ import annotations
 
-import asyncio
 from http import HTTPStatus
 import logging
 import os
@@ -193,7 +192,7 @@ class HassIOView(HomeAssistantView):
         except aiohttp.ClientError as err:
             _LOGGER.error("Client error on api %s request %s", path, err)
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             _LOGGER.error("Client timeout error on API request %s", path)
 
         raise HTTPBadGateway()

--- a/homeassistant/components/hlk_sw16/config_flow.py
+++ b/homeassistant/components/hlk_sw16/config_flow.py
@@ -43,7 +43,7 @@ async def validate_input(hass: HomeAssistant, user_input):
     """Validate the user input allows us to connect."""
     try:
         client = await connect_client(hass, user_input)
-    except asyncio.TimeoutError as err:
+    except TimeoutError as err:
         raise CannotConnect from err
 
     try:

--- a/homeassistant/components/homeassistant_alerts/__init__.py
+++ b/homeassistant/components/homeassistant_alerts/__init__.py
@@ -1,7 +1,6 @@
 """The Home Assistant alerts integration."""
 from __future__ import annotations
 
-import asyncio
 import dataclasses
 from datetime import timedelta
 import logging
@@ -53,7 +52,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                     f"https://alerts.home-assistant.io/alerts/{alert.alert_id}.json",
                     timeout=aiohttp.ClientTimeout(total=30),
                 )
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 _LOGGER.warning("Error fetching %s: timeout", alert.filename)
                 continue
 

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -43,13 +43,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         await conn.async_setup()
     except (
-        asyncio.TimeoutError,
+        TimeoutError,
         AccessoryNotFoundError,
         EncryptionError,
         AccessoryDisconnectedError,
     ) as ex:
         del hass.data[KNOWN_DEVICES][conn.unique_id]
-        with contextlib.suppress(asyncio.TimeoutError):
+        with contextlib.suppress(TimeoutError):
             await conn.pairing.close()
         raise ConfigEntryNotReady from ex
 

--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -1,5 +1,4 @@
 """Constants for the homekit_controller component."""
-import asyncio
 
 from aiohomekit.exceptions import (
     AccessoryDisconnectedError,
@@ -108,7 +107,7 @@ CHARACTERISTIC_PLATFORMS = {
 }
 
 STARTUP_EXCEPTIONS = (
-    asyncio.TimeoutError,
+    TimeoutError,
     AccessoryNotFoundError,
     EncryptionError,
     AccessoryDisconnectedError,

--- a/homeassistant/components/honeywell/__init__.py
+++ b/homeassistant/components/honeywell/__init__.py
@@ -1,5 +1,4 @@
 """Support for Honeywell (US) Total Connect Comfort climate systems."""
-import asyncio
 from dataclasses import dataclass
 
 import aiosomecomfort
@@ -68,7 +67,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         aiosomecomfort.device.ConnectionError,
         aiosomecomfort.device.ConnectionTimeout,
         aiosomecomfort.device.SomeComfortError,
-        asyncio.TimeoutError,
+        TimeoutError,
     ) as ex:
         raise ConfigEntryNotReady(
             "Failed to initialize the Honeywell client: Connection error"

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -1,7 +1,6 @@
 """Support for Honeywell (US) Total Connect Comfort climate systems."""
 from __future__ import annotations
 
-import asyncio
 import datetime
 from typing import Any
 
@@ -508,7 +507,7 @@ class HoneywellUSThermostat(ClimateEntity):
                 AuthError,
                 ClientConnectionError,
                 AscConnectionError,
-                asyncio.TimeoutError,
+                TimeoutError,
             ):
                 self._retry += 1
                 self._attr_available = self._retry <= RETRY
@@ -524,7 +523,7 @@ class HoneywellUSThermostat(ClimateEntity):
             await _login()
             return
 
-        except (AscConnectionError, ClientConnectionError, asyncio.TimeoutError):
+        except (AscConnectionError, ClientConnectionError, TimeoutError):
             self._retry += 1
             self._attr_available = self._retry <= RETRY
             return

--- a/homeassistant/components/honeywell/config_flow.py
+++ b/homeassistant/components/honeywell/config_flow.py
@@ -1,7 +1,6 @@
 """Config flow to configure the honeywell integration."""
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Mapping
 from typing import Any
 
@@ -61,7 +60,7 @@ class HoneywellConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except (
                 aiosomecomfort.ConnectionError,
                 aiosomecomfort.ConnectionTimeout,
-                asyncio.TimeoutError,
+                TimeoutError,
             ):
                 errors["base"] = "cannot_connect"
 
@@ -93,7 +92,7 @@ class HoneywellConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except (
                 aiosomecomfort.ConnectionError,
                 aiosomecomfort.ConnectionTimeout,
-                asyncio.TimeoutError,
+                TimeoutError,
             ):
                 errors["base"] = "cannot_connect"
 

--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -83,7 +83,7 @@ class HueBridge:
             create_config_flow(self.hass, self.host)
             return False
         except (
-            asyncio.TimeoutError,
+            TimeoutError,
             client_exceptions.ClientOSError,
             client_exceptions.ServerDisconnectedError,
             client_exceptions.ContentTypeError,

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -111,7 +111,7 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 bridges = await discover_nupnp(
                     websession=aiohttp_client.async_get_clientsession(self.hass)
                 )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             return self.async_abort(reason="discover_timeout")
 
         if bridges:

--- a/homeassistant/components/huisbaasje/__init__.py
+++ b/homeassistant/components/huisbaasje/__init__.py
@@ -84,7 +84,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_update_huisbaasje(energyflip: EnergyFlip) -> dict[str, dict[str, Any]]:
     """Update the data by performing a request to Huisbaasje."""
     try:
-        # Note: asyncio.TimeoutError and aiohttp.ClientError are already
+        # Note: TimeoutError and aiohttp.ClientError are already
         # handled by the data update coordinator.
         async with asyncio.timeout(FETCH_TIMEOUT):
             if not energyflip.is_authenticated():

--- a/homeassistant/components/hunterdouglas_powerview/const.py
+++ b/homeassistant/components/hunterdouglas_powerview/const.py
@@ -1,6 +1,5 @@
 """Support for Powerview scenes from a Powerview hub."""
 
-import asyncio
 
 from aiohttp.client_exceptions import ServerDisconnectedError
 from aiopvapi.helpers.aiorequest import PvApiConnectionError, PvApiResponseStatusError
@@ -53,7 +52,7 @@ STATE_ATTRIBUTE_ROOM_NAME = "roomName"
 
 HUB_EXCEPTIONS = (
     ServerDisconnectedError,
-    asyncio.TimeoutError,
+    TimeoutError,
     PvApiConnectionError,
     PvApiResponseStatusError,
 )

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -82,7 +82,7 @@ async def async_setup_entry(
         # so we force a refresh when we add it if possible
         shade: BaseShade = PvShade(raw_shade, pv_entry.api)
         name_before_refresh = shade.name
-        with suppress(asyncio.TimeoutError):
+        with suppress(TimeoutError):
             async with asyncio.timeout(1):
                 await shade.refresh()
 

--- a/homeassistant/components/ialarm/__init__.py
+++ b/homeassistant/components/ialarm/__init__.py
@@ -28,7 +28,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         async with asyncio.timeout(10):
             mac = await hass.async_add_executor_job(ialarm.get_mac)
-    except (asyncio.TimeoutError, ConnectionError) as ex:
+    except (TimeoutError, ConnectionError) as ex:
         raise ConfigEntryNotReady from ex
 
     coordinator = IAlarmDataUpdateCoordinator(hass, ialarm, mac)

--- a/homeassistant/components/iammeter/sensor.py
+++ b/homeassistant/components/iammeter/sensor.py
@@ -1,7 +1,6 @@
 """Support for iammeter via local API."""
 from __future__ import annotations
 
-import asyncio
 from asyncio import timeout
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -117,7 +116,7 @@ async def async_setup_platform(
         api = await hass.async_add_executor_job(
             IamMeter, config_host, config_port, config_name
         )
-    except asyncio.TimeoutError as err:
+    except TimeoutError as err:
         _LOGGER.error("Device is not ready")
         raise PlatformNotReady from err
 
@@ -125,7 +124,7 @@ async def async_setup_platform(
         try:
             async with timeout(PLATFORM_TIMEOUT):
                 return await hass.async_add_executor_job(api.client.get_data)
-        except asyncio.TimeoutError as err:
+        except TimeoutError as err:
             raise UpdateFailed from err
 
     coordinator = DataUpdateCoordinator(

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -1,7 +1,6 @@
 """Component to embed Aqualink devices."""
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Awaitable, Callable, Coroutine
 from datetime import datetime
 from functools import wraps
@@ -79,7 +78,7 @@ async def async_setup_entry(  # noqa: C901
         _LOGGER.error("Failed to login: %s", login_exception)
         await aqualink.close()
         return False
-    except (asyncio.TimeoutError, httpx.HTTPError) as aio_exception:
+    except (TimeoutError, httpx.HTTPError) as aio_exception:
         await aqualink.close()
         raise ConfigEntryNotReady(
             f"Error while attempting login: {aio_exception}"

--- a/homeassistant/components/image/__init__.py
+++ b/homeassistant/components/image/__init__.py
@@ -75,7 +75,7 @@ def valid_image_content_type(content_type: str | None) -> str:
 
 async def _async_get_image(image_entity: ImageEntity, timeout: int) -> Image:
     """Fetch image from an image entity."""
-    with suppress(asyncio.CancelledError, asyncio.TimeoutError, ImageContentTypeError):
+    with suppress(asyncio.CancelledError, TimeoutError, ImageContentTypeError):
         async with asyncio.timeout(timeout):
             if image_bytes := await image_entity.async_image():
                 content_type = valid_image_content_type(image_entity.content_type)

--- a/homeassistant/components/imap/__init__.py
+++ b/homeassistant/components/imap/__init__.py
@@ -1,8 +1,6 @@
 """The imap integration."""
 from __future__ import annotations
 
-import asyncio
-
 from aioimaplib import IMAP4_SSL, AioImapException
 
 from homeassistant.config_entries import ConfigEntry
@@ -33,7 +31,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryAuthFailed from err
     except InvalidFolder as err:
         raise ConfigEntryError("Selected mailbox folder is invalid.") from err
-    except (asyncio.TimeoutError, AioImapException) as err:
+    except (TimeoutError, AioImapException) as err:
         raise ConfigEntryNotReady from err
 
     coordinator_class: type[

--- a/homeassistant/components/imap/config_flow.py
+++ b/homeassistant/components/imap/config_flow.py
@@ -1,7 +1,6 @@
 """Config flow for imap integration."""
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Mapping
 import ssl
 from typing import Any
@@ -108,7 +107,7 @@ async def validate_input(
         # See https://github.com/bamthomas/aioimaplib/issues/91
         # This handler is added to be able to supply a better error message
         errors["base"] = "ssl_error"
-    except (asyncio.TimeoutError, AioImapException, ConnectionRefusedError):
+    except (TimeoutError, AioImapException, ConnectionRefusedError):
         errors["base"] = "cannot_connect"
     else:
         if result != "OK":

--- a/homeassistant/components/imap/coordinator.py
+++ b/homeassistant/components/imap/coordinator.py
@@ -346,7 +346,7 @@ class ImapDataUpdateCoordinator(DataUpdateCoordinator[int | None]):
                 await self.imap_client.stop_wait_server_push()
                 await self.imap_client.close()
                 await self.imap_client.logout()
-            except (AioImapException, asyncio.TimeoutError):
+            except (AioImapException, TimeoutError):
                 if log_error:
                     _LOGGER.debug("Error while cleaning up imap connection")
             finally:
@@ -378,7 +378,7 @@ class ImapPollingDataUpdateCoordinator(ImapDataUpdateCoordinator):
         except (
             AioImapException,
             UpdateFailed,
-            asyncio.TimeoutError,
+            TimeoutError,
         ) as ex:
             await self._cleanup()
             self.async_set_update_error(ex)
@@ -450,7 +450,7 @@ class ImapPushDataUpdateCoordinator(ImapDataUpdateCoordinator):
             except (
                 UpdateFailed,
                 AioImapException,
-                asyncio.TimeoutError,
+                TimeoutError,
             ) as ex:
                 await self._cleanup()
                 self.async_set_update_error(ex)
@@ -466,8 +466,7 @@ class ImapPushDataUpdateCoordinator(ImapDataUpdateCoordinator):
                 async with asyncio.timeout(10):
                     await idle
 
-            # From python 3.11 asyncio.TimeoutError is an alias of TimeoutError
-            except (AioImapException, asyncio.TimeoutError):
+            except (AioImapException, TimeoutError):
                 _LOGGER.debug(
                     "Lost %s (will attempt to reconnect after %s s)",
                     self.config_entry.data[CONF_SERVER],

--- a/homeassistant/components/incomfort/water_heater.py
+++ b/homeassistant/components/incomfort/water_heater.py
@@ -1,7 +1,6 @@
 """Support for an Intergas boiler via an InComfort/Intouch Lan2RF gateway."""
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import Any
 
@@ -101,7 +100,7 @@ class IncomfortWaterHeater(IncomfortEntity, WaterHeaterEntity):
         try:
             await self._heater.update()
 
-        except (ClientResponseError, asyncio.TimeoutError) as err:
+        except (ClientResponseError, TimeoutError) as err:
             _LOGGER.warning("Update failed, message is: %s", err)
 
         else:

--- a/homeassistant/components/ipma/__init__.py
+++ b/homeassistant/components/ipma/__init__.py
@@ -33,7 +33,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     try:
         async with asyncio.timeout(30):
             location = await Location.get(api, float(latitude), float(longitude))
-    except (IPMAException, asyncio.TimeoutError) as err:
+    except (IPMAException, TimeoutError) as err:
         raise ConfigEntryNotReady(
             f"Could not get location for ({latitude},{longitude})"
         ) from err

--- a/homeassistant/components/ipma/weather.py
+++ b/homeassistant/components/ipma/weather.py
@@ -217,7 +217,7 @@ class IPMAWeather(WeatherEntity, IPMADevice):
         period: int,
     ) -> None:
         """Try to update weather forecast."""
-        with contextlib.suppress(asyncio.TimeoutError):
+        with contextlib.suppress(TimeoutError):
             async with asyncio.timeout(10):
                 await self._update_forecast(forecast_type, period, False)
 

--- a/homeassistant/components/isy994/__init__.py
+++ b/homeassistant/components/isy994/__init__.py
@@ -102,7 +102,7 @@ async def async_setup_entry(
     try:
         async with asyncio.timeout(60):
             await isy.initialize()
-    except asyncio.TimeoutError as err:
+    except TimeoutError as err:
         raise ConfigEntryNotReady(
             "Timed out initializing the ISY; device may be busy, trying again later:"
             f" {err}"

--- a/homeassistant/components/izone/config_flow.py
+++ b/homeassistant/components/izone/config_flow.py
@@ -25,7 +25,7 @@ async def _async_has_devices(hass: HomeAssistant) -> bool:
 
     disco = await async_start_discovery_service(hass)
 
-    with suppress(asyncio.TimeoutError):
+    with suppress(TimeoutError):
         async with asyncio.timeout(TIMEOUT_DISCOVERY):
             await controller_ready.wait()
 

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test config flow."""
-import asyncio
 from ipaddress import ip_address
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -500,7 +499,7 @@ async def test_user_discovers_name_and_dashboard_is_unavailable(
 
     with patch(
         "esphome_dashboard_api.ESPHomeDashboardAPI.get_devices",
-        side_effect=asyncio.TimeoutError,
+        side_effect=TimeoutError,
     ):
         await dashboard.async_get_dashboard(hass).async_refresh()
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/esphome/test_dashboard.py
+++ b/tests/components/esphome/test_dashboard.py
@@ -1,5 +1,4 @@
 """Test ESPHome dashboard features."""
-import asyncio
 from unittest.mock import patch
 
 from aioesphomeapi import DeviceInfo, InvalidAuthAPIError
@@ -69,7 +68,7 @@ async def test_setup_dashboard_fails(
 ) -> MockConfigEntry:
     """Test that nothing is stored on failed dashboard setup when there was no dashboard before."""
     with patch.object(
-        dashboard.ESPHomeDashboardAPI, "get_devices", side_effect=asyncio.TimeoutError
+        dashboard.ESPHomeDashboardAPI, "get_devices", side_effect=TimeoutError
     ) as mock_get_devices:
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
@@ -99,7 +98,7 @@ async def test_setup_dashboard_fails_when_already_setup(
     await hass.async_block_till_done()
 
     with patch.object(
-        dashboard.ESPHomeDashboardAPI, "get_devices", side_effect=asyncio.TimeoutError
+        dashboard.ESPHomeDashboardAPI, "get_devices", side_effect=TimeoutError
     ) as mock_get_devices, patch(
         "homeassistant.components.esphome.async_setup_entry", return_value=True
     ) as mock_setup:

--- a/tests/components/esphome/test_update.py
+++ b/tests/components/esphome/test_update.py
@@ -1,5 +1,4 @@
 """Test ESPHome update entities."""
-import asyncio
 from collections.abc import Awaitable, Callable
 import dataclasses
 from unittest.mock import Mock, patch
@@ -280,7 +279,7 @@ async def test_update_entity_dashboard_not_available_startup(
         return_value=Mock(available=True, device_info=mock_device_info),
     ), patch(
         "esphome_dashboard_api.ESPHomeDashboardAPI.get_devices",
-        side_effect=asyncio.TimeoutError,
+        side_effect=TimeoutError,
     ):
         await async_get_dashboard(hass).async_refresh()
         assert await hass.config_entries.async_forward_entry_setup(
@@ -324,7 +323,7 @@ async def test_update_entity_dashboard_discovered_after_startup_but_update_faile
     """Test ESPHome update entity when dashboard is discovered after startup and the first update fails."""
     with patch(
         "esphome_dashboard_api.ESPHomeDashboardAPI.get_devices",
-        side_effect=asyncio.TimeoutError,
+        side_effect=TimeoutError,
     ):
         await async_get_dashboard(hass).async_refresh()
         await hass.async_block_till_done()

--- a/tests/components/evil_genius_labs/test_config_flow.py
+++ b/tests/components/evil_genius_labs/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test the Evil Genius Labs config flow."""
-import asyncio
 from unittest.mock import patch
 
 import aiohttp
@@ -82,7 +81,7 @@ async def test_form_timeout(hass: HomeAssistant) -> None:
 
     with patch(
         "pyevilgenius.EvilGeniusDevice.get_all",
-        side_effect=asyncio.TimeoutError,
+        side_effect=TimeoutError,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/flick_electric/test_config_flow.py
+++ b/tests/components/flick_electric/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test the Flick Electric config flow."""
-import asyncio
 from unittest.mock import patch
 
 from pyflick.authentication import AuthException
@@ -86,7 +85,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     with patch(
         "homeassistant.components.flick_electric.config_flow.SimpleFlickAuth.async_get_access_token",
-        side_effect=asyncio.TimeoutError,
+        side_effect=TimeoutError,
     ):
         result = await _flow_submit(hass)
 

--- a/tests/components/foobot/test_sensor.py
+++ b/tests/components/foobot/test_sensor.py
@@ -1,5 +1,4 @@
 """The tests for the Foobot sensor platform."""
-import asyncio
 from http import HTTPStatus
 import re
 from unittest.mock import MagicMock
@@ -65,9 +64,7 @@ async def test_setup_timeout_error(
     """Expected failures caused by a timeout in API response."""
     fake_async_add_entities = MagicMock()
 
-    aioclient_mock.get(
-        re.compile("api.foobot.io/v2/owner/.*"), exc=asyncio.TimeoutError()
-    )
+    aioclient_mock.get(re.compile("api.foobot.io/v2/owner/.*"), exc=TimeoutError())
     with pytest.raises(PlatformNotReady):
         await foobot.async_setup_platform(hass, VALID_CONFIG, fake_async_add_entities)
 

--- a/tests/components/fully_kiosk/test_config_flow.py
+++ b/tests/components/fully_kiosk/test_config_flow.py
@@ -1,6 +1,5 @@
 """Test the Fully Kiosk Browser config flow."""
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 from aiohttp.client_exceptions import ClientConnectorError
@@ -67,7 +66,7 @@ async def test_user_flow(
     [
         (FullyKioskError("error", "status"), "cannot_connect"),
         (ClientConnectorError(None, Mock()), "cannot_connect"),
-        (asyncio.TimeoutError, "cannot_connect"),
+        (TimeoutError, "cannot_connect"),
         (RuntimeError, "unknown"),
     ],
 )

--- a/tests/components/fully_kiosk/test_init.py
+++ b/tests/components/fully_kiosk/test_init.py
@@ -1,5 +1,4 @@
 """Tests for the Fully Kiosk Browser integration."""
-import asyncio
 import json
 from unittest.mock import MagicMock, patch
 
@@ -45,7 +44,7 @@ async def test_load_unload_config_entry(
 
 @pytest.mark.parametrize(
     "side_effect",
-    [FullyKioskError("error", "status"), asyncio.TimeoutError],
+    [FullyKioskError("error", "status"), TimeoutError],
 )
 async def test_config_entry_not_ready(
     hass: HomeAssistant,

--- a/tests/components/generic/test_camera.py
+++ b/tests/components/generic/test_camera.py
@@ -249,7 +249,7 @@ async def test_limit_refetch(
     hass.states.async_set("sensor.temp", "5")
 
     with pytest.raises(aiohttp.ServerTimeoutError), patch(
-        "asyncio.timeout", side_effect=asyncio.TimeoutError()
+        "asyncio.timeout", side_effect=TimeoutError()
     ):
         resp = await client.get("/api/camera_proxy/camera.config_test")
 

--- a/tests/components/gogogate2/test_init.py
+++ b/tests/components/gogogate2/test_init.py
@@ -1,5 +1,4 @@
 """Tests for the GogoGate2 component."""
-import asyncio
 from unittest.mock import MagicMock, patch
 
 from ismartgate import GogoGate2Api
@@ -94,6 +93,6 @@ async def test_api_failure_on_startup(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.gogogate2.common.ISmartGateApi.async_info",
-        side_effect=asyncio.TimeoutError,
+        side_effect=TimeoutError,
     ), pytest.raises(ConfigEntryNotReady):
         await async_setup_entry(hass, config_entry)

--- a/tests/components/govee_light_local/test_light.py
+++ b/tests/components/govee_light_local/test_light.py
@@ -1,6 +1,5 @@
 """Test Govee light local."""
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from govee_local_api import GoveeDevice
@@ -133,7 +132,7 @@ async def test_light_setup_retry(
 
         with patch(
             "homeassistant.components.govee_light_local.asyncio.timeout",
-            side_effect=asyncio.TimeoutError,
+            side_effect=TimeoutError,
         ):
             await hass.config_entries.async_setup(entry.entry_id)
         assert entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/hassio/test_http.py
+++ b/tests/components/hassio/test_http.py
@@ -1,5 +1,4 @@
 """The tests for the hassio component."""
-import asyncio
 from http import HTTPStatus
 from unittest.mock import patch
 
@@ -396,7 +395,7 @@ async def test_bad_gateway_when_cannot_find_supervisor(
     hassio_client, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test we get a bad gateway error if we can't find supervisor."""
-    aioclient_mock.get("http://127.0.0.1/app/entrypoint.js", exc=asyncio.TimeoutError)
+    aioclient_mock.get("http://127.0.0.1/app/entrypoint.js", exc=TimeoutError)
 
     resp = await hassio_client.get("/api/hassio/app/entrypoint.js")
     assert resp.status == HTTPStatus.BAD_GATEWAY

--- a/tests/components/hlk_sw16/test_config_flow.py
+++ b/tests/components/hlk_sw16/test_config_flow.py
@@ -189,7 +189,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.hlk_sw16.config_flow.connect_client",
-        side_effect=asyncio.TimeoutError,
+        side_effect=TimeoutError,
         return_value=None,
     ):
         result2 = await hass.config_entries.flow.async_configure(

--- a/tests/components/honeywell/test_config_flow.py
+++ b/tests/components/honeywell/test_config_flow.py
@@ -1,5 +1,4 @@
 """Tests for honeywell config flow."""
-import asyncio
 from unittest.mock import MagicMock, patch
 
 import aiosomecomfort
@@ -213,7 +212,7 @@ async def test_reauth_flow_auth_error(hass: HomeAssistant, client: MagicMock) ->
     [
         aiosomecomfort.device.ConnectionError,
         aiosomecomfort.device.ConnectionTimeout,
-        asyncio.TimeoutError,
+        TimeoutError,
     ],
 )
 async def test_reauth_flow_connnection_error(

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -1,5 +1,4 @@
 """Tests for Philips Hue config flow."""
-import asyncio
 from ipaddress import ip_address
 from unittest.mock import Mock, patch
 
@@ -254,7 +253,7 @@ async def test_flow_timeout_discovery(hass: HomeAssistant) -> None:
     """Test config flow ."""
     with patch(
         "homeassistant.components.hue.config_flow.discover_nupnp",
-        side_effect=asyncio.TimeoutError,
+        side_effect=TimeoutError,
     ):
         result = await hass.config_entries.flow.async_init(
             const.DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/hue/test_light_v1.py
+++ b/tests/components/hue/test_light_v1.py
@@ -1,5 +1,4 @@
 """Philips Hue lights platform tests."""
-import asyncio
 from unittest.mock import Mock
 
 import aiohue
@@ -558,8 +557,8 @@ async def test_other_light_update(hass: HomeAssistant, mock_bridge_v1) -> None:
 
 async def test_update_timeout(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test bridge marked as not available if timeout error during update."""
-    mock_bridge_v1.api.lights.update = Mock(side_effect=asyncio.TimeoutError)
-    mock_bridge_v1.api.groups.update = Mock(side_effect=asyncio.TimeoutError)
+    mock_bridge_v1.api.lights.update = Mock(side_effect=TimeoutError)
+    mock_bridge_v1.api.groups.update = Mock(side_effect=TimeoutError)
     await setup_bridge(hass, mock_bridge_v1)
     assert len(mock_bridge_v1.mock_requests) == 0
     assert len(hass.states.async_all()) == 0

--- a/tests/components/hue/test_sensor_v1.py
+++ b/tests/components/hue/test_sensor_v1.py
@@ -1,5 +1,4 @@
 """Philips Hue sensors platform tests."""
-import asyncio
 from unittest.mock import Mock
 
 import aiohue
@@ -433,7 +432,7 @@ async def test_sensor_removed(hass: HomeAssistant, mock_bridge_v1) -> None:
 
 async def test_update_timeout(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test bridge marked as not available if timeout error during update."""
-    mock_bridge_v1.api.sensors.update = Mock(side_effect=asyncio.TimeoutError)
+    mock_bridge_v1.api.sensors.update = Mock(side_effect=TimeoutError)
     await setup_platform(hass, mock_bridge_v1, ["binary_sensor", "sensor"])
     assert len(mock_bridge_v1.mock_requests) == 0
     assert len(hass.states.async_all()) == 0

--- a/tests/components/hunterdouglas_powerview/test_config_flow.py
+++ b/tests/components/hunterdouglas_powerview/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test the Hunter Douglas Powerview config flow."""
-import asyncio
 from ipaddress import ip_address
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -191,9 +190,7 @@ async def test_form_homekit_and_dhcp_cannot_connect(
     )
     ignored_config_entry.add_to_hass(hass)
 
-    mock_powerview_userdata = _get_mock_powerview_userdata(
-        get_resources=asyncio.TimeoutError
-    )
+    mock_powerview_userdata = _get_mock_powerview_userdata(get_resources=TimeoutError)
     with patch(
         "homeassistant.components.hunterdouglas_powerview.UserData",
         return_value=mock_powerview_userdata,
@@ -300,9 +297,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    mock_powerview_userdata = _get_mock_powerview_userdata(
-        get_resources=asyncio.TimeoutError
-    )
+    mock_powerview_userdata = _get_mock_powerview_userdata(get_resources=TimeoutError)
     with patch(
         "homeassistant.components.hunterdouglas_powerview.UserData",
         return_value=mock_powerview_userdata,

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -1,5 +1,4 @@
 """Tests for iAqualink integration."""
-import asyncio
 import logging
 from unittest.mock import AsyncMock, patch
 
@@ -56,7 +55,7 @@ async def test_setup_login_timeout(hass: HomeAssistant, config_entry) -> None:
 
     with patch(
         "homeassistant.components.iaqualink.AqualinkClient.login",
-        side_effect=asyncio.TimeoutError,
+        side_effect=TimeoutError,
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/imap/test_config_flow.py
+++ b/tests/components/imap/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test the imap config flow."""
-import asyncio
 import ssl
 from unittest.mock import AsyncMock, patch
 
@@ -117,7 +116,7 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     ("exc", "error"),
     [
-        (asyncio.TimeoutError, "cannot_connect"),
+        (TimeoutError, "cannot_connect"),
         (AioImapException(""), "cannot_connect"),
         (ssl.SSLError, "ssl_error"),
     ],
@@ -306,7 +305,7 @@ async def test_reauth_failed_conn_error(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.imap.config_flow.connect_to_server",
-        side_effect=asyncio.TimeoutError,
+        side_effect=TimeoutError,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -520,7 +519,7 @@ async def test_config_flow_from_with_advanced_settings(
 
     with patch(
         "homeassistant.components.imap.config_flow.connect_to_server",
-        side_effect=asyncio.TimeoutError,
+        side_effect=TimeoutError,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], config

--- a/tests/components/imap/test_init.py
+++ b/tests/components/imap/test_init.py
@@ -82,7 +82,7 @@ async def test_entry_startup_and_unload(
     [
         InvalidAuth,
         InvalidFolder,
-        asyncio.TimeoutError,
+        TimeoutError,
     ],
 )
 async def test_entry_startup_fails(
@@ -417,7 +417,7 @@ async def test_late_folder_error(
     "imap_close",
     [
         AsyncMock(side_effect=AioImapException("Something went wrong")),
-        AsyncMock(side_effect=asyncio.TimeoutError),
+        AsyncMock(side_effect=TimeoutError),
     ],
     ids=["AioImapException", "TimeoutError"],
 )
@@ -460,7 +460,7 @@ async def test_handle_cleanup_exception(
     "imap_wait_server_push_exception",
     [
         AioImapException("Something went wrong"),
-        asyncio.TimeoutError,
+        TimeoutError,
     ],
     ids=["AioImapException", "TimeoutError"],
 )
@@ -468,7 +468,7 @@ async def test_lost_connection_with_imap_push(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     mock_imap_protocol: MagicMock,
-    imap_wait_server_push_exception: AioImapException | asyncio.TimeoutError,
+    imap_wait_server_push_exception: AioImapException | TimeoutError,
 ) -> None:
     """Test error handling when the connection is lost."""
     # Mock an error in waiting for a pushed update


### PR DESCRIPTION
## Proposed change
In Python 3.11 `asyncio.TimeoutError` was made an alias of the builtin `TimeoutError` and subsequently deprecated. This is in preparation for the ruff `0.2.0` update which will be able to detect / fix this automatically.
https://docs.python.org/3/library/asyncio-exceptions.html#asyncio.TimeoutError

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
